### PR TITLE
feat(cli)!: unify ks/hr/all layout across get and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,16 @@ flate diff images  --path ./kubernetes --path-orig ../baseline/kubernetes -o jso
 |---|---|---|
 | `flate get ks` | `kustomization`, `kustomizations` | List Kustomizations |
 | `flate get hr` | `helmrelease`, `helmreleases` | List HelmReleases |
-| `flate get cl` | `cluster`, `clusters` | Cluster summary (`--enable-images`, `--only-images`) |
+| `flate get all` | | Cluster summary (`--enable-images`, `--only-images`) |
 | `flate build ks` | | Render Kustomizations to YAML |
 | `flate build hr` | | Render HelmReleases to YAML |
 | `flate build all` | | Render every Kustomization and HelmRelease |
 | `flate diff ks` | | Unified diff of rendered Kustomizations |
 | `flate diff hr` | | Unified diff of rendered HelmReleases |
 | `flate diff images` | | Set diff of container images (CI-friendly) |
-| `flate test` | | Codegen + run table-driven Go tests against the repo |
+| `flate test ks` | `kustomization`, `kustomizations` | Validate Kustomization reconcile status |
+| `flate test hr` | `helmrelease`, `helmreleases` | Validate HelmRelease reconcile status |
+| `flate test all` | | Validate every Kustomization and HelmRelease |
 | `flate diag` | | YAML / `.krmignore` sanity checks |
 
 Every command takes `--path <dir>` (default `.`). Add `--path-orig <dir>` to switch into [changed-only mode](#changed-only-mode).
@@ -88,10 +90,10 @@ Every command takes `--path <dir>` (default `.`). Add `--path-orig <dir>` to swi
 ```bash
 flate get ks --path ./kubernetes -o json
 flate get hr --path ./kubernetes -l app.kubernetes.io/part-of=media
-flate get cl --path ./kubernetes --only-images
+flate get all --path ./kubernetes --only-images
 ```
 
-`get cl --enable-images` groups images per HelmRelease; `--only-images` emits a flat, deduplicated list across both HelmReleases and Kustomization-managed workloads (Deployments, StatefulSets, Pods, Jobs).
+`get all --enable-images` groups images per HelmRelease; `--only-images` emits a flat, deduplicated list across both HelmReleases and Kustomization-managed workloads (Deployments, StatefulSets, Pods, Jobs).
 
 ### `flate build`
 
@@ -135,7 +137,7 @@ The header always shows the **parent** (HelmRelease or Kustomization) and the re
 
 #### `flate diff images`
 
-A diff-aware companion to `get cl --only-images`. Emits images whose string actually changed between `--path` and `--path-orig` — touching an env var doesn't produce noise.
+A diff-aware companion to `get all --only-images`. Emits images whose string actually changed between `--path` and `--path-orig` — touching an env var doesn't produce noise.
 
 | Flag | Effect |
 |---|---|
@@ -151,10 +153,12 @@ flate diff images --path ./pull --path-orig ./default -o json
 
 ### `flate test`
 
-Generates table-driven Go tests for every Kustomization and HelmRelease in the repo, then runs them. Tests assert that each resource reconciles successfully and renders a non-empty manifest set.
+Reports the reconcile status of every Kustomization and HelmRelease in the repo in a pytest-like progress format. A case passes when the resource reached `Ready`; it fails otherwise. Resources skipped by [changed-only mode](#changed-only-mode) appear as `SKIPPED`.
 
 ```bash
-flate test --path ./kubernetes
+flate test all --path ./kubernetes              # both kinds
+flate test ks  --path ./kubernetes              # only Kustomizations
+flate test hr  --path ./kubernetes media/plex   # one HelmRelease by name
 ```
 
 ### `flate diag`

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -18,7 +18,7 @@ import (
 
 func newGetCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "get", Short: "List Flux objects"}
-	cmd.AddCommand(newGetKSCmd(), newGetHRCmd(), newGetClusterCmd())
+	cmd.AddCommand(newGetKSCmd(), newGetHRCmd(), newGetAllCmd())
 	return cmd
 }
 
@@ -54,14 +54,13 @@ func newGetHRCmd() *cobra.Command {
 		})
 }
 
