### PR TITLE
fix(diff): correct deletion output and stabilize reconcile race

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -39,10 +39,12 @@ type Controller struct {
 	WipeSecrets bool
 
 	unsub []store.Unsubscribe
+	coal  *task.Coalescer[manifest.NamedResource]
 }
 
 // Start registers the listeners. The controller runs until Close.
 func (c *Controller) Start(ctx context.Context) {
+	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
 	c.unsub = append(c.unsub,
 		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
 		c.Store.AddListener(store.EventArtifactUpdated, c.onArtifactUpdated, true),
@@ -69,15 +71,20 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				c.Helm.AddOCIRepo(r)
 			}
 		case manifest.KindHelmRelease:
-			hr, ok := payload.(*manifest.HelmRelease)
-			if !ok {
+			if _, ok := payload.(*manifest.HelmRelease); !ok {
 				return
 			}
 			if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {
 				c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
 				return
 			}
-			c.Tasks.Go(ctx, "helmrelease/"+id.String(), func(ctx context.Context) {
+			c.coal.Submit(ctx, "helmrelease/"+id.String(), id, func(ctx context.Context) {
+				// Re-read each iteration so a coalesced re-run picks up
+				// a parent KS's patches rather than the stale payload.
+				hr, _ := c.Store.GetObject(id).(*manifest.HelmRelease)
+				if hr == nil {
+					return
+				}
 				if err := c.reconcile(ctx, hr); err != nil {
 					c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
 					return

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -39,10 +39,12 @@ type Controller struct {
 	WipeSecrets bool
 
 	unsub []store.Unsubscribe
+	coal  *task.Coalescer[manifest.NamedResource]
 }
 
 // Start registers the listener that drives reconciliation.
 func (c *Controller) Start(ctx context.Context) {
+	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
 	c.unsub = append(c.unsub,
 		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
 	)
@@ -61,15 +63,21 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if id.Kind != manifest.KindKustomization {
 			return
 		}
-		ks, ok := payload.(*manifest.Kustomization)
-		if !ok {
+		if _, ok := payload.(*manifest.Kustomization); !ok {
 			return
 		}
 		if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {
 			c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
 			return
 		}
-		c.Tasks.Go(ctx, "kustomization/"+id.String(), func(ctx context.Context) {
+		c.coal.Submit(ctx, "kustomization/"+id.String(), id, func(ctx context.Context) {
+			// Re-read the spec each iteration so a coalesced re-run
+			// picks up patches a parent KS installed mid-flight rather
+			// than the stale payload from the original event.
+			ks, _ := c.Store.GetObject(id).(*manifest.Kustomization)
+			if ks == nil {
+				return
+			}
 			if err := c.reconcile(ctx, ks); err != nil {
 				c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
 				return

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -104,11 +104,11 @@ func Run(left, right []Doc, opts Options) ([]ResourceDiff, error) {
 	pairs := pair(left, right)
 	out := make([]ResourceDiff, 0, len(pairs))
 	for _, p := range pairs {
-		a, err := yaml.Marshal(p.a)
+		a, err := marshalSide(p.a)
 		if err != nil {
 			return nil, err
 		}
-		b, err := yaml.Marshal(p.b)
+		b, err := marshalSide(p.b)
 		if err != nil {
 			return nil, err
 		}
@@ -261,6 +261,25 @@ func deepCopyValue(v any) any {
 	default:
 		return v
 	}
+}
+
+// marshalSide serializes one side of a paired manifest. A nil manifest
+// (added or deleted between baseline and current) yields an empty
+// byte slice, not "null\n", so the diff body never contains a
+// "+null" / "-null" line. Non-nil manifests are prefixed with the YAML
+// document separator to match flux-local's output.
+func marshalSide(m map[string]any) ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	body, err := yaml.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]byte, 0, len(body)+4)
+	out = append(out, "---\n"...)
+	out = append(out, body...)
+	return out, nil
 }
 
 func unified(a, b string, context int) (string, error) {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -56,6 +56,42 @@ func TestRun_AddedAndRemoved(t *testing.T) {
 	}
 }
 
+func TestRun_DeletionHasNoNullCounterpart(t *testing.T) {
+	left := []Doc{cm("a", "ns", "owner", "v1")}
+	diffs, err := Run(left, nil, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for deletion, got %d", len(diffs))
+	}
+	body := diffs[0].Diff
+	if strings.Contains(body, "+null") {
+		t.Errorf("deletion diff contained spurious +null line:\n%s", body)
+	}
+	if !strings.Contains(body, "----\n") {
+		t.Errorf("expected '---' YAML document separator in removed body:\n%s", body)
+	}
+}
+
+func TestRun_AdditionHasNoNullCounterpart(t *testing.T) {
+	right := []Doc{cm("a", "ns", "owner", "v1")}
+	diffs, err := Run(nil, right, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff for addition, got %d", len(diffs))
+	}
+	body := diffs[0].Diff
+	if strings.Contains(body, "-null") {
+		t.Errorf("addition diff contained spurious -null line:\n%s", body)
+	}
+	if !strings.Contains(body, "+---\n") {
+		t.Errorf("expected '---' YAML document separator in added body:\n%s", body)
+	}
+}
+
 func TestFormat_JSON(t *testing.T) {
 	diffs := []ResourceDiff{{Kind: "ConfigMap", Name: "a", Diff: "..."}}
 	out, err := Render(diffs, FormatJSON)

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -120,3 +120,55 @@ func (s *Service) BlockTillAllDone() {
 	s.wgActive.Wait()
 	s.wgBack.Wait()
 }
+
+// Coalescer keeps at most one task per key in flight; submits that
+// arrive while a key is running collapse into a single re-run after it
+// returns. fn must re-read its inputs each call — a coalesced re-run
+// exists precisely because the previous submit's inputs went stale.
+type Coalescer[K comparable] struct {
+	svc  *Service
+	mu   sync.Mutex
+	slot map[K]*coalSlot
+}
+
+type coalSlot struct {
+	running bool
+	pending bool
+}
+
+// NewCoalescer constructs a Coalescer that schedules work onto svc.
+func NewCoalescer[K comparable](svc *Service) *Coalescer[K] {
+	return &Coalescer[K]{svc: svc, slot: make(map[K]*coalSlot)}
+}
+
+// Submit schedules fn for key, starting a new active task if key is
+// idle or marking the running slot pending otherwise.
+func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(context.Context)) {
+	c.mu.Lock()
+	s := c.slot[key]
+	if s == nil {
+		s = &coalSlot{}
+		c.slot[key] = s
+	}
+	if s.running {
+		s.pending = true
+		c.mu.Unlock()
+		return
+	}
+	s.running = true
+	c.mu.Unlock()
+
+	c.svc.Go(ctx, name, func(ctx context.Context) {
+		for {
+			fn(ctx)
+			c.mu.Lock()
+			if !s.pending {
+				s.running = false
+				c.mu.Unlock()
+				return
+			}
+			s.pending = false
+			c.mu.Unlock()
+		}
+	})
+}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -55,6 +55,76 @@ func TestService_PanicCountedAndRecovered(t *testing.T) {
 	}
 }
 
+func TestCoalescer_SerializesPerKey(t *testing.T) {
+	s := New()
+	c := NewCoalescer[string](s)
+
+	var concurrent atomic.Int32
+	var maxConcurrent atomic.Int32
+	var runs atomic.Int64
+	gate := make(chan struct{})
+
+	bumpPeak := func() {
+		now := concurrent.Add(1)
+		for {
+			peak := maxConcurrent.Load()
+			if now <= peak || maxConcurrent.CompareAndSwap(peak, now) {
+				return
+			}
+		}
+	}
+
+	c.Submit(context.Background(), "k", "k", func(_ context.Context) {
+		bumpPeak()
+		runs.Add(1)
+		<-gate
+		concurrent.Add(-1)
+	})
+	for range 5 {
+		c.Submit(context.Background(), "k", "k", func(_ context.Context) {
+			bumpPeak()
+			runs.Add(1)
+			concurrent.Add(-1)
+		})
+	}
+
+	close(gate)
+	s.BlockTillDone()
+
+	if got := runs.Load(); got != 2 {
+		t.Errorf("expected exactly 2 runs (initial + 1 coalesced re-run), got %d", got)
+	}
+	if peak := maxConcurrent.Load(); peak > 1 {
+		t.Errorf("Coalescer permitted %d concurrent runs for same key; must be 1", peak)
+	}
+}
+
+func TestCoalescer_DistinctKeysRunConcurrently(t *testing.T) {
+	s := New()
+	c := NewCoalescer[string](s)
+
+	bothStarted := make(chan struct{}, 2)
+	release := make(chan struct{})
+
+	for _, k := range []string{"a", "b"} {
+		c.Submit(context.Background(), k, k, func(_ context.Context) {
+			bothStarted <- struct{}{}
+			<-release
+		})
+	}
+
+	deadline := time.After(2 * time.Second)
+	for range 2 {
+		select {
+		case <-bothStarted:
+		case <-deadline:
+			t.Fatal("distinct keys did not run concurrently")
+		}
+	}
+	close(release)
+	s.BlockTillDone()
+}
+
 func TestService_ActiveNames(t *testing.T) {
 	s := New()
 	gate := make(chan struct{})


### PR DESCRIPTION
## Summary

Two related bugs surfaced when running `flate diff` against a PR that deletes a whole Kustomization (e.g. removing a child app from `--path` and keeping the baseline in `--path-orig`).

### Bug 1 — `+null` in deletion diffs

`pkg/diff/diff.go` was calling `yaml.Marshal(p.b)` even when `p.b` was nil (resource missing on one side). `yaml.Marshal(nil)` returns `\"null\\n\"`, so a fully-deleted Kustomization rendered like this:

```diff
@@ -1,98 +1,2 @@
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
…
+null
```

Compare to the flux-local format reviewers expect:

```diff
@@ -1,102 +0,0 @@
----
-apiVersion: helm.toolkit.fluxcd.io/v2
-kind: HelmRelease
…
```

**Fix:** new `marshalSide` helper that returns an empty byte slice for nil manifests and prepends `---\n` to non-nil manifests so the YAML document marker shows up as a removed/added line on full deletions/additions.

### Bug 2 — Non-deterministic reconcile output

Running the same `flate diff` repeatedly against the same inputs produced different output across runs — sometimes 9 diff headers, sometimes 19, with unrelated HelmReleases (recyclarr, victoria-logs-collector, home-assistant, etc.) flipping between \"has install/upgrade/rollback patches\" and \"doesn't.\"

**Root cause:** the loader pre-populates the Store with every `Kustomization` and `HelmRelease` parsed from disk. Each `Store.AddObject` fires an `EventObjectAdded`, and the controllers respond by spawning a reconcile via `c.Tasks.Go`. When a meta-KS like `cluster-apps` reconciles, it re-publishes patched versions of the child KSes (via `kustomize build` + `spec.patches`), which calls `AddObject` again — firing a *second* event for each child while the first reconcile is still in flight. Both reconciles then race to call `SetArtifact`, and whichever finishes last wins.

```
cluster-apps reconcile ─┐                        Store.AddObject(media/qui patched)
                         └─ produces patched ──→ EventObjectAdded ──→ reconcile-B (patched)
loader ──→ Store.AddObject(media/qui raw)
            └─ EventObjectAdded ──→ reconcile-A (raw)        race  ←┘
                                          │  ┌─→ SetArtifact (last writer wins)
                                          └──┘
```

**Fix:** new generic `task.Coalescer[K]` that:

- Allows at most one reconcile per id to run at a time.
- Coalesces submits arriving during an in-flight run into a single follow-up run.
- Drives a loop where the worker re-reads its spec from the store at the top of every iteration — so a coalesced re-run picks up the latest patched object, not the stale event payload.

The Kustomization and HelmRelease controllers now submit through the Coalescer instead of calling `c.Tasks.Go` directly. Source controller already had artifact-based idempotency, so no change there.

## Verification

Tested on `buroa/k8s-gitops` by deleting `kubernetes/apps/media/qui/` plus its entry in `apps/media/kustomization.yaml`:

- **Before:** header count fluctuated 9 ↔ 19 across runs.
- **After:** 10 consecutive runs all produced exactly 9 headers (only the qui deletion + its children).
- The deletion diff body now matches the flux-local format the bot comments in PRs use (`@@ -1,N +0,0 @@`, `---` doc separator, no `+null`).

## Test plan

- [x] `mise run vet` — clean
- [x] `mise run lint` (golangci-lint v2) — 0 issues
- [x] `mise run test` — all packages pass
- [x] `gosec ./pkg/task/... ./pkg/controllers/... ./pkg/diff/...` — 0 issues (12 pre-existing G304 path-traversal warnings remain in unrelated files)
- [x] `go test ./pkg/task/... -race -run Coalescer` — passes under the race detector
- [x] Manual smoke test against `buroa/k8s-gitops` — deletion diff now matches `onedr0p/home-ops` PR comment format
- [ ] CI verifies all of the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)