### PR TITLE
feat(diff): add `diff images` for set-diffing changed container images

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,7 +1,7 @@
 package cli
 
 import (
-	"errors"
+	"slices"
 
 	"github.com/spf13/cobra"
 
@@ -14,7 +14,7 @@ func newDiffCmd() *cobra.Command {
 		Use:   "diff",
 		Short: "Diff rendered output against a previous revision",
 	}
-	cmd.AddCommand(newDiffKSCmd(), newDiffHRCmd())
+	cmd.AddCommand(newDiffKSCmd(), newDiffHRCmd(), newDiffImagesCmd())
 	return cmd
 }
 
@@ -68,31 +68,67 @@ func newDiffHRCmd() *cobra.Command {
 	return cmd
 }
 
+func newDiffImagesCmd() *cobra.Command {
+	c := &commonFlags{}
+	h := &helmFlags{}
+	var includeRemoved bool
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "Diff container images between current and baseline",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDiffImages(cmd, c, h, includeRemoved)
+		},
+	}
+	bindCommon(cmd.Flags(), c)
+	bindHelmFlags(cmd.Flags(), h)
+	cmd.Flags().BoolVar(&includeRemoved, "include-removed", false,
+		"also emit images present only in --path-orig (default: only newly added images)")
+	return cmd
+}
+
+func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemoved bool) error {
+	orig, current, err := runDiffOrchestrators(cmdContext(cmd), c, h)
+	if err != nil {
+		return err
+	}
+	imgs := imageSetDiff(collectImages(orig, c), collectImages(current, c), includeRemoved)
+
+	w, closeFn, err := c.resolveWriter(cmd.OutOrStdout())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeFn() }()
+	return emitImageList(w, imgs, c.output)
+}
+
+// imageSetDiff returns the sorted images that differ between orig and
+// current. Images added in current are always included; when
+// includeRemoved is set, images dropped from orig are added too.
+func imageSetDiff(orig, current map[string]struct{}, includeRemoved bool) []string {
+	out := make([]string, 0, len(current))
+	for img := range current {
+		if _, ok := orig[img]; !ok {
+			out = append(out, img)
+		}
+	}
+	if includeRemoved {
+		for img := range orig {
+			if _, ok := current[img]; !ok {
+				out = append(out, img)
+			}
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
 func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kind, name string) error {
-	if c.pathOrig == "" {
-		return errors.New("diff requires --path-orig")
-	}
-
-	// Run two orchestrators — current and baseline — each in
-	// changed-only mode against the other. Both sides compute the
-	// same change set (it's symmetric) and only render the resources
-	// that differ.
-	ctx := cmdContext(cmd)
-	currentCfg := buildOrchCfg(*c, *h)
-	currentOrch, err := runOrchestratorCfg(ctx, currentCfg)
-	if err != nil && currentOrch == nil {
+	orig, current, err := runDiffOrchestrators(cmdContext(cmd), c, h)
+	if err != nil {
 		return err
 	}
-
-	origCfg := currentCfg
-	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path
-	origOrch, err := runOrchestratorCfg(ctx, origCfg)
-	if err != nil && origOrch == nil {
-		return err
-	}
-
-	origDocs := gatherArtifacts(origOrch, kind, name, c)
-	currentDocs := gatherArtifacts(currentOrch, kind, name, c)
+	origDocs := gatherArtifacts(orig, kind, name, c)
+	currentDocs := gatherArtifacts(current, kind, name, c)
 
 	outFormat := c.output
 	if outFormat == "table" {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -73,7 +73,7 @@ func newGetClusterCmd() *cobra.Command {
 			}
 			defer func() { _ = closeFn() }()
 			if enableImages || onlyImages {
-				return printClusterImages(w, o, c.output, onlyImages)
+				return printClusterImages(w, o, c, onlyImages)
 			}
 			return printCluster(w, o, c.output)
 		},
@@ -192,51 +192,39 @@ type imageEntry struct {
 	Images      []string `json:"images"      yaml:"images"`
 }
 
-func printClusterImages(w io.Writer, o *orchestrator.Orchestrator, out string, onlyImages bool) error {
-	uniq := map[string]struct{}{}
+func printClusterImages(w io.Writer, o *orchestrator.Orchestrator, c *commonFlags, onlyImages bool) error {
+	if onlyImages {
+		return emitImageList(w, slices.Sorted(maps.Keys(collectImages(o, c))), c.output)
+	}
+
 	var releases []imageEntry
 	for _, obj := range o.Store().ListObjects(manifest.KindHelmRelease) {
 		hr := obj.(*manifest.HelmRelease)
+		if !c.includeNamespace(o.Filter(), hr.Namespace) {
+			continue
+		}
 		art, ok := o.Store().GetArtifact(hr.Named()).(*store.HelmReleaseArtifact)
 		if !ok {
 			continue
 		}
 		set := map[string]struct{}{}
 		for _, doc := range art.Manifests {
-			imgs, err := image.Extract(doc)
-			if err != nil {
-				continue
-			}
+			imgs, _ := image.Extract(doc)
 			for _, img := range imgs {
 				set[img] = struct{}{}
-				uniq[img] = struct{}{}
 			}
 		}
 		if len(set) == 0 {
 			continue
 		}
-		list := slices.Sorted(maps.Keys(set))
-		releases = append(releases, imageEntry{HelmRelease: hr.NamespacedName(), Images: list})
+		releases = append(releases, imageEntry{
+			HelmRelease: hr.NamespacedName(),
+			Images:      slices.Sorted(maps.Keys(set)),
+		})
 	}
 	slices.SortFunc(releases, func(a, b imageEntry) int { return cmp.Compare(a.HelmRelease, b.HelmRelease) })
 
-	if onlyImages {
-		flat := slices.Sorted(maps.Keys(uniq))
-		switch format.Output(out) {
-		case format.OutputJSON:
-			return format.JSON(w, flat)
-		case format.OutputYAML:
-			return format.YAML(w, flat)
-		}
-		for _, img := range flat {
-			if _, err := io.WriteString(w, img+"\n"); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	if format.Output(out) == format.OutputJSON {
+	if format.Output(c.output) == format.OutputJSON {
 		return format.JSON(w, releases)
 	}
 	return format.YAML(w, releases)

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -2,10 +2,15 @@ package cli
 
 import (
 	"cmp"
+	"context"
+	"errors"
+	"io"
 	"slices"
 	"strings"
 
+	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/diff"
+	"github.com/home-operations/flate/pkg/image"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/store"
@@ -28,6 +33,75 @@ func sortRows(rows []map[string]string) {
 		}
 		return cmp.Compare(a["name"], b["name"])
 	})
+}
+
+// collectImages returns the union of container images found in every
+// rendered Kustomization and HelmRelease artifact reachable from the
+// store — Deployments, StatefulSets, Pods, Jobs, and anything else
+// `image.Extract` can recognise. The namespace scope on c is honored:
+// resources whose parent is out of scope contribute nothing.
+func collectImages(o *orchestrator.Orchestrator, c *commonFlags) map[string]struct{} {
+	set := map[string]struct{}{}
+	add := func(docs []map[string]any) {
+		for _, doc := range docs {
+			imgs, _ := image.Extract(doc)
+			for _, img := range imgs {
+				set[img] = struct{}{}
+			}
+		}
+	}
+	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+		for _, obj := range o.Store().ListObjects(kind) {
+			id := obj.Named()
+			if !c.includeNamespace(o.Filter(), id.Namespace) {
+				continue
+			}
+			switch art := o.Store().GetArtifact(id).(type) {
+			case *store.KustomizationArtifact:
+				add(art.Manifests)
+			case *store.HelmReleaseArtifact:
+				add(art.Manifests)
+			}
+		}
+	}
+	return set
+}
+
+// emitImageList writes a sorted image list in the requested format.
+// Non-structured outputs fall back to one image per line.
+func emitImageList(w io.Writer, imgs []string, out string) error {
+	switch format.Output(out) {
+	case format.OutputJSON:
+		return format.JSON(w, imgs)
+	case format.OutputYAML:
+		return format.YAML(w, imgs)
+	}
+	for _, img := range imgs {
+		if _, err := io.WriteString(w, img+"\n"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runDiffOrchestrators boots two orchestrators in changed-only mode,
+// each treating the other as baseline. Both sides resolve the same
+// (symmetric) change set, so reconciliation is restricted to resources
+// that differ between paths.
+func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (orig, current *orchestrator.Orchestrator, err error) {
+	if c.pathOrig == "" {
+		return nil, nil, errors.New("diff requires --path-orig")
+	}
+	currentCfg := buildOrchCfg(*c, *h)
+	if current, err = runOrchestratorCfg(ctx, currentCfg); err != nil && current == nil {
+		return nil, nil, err
+	}
+	origCfg := currentCfg
+	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path
+	if orig, err = runOrchestratorCfg(ctx, origCfg); err != nil && orig == nil {
+		return nil, nil, err
+	}
+	return orig, current, nil
 }
 
 // gatherArtifacts collects every rendered manifest produced by the

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,6 +27,19 @@ func runCLI(t *testing.T, args ...string) string {
 	return stdout.String() + stderr.String()
 }
 
+// runCLIStdout is like runCLI but returns stdout only, so tests can
+// parse the payload without log lines mixed in.
+func runCLIStdout(t *testing.T, args ...string) string {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := cli.Run(args, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("flate %s exited %d\nstdout:\n%s\nstderr:\n%s",
+			strings.Join(args, " "), code, stdout.String(), stderr.String())
+	}
+	return stdout.String()
+}
+
 func runCLIExpectErr(t *testing.T, args ...string) (string, int) {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
@@ -123,6 +136,25 @@ func TestE2E_DiffNoChange(t *testing.T) {
 	if strings.Contains(out, "---") && strings.Contains(out, "+++") &&
 		strings.Contains(out, "@@") {
 		t.Errorf("unexpected diff content for identical paths:\n%s", out)
+	}
+}
+
+func TestE2E_DiffImagesNoChange(t *testing.T) {
+	p := testdataPath(t, "simple")
+	out := runCLIStdout(t, "diff", "images", "--path", p, "--path-orig", p, "-o", "json")
+	got := strings.TrimSpace(out)
+	if got != "[]" && got != "null" {
+		t.Errorf("expected empty image diff for identical paths, got: %q", got)
+	}
+}
+
+func TestE2E_DiffImagesRequiresPathOrig(t *testing.T) {
+	out, code := runCLIExpectErr(t, "diff", "images", "--path", testdataPath(t, "simple"))
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when --path-orig is missing, got 0:\n%s", out)
+	}
+	if !strings.Contains(out, "--path-orig") {
+		t.Errorf("error should mention --path-orig:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `flate diff images`, the diff-aware companion to `get cluster --only-images`. Default output is images present in `--path` but not in `--path-orig` (drop-in for CI "pull-test new tags" workflows); `--include-removed` widens to the full symmetric difference.
- `collectImages` now walks both `KustomizationArtifact` and `HelmReleaseArtifact` manifests, so images on plain KS-managed Deployments / StatefulSets / Pods / Jobs are no longer invisible to image-listing commands.
- `--namespace` (and the implicit changed-only scope) are now honored across `get cluster --enable-images`, `get cluster --only-images`, and `diff images` — out-of-scope parents contribute nothing.

## Why

`get cluster --only-images --path-orig X` re-emits every image attached to a HelmRelease the moment any field in that HR changes — touch one env var, the whole HR's image list gets re-pulled in CI even though no image string actually moved. That's because the existing pipeline is granularity-at-the-HR, not granularity-at-the-image. `diff images` closes the gap by rendering both sides and emitting the set difference of extracted images.

Repro (against `buroa/k8s-gitops#5331`, which adds `HI: BYE` to plex's env block):

```console
$ flate get cluster --only-images --path ./pull --path-orig ./default
ghcr.io/home-operations/plex-next:1.43.2.10687@sha256:b7b3a...   # noise — unchanged

$ flate diff images --path ./pull --path-orig ./default
# (empty — image string didn't change)
```

## Architecture

Two orchestrators boot in changed-only mode against each other (each treats the other as baseline). Their stores are read after `Run()` returns, so the goroutines have drained and reads are race-free (verified with `go test -race`). Shared helpers live in `internal/cli/helpers.go`:

- `collectImages(o, c)` — union of images across both artifact kinds, namespace-scoped.
- `emitImageList(w, imgs, out)` — json / yaml / line-per-image emission, shared with `printClusterImages`.
- `runDiffOrchestrators(ctx, c, h)` — boots the symmetric pair; `runDiff` (ks/hr) was refactored to use it too, removing a duplicated block.

Sequential orchestrator execution is intentional: shared on-disk caches under `flate-cache/` mean the second orch hits the first's warm cache, so wall time is close to `max(orig, current)` anyway, and the helm/source subsystems aren't audited for parallel cache writes.

## Test plan

- [x] `go test -race ./...` passes (including new e2e cases for the no-change and missing-`--path-orig` paths).
- [x] `go vet ./...` clean.
- [ ] Manual run against a real cluster with both a tag-only change and an env-only change — confirm the tag-only change emits the new image and the env-only change emits nothing.
- [ ] CI workflow `Image Pull` can swap `get cluster --only-images` for `diff images` and observe a quieter pull job on no-op PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)