### PR TITLE
docs: polish README and trim helper comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,123 @@
 # flate
 
-A single-binary Go rewrite of [flux-local](https://github.com/allenporter/flux-local)
-that renders and diffs Flux GitOps repositories **fully offline** — no
-cluster, no `kubectl`, no shelling out. Helm, Kustomize, go-git, and
-oras-go are linked in as native Go libraries.
+> A single-binary Go rewrite of [flux-local](https://github.com/allenporter/flux-local) — render and diff Flux GitOps repositories **fully offline**, without a cluster, `kubectl`, or shell calls.
+
+[![Tests](https://github.com/home-operations/flate/actions/workflows/tests.yaml/badge.svg)](https://github.com/home-operations/flate/actions/workflows/tests.yaml)
+[![Build](https://github.com/home-operations/flate/actions/workflows/build.yaml/badge.svg)](https://github.com/home-operations/flate/actions/workflows/build.yaml)
+[![Lint](https://github.com/home-operations/flate/actions/workflows/lint.yaml/badge.svg)](https://github.com/home-operations/flate/actions/workflows/lint.yaml)
+[![Release](https://img.shields.io/github/v/release/home-operations/flate)](https://github.com/home-operations/flate/releases)
+[![License](https://img.shields.io/github/license/home-operations/flate)](LICENSE)
+
+---
+
+## Contents
+
+- [Why](#why)
+- [Quick start](#quick-start)
+- [Subcommands](#subcommands)
+  - [`flate get`](#flate-get)
+  - [`flate build`](#flate-build)
+  - [`flate diff`](#flate-diff)
+  - [`flate test`](#flate-test)
+  - [`flate diag`](#flate-diag)
+- [Changed-only mode](#changed-only-mode)
+- [Output formats](#output-formats)
+- [Configuration](#configuration)
+  - [Common flags](#common-flags)
+  - [Helm rendering](#helm-rendering)
+  - [Diff flags](#diff-flags)
+- [Defaults](#defaults)
+- [Architecture](#architecture)
+- [Development](#development)
+- [Deferred](#deferred)
+- [License](#license)
+
+---
+
+## Why
+
+Validating a Flux GitOps repo from CI used to mean a `kind` cluster, a `flux install`, and a stack of binaries — `helm`, `kustomize`, `kubectl`, `flux` itself. flate folds that into a single static binary that links helm, kustomize, go-git, and oras-go as native Go libraries.
+
+- 🪶 **Single binary, no shellouts** — no `helm`, `kustomize`, `flux`, or `kubectl` on `PATH`.
+- ⚡ **PR-fast** — changed-only mode reconciles only the resources whose source files moved; one-file PRs drop from seconds to tens of milliseconds.
+- 🧪 **Diff-aware** — unified diffs of rendered output, with parent KS / HR headers and a flat image-set diff for CI pull-tests.
+- 📦 **CI-friendly** — `--output-file`, JSON / YAML / name output, no TTY assumptions.
+- 🧬 **Native Go SDKs** — helm v3 client-only, krusty, go-git, oras-go — linked in, not shelled out.
+
+## Quick start
 
 ```bash
 go install github.com/home-operations/flate/cmd/flate@latest
 ```
 
-## Commands
+…or pull the container image (used by the `home-operations/flate` GitHub Action):
 
-| Command | Purpose |
-| --- | --- |
-| `flate get ks\|hr\|cl` | list Kustomizations, HelmReleases, cluster summary |
-| `flate build ks\|hr\|all` | render manifests via the kustomize + helm SDKs |
-| `flate diff ks\|hr` | diff a working tree against a baseline (`--path-orig`) |
-| `flate test` | codegen + run table-driven Go tests against the repo |
-| `flate diag` | YAML / `.krmignore` sanity checks |
+```bash
+docker pull ghcr.io/home-operations/flate:latest
+```
 
-Every command takes `--path <dir>` (default `.`). Add `--path-orig <dir>`
-to switch into **changed-only mode**.
+A typical first run against a Flux repo:
 
-## Changed-only mode (PR-fast)
+```bash
+flate get ks       --path ./kubernetes
+flate build hr     --path ./kubernetes
+flate diff ks      --path ./kubernetes --path-orig ../baseline/kubernetes
+flate diff images  --path ./kubernetes --path-orig ../baseline/kubernetes -o json
+```
 
-Pass `--path-orig` to compare a working tree against a baseline. flate
-diffs files, picks the **most-specific Flux Kustomization that owns each
-change** (longest matching `spec.path`, including `spec.components`), and
-reconciles only that subtree.
+## Subcommands
 
-What's in the keep-set:
+| Command | Aliases | Purpose |
+|---|---|---|
+| `flate get ks` | `kustomization`, `kustomizations` | List Kustomizations |
+| `flate get hr` | `helmrelease`, `helmreleases` | List HelmReleases |
+| `flate get cl` | `cluster`, `clusters` | Cluster summary (`--enable-images`, `--only-images`) |
+| `flate build ks` | | Render Kustomizations to YAML |
+| `flate build hr` | | Render HelmReleases to YAML |
+| `flate build all` | | Render every Kustomization and HelmRelease |
+| `flate diff ks` | | Unified diff of rendered Kustomizations |
+| `flate diff hr` | | Unified diff of rendered HelmReleases |
+| `flate diff images` | | Set diff of container images (CI-friendly) |
+| `flate test` | | Codegen + run table-driven Go tests against the repo |
+| `flate diag` | | YAML / `.krmignore` sanity checks |
 
-- **direct edits** — every resource whose source file changed
-- **chart sources / KS `sourceRef` / HR `valuesFrom`** — content
-  dependencies, pulled in transitively
-- **kustomize components** — touching a shared component (Flux v1
-  `spec.components` or a kustomize-level `components:` entry) re-renders
-  **every consumer Kustomization**
+Every command takes `--path <dir>` (default `.`). Add `--path-orig <dir>` to switch into [changed-only mode](#changed-only-mode).
 
-What's _not_:
+### `flate get`
 
-- **`dependsOn`** — this is a reconcile-ordering signal in Flux, not a
-  content dependency. Skipped resources still get marked `Ready` so
-  downstream depwait completes naturally.
-- **meta-Kustomizations** — a top-level KS rooted at `apps/` doesn't
-  claim files inside `apps/media/plex/app/` when a deeper KS owns them.
+```bash
+flate get ks --path ./kubernetes -o json
+flate get hr --path ./kubernetes -l app.kubernetes.io/part-of=media
+flate get cl --path ./kubernetes --only-images
+```
+
+`get cl --enable-images` groups images per HelmRelease; `--only-images` emits a flat, deduplicated list across both HelmReleases and Kustomization-managed workloads (Deployments, StatefulSets, Pods, Jobs).
+
+### `flate build`
+
+Renders everything that would be applied to the cluster:
+
+```bash
+flate build hr --path ./kubernetes              # all HRs
+flate build hr --path ./kubernetes media/plex   # one HR
+flate build all --path ./kubernetes -o yaml
+```
+
+`--show-only` / `-s` accepts repeated `templates/<file>.yaml` paths to narrow the helm render.
+
+### `flate diff`
+
+Compare a working tree against a baseline. `--path-orig` is required.
 
 ```bash
 git worktree add ../baseline main
 flate diff ks --path ./kubernetes --path-orig ../baseline/kubernetes
+flate diff hr --path ./kubernetes --path-orig ../baseline/kubernetes
 ```
 
-One-file PRs in a 70-Kustomization repo drop reconcile time from seconds
-to tens of milliseconds.
+Output is unified diff with rich, reader-friendly headers and a blank line after every separator:
 
-## Narrow entries
-
-`--path` can point at a Flux entry like `./kubernetes/flux/cluster` —
-flate iteratively follows each loaded KS's `spec.path` to discover the
-full content tree (`apps/`, `components/`, …) without you having to
-widen the flag.
-
-## Diff format
-
-`diff` output is unified diff with rich, reader-friendly headers and a
-blank line after every separator:
-
-```
+```diff
 --- HelmRelease: media/qui Deployment: media/qui
 
 +++ HelmRelease: media/qui Deployment: media/qui
@@ -80,29 +131,131 @@ blank line after every separator:
 +        image: ghcr.io/autobrr/qui:v1.19.0@sha256:…
 ```
 
-The header always shows the **parent** (HelmRelease or Kustomization) and
-the rendered **child resource**. For KS parents the Flux `spec.path`
-prepends the line.
+The header always shows the **parent** (HelmRelease or Kustomization) and the rendered **child resource**. For KS parents the Flux `spec.path` prepends the line.
 
-## Namespace scoping
+#### `flate diff images`
 
-| Flag | Behavior |
-| --- | --- |
-| _(none)_ | every namespace |
-| `-n foo` | only namespace `foo` |
-| `--path-orig` | auto-scopes to the namespaces touched by the change set |
+A diff-aware companion to `get cl --only-images`. Emits images whose string actually changed between `--path` and `--path-orig` — touching an env var doesn't produce noise.
 
-Explicit `-n` always wins.
+| Flag | Effect |
+|---|---|
+| _(default)_ | Emit images present in `--path` but not in `--path-orig` (newly added). |
+| `--include-removed` | Emit the full symmetric difference (added + removed). |
 
-## Fast-fail dependency waits
+```bash
+flate diff images --path ./pull --path-orig ./default -o json
+# ["ghcr.io/foo/bar:v2.1@sha256:…"]
+```
 
-For offline use, `depwait` is tuned aggressively:
+`-o name` (the default for non-structured output) gives one image per line, ideal for piping into a CI pull-test loop.
 
-- **30-second per-dep ceiling** (vs. several minutes upstream).
-- **2-second missing-grace** — if a dependency never lands in the store
-  (typo'd `dependsOn`, broken `sourceRef`, missing chart source), flate
-  fails the dep with `dependency not found` rather than stalling out the
-  full budget.
+### `flate test`
+
+Generates table-driven Go tests for every Kustomization and HelmRelease in the repo, then runs them. Tests assert that each resource reconciles successfully and renders a non-empty manifest set.
+
+```bash
+flate test --path ./kubernetes
+```
+
+### `flate diag`
+
+Static sanity checks that don't require reconciliation — YAML parseability, `.krmignore` coverage, dangling sourceRefs:
+
+```bash
+flate diag --path ./kubernetes
+```
+
+## Changed-only mode
+
+Pass `--path-orig` to compare a working tree against a baseline. flate diffs files, picks the **most-specific Flux Kustomization that owns each change** (longest matching `spec.path`, including `spec.components`), and reconciles only that subtree.
+
+What's in the keep-set:
+
+- **direct edits** — every resource whose source file changed
+- **chart sources / KS `sourceRef` / HR `valuesFrom`** — content dependencies, pulled in transitively
+- **kustomize components** — touching a shared component (Flux v1 `spec.components` or a kustomize-level `components:` entry) re-renders **every consumer Kustomization**
+
+What's _not_:
+
+- **`dependsOn`** — this is a reconcile-ordering signal in Flux, not a content dependency. Skipped resources still get marked `Ready` so downstream depwait completes naturally.
+- **meta-Kustomizations** — a top-level KS rooted at `apps/` doesn't claim files inside `apps/media/plex/app/` when a deeper KS owns them.
+
+```bash
+git worktree add ../baseline main
+flate diff ks --path ./kubernetes --path-orig ../baseline/kubernetes
+```
+
+One-file PRs in a 70-Kustomization repo drop reconcile time from seconds to tens of milliseconds.
+
+> **Narrow entries.** `--path` can point at a Flux entry like `./kubernetes/flux/cluster` — flate iteratively follows each loaded KS's `spec.path` to discover the full content tree without you having to widen the flag.
+
+## Output formats
+
+| `-o` | Effect |
+|---|---|
+| `table` _(default for `get`)_ | Aligned columns. |
+| `wide` | Extra columns (`get` only). |
+| `yaml` | Multi-document YAML. |
+| `json` | One JSON array. |
+| `name` | `<namespace>/<name>` per line — script-friendly. |
+| `diff` _(default for `diff`)_ | Unified diff. |
+
+Pair with `--output-file <path>` (or `-` for stdout) to write directly to disk — convenient inside containers without a shell.
+
+## Configuration
+
+### Common flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--path` | `.` | Flux cluster directory. |
+| `--path-orig` | _(unset)_ | Baseline path; enables changed-only mode for every command. |
+| `-n`, `--namespace` | _(all)_ | Limit to a single namespace. Auto-scopes to the touched namespaces in changed-only mode. |
+| `-l`, `--selector` | _(none)_ | `key=value` label selector, repeatable. |
+| `-o`, `--output` | `table` | `table` / `wide` / `yaml` / `json` / `name`. |
+| `--output-file` | _(stdout)_ | Write output to a file; `-` is stdout. |
+| `--skip-crds` | `true` | Drop CRD objects from rendered output. |
+| `--skip-secrets` | `true` | Drop Secret objects from rendered output. |
+| `--skip-kinds` | _(none)_ | Extra kinds to drop, repeatable. |
+| `--enable-oci` | `true` | Reconcile OCIRepository sources. |
+| `--enable-helm` | `true` | Render HelmReleases via the helm SDK. |
+| `--registry-config` | _(none)_ | Docker `config.json` for OCI auth. |
+| `--log-level` | `info` | `debug` / `info` / `warn` / `error`. |
+
+### Helm rendering
+
+| Flag | Default | Description |
+|---|---|---|
+| `--kube-version` | bundled `k8s.io/api` minor | Kubernetes version for `.Capabilities.KubeVersion`. |
+| `-a`, `--api-versions` | _(empty)_ | Extra API versions for `.Capabilities.APIVersions`. |
+| `--is-upgrade` | `false` | Set `.Release.IsUpgrade` instead of `.Release.IsInstall`. |
+| `--no-hooks` | `false` | Exclude hook-annotated templates. |
+| `-s`, `--show-only` | _(none)_ | Restrict render to specific template paths, repeatable. |
+| `--enable-dns` | `false` | Allow DNS lookups during `helm template`. |
+
+### Diff flags
+
+Apply to `diff ks` / `diff hr`:
+
+| Flag | Default | Description |
+|---|---|---|
+| `-u`, `--unified` | `3` | Unified diff context lines. |
+| `--strip-attrs` | _(none)_ | Annotation / label keys to strip before diffing, repeatable. |
+| `--limit-bytes` | `0` | Truncate per-resource diffs (0 = unlimited). |
+
+`diff images` adds:
+
+| Flag | Default | Description |
+|---|---|---|
+| `--include-removed` | `false` | Emit images dropped from `--path-orig` alongside newly added ones. |
+
+## Defaults
+
+- `--enable-helm`, `--enable-oci` → **true**.
+- `--kube-version` defaults to the Kubernetes minor bundled with flate's `k8s.io/api` dependency — Helm charts gated on `KubeVersion` render against the latest version flate knows about.
+- Secrets are always replaced with `..PLACEHOLDER_<key>..` (matches flux-local).
+- `--skip-crds`, `--skip-secrets` → **true** for `build` / `diff`.
+- **Fast-fail dependency waits** for offline use: 30-second per-dep ceiling (vs. several minutes upstream) and a 2-second missing-grace, so typo'd `dependsOn` or broken `sourceRef` fail with `dependency not found` instead of stalling out the budget.
 
 ## Architecture
 
@@ -127,27 +280,27 @@ For offline use, `depwait` is tuned aggressively:
        └────────────┘ └──────────────┘ └──────────────────┘
 ```
 
-Orchestrator pipeline: load → iterative spec.path discovery →
-namespace inheritance → dependsOn validation → existence-only-ready →
-change-filter resolution → controllers → diff/build/get.
+Orchestrator pipeline: load → iterative `spec.path` discovery → namespace inheritance → `dependsOn` validation → existence-only-ready → change-filter resolution → controllers → diff / build / get.
 
-## Defaults
+## Development
 
-- `--enable-helm`, `--enable-oci` → **true**.
-- `--kube-version` defaults to the Kubernetes minor bundled with
-  flate's `k8s.io/api` dependency.
-- Secrets are always replaced with `..PLACEHOLDER_<key>..` (matches
-  flux-local).
-- `--skip-crds`, `--skip-secrets` → **true** for `build` / `diff`.
+```bash
+go build ./cmd/flate            # build the CLI
+go test ./...                   # full test suite, including in-process E2E
+go test -race ./...             # race detector
+go vet ./...                    # vet
+```
+
+Tool versions are pinned via [mise](https://mise.jdx.dev) (`mise install`).
+
+Testdata lives in [`testdata/`](testdata/); the [`test/e2e`](test/e2e/) suite runs the cobra command tree in-process via `cli.Run` — no fork/exec, no freshly built binary required.
 
 ## Deferred
 
 - `diff --branch-orig <branch>` (auto-worktree)
 - `shell` interactive REPL
-- Bucket sources, ResourceSet (Flux Operator), in-cluster `secretRef`
-  for OCI auth
+- Bucket sources, ResourceSet (Flux Operator), in-cluster `secretRef` for OCI auth
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE) for upstream
-attribution.
+AGPL-3.0 — see [LICENSE](LICENSE). flate borrows behavior and test fixtures from [flux-local](https://github.com/allenporter/flux-local) (Apache-2.0).

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -101,9 +101,8 @@ func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemo
 	return emitImageList(w, imgs, c.output)
 }
 
-// imageSetDiff returns the sorted images that differ between orig and
-// current. Images added in current are always included; when
-// includeRemoved is set, images dropped from orig are added too.
+// imageSetDiff returns the sorted images added in current; when
+// includeRemoved is set, images dropped from orig are included too.
 func imageSetDiff(orig, current map[string]struct{}, includeRemoved bool) []string {
 	out := make([]string, 0, len(current))
 	for img := range current {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -35,11 +35,9 @@ func sortRows(rows []map[string]string) {
 	})
 }
 
-// collectImages returns the union of container images found in every
-// rendered Kustomization and HelmRelease artifact reachable from the
-// store — Deployments, StatefulSets, Pods, Jobs, and anything else
-// `image.Extract` can recognise. The namespace scope on c is honored:
-// resources whose parent is out of scope contribute nothing.
+// collectImages returns the union of images extracted from every
+// rendered Kustomization and HelmRelease artifact. Namespace scope on
+// c is honored.
 func collectImages(o *orchestrator.Orchestrator, c *commonFlags) map[string]struct{} {
 	set := map[string]struct{}{}
 	add := func(docs []map[string]any) {
@@ -67,8 +65,8 @@ func collectImages(o *orchestrator.Orchestrator, c *commonFlags) map[string]stru
 	return set
 }
 
-// emitImageList writes a sorted image list in the requested format.
-// Non-structured outputs fall back to one image per line.
+// emitImageList writes a sorted image list — JSON / YAML when
+// requested, otherwise one image per line.
 func emitImageList(w io.Writer, imgs []string, out string) error {
 	switch format.Output(out) {
 	case format.OutputJSON:
@@ -84,10 +82,9 @@ func emitImageList(w io.Writer, imgs []string, out string) error {
 	return nil
 }
 
-// runDiffOrchestrators boots two orchestrators in changed-only mode,
-// each treating the other as baseline. Both sides resolve the same
-// (symmetric) change set, so reconciliation is restricted to resources
-// that differ between paths.
+// runDiffOrchestrators boots two orchestrators with each side's
+// --path-orig pointing at the other, so both resolve the same symmetric
+// change set and only render resources that differ between paths.
 func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (orig, current *orchestrator.Orchestrator, err error) {
 	if c.pathOrig == "" {
 		return nil, nil, errors.New("diff requires --path-orig")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -27,8 +27,8 @@ func runCLI(t *testing.T, args ...string) string {
 	return stdout.String() + stderr.String()
 }
 
-// runCLIStdout is like runCLI but returns stdout only, so tests can
-// parse the payload without log lines mixed in.
+// runCLIStdout returns stdout only — log lines on stderr would
+// otherwise pollute payloads that tests parse.
 func runCLIStdout(t *testing.T, args ...string) string {
 	t.Helper()
 	var stdout, stderr bytes.Buffer


### PR DESCRIPTION
## Summary

- Rewrites the README in the style of [home-operations/gatus-sidecar](https://github.com/home-operations/gatus-sidecar): badges, contents TOC, emoji-tagged "Why" section, per-subcommand walkthrough (including the new `flate diff images`), and a configuration reference grouped into Common / Helm / Diff flags.
- Adds a dedicated section for `flate diff images` documenting the default-additions / `--include-removed` semantics and showing the CI-friendly JSON output.
- Trims the doc comments on `collectImages`, `emitImageList`, `runDiffOrchestrators`, `imageSetDiff`, and `runCLIStdout` to keep only the non-obvious "why" — names already convey "what."

## ⚠️ License claim correction

The previous README said `Apache-2.0`, but [`LICENSE`](LICENSE) is AGPL-3.0. The README's "see [NOTICE]" link also pointed at a file that doesn't exist. This PR updates the README to read `AGPL-3.0` to match the on-disk license.

**If the intent was for the repo to be Apache-2.0, revert this line and replace `LICENSE` instead** — the README change is easy to flip, but the source of truth needs to land somewhere consistent.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all green.
- [x] Race detector still clean (`go test -race ./...`).
- [ ] Eyeball the rendered README on GitHub once the PR opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)