### PR TITLE
refactor(store): switch internal status to []metav1.Condition

### DIFF
--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -1,8 +1,14 @@
 package store
 
-import "github.com/home-operations/flate/pkg/manifest"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// Status is the processing state of a resource.
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// Status is the processing state of a resource as projected from its
+// Ready condition. Kept as a high-level rollup for callers (depwait,
+// `test` reporting) that don't need the full condition slice.
 type Status string
 
 // Possible Status values.
@@ -13,10 +19,33 @@ const (
 )
 
 // StatusInfo bundles a status with an optional descriptive message.
+// Derived from the Ready condition; see Store.GetStatus.
 type StatusInfo struct {
 	Status  Status
 	Message string
 }
+
+// Condition is an alias for k8s metav1.Condition. flate stores
+// per-resource conditions so SOPS-encrypted-secret detection,
+// health-check rollups, and Flux's dependsOn ReadyExpr CEL evaluation
+// can interoperate with the rest of the K8s ecosystem.
+type Condition = metav1.Condition
+
+// Condition type identifiers used by flate. These mirror Flux's
+// conventions so a future watch-mode could publish to a real cluster
+// without translating.
+const (
+	ConditionReady       = "Ready"
+	ConditionReconciling = "Reconciling"
+	ConditionHealthy     = "Healthy"
+)
+
+// Condition reasons attached to the Ready condition.
+const (
+	ReasonSucceeded   = "Succeeded"
+	ReasonFailed      = "Failed"
+	ReasonReconciling = "Reconciling"
+)
 
 // SupportsStatus reports whether the given kind participates in the
 // status pipeline. Kinds outside this set (ConfigMap, Secret, ...) are
@@ -31,4 +60,48 @@ func SupportsStatus(kind string) bool {
 		return true
 	}
 	return false
