### PR TITLE
fix(flux-fidelity): correctness bugs C1-C5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/home-operations/flate
 go 1.26.3
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/fluxcd/kustomize-controller/api v1.8.5
@@ -26,7 +27,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/home-operations/flate/pkg/image"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -93,6 +96,19 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (*o
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg
 	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path
+
+	// One source.Cache shared across both orchestrators. They write into
+	// the same on-disk cache root; without a shared *Cache each side has
+	// its own mutex, and concurrent first-time clones of the same
+	// (url, ref) slot can race past the mkdir/Readdirnames check and
+	// step on each other.
+	cacheRoot := currentCfg.CacheDir
+	if cacheRoot == "" {
+		cacheRoot = filepath.Join(os.TempDir(), "flate-cache")
+	}
+	shared := source.NewCache(filepath.Join(cacheRoot, "sources"))
+	currentCfg.SourceCache = shared
+	origCfg.SourceCache = shared
 
 	var orig, current *orchestrator.Orchestrator
 	g, gctx := errgroup.WithContext(ctx)

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strings"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -83,7 +84,12 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				c.chartSourcesMu.Unlock()
 			}
 		case manifest.KindHelmRelease:
-			if _, ok := payload.(*manifest.HelmRelease); !ok {
+			hr, ok := payload.(*manifest.HelmRelease)
+			if !ok {
+				return
+			}
+			if hr.Suspend {
+				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 				return
 			}
 			if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {
@@ -133,6 +139,22 @@ func (c *Controller) onArtifactUpdated(id manifest.NamedResource, payload any) {
 
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {
 	id := hr.Named()
+
+	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
+	// each dependency reaching Ready before this HR reconciles.
+	if deps := c.collectHRDeps(hr); len(deps) > 0 {
+		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
+		w := &depwait.Waiter{Store: c.Store, Parent: id}
+		sum := depwait.WaitAll(w.Watch(ctx, deps))
+		if sum.AnyFailed() {
+			var msgs []string
+			for _, f := range sum.Failed {
+				msgs = append(msgs, f.String()+": "+sum.Messages[f])
+			}
+			return fmt.Errorf("dependencies failed: %s", strings.Join(msgs, "; "))
+		}
+	}
+
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
 
 	// Resolve chartRef if applicable.
@@ -182,6 +204,26 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		Values:    hr.Values,
 	})
 	return nil
+}
+
+// collectHRDeps converts hr.DependsOn ("namespace/name" entries) into
+// NamedResources for the depwait Waiter. dependsOn on a HelmRelease
+// references other HelmReleases only (per Flux spec).
+func (c *Controller) collectHRDeps(hr *manifest.HelmRelease) []manifest.NamedResource {
+	if len(hr.DependsOn) == 0 {
+		return nil
+	}
+	out := make([]manifest.NamedResource, 0, len(hr.DependsOn))
+	for _, dep := range hr.DependsOn {
+		ns, name, ok := manifest.SplitNamespacedName(dep, hr.Namespace)
+		if !ok {
+			continue
+		}
+		out = append(out, manifest.NamedResource{
+			Kind: manifest.KindHelmRelease, Namespace: ns, Name: name,
+		})
+	}
+	return out
 }
 
 // gatherHelmChartSources returns a snapshot of the HelmChart lookup

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -63,7 +63,12 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if id.Kind != manifest.KindKustomization {
 			return
 		}
-		if _, ok := payload.(*manifest.Kustomization); !ok {
+		ks, ok := payload.(*manifest.Kustomization)
+		if !ok {
+			return
+		}
+		if ks.Suspend {
+			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 			return
 		}
 		if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -59,6 +59,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			if !ok {
 				return
 			}
+			if repo.Suspend {
+				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+				return
+			}
 			if c.skip(id) {
 				return
 			}
@@ -72,6 +76,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			}
 			repo, ok := payload.(*manifest.OCIRepository)
 			if !ok {
+				return
+			}
+			if repo.Suspend {
+				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 				return
 			}
 			if c.skip(id) {

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -7,16 +7,19 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/cli"
 	release "helm.sh/helm/v4/pkg/release/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/values"
 )
 
 // Template renders a HelmRelease and returns the rendered manifest as a
 // single YAML string (multiple documents separated by "---" lines).
-func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, values map[string]any, opts Options) (string, error) {
+func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValues map[string]any, opts Options) (string, error) {
 	loaded, err := c.LoadChart(ctx, hr)
 	if err != nil {
 		return "", err
@@ -53,15 +56,27 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, values 
 		}
 		inst.KubeVersion = kv
 	}