-func newGetClusterCmd() *cobra.Command {
+func newGetAllCmd() *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
 	var enableImages, onlyImages bool
 	cmd := &cobra.Command{
-		Use:     "cl",
-		Aliases: []string{"cluster", "clusters"},
-		Short:   "Summarize the cluster",
+		Use:   "all",
+		Short: "Summarize every Kustomization and HelmRelease",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			o, err := runOrchestrator(cmdContext(cmd), *c, *h)
 			if err != nil && o == nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,11 +1,12 @@
 // Package cli wires flate's command-line interface using cobra.
 //
-// Commands:
-//   - get   — list Flux objects (Kustomizations, HelmReleases, Clusters).
-//   - build — render Flux objects to YAML.
-//   - diff  — compare current vs. another path.
-//   - test  — report Kustomization + HelmRelease reconcile status.
-//   - diag  — sanity-check local manifests.
+// Every multi-kind command takes the same ks/hr/all positional layout:
+//
+//   - get   ks|hr|all — list Flux objects or summarize the cluster.
+//   - build ks|hr|all — render Flux objects to YAML.
+//   - diff  ks|hr|images — compare current vs. another path.
+//   - test  ks|hr|all — report reconcile status.
+//   - diag             — sanity-check local manifests.
 //
 // Use New() to obtain a cobra.Command for embedding flate in a parent
 // CLI; Execute() and Run() are the entry points used by cmd/flate and

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -1,28 +1,54 @@
 package cli
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 
 	"github.com/home-operations/flate/internal/testrunner"
+	"github.com/home-operations/flate/pkg/manifest"
 )
 
 func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Report Kustomization + HelmRelease reconcile status",
+	}
+	cmd.AddCommand(
+		testCmd("ks [name]", []string{"kustomization", "kustomizations"},
+			"Validate Kustomizations", cobra.MaximumNArgs(1),
+			manifest.KindKustomization),
+		testCmd("hr [name]", []string{"helmrelease", "helmreleases"},
+			"Validate HelmReleases", cobra.MaximumNArgs(1),
+			manifest.KindHelmRelease),
+		testCmd("all", nil,
+			"Validate every Kustomization and HelmRelease", cobra.NoArgs,
+			manifest.KindKustomization, manifest.KindHelmRelease),
+	)
+	return cmd
+}
+
+func testCmd(use string, aliases []string, short string, args cobra.PositionalArgs, kinds ...string) *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
 	cmd := &cobra.Command{
-		Use:   "test",
-		Short: "Validate cluster resources (reports Kustomization + HelmRelease reconcile status)",
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Use:     use,
+		Aliases: aliases,
+		Short:   short,
+		Args:    args,
+		RunE: func(cmd *cobra.Command, argv []string) error {
 			o, err := runOrchestrator(cmdContext(cmd), *c, *h)
 			if err != nil && o == nil {
 				return err
 			}
-			report := testrunner.Run(testrunner.Job{Store: o.Store()})
+			report := testrunner.Run(testrunner.Job{
+				Store: o.Store(),
+				Kinds: kinds,
+				Name:  firstArg(argv),
+			})
 			report.Write(cmd.OutOrStdout())
 			if report.AnyFailed() {
-				return fmt.Errorf("test failures detected")
+				return errors.New("test failures detected")
 			}
 			return nil
 		},

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -21,6 +21,11 @@ import (
 // Job collects the orchestrator's post-run state.
 type Job struct {
 	Store *store.Store
+	// Kinds limits the kinds reported on. Empty ↦ both Kustomization
+	// and HelmRelease.
+	Kinds []string
+	// Name optionally narrows the report to a single resource.
+	Name string
 }
 
 // Outcome enumerates the per-resource result.
@@ -76,24 +81,31 @@ func (r Report) Write(w io.Writer) {
 	_, _ = io.WriteString(w, b.String())
 }
 
-// Run inspects the store and produces a Report. The set of kinds to
-// include is the reconciler-driven ones: Kustomization, HelmRelease.
+// Run inspects the store and produces a Report. When j.Kinds is empty,
+// both reconciler-driven kinds (Kustomization, HelmRelease) are
+// reported on.
 func Run(j Job) Report {
-	kinds := []string{manifest.KindKustomization, manifest.KindHelmRelease}
+	kinds := j.Kinds
+	if len(kinds) == 0 {
+		kinds = []string{manifest.KindKustomization, manifest.KindHelmRelease}
+	}
 	var rep Report
 	for _, kind := range kinds {
 		for _, obj := range j.Store.ListObjects(kind) {
-			rep.Cases = append(rep.Cases, classify(j.Store, obj.Named()))
-		}
-	}
-	for _, c := range rep.Cases {
-		switch c.Outcome {
-		case OutcomePassed:
-			rep.Passed++
-		case OutcomeSkipped:
-			rep.Skipped++
-		case OutcomeFailed:
-			rep.Failed++
+			id := obj.Named()
+			if j.Name != "" && id.Name != j.Name {
+				continue
+			}
+			c := classify(j.Store, id)
+			switch c.Outcome {
+			case OutcomePassed:
+				rep.Passed++
+			case OutcomeSkipped:
+				rep.Skipped++
+			case OutcomeFailed:
+				rep.Failed++
+			}
+			rep.Cases = append(rep.Cases, c)
 		}
 	}
 	return rep

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -92,8 +92,8 @@ func TestE2E_BuildHR(t *testing.T) {
 	}
 }
 
-func TestE2E_GetCluster_JSON(t *testing.T) {
-	out := runCLI(t, "get", "cl", "--path", testdataPath(t, "simple"), "-o", "json")
+func TestE2E_GetAll_JSON(t *testing.T) {
+	out := runCLI(t, "get", "all", "--path", testdataPath(t, "simple"), "-o", "json")
 	if !strings.Contains(out, `"kustomizations"`) {
 		t.Errorf("missing kustomizations in json:\n%s", out)
 	}
@@ -123,7 +123,7 @@ func TestE2E_BadPath(t *testing.T) {
 }
 
 func TestE2E_TestCommand(t *testing.T) {
-	out := runCLI(t, "test", "--path", copyTree(t, testdataPath(t, "simple")))
+	out := runCLI(t, "test", "all", "--path", copyTree(t, testdataPath(t, "simple")))
 	if !strings.Contains(out, "PASSED") {
 		t.Errorf("expected PASSED in test output:\n%s", out)
 	}


### PR DESCRIPTION
## Summary

- Rename `flate get cl` → `flate get all` (drops `cluster`/`clusters` aliases).
- Split flat `flate test` into `flate test ks|hr|all`, mirroring the layout of `build` and `diff`. `test ks [name]` and `test hr [name]` accept an optional name filter; `test all` reports both kinds.
- Add `Kinds` and `Name` filters to `testrunner.Job` so subcommands can scope the reconcile-status report; tally cases inline (one pass instead of two).
- Update package doc on `internal/cli` and the README subcommand table / examples to match the new ks/hr/all pattern.

**Breaking:** `flate get cl` and the bare `flate test` no longer work — use `flate get all` and `flate test all` (or `ks`/`hr`).

## Test plan

- [x] `mise run test` — all unit + e2e packages pass.
- [x] `mise run vet` — clean.
- [x] `mise run lint` — 0 issues.
- [x] `go test -v ./test/e2e/...` — all 13 e2e tests pass, including renamed `TestE2E_GetAll_JSON` and refactored `TestE2E_TestCommand`.
- [x] Smoke-tested `flate get --help`, `flate test --help`, `flate test all --help`, and `flate get all -o json` against `testdata/simple`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)