+}
+
+// readyCondition builds the Ready condition that corresponds to the
+// (status, message) pair UpdateStatus accepts. Reason is derived from
+// Status; Message is passed through verbatim.
+func readyCondition(status Status, message string) metav1.Condition {
+	c := metav1.Condition{
+		Type:    ConditionReady,
+		Message: message,
+	}
+	switch status {
+	case StatusReady:
+		c.Status = metav1.ConditionTrue
+		c.Reason = ReasonSucceeded
+	case StatusFailed:
+		c.Status = metav1.ConditionFalse
+		c.Reason = ReasonFailed
+	default: // StatusPending or unknown
+		c.Status = metav1.ConditionUnknown
+		c.Reason = ReasonReconciling
+	}
+	return c
+}
+
+// statusInfoFromConditions projects the rollup StatusInfo from the
+// Ready condition. Returns (zero, false) when no Ready condition is
+// present.
+func statusInfoFromConditions(conds []metav1.Condition) (StatusInfo, bool) {
+	for _, c := range conds {
+		if c.Type != ConditionReady {
+			continue
+		}
+		info := StatusInfo{Message: c.Message}
+		switch c.Status {
+		case metav1.ConditionTrue:
+			info.Status = StatusReady
+		case metav1.ConditionFalse:
+			info.Status = StatusFailed
+		default:
+			info.Status = StatusPending
+		}
+		return info, true
+	}
+	return StatusInfo{}, false
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -11,10 +11,10 @@ import (
 
 // Store is the central in-memory state container.
 type Store struct {
-	mu        sync.RWMutex
-	objects   map[manifest.NamedResource]manifest.BaseManifest
-	status    map[manifest.NamedResource]StatusInfo
-	artifacts map[manifest.NamedResource]Artifact
+	mu         sync.RWMutex
+	objects    map[manifest.NamedResource]manifest.BaseManifest
+	conditions map[manifest.NamedResource][]Condition
+	artifacts  map[manifest.NamedResource]Artifact
 
 	// byName is a secondary index keyed by kind, then "namespace/name".
 	// It makes hot-path namespaced lookups (e.g. valuesFrom ConfigMap /
@@ -32,10 +32,10 @@ type Store struct {
 // New constructs an empty Store.
 func New() *Store {
 	return &Store{
-		objects:   make(map[manifest.NamedResource]manifest.BaseManifest),
-		status:    make(map[manifest.NamedResource]StatusInfo),
-		artifacts: make(map[manifest.NamedResource]Artifact),
-		byName:    make(map[string]map[string]manifest.BaseManifest),
+		objects:    make(map[manifest.NamedResource]manifest.BaseManifest),
+		conditions: make(map[manifest.NamedResource][]Condition),
+		artifacts:  make(map[manifest.NamedResource]Artifact),
+		byName:     make(map[string]map[string]manifest.BaseManifest),
 		listeners: map[EventKind]*listenerSet{
 			EventObjectAdded:     newListenerSet(),
 			EventStatusUpdated:   newListenerSet(),
@@ -105,7 +105,7 @@ func (s *Store) DeleteObject(id manifest.NamedResource) bool {
 		return false
 	}
 	delete(s.objects, id)
-	delete(s.status, id)
+	delete(s.conditions, id)
 	delete(s.artifacts, id)
 	if inner := s.byName[id.Kind]; inner != nil {
 		delete(inner, nameKey(id.Namespace, id.Name))
@@ -140,27 +140,84 @@ func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 	return out
 }
 
-// UpdateStatus records a status transition and dispatches a
-// StatusUpdated event when the status info changes.
+// UpdateStatus records a Ready-condition transition and dispatches a
+// StatusUpdated event when the StatusInfo rollup changes. Internally
+// the (status, message) pair is stored as a metav1.Condition so
+// future callers (ReadyExpr CEL, SOPS detection, healthChecks) can
+// see the rich state via GetConditions.
 func (s *Store) UpdateStatus(id manifest.NamedResource, status Status, message string) {
-	info := StatusInfo{Status: status, Message: message}
-	s.mu.Lock()
-	prev, exists := s.status[id]
-	if exists && prev == info {
-		s.mu.Unlock()
-		return
-	}
-	s.status[id] = info
-	s.mu.Unlock()
-	s.fire(EventStatusUpdated, id, info)
+	s.SetCondition(id, readyCondition(status, message))
 }
 
-// GetStatus returns the status for id and whether it was present.
+// SetCondition upserts cond into the resource's condition list keyed
+// by cond.Type. Dispatches a StatusUpdated event with the *StatusInfo
+// rollup* (derived from Ready) when the rollup changed — non-Ready
+// conditions land silently to avoid event spam.
+func (s *Store) SetCondition(id manifest.NamedResource, cond Condition) {
+	s.mu.Lock()
+	prev := s.conditions[id]
+	prevInfo, _ := statusInfoFromConditions(prev)
+
+	updated := make([]Condition, 0, len(prev)+1)
+	replaced := false
+	for _, c := range prev {
+		if c.Type == cond.Type {
+			if conditionEqual(c, cond) {
+				// Identical condition — nothing to do, including no event.
+				s.mu.Unlock()
+				return
+			}
+			updated = append(updated, cond)
+			replaced = true
+			continue
+		}
+		updated = append(updated, c)
+	}
+	if !replaced {
+		updated = append(updated, cond)
+	}
+	s.conditions[id] = updated
+
+	newInfo, _ := statusInfoFromConditions(updated)
+	s.mu.Unlock()
+
+	if cond.Type == ConditionReady && prevInfo != newInfo {
+		s.fire(EventStatusUpdated, id, newInfo)
+	}
+}
+
+// GetStatus returns the Ready-derived StatusInfo for id and whether
+// a Ready condition was present.
 func (s *Store) GetStatus(id manifest.NamedResource) (StatusInfo, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	info, ok := s.status[id]
-	return info, ok
+	return statusInfoFromConditions(s.conditions[id])
+}
+
+// GetConditions returns a copy of id's condition list. Empty for
+// unknown ids.
+func (s *Store) GetConditions(id manifest.NamedResource) []Condition {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conds := s.conditions[id]
+	if len(conds) == 0 {
+		return nil
+	}
+	out := make([]Condition, len(conds))
+	copy(out, conds)
+	return out
+}
+
+// conditionEqual reports whether two conditions carry the same
+// observable state. LastTransitionTime is intentionally ignored — it
+// is reset on every transition by the controller-runtime libraries
+// and would otherwise prevent the no-op short-circuit from firing.
+func conditionEqual(a, b Condition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message &&
+		a.ObservedGeneration == b.ObservedGeneration
 }
 
 // SetArtifact stores an artifact for id and dispatches an
@@ -184,12 +241,12 @@ func (s *Store) GetArtifact(id manifest.NamedResource) Artifact {
 	return s.artifacts[id]
 }
 
-// HasFailedResources reports whether any tracked status is Failed.
+// HasFailedResources reports whether any tracked Ready condition is False.
 func (s *Store) HasFailedResources() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for _, info := range s.status {
-		if info.Status == StatusFailed {
+	for _, conds := range s.conditions {
+		if info, ok := statusInfoFromConditions(conds); ok && info.Status == StatusFailed {
 			return true
 		}
 	}
@@ -201,8 +258,8 @@ func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make(map[manifest.NamedResource]StatusInfo)
-	for id, info := range s.status {
-		if info.Status == StatusFailed {
+	for id, conds := range s.conditions {
+		if info, ok := statusInfoFromConditions(conds); ok && info.Status == StatusFailed {
 			out[id] = info
 		}
 	}
@@ -240,8 +297,12 @@ func (s *Store) replayInto(event EventKind, fn Listener) {
 		}
 	case EventStatusUpdated:
 		s.mu.RLock()
-		snap := make(map[manifest.NamedResource]StatusInfo, len(s.status))
-		maps.Copy(snap, s.status)
+		snap := make(map[manifest.NamedResource]StatusInfo, len(s.conditions))
+		for id, conds := range s.conditions {
+			if info, ok := statusInfoFromConditions(conds); ok {
+				snap[id] = info
+			}
+		}
 		s.mu.RUnlock()
 		for id, info := range snap {
 			fn(id, info)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -65,6 +67,59 @@ func TestStore_UpdateStatus_Idempotent(t *testing.T) {
 	info, ok := s.GetStatus(id)
 	if !ok || info.Status != StatusReady {
 		t.Errorf("status: %+v ok=%v", info, ok)
+	}
+}
+
+func TestStore_SetCondition_NonReadyDoesNotFireStatusEvent(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
+	s.UpdateStatus(id, StatusPending, "starting")
+	statusEvents := 0
+	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, _ any) {
+		statusEvents++
+	}, false)
+	// A non-Ready condition should land silently.
+	s.SetCondition(id, Condition{Type: ConditionHealthy, Status: metav1.ConditionTrue, Reason: "Healthy"})
+	if statusEvents != 0 {
+		t.Errorf("non-Ready SetCondition fired StatusUpdated event %d times", statusEvents)
+	}
+	got := s.GetConditions(id)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 conditions, got %d", len(got))
+	}
+}
+
+func TestStore_SetCondition_ReadyFiresStatusEvent(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
+	statusEvents := 0
+	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, payload any) {
+		statusEvents++
+		info, ok := payload.(StatusInfo)
+		if !ok || info.Status != StatusReady {
+			t.Errorf("expected Ready payload, got %+v", payload)
+		}
+	}, false)
+	s.SetCondition(id, Condition{
+		Type: ConditionReady, Status: metav1.ConditionTrue,
+		Reason: ReasonSucceeded, Message: "ok",
+	})
+	if statusEvents != 1 {
+		t.Errorf("Ready SetCondition fired %d events; want 1", statusEvents)
+	}
+}
+
+func TestStore_SetCondition_IdenticalIsNoOp(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
+	statusEvents := 0
+	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, _ any) { statusEvents++ }, false)
+
+	cond := Condition{Type: ConditionReady, Status: metav1.ConditionTrue, Reason: ReasonSucceeded}
+	s.SetCondition(id, cond)
+	s.SetCondition(id, cond)
+	if statusEvents != 1 {
+		t.Errorf("identical SetCondition fired %d events; want 1", statusEvents)
 	}
 }
 

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -163,6 +163,6 @@ func (s *Store) WatchAdded(ctx context.Context, kind string, bufSize int) <-chan
 func (s *Store) String() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return fmt.Sprintf("Store{objects:%d, status:%d, artifacts:%d}",
-		len(s.objects), len(s.status), len(s.artifacts))
+	return fmt.Sprintf("Store{objects:%d, conditions:%d, artifacts:%d}",
+		len(s.objects), len(s.conditions), len(s.artifacts))
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Flux-fidelity push (continued). **Stacked on #27 (\`refactor/controller-base\`).** Merge #26 then #27 then this.

The Store now keeps per-resource conditions internally instead of a flat \`StatusInfo\` struct. This unlocks future work without breaking any current callers — the existing API surface is preserved as a derived-from-Ready rollup.

## Backward compatibility

**Every existing API keeps working exactly as before.** \`Status\`, \`StatusInfo\`, \`UpdateStatus\`, \`GetStatus\`, \`FailedResources\`, \`HasFailedResources\`, the \`EventStatusUpdated\` event payload — none of them change shape. They derive from the Ready condition internally. depwait, change.Filter, controllers, the CLI, and the existing test suite all pass unchanged.

## New API

| Method | Purpose |
|---|---|
| \`Store.SetCondition(id, Condition)\` | Upsert a single condition by \`Type\`. Dispatches \`EventStatusUpdated\` **only when the Ready-derived rollup actually changes** — non-Ready conditions land silently to avoid event spam. |
| \`Store.GetConditions(id)\` | Returns a copy of the resource's full condition list. |

Constants exposed in \`pkg/store\`: \`ConditionReady\`, \`ConditionReconciling\`, \`ConditionHealthy\` (types); \`ReasonSucceeded\`, \`ReasonFailed\`, \`ReasonReconciling\` (Ready reasons).

\`Condition\` is a type alias for \`metav1.Condition\` so interop with the rest of the K8s ecosystem is seamless.

## What this unblocks

Without changing any current code paths, this lets a future PR add:

- **SOPS encrypted-secret detection.** \`SetCondition(..., Type: \"Healthy\", Status: False, Reason: \"DecryptionMissing\")\` without touching Ready. The agent's reconcile-semantics audit flagged that flate silently emits SOPS payloads as if they were rendered manifests; this is the foundation for refusing them like Flux does.
- **Flux \`dependsOn\` ReadyExpr CEL.** Evaluated against the full \`conditions[]\` array — needs the data to be there.
- **ExternalArtifact's \"trust upstream\" contract.** Relay upstream conditions verbatim into the local store.
- **ObservedGeneration tracking.** Ready-but-stale-spec is detectable when callers care.
- **healthCheck rollups.** Per-target conditions aggregated under one Healthy condition.

## Implementation notes

- \`readyCondition(status, message)\` projects (Status, Message) → \`metav1.Condition\` with the right \`Status\`/\`Reason\` mapping.
- \`statusInfoFromConditions\` is the reverse — finds the Ready condition and returns the rollup.
- \`conditionEqual\` ignores \`LastTransitionTime\` for the no-op short-circuit — controller-runtime libraries reset that field on every transition and would otherwise prevent dedup.

## Tests

- \`TestStore_SetCondition_NonReadyDoesNotFireStatusEvent\` — non-Ready condition lands silently.
- \`TestStore_SetCondition_ReadyFiresStatusEvent\` — Ready transition fires StatusUpdated with the right StatusInfo payload.
- \`TestStore_SetCondition_IdenticalIsNoOp\` — same condition twice produces one event.

Existing tests (\`TestStore_UpdateStatus_Idempotent\`, \`TestStore_HasFailedResources\`, the four \`WatchReady\` tests, depwait tests, controller e2e) all pass unchanged — that's the proof the backward-compat layer holds.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)