-	if values == nil {
-		values = map[string]any{}
+	if hrValues == nil {
+		hrValues = map[string]any{}
 	}
 
 	if hr.Chart.Version != "" {
 		inst.Version = hr.Chart.Version
 	}
 
-	rel, err := inst.RunWithContext(ctx, loaded.Chart, values)
+	// Apply chart valuesFiles BEFORE HR.Values so HR overrides win.
+	// Mirrors helm-controller's CoalesceValues layering: chart defaults
+	// (handled internally by helm) → chart-named valuesFiles → HR.Values.
+	finalValues := hrValues
+	if len(hr.ChartValuesFiles) > 0 {
+		base, err := mergeChartValuesFiles(loaded.Chart, hr.ChartValuesFiles, hr.IgnoreMissingValuesFiles)
+		if err != nil {
+			return "", fmt.Errorf("helm chart valuesFiles %s/%s: %w", hr.Namespace, hr.Name, err)
+		}
+		finalValues = values.DeepMerge(base, hrValues)
+	}
+
+	rel, err := inst.RunWithContext(ctx, loaded.Chart, finalValues)
 	if err != nil {
 		return "", fmt.Errorf("helm template %s/%s: %w", hr.Namespace, hr.Name, err)
 	}
@@ -71,6 +86,36 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, values 
 	}
 
 	return releaseManifest(relV1, opts), nil
+}
+
+// mergeChartValuesFiles merges the named values files (relative paths
+// inside the chart archive) in the supplied order. Missing files are
+// skipped when ignoreMissing is true; otherwise the first missing file
+// is an error. Mirrors helm-controller's chartutil layering: each file
+// is merged on top of the previous one.
+func mergeChartValuesFiles(c *chart.Chart, names []string, ignoreMissing bool) (map[string]any, error) {
+	out := map[string]any{}
+	for _, name := range names {
+		var data []byte
+		for _, f := range c.Files {
+			if f != nil && f.Name == name {
+				data = f.Data
+				break
+			}
+		}
+		if data == nil {
+			if ignoreMissing {
+				continue
+			}
+			return nil, fmt.Errorf("values file %q not found in chart", name)
+		}
+		var m map[string]any
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("parse values file %q: %w", name, err)
+		}
+		out = values.DeepMerge(out, m)
+	}
+	return out, nil
 }
 
 // TemplateDocs renders and returns each document parsed as a generic map.

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -97,13 +97,16 @@ func HelmChartFromSource(src *HelmChartSource) HelmChart {
 // HelmChartSource is the standalone HelmChart CRD
 // (source.toolkit.fluxcd.io/v1 HelmChart).
 type HelmChartSource struct {
-	Name          string `json:"name" yaml:"name"`
-	Namespace     string `json:"namespace" yaml:"namespace"`
-	Chart         string `json:"chart" yaml:"chart"`
-	Version       string `json:"version,omitempty" yaml:"version,omitempty"`
-	RepoName      string `json:"repoName" yaml:"repoName"`
-	RepoNamespace string `json:"repoNamespace" yaml:"repoNamespace"`
-	RepoKind      string `json:"repoKind" yaml:"repoKind"`
+	Name                     string   `json:"name" yaml:"name"`
+	Namespace                string   `json:"namespace" yaml:"namespace"`
+	Chart                    string   `json:"chart" yaml:"chart"`
+	Version                  string   `json:"version,omitempty" yaml:"version,omitempty"`
+	RepoName                 string   `json:"repoName" yaml:"repoName"`
+	RepoNamespace            string   `json:"repoNamespace" yaml:"repoNamespace"`
+	RepoKind                 string   `json:"repoKind" yaml:"repoKind"`
+	Suspend                  bool     `json:"-" yaml:"-"`
+	ValuesFiles              []string `json:"-" yaml:"-"`
+	IgnoreMissingValuesFiles bool     `json:"-" yaml:"-"`
 }
 
 // Named identifies the chart resource.
@@ -144,13 +147,16 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 		repoKind = KindHelmRepository
 	}
 	return &HelmChartSource{
-		Name:          cr.Name,
-		Namespace:     ns,
-		Chart:         cr.Spec.Chart,
-		Version:       cr.Spec.Version,
-		RepoName:      cr.Spec.SourceRef.Name,
-		RepoNamespace: ns,
-		RepoKind:      repoKind,
+		Name:                     cr.Name,
+		Namespace:                ns,
+		Chart:                    cr.Spec.Chart,
+		Version:                  cr.Spec.Version,
+		RepoName:                 cr.Spec.SourceRef.Name,
+		RepoNamespace:            ns,
+		RepoKind:                 repoKind,
+		Suspend:                  cr.Spec.Suspend,
+		ValuesFiles:              cr.Spec.ValuesFiles,
+		IgnoreMissingValuesFiles: cr.Spec.IgnoreMissingValuesFiles,
 	}, nil
 }
 
