### PR TITLE
refactor(controllers): extract base.Recover + base.RunWithStatus

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -1,0 +1,53 @@
+// Package base provides the small shared harness that the
+// kustomization, helmrelease, and source controllers wrap around their
+// per-resource reconcile bodies. It centralizes panic attribution
+// (so a panicked reconcile marks the affected resource Failed instead
+// of silently disappearing) and the post-reconcile status transition.
+package base
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// Recover catches a panic from the current goroutine and marks id
+// StatusFailed with a "panic: <r>" message so the orchestrator
+// surfaces it. Intended for use as `defer base.Recover(store, id, "kind")`
+// in controllers that don't go through RunWithStatus (e.g. source
+// fetchers that own their own status writes).
+func Recover(s *store.Store, id manifest.NamedResource, logKind string) {
+	if r := recover(); r != nil {
+		slog.Error(logKind+": panic during reconcile", "id", id.String(), "panic", r)
+		s.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
+	}
+}
+
+// RunWithStatus is the standard reconcile body for controllers that
+// (a) coalesce concurrent submits per-id and (b) want the recover →
+// re-read → run → mark-Ready/Failed pattern. The re-read lets a
+// coalesced re-run pick up patches a parent KS installed mid-flight
+// rather than the stale payload from the original event. A missing
+// object (deleted between coalescer enqueue and run) is treated as a
+// no-op rather than a failure.
+func RunWithStatus[T manifest.BaseManifest](
+	ctx context.Context,
+	s *store.Store,
+	id manifest.NamedResource,
+	logKind string,
+	fn func(context.Context, T) error,
+) {
+	defer Recover(s, id, logKind)
+	obj, ok := s.GetObject(id).(T)
+	if !ok {
+		return
+	}
+	if err := fn(ctx, obj); err != nil {
+		s.UpdateStatus(id, store.StatusFailed, err.Error())
+		return
+	}
+	s.UpdateStatus(id, store.StatusReady, "")
+}

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -1,0 +1,91 @@
+package base_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/controllers/base"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func TestRunWithStatus_Success(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			if obj.Name != "app" {
+				t.Errorf("re-read got %q, want app", obj.Name)
+			}
+			return nil
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusReady {
+		t.Errorf("status = %v, want Ready", got.Status)
+	}
+}
+
+func TestRunWithStatus_Failure(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			return errors.New("render failed")
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusFailed {
+		t.Errorf("status = %v, want Failed", got.Status)
+	}
+	if got.Message != "render failed" {
+		t.Errorf("message = %q, want %q", got.Message, "render failed")
+	}
+}
+
+func TestRunWithStatus_Panic(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	// Panic must be caught and converted into StatusFailed; no re-panic.
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			panic("kaboom")
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusFailed {
+		t.Errorf("status = %v, want Failed", got.Status)
+	}
+	if !strings.Contains(got.Message, "panic:") || !strings.Contains(got.Message, "kaboom") {
+		t.Errorf("message = %q, want a 'panic: kaboom' summary", got.Message)
+	}
+}
+
+func TestRunWithStatus_MissingObject(t *testing.T) {
+	s := store.New()
+	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "ghost"}
+	called := false
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			called = true
+			return nil
+		},
+	)
+	if called {
+		t.Error("fn ran for a missing object; expected silent no-op")
+	}
+	if _, ok := s.GetStatus(id); ok {
+		t.Error("missing object should not get a status entry")
+	}
+}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -97,23 +98,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				return
 			}
 			c.coal.Submit(ctx, "helmrelease/"+id.String(), id, func(ctx context.Context) {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("helmrelease: panic during reconcile", "id", id.String(), "panic", r)
-						c.Store.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
-					}
-				}()
-				// Re-read each iteration so a coalesced re-run picks up
-				// a parent KS's patches rather than the stale payload.
-				hr, _ := c.Store.GetObject(id).(*manifest.HelmRelease)
-				if hr == nil {
-					return
-				}
-				if err := c.reconcile(ctx, hr); err != nil {
-					c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
-					return
-				}
-				c.Store.UpdateStatus(id, store.StatusReady, "")
+				base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
 			})
 		}
 	}

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -76,24 +77,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			return
 		}
 		c.coal.Submit(ctx, "kustomization/"+id.String(), id, func(ctx context.Context) {
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("kustomization: panic during reconcile", "id", id.String(), "panic", r)
-					c.Store.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
-				}
-			}()
-			// Re-read the spec each iteration so a coalesced re-run
-			// picks up patches a parent KS installed mid-flight rather
-			// than the stale payload from the original event.
-			ks, _ := c.Store.GetObject(id).(*manifest.Kustomization)
-			if ks == nil {
-				return
-			}
-			if err := c.reconcile(ctx, ks); err != nil {
-				c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
-				return
-			}
-			c.Store.UpdateStatus(id, store.StatusReady, "")
+			base.RunWithStatus(ctx, c.Store, id, "kustomization", c.reconcile)
 		})
 	}
 }

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -6,10 +6,10 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	src "github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
@@ -67,7 +67,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				return
 			}
 			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer c.recoverPanic(id)
+				defer base.Recover(c.Store, id, "source")
 				c.reconcileGit(ctx, id, repo)
 			})
 		case manifest.KindOCIRepository:
@@ -86,17 +86,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				return
 			}
 			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer c.recoverPanic(id)
+				defer base.Recover(c.Store, id, "source")
 				c.reconcileOCI(ctx, id, repo)
 			})
 		}
-	}
-}
-
-func (c *Controller) recoverPanic(id manifest.NamedResource) {
-	if r := recover(); r != nil {
-		slog.Error("source: panic during reconcile", "id", id.String(), "panic", r)
-		c.Store.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the Flux-fidelity push (foundation refactor). **Stacked on #26 (\`fix/flux-fidelity-bugs\`).** Merge that first, then rebase this onto main.

Three controllers — kustomization, helmrelease, source — were each running variants of the same \"defer recover → mark Failed with panic context → re-read the object → run reconcile → mark Ready/Failed\" dance. Now in one place.

## What \`pkg/controllers/base\` exposes

- **\`Recover(store, id, kind)\`** — panic → \`StatusFailed\` with a \`\"panic: <r>\"\` message. Used by the source controller, which owns its own status writes inside \`reconcileGit\`/\`reconcileOCI\`.
- **\`RunWithStatus[T](ctx, store, id, kind, fn)\`** — the full harness used by kustomization + helmrelease: \`defer Recover\`, re-read object from store (the coalescer-staleness invariant), run \`fn\`, mark Ready on success or Failed with the error text. A missing object (deleted between coalescer enqueue and run) is silently no-op'd rather than treated as a failure.

## Honest sizing

The deep-review pass estimated ~120 LOC removed. Real number: **-38 LOC at the three callsites + 50 LOC new in \`base.go\` = ~+12 LOC overall**. Smaller than projected because the duplication was tighter than the audit suggested.

The real value isn't LOC: it's that the **panic-attribution semantics are now auditable in one file**. Today three controllers each ran their own \`defer recover() / UpdateStatus(StatusFailed, panic: …)\` block — a future controller could easily forget it. Now they call one helper.

## Tests

\`base_test.go\` covers:
- Success → \`Ready\`
- Reconcile error → \`Failed\` with the error message verbatim
- Panic → \`Failed\` with \`\"panic: <msg>\"\`, no re-panic
- Missing object → silent no-op, no status entry created

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)