### PR TITLE
docs: correct helm version reference from v3 to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Validating a Flux GitOps repo from CI used to mean a `kind` cluster, a `flux ins
 - ⚡ **PR-fast** — changed-only mode reconciles only the resources whose source files moved; one-file PRs drop from seconds to tens of milliseconds.
 - 🧪 **Diff-aware** — unified diffs of rendered output, with parent KS / HR headers and a flat image-set diff for CI pull-tests.
 - 📦 **CI-friendly** — `--output-file`, JSON / YAML / name output, no TTY assumptions.
-- 🧬 **Native Go SDKs** — helm v3 client-only, krusty, go-git, oras-go — linked in, not shelled out.
+- 🧬 **Native Go SDKs** — helm v4 client-only, krusty, go-git, oras-go — linked in, not shelled out.
 
 ## Quick start
 
@@ -275,7 +275,7 @@ Apply to `diff ks` / `diff hr`:
                  ▼      ▼        ▼                 │
        ┌────────────┐ ┌──────────────┐ ┌──────────────────┐
        │ SourceCtrl │ │ KSController │ │ HRController     │
-       │ go-git +   │ │ krusty +     │ │ helm v3          │
+       │ go-git +   │ │ krusty +     │ │ helm v4          │
        │ oras-go    │ │ Flux gen     │ │ (ClientOnly)     │
        └────────────┘ └──────────────┘ └──────────────────┘
 ```


### PR DESCRIPTION
## Summary

`go.mod` pins `helm.sh/helm/v4 v4.2.0` and every import under `pkg/helm/` resolves to v4. The README still said v3 in two places — the "Why" bullet and the HRController box in the architecture diagram. Fixed both.

## Test plan

- [x] `grep -rn "helm v3\|helm.v3"` returns nothing in `pkg/`, `internal/`, or `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)