@@ -187,8 +193,19 @@ type HelmRelease struct {
 	ValuesFrom               []ValuesReference `json:"-" yaml:"-"`
 	Images                   []string          `json:"images,omitempty" yaml:"images,omitempty"`
 	Labels                   map[string]string `json:"-" yaml:"-"`
+	DependsOn                []string          `json:"-" yaml:"-"`
+	Suspend                  bool              `json:"-" yaml:"-"`
 	DisableSchemaValidation  bool              `json:"-" yaml:"-"`
 	DisableOpenAPIValidation bool              `json:"-" yaml:"-"`
+	// ChartValuesFiles are values files baked into the chart that
+	// should be merged BEFORE the HR's own Values overrides. Sourced
+	// from either spec.chart.spec.valuesFiles (inline template) or the
+	// referenced HelmChart CRD's spec.valuesFiles (when chartRef is
+	// used; populated by ResolveChartRef).
+	ChartValuesFiles []string `json:"-" yaml:"-"`
+	// IgnoreMissingValuesFiles: when true, missing ChartValuesFiles
+	// entries are skipped instead of erroring.
+	IgnoreMissingValuesFiles bool `json:"-" yaml:"-"`
 }
 
 // Named identifies the release.
@@ -234,6 +251,9 @@ func (h *HelmRelease) ResourceDependencies() []NamedResource {
 
 // ResolveChartRef replaces a chartRef placeholder with the resolved source
 // when version was not pinned. helmCharts is keyed by ResourceFullName.
+// When the chartRef resolves to a HelmChart CRD, its spec.valuesFiles +
+// spec.ignoreMissingValuesFiles propagate onto the HelmRelease so the
+// rendering pipeline can merge them ahead of HR.Values.
 func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) error {
 	if h.Chart.RepoKind != KindHelmChart || h.Chart.Version != "" {
 		return nil
@@ -245,6 +265,10 @@ func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) er
 	}
 	if src.Version != "" {
 		h.Chart = HelmChartFromSource(src)
+	}
+	if len(src.ValuesFiles) > 0 {
+		h.ChartValuesFiles = src.ValuesFiles
+		h.IgnoreMissingValuesFiles = src.IgnoreMissingValuesFiles
 	}
 	return nil
 }
@@ -290,6 +314,27 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		(cr.Spec.Upgrade != nil && cr.Spec.Upgrade.DisableSchemaValidation)
 	disableOpenAPI := (cr.Spec.Install != nil && cr.Spec.Install.DisableOpenAPIValidation) ||
 		(cr.Spec.Upgrade != nil && cr.Spec.Upgrade.DisableOpenAPIValidation)
+	var dependsOn []string
+	for _, dep := range cr.Spec.DependsOn {
+		if dep.Name == "" {
+			return nil, inputf("HelmRelease missing dependsOn.name")
+		}
+		depNS := dep.Namespace
+		if depNS == "" {
+			depNS = cr.Namespace
+		}
+		dependsOn = append(dependsOn, depNS+"/"+dep.Name)
+	}
+	// spec.chart.spec.valuesFiles (inline template). spec.chartRef
+	// case is handled later by ResolveChartRef once HelmChartSource is
+	// available in the store.
+	var chartValuesFiles []string
+	var ignoreMissingValuesFiles bool
+	if cr.Spec.Chart != nil {
+		chartValuesFiles = cr.Spec.Chart.Spec.ValuesFiles
+		ignoreMissingValuesFiles = cr.Spec.Chart.Spec.IgnoreMissingValuesFiles
+	}
+
 	return &HelmRelease{
 		Name:                     cr.Name,
 		Namespace:                cr.Namespace,
@@ -298,8 +343,12 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		Values:                   values,
 		ValuesFrom:               vfs,
 		Labels:                   cr.Labels,
+		DependsOn:                dependsOn,
+		Suspend:                  cr.Spec.Suspend,
 		DisableSchemaValidation:  disableSchema,
 		DisableOpenAPIValidation: disableOpenAPI,
+		ChartValuesFiles:         chartValuesFiles,
+		IgnoreMissingValuesFiles: ignoreMissingValuesFiles,
 	}, nil
 }
 
@@ -310,6 +359,7 @@ type HelmRepository struct {
 	URL       string `json:"url" yaml:"url"`
 	// RepoType is "default" or "oci".
 	RepoType string `json:"repoType,omitempty" yaml:"repoType,omitempty"`
+	Suspend  bool   `json:"-" yaml:"-"`
 }
 
 // Named identifies the repo.
@@ -354,5 +404,6 @@ func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
 		RepoType:  repoType,
+		Suspend:   cr.Spec.Suspend,
 	}, nil
 }

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -45,6 +45,8 @@ type Kustomization struct {
 	// Components is Flux v1's spec.components — paths to kustomize
 	// components injected on top of spec.path at reconcile time.
 	Components []string `json:"-" yaml:"-"`
+	// Suspend mirrors spec.suspend — controllers skip suspended objects.
+	Suspend bool `json:"-" yaml:"-"`
 
 	Images []string `json:"images,omitempty" yaml:"images,omitempty"`
 }
@@ -178,5 +180,6 @@ func ParseKustomization(doc map[string]any) (*Kustomization, error) {
 		DependsOn:               dependsOn,
 		Labels:                  cr.Labels,
 		Components:              cr.Spec.Components,
+		Suspend:                 cr.Spec.Suspend,
 	}, nil
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -43,6 +43,73 @@ func TestNamedResource(t *testing.T) {
 	}
 }
 
+func TestParseHelmRelease_Suspend(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  suspend: true
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	hr, err := ParseHelmRelease(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmRelease: %v", err)
+	}
+	if !hr.Suspend {
+		t.Errorf("expected Suspend=true; got false")
+	}
+}
+
+func TestParseKustomization_Suspend(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: ks, namespace: ns}
+spec:
+  suspend: true
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: src, namespace: ns}
+  interval: 5m
+`)
+	ks, err := ParseKustomization(doc)
+	if err != nil {
+		t.Fatalf("ParseKustomization: %v", err)
+	}
+	if !ks.Suspend {
+		t.Errorf("expected Suspend=true; got false")
+	}
+}
+
+func TestParseHelmRelease_DependsOn(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  dependsOn:
+    - name: other
+    - {name: cross, namespace: other-ns}
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	hr, err := ParseHelmRelease(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmRelease: %v", err)
+	}
+	if got, want := len(hr.DependsOn), 2; got != want {
+		t.Fatalf("DependsOn len = %d, want %d", got, want)
+	}
+	if hr.DependsOn[0] != "ns/other" {
+		t.Errorf("DependsOn[0] = %q, want ns/other", hr.DependsOn[0])
+	}
+}
+
 func TestParseHelmRelease_Inline(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -37,6 +37,7 @@ type GitRepository struct {
 	Namespace string           `json:"namespace" yaml:"namespace"`
 	URL       string           `json:"url" yaml:"url"`
 	Ref       GitRepositoryRef `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Suspend   bool             `json:"-" yaml:"-"`
 }
 
 // Named identifies the GitRepository.
@@ -78,6 +79,7 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
 		Ref:       ref,
+		Suspend:   cr.Spec.Suspend,
 	}, nil
 }
 
@@ -99,6 +101,7 @@ type OCIRepository struct {
 	URL       string                `json:"url" yaml:"url"`
 	Ref       OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	Suspend   bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the OCIRepository.
@@ -109,14 +112,12 @@ func (o *OCIRepository) Named() NamedResource {
 // RepoName is "<namespace>-<name>".
 func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }
 
-// Version returns the digest, tag, or semver in that order. semverFilter
-// is not supported and will return an error.
+// Version returns the digest, tag, or semver expression in that order.
+// A semver expression is returned verbatim — callers wanting a concrete
+// tag must resolve it against remote tag listing (pkg/source).
 func (o *OCIRepository) Version() (string, error) {
 	if o.Ref.IsEmpty() {
 		return "", nil
-	}
-	if o.Ref.SemverFilter != "" {
-		return "", inputf("OCIRepository semverFilter is not supported")
 	}
 	switch {
 	case o.Ref.Digest != "":
@@ -165,6 +166,7 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		Name:      cr.Name,
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
+		Suspend:   cr.Spec.Suspend,
 	}
 	if r := cr.Spec.Reference; r != nil {
 		out.Ref = OCIRepositoryRef{

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -44,6 +45,13 @@ type Config struct {
 	// CacheDir overrides the default on-disk cache root
 	// (os.TempDir()/flate-cache).
 	CacheDir string
+	// SourceCache, when non-nil, is shared across orchestrators. The
+	// `flate diff` flow constructs two orchestrators that point at the
+	// same on-disk source-cache root; they MUST share one *Cache so the
+	// internal mutex serializes concurrent slot allocation. When nil a
+	// per-orchestrator cache is constructed (fine for single-orchestrator
+	// commands like `build` / `get`).
+	SourceCache *source.Cache
 	// ExternalChanges, when non-nil, supplies the file-level diff so
 	// the orchestrator skips its built-in change.Detect step. The
 	// filter is still built from this set + the loaded SourceFiles
@@ -101,7 +109,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		src: &sourcectrl.Controller{
 			Store:          st,
 			Tasks:          ts,
-			Cache:          source.NewCache(filepath.Join(cacheRoot, "sources")),
+			Cache:          cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources"))),
 			RegistryConfig: cfg.RegistryConfig,
 			EnableOCI:      cfg.EnableOCI,
 		},

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"oras.land/oras-go/v2"
 	orasfile "oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
@@ -20,7 +23,9 @@ import (
 
 // FetchOCI pulls the OCIRepository artifact into cache. Credentials are
 // read from a docker-style config.json honored by oras-go's
-// credentials.NewFileStore.
+// credentials.NewFileStore. When spec.ref.semver is set, the registry
+// is listed and the highest matching tag (filtered by semverFilter, if
+// any) is resolved before pulling.
 func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.OCIArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
@@ -29,38 +34,43 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("%w: OCIRepository %s missing url", manifest.ErrInput, repo.RepoName())
 	}
 
-	versioned := repo.VersionedURL()
+	reference, err := parseOCIRef("oci://" + strings.TrimPrefix(repo.URL, "oci://"))
+	if err != nil {
+		return nil, err
+	}
+	repoClient, err := remote.NewRepository(reference)
+	if err != nil {
+		return nil, fmt.Errorf("oras: %w", err)
+	}
+	credStore, err := loadCredentials(registryConfig)
+	if err != nil {
+		return nil, err
+	}
+	if credStore != nil {
+		repoClient.Client = &auth.Client{Credential: credentials.Credential(credStore)}
+	}
+
+	// Resolve spec.ref into a concrete (tag-or-digest) BEFORE choosing
+	// the cache slot, so different semver matches don't share a slot.
+	ref := repo.Ref
+	if ref.Semver != "" {
+		resolved, err := resolveOCISemver(ctx, repoClient, ref.Semver, ref.SemverFilter)
+		if err != nil {
+			return nil, fmt.Errorf("OCIRepository %s semver: %w", repo.RepoName(), err)
+		}
+		ref = manifest.OCIRepositoryRef{Tag: resolved}
+	}
+
+	versioned := versionedURL(repo.URL, ref)
 	slot, exists, err := cache.Slot(versioned, "")
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
 	if exists {
-		return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Digest: repo.Ref.Digest}, nil
+		return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: ref.Digest}, nil
 	}
 
-	reference, err := parseOCIRef(versioned)
-	if err != nil {
-		_ = cache.Reset(slot)
-		return nil, err
-	}
-
-	repoClient, err := remote.NewRepository(reference)
-	if err != nil {
-		_ = cache.Reset(slot)
-		return nil, fmt.Errorf("oras: %w", err)
-	}
-
-	credStore, err := loadCredentials(registryConfig)
-	if err != nil {
-		_ = cache.Reset(slot)
-		return nil, err
-	}
-	if credStore != nil {
-		client := &auth.Client{Credential: credentials.Credential(credStore)}
-		repoClient.Client = client
-	}
-
-	tag := versionTag(repo.Ref)
+	tag := versionTag(ref)
 	if tag == "" {
 		tag = "latest"
 	}
@@ -77,7 +87,68 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
-	return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Digest: desc.Digest.String()}, nil
+	return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: desc.Digest.String()}, nil
+}
+
+// versionedURL composes a Flux-style versioned URL from a base + ref.
+// Used here for cache-slot keying after semver resolution.
+func versionedURL(base string, ref manifest.OCIRepositoryRef) string {
+	switch {
+	case ref.Digest != "":
+		return base + "@" + ref.Digest
+	case ref.Tag != "":
+		return base + ":" + ref.Tag
+	}
+	return base
+}
+
+// resolveOCISemver lists the remote tags, applies an optional regex
+// filter, then returns the highest tag matching the semver constraint.
+// Mirrors source-controller's `getTagBySemver` (ocirepository_controller.go).
+func resolveOCISemver(ctx context.Context, repoClient *remote.Repository, expr, filterPattern string) (string, error) {
+	constraint, err := semver.NewConstraint(expr)
+	if err != nil {
+		return "", fmt.Errorf("semver %q: %w", expr, err)
+	}
+	var pattern *regexp.Regexp
+	if filterPattern != "" {
+		pattern, err = regexp.Compile(filterPattern)
+		if err != nil {
+			return "", fmt.Errorf("semverFilter %q: %w", filterPattern, err)
+		}
+	}
+
+	var matching semver.Collection
+	var matchingTags []string
+	err = repoClient.Tags(ctx, "", func(tags []string) error {
+		for _, tag := range tags {
+			if pattern != nil && !pattern.MatchString(tag) {
+				continue
+			}
+			v, perr := semver.NewVersion(tag)
+			if perr != nil {
+				continue
+			}
+			if constraint.Check(v) {
+				matching = append(matching, v)
+				matchingTags = append(matchingTags, tag)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("list tags: %w", err)
+	}
+	if len(matching) == 0 {
+		return "", fmt.Errorf("no tag matched semver %q (filter %q)", expr, filterPattern)
+	}
+	// Highest match wins.
+	idx := make([]int, len(matching))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool { return matching[idx[a]].LessThan(matching[idx[b]]) })
+	return matchingTags[idx[len(idx)-1]], nil
 }
 
 // loadCredentials returns a credentials.Store backed by the given config


### PR DESCRIPTION
## Summary

Five silent-wrong-output bugs surfaced by the recent deep-review pass. Each makes flate diverge from Flux's actual reconcile behavior in ways that produce output the cluster would never apply.

**Phase 1 of a Flux-fidelity push.** A4 (controller base extraction), A3 (metav1.Condition status), and A1+A2 (Fetcher interface + unified SourceArtifact) follow in subsequent PRs and unblock the missing source kinds (Bucket, ExternalArtifact) plus deeper auth/verify/SOPS parity.

## The five fixes

### C5 — `source.Cache` race in `flate diff`
Q1 parallelized `runDiffOrchestrators` but each orchestrator constructed its own `*source.Cache` over the same on-disk root. Concurrent first-time clones of the same `(url, ref)` slot can race past the `mkdir`/`Readdirnames` check, with both goroutines proceeding into the same destination and one corrupting the other.

**Fix:** `orchestrator.Config` gains `SourceCache *source.Cache`. `internal/cli/helpers.go` constructs one shared cache and assigns it to both diff orchestrators so the existing mutex serializes slot allocation.

### C1 — `spec.suspend` honored
Was **completely ignored** on every reconcilable CR. flate would happily render a HelmRelease or Kustomization with `suspend: true` that the cluster would never apply.

**Fix:** Parsed from the typed Flux CRs (`helmv2`/`kustomizev1`/`sourcev1` all have `Spec.Suspend bool`) onto flate's local types. Each controller short-circuits at the top of `onObjectAdded` with `StatusReady` + message `\"suspended\"`. No artifact is written, so suspended resources naturally drop from rendered output.

Covered: `Kustomization`, `HelmRelease`, `GitRepository`, `OCIRepository`. `HelmRepository`/`HelmChart` parse the field but don't have a dedicated reconcile loop today — they're existence-only.

### C2 — `HelmRelease.spec.dependsOn`
HR-to-HR ordering was completely unread. Only the chart `sourceRef` gated HR rendering; if a HelmRelease declared `dependsOn`, flate ignored it.

**Fix:** Parsed `cr.Spec.DependsOn []meta.NamespacedObjectReference` into `HelmRelease.DependsOn []string` (namespace-qualified `\"ns/name\"`). Added `collectHRDeps` in the helmrelease controller, mirroring the kustomization controller's existing shape; deps flow through the existing `depwait.Waiter` before chart resolution.

### C3 — `OCIRepository spec.ref.semver` resolved against remote tags
- `pkg/manifest/source.go` rejected `semverFilter` outright, but it's a sub-property of `semver`, not an alternative.
- `pkg/source/oci.go` passed the raw semver expression as a literal tag to oras, which then 404s.

**Fix:** New `resolveOCISemver` lists remote tags via `oras.Repository.Tags`, applies the optional regex filter, parses each as semver via `Masterminds/semver/v3`, and returns the highest match against the constraint. Mirrors source-controller's `getTagBySemver`. The cache slot key uses the resolved tag so different semver matches don't share a slot. `Version()` no longer errors on `semverFilter`.

### C4 — `HelmChart.spec.valuesFiles` applied
Both inline (`HR.spec.chart.spec.valuesFiles`) and `chartRef → HelmChart` variants were silently dropped. Charts that declared `valuesFiles: [values-prod.yaml]` rendered with the chart's default `values.yaml` only.

**Fix:** 
- `HelmRelease` gains `ChartValuesFiles []string` + `IgnoreMissingValuesFiles bool`. `ParseHelmRelease` populates them from `cr.Spec.Chart.Spec.ValuesFiles` (inline case). `ResolveChartRef` propagates them from the standalone HelmChart CRD (chartRef case).
- `pkg/helm/template.go` new `mergeChartValuesFiles` reads each named file from `loaded.Chart.Files` and YAML-merges them in declared order. The result feeds into `inst.RunWithContext` ahead of `HR.Values`, matching helm-controller's CoalesceValues layering: chart defaults → chart valuesFiles → HR.Values overrides.

## Tests added

- `TestParseHelmRelease_Suspend`
- `TestParseKustomization_Suspend`
- `TestParseHelmRelease_DependsOn`

Existing manifest, store, controller, orchestrator, source, helm, and e2e tests all green.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`go mod tidy\` no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)