### PR TITLE
refactor(source): unified SourceArtifact + Fetcher interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/home-operations/flate
 go 1.26.3
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/distribution/reference v0.6.0
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/fluxcd/kustomize-controller/api v1.8.5
@@ -26,7 +27,6 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/home-operations/flate/pkg/image"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -93,6 +96,19 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (*o
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg
 	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path
+
+	// One source.Cache shared across both orchestrators. They write into
+	// the same on-disk cache root; without a shared *Cache each side has
+	// its own mutex, and concurrent first-time clones of the same
+	// (url, ref) slot can race past the mkdir/Readdirnames check and
+	// step on each other.
+	cacheRoot := currentCfg.CacheDir
+	if cacheRoot == "" {
+		cacheRoot = filepath.Join(os.TempDir(), "flate-cache")
+	}
+	shared := source.NewCache(filepath.Join(cacheRoot, "sources"))
+	currentCfg.SourceCache = shared
+	origCfg.SourceCache = shared
 
 	var orig, current *orchestrator.Orchestrator
 	g, gctx := errgroup.WithContext(ctx)

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -1,0 +1,53 @@
+// Package base provides the small shared harness that the
+// kustomization, helmrelease, and source controllers wrap around their
+// per-resource reconcile bodies. It centralizes panic attribution
+// (so a panicked reconcile marks the affected resource Failed instead
+// of silently disappearing) and the post-reconcile status transition.
+package base
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// Recover catches a panic from the current goroutine and marks id
+// StatusFailed with a "panic: <r>" message so the orchestrator
+// surfaces it. Intended for use as `defer base.Recover(store, id, "kind")`
+// in controllers that don't go through RunWithStatus (e.g. source
+// fetchers that own their own status writes).
+func Recover(s *store.Store, id manifest.NamedResource, logKind string) {
+	if r := recover(); r != nil {
+		slog.Error(logKind+": panic during reconcile", "id", id.String(), "panic", r)
+		s.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
+	}
+}
+
+// RunWithStatus is the standard reconcile body for controllers that
+// (a) coalesce concurrent submits per-id and (b) want the recover →
+// re-read → run → mark-Ready/Failed pattern. The re-read lets a
+// coalesced re-run pick up patches a parent KS installed mid-flight
+// rather than the stale payload from the original event. A missing
+// object (deleted between coalescer enqueue and run) is treated as a
+// no-op rather than a failure.
+func RunWithStatus[T manifest.BaseManifest](
+	ctx context.Context,
+	s *store.Store,
+	id manifest.NamedResource,
+	logKind string,
+	fn func(context.Context, T) error,
+) {
+	defer Recover(s, id, logKind)
+	obj, ok := s.GetObject(id).(T)
+	if !ok {
+		return
+	}
+	if err := fn(ctx, obj); err != nil {
+		s.UpdateStatus(id, store.StatusFailed, err.Error())
+		return
+	}
+	s.UpdateStatus(id, store.StatusReady, "")
+}

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -1,0 +1,91 @@
+package base_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/controllers/base"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func TestRunWithStatus_Success(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			if obj.Name != "app" {
+				t.Errorf("re-read got %q, want app", obj.Name)
+			}
+			return nil
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusReady {
+		t.Errorf("status = %v, want Ready", got.Status)
+	}
+}
+
+func TestRunWithStatus_Failure(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			return errors.New("render failed")
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusFailed {
+		t.Errorf("status = %v, want Failed", got.Status)
+	}
+	if got.Message != "render failed" {
+		t.Errorf("message = %q, want %q", got.Message, "render failed")
+	}
+}
+
+func TestRunWithStatus_Panic(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	// Panic must be caught and converted into StatusFailed; no re-panic.
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			panic("kaboom")
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusFailed {
+		t.Errorf("status = %v, want Failed", got.Status)
+	}
+	if !strings.Contains(got.Message, "panic:") || !strings.Contains(got.Message, "kaboom") {
+		t.Errorf("message = %q, want a 'panic: kaboom' summary", got.Message)
+	}
+}
+
+func TestRunWithStatus_MissingObject(t *testing.T) {
+	s := store.New()
+	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "ghost"}
+	called := false
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(ctx context.Context, obj *manifest.HelmRelease) error {
+			called = true
+			return nil
+		},
+	)
+	if called {
+		t.Error("fn ran for a missing object; expected silent no-op")
+	}
+	if _, ok := s.GetStatus(id); ok {
+		t.Error("missing object should not get a status entry")
+	}
+}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -97,23 +98,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				return
 			}
 			c.coal.Submit(ctx, "helmrelease/"+id.String(), id, func(ctx context.Context) {
-				defer func() {
-					if r := recover(); r != nil {
-						slog.Error("helmrelease: panic during reconcile", "id", id.String(), "panic", r)
-						c.Store.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
-					}
-				}()
-				// Re-read each iteration so a coalesced re-run picks up
-				// a parent KS's patches rather than the stale payload.
-				hr, _ := c.Store.GetObject(id).(*manifest.HelmRelease)
-				if hr == nil {
-					return
-				}
-				if err := c.reconcile(ctx, hr); err != nil {
-					c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
-					return
-				}
-				c.Store.UpdateStatus(id, store.StatusReady, "")
+				base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
 			})
 		}
 	}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"strings"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -83,7 +84,12 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				c.chartSourcesMu.Unlock()
 			}
 		case manifest.KindHelmRelease:
-			if _, ok := payload.(*manifest.HelmRelease); !ok {
+			hr, ok := payload.(*manifest.HelmRelease)
+			if !ok {
+				return
+			}
+			if hr.Suspend {
+				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 				return
 			}
 			if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {
@@ -133,6 +139,22 @@ func (c *Controller) onArtifactUpdated(id manifest.NamedResource, payload any) {
 
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {
 	id := hr.Named()
+
+	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
+	// each dependency reaching Ready before this HR reconciles.
+	if deps := c.collectHRDeps(hr); len(deps) > 0 {
+		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
+		w := &depwait.Waiter{Store: c.Store, Parent: id}
+		sum := depwait.WaitAll(w.Watch(ctx, deps))
+		if sum.AnyFailed() {
+			var msgs []string
+			for _, f := range sum.Failed {
+				msgs = append(msgs, f.String()+": "+sum.Messages[f])
+			}
+			return fmt.Errorf("dependencies failed: %s", strings.Join(msgs, "; "))
+		}
+	}
+
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
 
 	// Resolve chartRef if applicable.
@@ -182,6 +204,26 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		Values:    hr.Values,
 	})
 	return nil
+}
+
+// collectHRDeps converts hr.DependsOn ("namespace/name" entries) into
+// NamedResources for the depwait Waiter. dependsOn on a HelmRelease
+// references other HelmReleases only (per Flux spec).
+func (c *Controller) collectHRDeps(hr *manifest.HelmRelease) []manifest.NamedResource {
+	if len(hr.DependsOn) == 0 {
+		return nil
+	}
+	out := make([]manifest.NamedResource, 0, len(hr.DependsOn))
+	for _, dep := range hr.DependsOn {
+		ns, name, ok := manifest.SplitNamespacedName(dep, hr.Namespace)
+		if !ok {
+			continue
+		}
+		out = append(out, manifest.NamedResource{
+			Kind: manifest.KindHelmRelease, Namespace: ns, Name: name,
+		})
+	}
+	return out
 }
 
 // gatherHelmChartSources returns a snapshot of the HelmChart lookup

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -111,8 +111,8 @@ func (c *Controller) onArtifactUpdated(id manifest.NamedResource, payload any) {
 	if id.Kind != manifest.KindGitRepository {
 		return
 	}
-	gitArt, ok := payload.(*store.GitArtifact)
-	if !ok {
+	gitArt, ok := payload.(*store.SourceArtifact)
+	if !ok || gitArt.Kind != manifest.KindGitRepository {
 		return
 	}
 	repo, _ := c.Store.GetObject(id).(*manifest.GitRepository)

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -63,7 +63,12 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if id.Kind != manifest.KindKustomization {
 			return
 		}
-		if _, ok := payload.(*manifest.Kustomization); !ok {
+		ks, ok := payload.(*manifest.Kustomization)
+		if !ok {
+			return
+		}
+		if ks.Suspend {
+			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 			return
 		}
 		if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -191,11 +191,8 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 	if art == nil {
 		return "", fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())
 	}
-	switch a := art.(type) {
-	case *store.GitArtifact:
-		return a.LocalPath, nil
-	case *store.OCIArtifact:
-		return a.LocalPath, nil
+	if sa, ok := art.(*store.SourceArtifact); ok {
+		return sa.LocalPath, nil
 	}
 	return "", fmt.Errorf("unsupported source artifact type %T for %s", art, srcID.String())
 }

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -76,24 +77,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			return
 		}
 		c.coal.Submit(ctx, "kustomization/"+id.String(), id, func(ctx context.Context) {
-			defer func() {
-				if r := recover(); r != nil {
-					slog.Error("kustomization: panic during reconcile", "id", id.String(), "panic", r)
-					c.Store.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
-				}
-			}()
-			// Re-read the spec each iteration so a coalesced re-run
-			// picks up patches a parent KS installed mid-flight rather
-			// than the stale payload from the original event.
-			ks, _ := c.Store.GetObject(id).(*manifest.Kustomization)
-			if ks == nil {
-				return
-			}
-			if err := c.reconcile(ctx, ks); err != nil {
-				c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
-				return
-			}
-			c.Store.UpdateStatus(id, store.StatusReady, "")
+			base.RunWithStatus(ctx, c.Store, id, "kustomization", c.reconcile)
 		})
 	}
 }

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -59,6 +59,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			if !ok {
 				return
 			}
+			if repo.Suspend {
+				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+				return
+			}
 			if c.skip(id) {
 				return
 			}
@@ -72,6 +76,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			}
 			repo, ok := payload.(*manifest.OCIRepository)
 			if !ok {
+				return
+			}
+			if repo.Suspend {
+				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 				return
 			}
 			if c.skip(id) {

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -6,10 +6,10 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	src "github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
@@ -67,7 +67,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				return
 			}
 			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer c.recoverPanic(id)
+				defer base.Recover(c.Store, id, "source")
 				c.reconcileGit(ctx, id, repo)
 			})
 		case manifest.KindOCIRepository:
@@ -86,17 +86,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				return
 			}
 			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer c.recoverPanic(id)
+				defer base.Recover(c.Store, id, "source")
 				c.reconcileOCI(ctx, id, repo)
 			})
 		}
-	}
-}
-
-func (c *Controller) recoverPanic(id manifest.NamedResource) {
-	if r := recover(); r != nil {
-		slog.Error("source: panic during reconcile", "id", id.String(), "panic", r)
-		c.Store.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
 	}
 }
 

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -1,7 +1,12 @@
 // Package source reconciles Flux source CRs (GitRepository,
-// OCIRepository) into on-disk artifacts via the pkg/source SDK adapter,
-// then publishes the result to the Store. It mirrors
+// OCIRepository, future: Bucket, ExternalArtifact, …) into on-disk
+// artifacts via per-kind Fetcher implementations from pkg/source, then
+// publishes the result to the Store. Mirrors
 // pkg/controllers/{kustomization,helmrelease}.
+//
+// The controller does not know about individual source kinds — it
+// dispatches via the Fetchers map keyed by id.Kind, so adding a new
+// kind is a one-line registration at orchestrator-construction time.
 package source
 
 import (
@@ -16,21 +21,21 @@ import (
 	"github.com/home-operations/flate/pkg/task"
 )
 
-// Controller watches the Store for GitRepository and OCIRepository
-// objects, reconciles each into an on-disk artifact, and updates the
+// Controller watches the Store for source-kind objects, fetches each
+// into an on-disk artifact via the matching Fetcher, and updates the
 // Store with the result.
 type Controller struct {
-	Store          *store.Store
-	Tasks          *task.Service
-	Cache          *src.Cache
-	RegistryConfig string
+	Store *store.Store
+	Tasks *task.Service
 	// Filter, when non-nil and enabled, narrows fetches to only
 	// sources referenced by changed resources.
 	Filter *change.Filter
 
-	// EnableOCI controls whether OCIRepository reconciliation is active.
-	// The upstream Python defaults to off so behavior matches.
-	EnableOCI bool
+	// Fetchers maps source CR kind → Fetcher implementation. Source
+	// kinds with no entry are ignored, which is also how a flate caller
+	// disables a kind (e.g. EnableOCI=false simply omits OCIRepository
+	// from the map).
+	Fetchers map[string]src.Fetcher
 
 	unsubscribers []store.Unsubscribe
 }
@@ -53,43 +58,25 @@ func (c *Controller) Close() {
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	return func(id manifest.NamedResource, payload any) {
-		switch id.Kind {
-		case manifest.KindGitRepository:
-			repo, ok := payload.(*manifest.GitRepository)
-			if !ok {
-				return
-			}
-			if repo.Suspend {
-				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
-				return
-			}
-			if c.skip(id) {
-				return
-			}
-			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer base.Recover(c.Store, id, "source")
-				c.reconcileGit(ctx, id, repo)
-			})
-		case manifest.KindOCIRepository:
-			if !c.EnableOCI {
-				return
-			}
-			repo, ok := payload.(*manifest.OCIRepository)
-			if !ok {
-				return
-			}
-			if repo.Suspend {
-				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
-				return
-			}
-			if c.skip(id) {
-				return
-			}
-			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer base.Recover(c.Store, id, "source")
-				c.reconcileOCI(ctx, id, repo)
-			})
+		fetcher, registered := c.Fetchers[id.Kind]
+		if !registered {
+			return
 		}
+		obj, ok := payload.(manifest.BaseManifest)
+		if !ok {
+			return
+		}
+		if sus, ok := obj.(src.Suspendable); ok && sus.Suspended() {
+			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+			return
+		}
+		if c.skip(id) {
+			return
+		}
+		c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
+			defer base.Recover(c.Store, id, "source")
+			c.runFetch(ctx, id, obj, fetcher)
+		})
 	}
 }
 
@@ -106,30 +93,17 @@ func (c *Controller) skip(id manifest.NamedResource) bool {
 	return true
 }
 
-func (c *Controller) reconcileGit(ctx context.Context, id manifest.NamedResource, repo *manifest.GitRepository) {
+// runFetch invokes the registered Fetcher and translates the result
+// into Store status + artifact writes. Generic over kind: the only
+// per-kind decision (which Fetcher to call) was made above.
+func (c *Controller) runFetch(ctx context.Context, id manifest.NamedResource, obj manifest.BaseManifest, fetcher src.Fetcher) {
 	c.Store.UpdateStatus(id, store.StatusPending, "fetching")
 	if art := c.Store.GetArtifact(id); art != nil {
 		c.Store.UpdateStatus(id, store.StatusReady, "")
 		return
 	}
-	slog.Debug("source: git fetch", "id", id.String(), "url", repo.URL)
-	artifact, err := src.FetchGit(ctx, c.Cache, repo)
-	if err != nil {
-		c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
-		return
-	}
-	c.Store.SetArtifact(id, artifact)
-	c.Store.UpdateStatus(id, store.StatusReady, "")
-}
-
-func (c *Controller) reconcileOCI(ctx context.Context, id manifest.NamedResource, repo *manifest.OCIRepository) {
-	c.Store.UpdateStatus(id, store.StatusPending, "fetching")
-	if art := c.Store.GetArtifact(id); art != nil {
-		c.Store.UpdateStatus(id, store.StatusReady, "")
-		return
-	}
-	slog.Debug("source: oci fetch", "id", id.String(), "url", repo.URL)
-	artifact, err := src.FetchOCI(ctx, c.Cache, repo, c.RegistryConfig)
+	slog.Debug("source: fetch", "id", id.String())
+	artifact, err := fetcher.Fetch(ctx, obj)
 	if err != nil {
 		c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
 		return

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -21,7 +21,7 @@ import (
 // resolve charts whose sourceRef.kind is GitRepository.
 type LocalGitRepository struct {
 	Repo     *manifest.GitRepository
-	Artifact *store.GitArtifact
+	Artifact *store.SourceArtifact
 }
 
 // RepoName mirrors HelmRepository.RepoName for convenience in lookups.

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -35,7 +35,7 @@ data:
 			Name: "chart-repo", Namespace: "flux-system",
 			URL: "file://" + dir,
 		},
-		Artifact: &store.GitArtifact{URL: "file://" + dir, LocalPath: dir},
+		Artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
 	})
 
 	hr := &manifest.HelmRelease{

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -7,16 +7,19 @@ import (
 	"strings"
 
 	"helm.sh/helm/v4/pkg/action"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/common"
 	"helm.sh/helm/v4/pkg/cli"
 	release "helm.sh/helm/v4/pkg/release/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/values"
 )
 
 // Template renders a HelmRelease and returns the rendered manifest as a
 // single YAML string (multiple documents separated by "---" lines).
-func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, values map[string]any, opts Options) (string, error) {
+func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValues map[string]any, opts Options) (string, error) {
 	loaded, err := c.LoadChart(ctx, hr)
 	if err != nil {
 		return "", err
@@ -53,15 +56,27 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, values 
 		}
 		inst.KubeVersion = kv
 	}
-	if values == nil {
-		values = map[string]any{}
+	if hrValues == nil {
+		hrValues = map[string]any{}
 	}
 
 	if hr.Chart.Version != "" {
 		inst.Version = hr.Chart.Version
 	}
 
-	rel, err := inst.RunWithContext(ctx, loaded.Chart, values)
+	// Apply chart valuesFiles BEFORE HR.Values so HR overrides win.
+	// Mirrors helm-controller's CoalesceValues layering: chart defaults
+	// (handled internally by helm) → chart-named valuesFiles → HR.Values.
+	finalValues := hrValues
+	if len(hr.ChartValuesFiles) > 0 {
+		base, err := mergeChartValuesFiles(loaded.Chart, hr.ChartValuesFiles, hr.IgnoreMissingValuesFiles)
+		if err != nil {
+			return "", fmt.Errorf("helm chart valuesFiles %s/%s: %w", hr.Namespace, hr.Name, err)
+		}
+		finalValues = values.DeepMerge(base, hrValues)
+	}
+
+	rel, err := inst.RunWithContext(ctx, loaded.Chart, finalValues)
 	if err != nil {
 		return "", fmt.Errorf("helm template %s/%s: %w", hr.Namespace, hr.Name, err)
 	}
@@ -71,6 +86,36 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, values 
 	}
 
 	return releaseManifest(relV1, opts), nil
+}
+
+// mergeChartValuesFiles merges the named values files (relative paths
+// inside the chart archive) in the supplied order. Missing files are
+// skipped when ignoreMissing is true; otherwise the first missing file
+// is an error. Mirrors helm-controller's chartutil layering: each file
+// is merged on top of the previous one.
+func mergeChartValuesFiles(c *chart.Chart, names []string, ignoreMissing bool) (map[string]any, error) {
+	out := map[string]any{}
+	for _, name := range names {
+		var data []byte
+		for _, f := range c.Files {
+			if f != nil && f.Name == name {
+				data = f.Data
+				break
+			}
+		}
+		if data == nil {
+			if ignoreMissing {
+				continue
+			}
+			return nil, fmt.Errorf("values file %q not found in chart", name)
+		}
+		var m map[string]any
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			return nil, fmt.Errorf("parse values file %q: %w", name, err)
+		}
+		out = values.DeepMerge(out, m)
+	}
+	return out, nil
 }
 
 // TemplateDocs renders and returns each document parsed as a generic map.

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -97,13 +97,16 @@ func HelmChartFromSource(src *HelmChartSource) HelmChart {
 // HelmChartSource is the standalone HelmChart CRD
 // (source.toolkit.fluxcd.io/v1 HelmChart).
 type HelmChartSource struct {
-	Name          string `json:"name" yaml:"name"`
-	Namespace     string `json:"namespace" yaml:"namespace"`
-	Chart         string `json:"chart" yaml:"chart"`
-	Version       string `json:"version,omitempty" yaml:"version,omitempty"`
-	RepoName      string `json:"repoName" yaml:"repoName"`
-	RepoNamespace string `json:"repoNamespace" yaml:"repoNamespace"`
-	RepoKind      string `json:"repoKind" yaml:"repoKind"`
+	Name                     string   `json:"name" yaml:"name"`
+	Namespace                string   `json:"namespace" yaml:"namespace"`
+	Chart                    string   `json:"chart" yaml:"chart"`
+	Version                  string   `json:"version,omitempty" yaml:"version,omitempty"`
+	RepoName                 string   `json:"repoName" yaml:"repoName"`
+	RepoNamespace            string   `json:"repoNamespace" yaml:"repoNamespace"`
+	RepoKind                 string   `json:"repoKind" yaml:"repoKind"`
+	Suspend                  bool     `json:"-" yaml:"-"`
+	ValuesFiles              []string `json:"-" yaml:"-"`
+	IgnoreMissingValuesFiles bool     `json:"-" yaml:"-"`
 }
 
 // Named identifies the chart resource.
@@ -144,13 +147,16 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 		repoKind = KindHelmRepository
 	}
 	return &HelmChartSource{
-		Name:          cr.Name,
-		Namespace:     ns,
-		Chart:         cr.Spec.Chart,
-		Version:       cr.Spec.Version,
-		RepoName:      cr.Spec.SourceRef.Name,
-		RepoNamespace: ns,
-		RepoKind:      repoKind,
+		Name:                     cr.Name,
+		Namespace:                ns,
+		Chart:                    cr.Spec.Chart,
+		Version:                  cr.Spec.Version,
+		RepoName:                 cr.Spec.SourceRef.Name,
+		RepoNamespace:            ns,
+		RepoKind:                 repoKind,
+		Suspend:                  cr.Spec.Suspend,
+		ValuesFiles:              cr.Spec.ValuesFiles,
+		IgnoreMissingValuesFiles: cr.Spec.IgnoreMissingValuesFiles,
 	}, nil
 }
 
@@ -187,8 +193,19 @@ type HelmRelease struct {
 	ValuesFrom               []ValuesReference `json:"-" yaml:"-"`
 	Images                   []string          `json:"images,omitempty" yaml:"images,omitempty"`
 	Labels                   map[string]string `json:"-" yaml:"-"`
+	DependsOn                []string          `json:"-" yaml:"-"`
+	Suspend                  bool              `json:"-" yaml:"-"`
 	DisableSchemaValidation  bool              `json:"-" yaml:"-"`
 	DisableOpenAPIValidation bool              `json:"-" yaml:"-"`
+	// ChartValuesFiles are values files baked into the chart that
+	// should be merged BEFORE the HR's own Values overrides. Sourced
+	// from either spec.chart.spec.valuesFiles (inline template) or the
+	// referenced HelmChart CRD's spec.valuesFiles (when chartRef is
+	// used; populated by ResolveChartRef).
+	ChartValuesFiles []string `json:"-" yaml:"-"`
+	// IgnoreMissingValuesFiles: when true, missing ChartValuesFiles
+	// entries are skipped instead of erroring.
+	IgnoreMissingValuesFiles bool `json:"-" yaml:"-"`
 }
 
 // Named identifies the release.
@@ -234,6 +251,9 @@ func (h *HelmRelease) ResourceDependencies() []NamedResource {
 
 // ResolveChartRef replaces a chartRef placeholder with the resolved source
 // when version was not pinned. helmCharts is keyed by ResourceFullName.
+// When the chartRef resolves to a HelmChart CRD, its spec.valuesFiles +
+// spec.ignoreMissingValuesFiles propagate onto the HelmRelease so the
+// rendering pipeline can merge them ahead of HR.Values.
 func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) error {
 	if h.Chart.RepoKind != KindHelmChart || h.Chart.Version != "" {
 		return nil
@@ -245,6 +265,10 @@ func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) er
 	}
 	if src.Version != "" {
 		h.Chart = HelmChartFromSource(src)
+	}
+	if len(src.ValuesFiles) > 0 {
+		h.ChartValuesFiles = src.ValuesFiles
+		h.IgnoreMissingValuesFiles = src.IgnoreMissingValuesFiles
 	}
 	return nil
 }
@@ -290,6 +314,27 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		(cr.Spec.Upgrade != nil && cr.Spec.Upgrade.DisableSchemaValidation)
 	disableOpenAPI := (cr.Spec.Install != nil && cr.Spec.Install.DisableOpenAPIValidation) ||
 		(cr.Spec.Upgrade != nil && cr.Spec.Upgrade.DisableOpenAPIValidation)
+	var dependsOn []string
+	for _, dep := range cr.Spec.DependsOn {
+		if dep.Name == "" {
+			return nil, inputf("HelmRelease missing dependsOn.name")
+		}
+		depNS := dep.Namespace
+		if depNS == "" {
+			depNS = cr.Namespace
+		}
+		dependsOn = append(dependsOn, depNS+"/"+dep.Name)
+	}
+	// spec.chart.spec.valuesFiles (inline template). spec.chartRef
+	// case is handled later by ResolveChartRef once HelmChartSource is
+	// available in the store.
+	var chartValuesFiles []string
+	var ignoreMissingValuesFiles bool
+	if cr.Spec.Chart != nil {
+		chartValuesFiles = cr.Spec.Chart.Spec.ValuesFiles
+		ignoreMissingValuesFiles = cr.Spec.Chart.Spec.IgnoreMissingValuesFiles
+	}
+
 	return &HelmRelease{
 		Name:                     cr.Name,
 		Namespace:                cr.Namespace,
@@ -298,8 +343,12 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		Values:                   values,
 		ValuesFrom:               vfs,
 		Labels:                   cr.Labels,
+		DependsOn:                dependsOn,
+		Suspend:                  cr.Spec.Suspend,
 		DisableSchemaValidation:  disableSchema,
 		DisableOpenAPIValidation: disableOpenAPI,
+		ChartValuesFiles:         chartValuesFiles,
+		IgnoreMissingValuesFiles: ignoreMissingValuesFiles,
 	}, nil
 }
 
@@ -310,6 +359,7 @@ type HelmRepository struct {
 	URL       string `json:"url" yaml:"url"`
 	// RepoType is "default" or "oci".
 	RepoType string `json:"repoType,omitempty" yaml:"repoType,omitempty"`
+	Suspend  bool   `json:"-" yaml:"-"`
 }
 
 // Named identifies the repo.
@@ -354,5 +404,6 @@ func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
 		RepoType:  repoType,
+		Suspend:   cr.Spec.Suspend,
 	}, nil
 }

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -45,6 +45,8 @@ type Kustomization struct {
 	// Components is Flux v1's spec.components — paths to kustomize
 	// components injected on top of spec.path at reconcile time.
 	Components []string `json:"-" yaml:"-"`
+	// Suspend mirrors spec.suspend — controllers skip suspended objects.
+	Suspend bool `json:"-" yaml:"-"`
 
 	Images []string `json:"images,omitempty" yaml:"images,omitempty"`
 }
@@ -178,5 +180,6 @@ func ParseKustomization(doc map[string]any) (*Kustomization, error) {
 		DependsOn:               dependsOn,
 		Labels:                  cr.Labels,
 		Components:              cr.Spec.Components,
+		Suspend:                 cr.Spec.Suspend,
 	}, nil
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -43,6 +43,73 @@ func TestNamedResource(t *testing.T) {
 	}
 }
 
+func TestParseHelmRelease_Suspend(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  suspend: true
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	hr, err := ParseHelmRelease(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmRelease: %v", err)
+	}
+	if !hr.Suspend {
+		t.Errorf("expected Suspend=true; got false")
+	}
+}
+
+func TestParseKustomization_Suspend(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: ks, namespace: ns}
+spec:
+  suspend: true
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: src, namespace: ns}
+  interval: 5m
+`)
+	ks, err := ParseKustomization(doc)
+	if err != nil {
+		t.Fatalf("ParseKustomization: %v", err)
+	}
+	if !ks.Suspend {
+		t.Errorf("expected Suspend=true; got false")
+	}
+}
+
+func TestParseHelmRelease_DependsOn(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  dependsOn:
+    - name: other
+    - {name: cross, namespace: other-ns}
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	hr, err := ParseHelmRelease(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmRelease: %v", err)
+	}
+	if got, want := len(hr.DependsOn), 2; got != want {
+		t.Fatalf("DependsOn len = %d, want %d", got, want)
+	}
+	if hr.DependsOn[0] != "ns/other" {
+		t.Errorf("DependsOn[0] = %q, want ns/other", hr.DependsOn[0])
+	}
+}
+
 func TestParseHelmRelease_Inline(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -37,6 +37,7 @@ type GitRepository struct {
 	Namespace string           `json:"namespace" yaml:"namespace"`
 	URL       string           `json:"url" yaml:"url"`
 	Ref       GitRepositoryRef `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Suspend   bool             `json:"-" yaml:"-"`
 }
 
 // Named identifies the GitRepository.
@@ -78,6 +79,7 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
 		Ref:       ref,
+		Suspend:   cr.Spec.Suspend,
 	}, nil
 }
 
@@ -99,6 +101,7 @@ type OCIRepository struct {
 	URL       string                `json:"url" yaml:"url"`
 	Ref       OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	Suspend   bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the OCIRepository.
@@ -109,14 +112,12 @@ func (o *OCIRepository) Named() NamedResource {
 // RepoName is "<namespace>-<name>".
 func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }
 
-// Version returns the digest, tag, or semver in that order. semverFilter
-// is not supported and will return an error.
+// Version returns the digest, tag, or semver expression in that order.
+// A semver expression is returned verbatim — callers wanting a concrete
+// tag must resolve it against remote tag listing (pkg/source).
 func (o *OCIRepository) Version() (string, error) {
 	if o.Ref.IsEmpty() {
 		return "", nil
-	}
-	if o.Ref.SemverFilter != "" {
-		return "", inputf("OCIRepository semverFilter is not supported")
 	}
 	switch {
 	case o.Ref.Digest != "":
@@ -165,6 +166,7 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		Name:      cr.Name,
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
+		Suspend:   cr.Spec.Suspend,
 	}
 	if r := cr.Spec.Reference; r != nil {
 		out.Ref = OCIRepositoryRef{

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -45,6 +45,9 @@ func (g *GitRepository) Named() NamedResource {
 	return NamedResource{Kind: KindGitRepository, Namespace: g.Namespace, Name: g.Name}
 }
 
+// Suspended reports whether reconciliation is paused on this resource.
+func (g *GitRepository) Suspended() bool { return g.Suspend }
+
 // RepoName is "<namespace>-<name>".
 func (g *GitRepository) RepoName() string { return g.Namespace + "-" + g.Name }
 
@@ -108,6 +111,9 @@ type OCIRepository struct {
 func (o *OCIRepository) Named() NamedResource {
 	return NamedResource{Kind: KindOCIRepository, Namespace: o.Namespace, Name: o.Name}
 }
+
+// Suspended reports whether reconciliation is paused on this resource.
+func (o *OCIRepository) Suspended() bool { return o.Suspend }
 
 // RepoName is "<namespace>-<name>".
 func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -102,16 +102,23 @@ func New(cfg Config) (*Orchestrator, error) {
 
 	st := store.New()
 	ts := task.New()
+	cache := cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources")))
+	fetchers := map[string]source.Fetcher{
+		manifest.KindGitRepository: &source.GitFetcher{Cache: cache},
+	}
+	if cfg.EnableOCI {
+		fetchers[manifest.KindOCIRepository] = &source.OCIFetcher{
+			Cache: cache, RegistryConfig: cfg.RegistryConfig,
+		}
+	}
 	o := &Orchestrator{
 		cfg:   cfg,
 		store: st,
 		tasks: ts,
 		src: &sourcectrl.Controller{
-			Store:          st,
-			Tasks:          ts,
-			Cache:          cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources"))),
-			RegistryConfig: cfg.RegistryConfig,
-			EnableOCI:      cfg.EnableOCI,
+			Store:    st,
+			Tasks:    ts,
+			Fetchers: fetchers,
 		},
 		ksc:     &kustomization.Controller{Store: st, Tasks: ts, Staging: staging, WipeSecrets: cfg.WipeSecrets},
 		hrc:     &helmrelease.Controller{Store: st, Tasks: ts, Helm: helmClient, Options: cfg.HelmOptions, WipeSecrets: cfg.WipeSecrets},
@@ -162,7 +169,10 @@ func (o *Orchestrator) seedBootstrapSource() (string, error) {
 	}
 	id := repo.Named()
 	o.store.AddObject(repo)
-	o.store.SetArtifact(id, &store.GitArtifact{URL: repo.URL, LocalPath: root})
+	o.store.SetArtifact(id, &store.SourceArtifact{
+		Kind: manifest.KindGitRepository,
+		URL:  repo.URL, LocalPath: root,
+	})
 	o.store.UpdateStatus(id, store.StatusReady, "bootstrap")
 	return root, nil
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log/slog"
@@ -44,6 +45,13 @@ type Config struct {
 	// CacheDir overrides the default on-disk cache root
 	// (os.TempDir()/flate-cache).
 	CacheDir string
+	// SourceCache, when non-nil, is shared across orchestrators. The
+	// `flate diff` flow constructs two orchestrators that point at the
+	// same on-disk source-cache root; they MUST share one *Cache so the
+	// internal mutex serializes concurrent slot allocation. When nil a
+	// per-orchestrator cache is constructed (fine for single-orchestrator
+	// commands like `build` / `get`).
+	SourceCache *source.Cache
 	// ExternalChanges, when non-nil, supplies the file-level diff so
 	// the orchestrator skips its built-in change.Detect step. The
 	// filter is still built from this set + the loaded SourceFiles
@@ -101,7 +109,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		src: &sourcectrl.Controller{
 			Store:          st,
 			Tasks:          ts,
-			Cache:          source.NewCache(filepath.Join(cacheRoot, "sources")),
+			Cache:          cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources"))),
 			RegistryConfig: cfg.RegistryConfig,
 			EnableOCI:      cfg.EnableOCI,
 		},

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -14,14 +14,30 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// GitFetcher is the Fetcher implementation for KindGitRepository.
+// It owns a shared Cache so multiple GitRepository CRs writing to the
+// same cache root serialize on slot allocation correctly.
+type GitFetcher struct {
+	Cache *Cache
+}
+
+// Fetch implements source.Fetcher for *manifest.GitRepository.
+func (f *GitFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+	repo, ok := obj.(*manifest.GitRepository)
+	if !ok {
+		return nil, fmt.Errorf("%w: GitFetcher: unexpected payload %T", manifest.ErrInput, obj)
+	}
+	return FetchGit(ctx, f.Cache, repo)
+}
+
 // FetchGit clones the GitRepository referenced by repo into the supplied
-// cache and returns a populated *store.GitArtifact. If a usable cached
+// cache and returns a populated *store.SourceArtifact. If a usable cached
 // copy already exists, it is reused.
 //
 // Supported transports: public HTTPS, ssh-with-agent (handled by go-git
 // transparently), and file:// URLs. Per-host credential lookups via a
 // Secret reference will be added when a use case demands it.
-func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (*store.GitArtifact, error) {
+func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}
@@ -43,8 +59,9 @@ func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (
 		// Validate it's a usable repo before reusing.
 		if _, err := git.PlainOpen(slot); err == nil {
 			rev, _ := readResolvedRevision(slot)
-			return &store.GitArtifact{
-				URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Revision: rev,
+			return &store.SourceArtifact{
+				Kind: manifest.KindGitRepository,
+				URL:  repo.URL, LocalPath: slot, Revision: rev,
 			}, nil
 		}
 		// Stale slot — wipe and re-clone.
@@ -72,8 +89,9 @@ func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (
 	}
 
 	rev, _ := readResolvedRevision(slot)
-	return &store.GitArtifact{
-		URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Revision: rev,
+	return &store.SourceArtifact{
+		Kind: manifest.KindGitRepository,
+		URL:  repo.URL, LocalPath: slot, Revision: rev,
 	}, nil
 }
 

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"oras.land/oras-go/v2"
 	orasfile "oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
@@ -20,7 +23,9 @@ import (
 
 // FetchOCI pulls the OCIRepository artifact into cache. Credentials are
 // read from a docker-style config.json honored by oras-go's
-// credentials.NewFileStore.
+// credentials.NewFileStore. When spec.ref.semver is set, the registry
+// is listed and the highest matching tag (filtered by semverFilter, if
+// any) is resolved before pulling.
 func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.OCIArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
@@ -29,38 +34,43 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("%w: OCIRepository %s missing url", manifest.ErrInput, repo.RepoName())
 	}
 
-	versioned := repo.VersionedURL()
+	reference, err := parseOCIRef("oci://" + strings.TrimPrefix(repo.URL, "oci://"))
+	if err != nil {
+		return nil, err
+	}
+	repoClient, err := remote.NewRepository(reference)
+	if err != nil {
+		return nil, fmt.Errorf("oras: %w", err)
+	}
+	credStore, err := loadCredentials(registryConfig)
+	if err != nil {
+		return nil, err
+	}
+	if credStore != nil {
+		repoClient.Client = &auth.Client{Credential: credentials.Credential(credStore)}
+	}
+
+	// Resolve spec.ref into a concrete (tag-or-digest) BEFORE choosing
+	// the cache slot, so different semver matches don't share a slot.
+	ref := repo.Ref
+	if ref.Semver != "" {
+		resolved, err := resolveOCISemver(ctx, repoClient, ref.Semver, ref.SemverFilter)
+		if err != nil {
+			return nil, fmt.Errorf("OCIRepository %s semver: %w", repo.RepoName(), err)
+		}
+		ref = manifest.OCIRepositoryRef{Tag: resolved}
+	}
+
+	versioned := versionedURL(repo.URL, ref)
 	slot, exists, err := cache.Slot(versioned, "")
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
 	if exists {
-		return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Digest: repo.Ref.Digest}, nil
+		return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: ref.Digest}, nil
 	}
 
-	reference, err := parseOCIRef(versioned)
-	if err != nil {
-		_ = cache.Reset(slot)
-		return nil, err
-	}
-
-	repoClient, err := remote.NewRepository(reference)
-	if err != nil {
-		_ = cache.Reset(slot)
-		return nil, fmt.Errorf("oras: %w", err)
-	}
-
-	credStore, err := loadCredentials(registryConfig)
-	if err != nil {
-		_ = cache.Reset(slot)
-		return nil, err
-	}
-	if credStore != nil {
-		client := &auth.Client{Credential: credentials.Credential(credStore)}
-		repoClient.Client = client
-	}
-
-	tag := versionTag(repo.Ref)
+	tag := versionTag(ref)
 	if tag == "" {
 		tag = "latest"
 	}
@@ -77,7 +87,68 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
-	return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Digest: desc.Digest.String()}, nil
+	return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: desc.Digest.String()}, nil
+}
+
+// versionedURL composes a Flux-style versioned URL from a base + ref.
+// Used here for cache-slot keying after semver resolution.
+func versionedURL(base string, ref manifest.OCIRepositoryRef) string {
+	switch {
+	case ref.Digest != "":
+		return base + "@" + ref.Digest
+	case ref.Tag != "":
+		return base + ":" + ref.Tag
+	}
+	return base
+}
+
+// resolveOCISemver lists the remote tags, applies an optional regex
+// filter, then returns the highest tag matching the semver constraint.
+// Mirrors source-controller's `getTagBySemver` (ocirepository_controller.go).
+func resolveOCISemver(ctx context.Context, repoClient *remote.Repository, expr, filterPattern string) (string, error) {
+	constraint, err := semver.NewConstraint(expr)
+	if err != nil {
+		return "", fmt.Errorf("semver %q: %w", expr, err)
+	}
+	var pattern *regexp.Regexp
+	if filterPattern != "" {
+		pattern, err = regexp.Compile(filterPattern)
+		if err != nil {
+			return "", fmt.Errorf("semverFilter %q: %w", filterPattern, err)
+		}
+	}
+
+	var matching semver.Collection
+	var matchingTags []string
+	err = repoClient.Tags(ctx, "", func(tags []string) error {
+		for _, tag := range tags {
+			if pattern != nil && !pattern.MatchString(tag) {
+				continue
+			}
+			v, perr := semver.NewVersion(tag)
+			if perr != nil {
+				continue
+			}
+			if constraint.Check(v) {
+				matching = append(matching, v)
+				matchingTags = append(matchingTags, tag)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("list tags: %w", err)
+	}
+	if len(matching) == 0 {
+		return "", fmt.Errorf("no tag matched semver %q (filter %q)", expr, filterPattern)
+	}
+	// Highest match wins.
+	idx := make([]int, len(matching))
+	for i := range idx {
+		idx[i] = i
+	}
+	sort.Slice(idx, func(a, b int) bool { return matching[idx[a]].LessThan(matching[idx[b]]) })
+	return matchingTags[idx[len(idx)-1]], nil
 }
 
 // loadCredentials returns a credentials.Store backed by the given config

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -21,12 +21,27 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// OCIFetcher is the Fetcher implementation for KindOCIRepository.
+type OCIFetcher struct {
+	Cache          *Cache
+	RegistryConfig string
+}
+
+// Fetch implements source.Fetcher for *manifest.OCIRepository.
+func (f *OCIFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+	repo, ok := obj.(*manifest.OCIRepository)
+	if !ok {
+		return nil, fmt.Errorf("%w: OCIFetcher: unexpected payload %T", manifest.ErrInput, obj)
+	}
+	return FetchOCI(ctx, f.Cache, repo, f.RegistryConfig)
+}
+
 // FetchOCI pulls the OCIRepository artifact into cache. Credentials are
 // read from a docker-style config.json honored by oras-go's
 // credentials.NewFileStore. When spec.ref.semver is set, the registry
 // is listed and the highest matching tag (filtered by semverFilter, if
 // any) is resolved before pulling.
-func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.OCIArtifact, error) {
+func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
 	}
@@ -67,7 +82,12 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
 	if exists {
-		return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: ref.Digest}, nil
+		return &store.SourceArtifact{
+			Kind: manifest.KindOCIRepository,
+			URL:  repo.URL, LocalPath: slot,
+			Revision: ociRevision(ref, ref.Digest),
+			Digest:   ref.Digest,
+		}, nil
 	}
 
 	tag := versionTag(ref)
@@ -87,7 +107,32 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
-	return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: desc.Digest.String()}, nil
+	digest := desc.Digest.String()
+	return &store.SourceArtifact{
+		Kind: manifest.KindOCIRepository,
+		URL:  repo.URL, LocalPath: slot,
+		Revision: ociRevision(ref, digest),
+		Digest:   digest,
+		Size:     desc.Size,
+	}, nil
+}
+
+// ociRevision composes a Flux-style "<tag>@<digest>" revision string.
+// When tag is empty, falls back to bare digest; when digest is empty,
+// returns just the tag. Matches source-controller's ocirepository
+// revision conventions.
+func ociRevision(ref manifest.OCIRepositoryRef, digest string) string {
+	tag := ref.Tag
+	if tag == "" && ref.Digest == "" {
+		tag = "latest"
+	}
+	switch {
+	case tag != "" && digest != "":
+		return tag + "@" + digest
+	case digest != "":
+		return digest
+	}
+	return tag
 }
 
 // versionedURL composes a Flux-style versioned URL from a base + ref.

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -1,0 +1,39 @@
+// Package source is the SDK adapter for Flux's source-controller CRs.
+// It exposes per-kind Fetcher implementations (one per source type)
+// plus a content-addressed disk Cache that all fetchers write into.
+//
+// Adding a new source kind:
+//
+//  1. Implement source.Fetcher for the new kind in a new file (or
+//     subpackage) under pkg/source.
+//  2. Register the fetcher with the orchestrator at construction time.
+//
+// The source controller (pkg/controllers/source) does not know about
+// individual kinds — it dispatches via the Fetchers map keyed by
+// id.Kind, so adding a new kind is one registration call.
+package source
+
+import (
+	"context"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// Fetcher resolves a single source CR into an on-disk artifact. Each
+// kind (GitRepository, OCIRepository, Bucket, …) provides its own
+// implementation; the source controller dispatches by id.Kind.
+//
+// obj is the typed manifest payload (e.g. *manifest.GitRepository).
+// Implementations type-assert and return an InputError on mismatch
+// rather than panic.
+type Fetcher interface {
+	Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error)
+}
+
+// Suspendable is satisfied by source CR types that carry a
+// spec.suspend bool. The source controller short-circuits suspended
+// objects before invoking the Fetcher.
+type Suspendable interface {
+	Suspended() bool
+}

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -1,7 +1,5 @@
 package store
 
-import "github.com/home-operations/flate/pkg/manifest"
-
 // Artifact is a marker interface implemented by every artifact type.
 // Controllers type-assert to the concrete type they expect.
 type Artifact interface {
@@ -17,27 +15,28 @@ type RenderedArtifact interface {
 	RenderedManifests() []map[string]any
 }
 
-// GitArtifact is the working tree produced by SourceController for a
-// GitRepository.
-type GitArtifact struct {
+// SourceArtifact is the unified working-tree artifact produced by
+// source fetchers (GitRepository, OCIRepository, Bucket, ExternalArtifact, …).
+// Kind identifies which CR kind produced it so consumers that care
+// (e.g. the helm-controller's local-git registration) can filter
+// without the previous per-kind type union.
+//
+// Mirrors Flux's meta.Artifact contract: URL is the upstream address,
+// Revision is the human-readable identifier (branch:main, tag:v1.2.3,
+// commit sha), Digest is the content-addressed verification value,
+// Size is the artifact size in bytes when known, and Metadata holds
+// kind-specific annotations (OCI image annotations, bucket ETag…).
+type SourceArtifact struct {
+	Kind      string
 	URL       string
 	LocalPath string
-	Ref       manifest.GitRepositoryRef
-	Revision  string // resolved commit SHA, when known
-}
-
-func (*GitArtifact) artifact() {}
-
-// OCIArtifact is the working tree produced by SourceController for an
-// OCIRepository.
-type OCIArtifact struct {
-	URL       string
-	LocalPath string
-	Ref       manifest.OCIRepositoryRef
+	Revision  string
 	Digest    string
+	Size      int64
+	Metadata  map[string]string
 }
 
-func (*OCIArtifact) artifact() {}
+func (*SourceArtifact) artifact() {}
 
 // KustomizationArtifact is the rendered output of a Kustomization build.
 type KustomizationArtifact struct {

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -1,8 +1,14 @@
 package store
 
-import "github.com/home-operations/flate/pkg/manifest"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// Status is the processing state of a resource.
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// Status is the processing state of a resource as projected from its
+// Ready condition. Kept as a high-level rollup for callers (depwait,
+// `test` reporting) that don't need the full condition slice.
 type Status string
 
 // Possible Status values.
@@ -13,10 +19,33 @@ const (
 )
 
 // StatusInfo bundles a status with an optional descriptive message.
+// Derived from the Ready condition; see Store.GetStatus.
 type StatusInfo struct {
 	Status  Status
 	Message string
 }
+
+// Condition is an alias for k8s metav1.Condition. flate stores
+// per-resource conditions so SOPS-encrypted-secret detection,
+// health-check rollups, and Flux's dependsOn ReadyExpr CEL evaluation
+// can interoperate with the rest of the K8s ecosystem.
+type Condition = metav1.Condition
+
+// Condition type identifiers used by flate. These mirror Flux's
+// conventions so a future watch-mode could publish to a real cluster
+// without translating.
+const (
+	ConditionReady       = "Ready"
+	ConditionReconciling = "Reconciling"
+	ConditionHealthy     = "Healthy"
+)
+
+// Condition reasons attached to the Ready condition.
+const (
+	ReasonSucceeded   = "Succeeded"
+	ReasonFailed      = "Failed"
+	ReasonReconciling = "Reconciling"
+)
 
 // SupportsStatus reports whether the given kind participates in the
 // status pipeline. Kinds outside this set (ConfigMap, Secret, ...) are
@@ -31,4 +60,48 @@ func SupportsStatus(kind string) bool {
 		return true
 	}
 	return false
+}
+
+// readyCondition builds the Ready condition that corresponds to the
+// (status, message) pair UpdateStatus accepts. Reason is derived from
+// Status; Message is passed through verbatim.
+func readyCondition(status Status, message string) metav1.Condition {
+	c := metav1.Condition{
+		Type:    ConditionReady,
+		Message: message,
+	}
+	switch status {
+	case StatusReady:
+		c.Status = metav1.ConditionTrue
+		c.Reason = ReasonSucceeded
+	case StatusFailed:
+		c.Status = metav1.ConditionFalse
+		c.Reason = ReasonFailed
+	default: // StatusPending or unknown
+		c.Status = metav1.ConditionUnknown
+		c.Reason = ReasonReconciling
+	}
+	return c
+}
+
+// statusInfoFromConditions projects the rollup StatusInfo from the
+// Ready condition. Returns (zero, false) when no Ready condition is
+// present.
+func statusInfoFromConditions(conds []metav1.Condition) (StatusInfo, bool) {
+	for _, c := range conds {
+		if c.Type != ConditionReady {
+			continue
+		}
+		info := StatusInfo{Message: c.Message}
+		switch c.Status {
+		case metav1.ConditionTrue:
+			info.Status = StatusReady
+		case metav1.ConditionFalse:
+			info.Status = StatusFailed
+		default:
+			info.Status = StatusPending
+		}
+		return info, true
+	}
+	return StatusInfo{}, false
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -11,10 +11,10 @@ import (
 
 // Store is the central in-memory state container.
 type Store struct {
-	mu        sync.RWMutex
-	objects   map[manifest.NamedResource]manifest.BaseManifest
-	status    map[manifest.NamedResource]StatusInfo
-	artifacts map[manifest.NamedResource]Artifact
+	mu         sync.RWMutex
+	objects    map[manifest.NamedResource]manifest.BaseManifest
+	conditions map[manifest.NamedResource][]Condition
+	artifacts  map[manifest.NamedResource]Artifact
 
 	// byName is a secondary index keyed by kind, then "namespace/name".
 	// It makes hot-path namespaced lookups (e.g. valuesFrom ConfigMap /
@@ -32,10 +32,10 @@ type Store struct {
 // New constructs an empty Store.
 func New() *Store {
 	return &Store{
-		objects:   make(map[manifest.NamedResource]manifest.BaseManifest),
-		status:    make(map[manifest.NamedResource]StatusInfo),
-		artifacts: make(map[manifest.NamedResource]Artifact),
-		byName:    make(map[string]map[string]manifest.BaseManifest),
+		objects:    make(map[manifest.NamedResource]manifest.BaseManifest),
+		conditions: make(map[manifest.NamedResource][]Condition),
+		artifacts:  make(map[manifest.NamedResource]Artifact),
+		byName:     make(map[string]map[string]manifest.BaseManifest),
 		listeners: map[EventKind]*listenerSet{
 			EventObjectAdded:     newListenerSet(),
 			EventStatusUpdated:   newListenerSet(),
@@ -105,7 +105,7 @@ func (s *Store) DeleteObject(id manifest.NamedResource) bool {
 		return false
 	}
 	delete(s.objects, id)
-	delete(s.status, id)
+	delete(s.conditions, id)
 	delete(s.artifacts, id)
 	if inner := s.byName[id.Kind]; inner != nil {
 		delete(inner, nameKey(id.Namespace, id.Name))
@@ -140,27 +140,84 @@ func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 	return out
 }
 
-// UpdateStatus records a status transition and dispatches a
-// StatusUpdated event when the status info changes.
+// UpdateStatus records a Ready-condition transition and dispatches a
+// StatusUpdated event when the StatusInfo rollup changes. Internally
+// the (status, message) pair is stored as a metav1.Condition so
+// future callers (ReadyExpr CEL, SOPS detection, healthChecks) can
+// see the rich state via GetConditions.
 func (s *Store) UpdateStatus(id manifest.NamedResource, status Status, message string) {
-	info := StatusInfo{Status: status, Message: message}
-	s.mu.Lock()
-	prev, exists := s.status[id]
-	if exists && prev == info {
-		s.mu.Unlock()
-		return
-	}
-	s.status[id] = info
-	s.mu.Unlock()
-	s.fire(EventStatusUpdated, id, info)
+	s.SetCondition(id, readyCondition(status, message))
 }
 
-// GetStatus returns the status for id and whether it was present.
+// SetCondition upserts cond into the resource's condition list keyed
+// by cond.Type. Dispatches a StatusUpdated event with the *StatusInfo
+// rollup* (derived from Ready) when the rollup changed — non-Ready
+// conditions land silently to avoid event spam.
+func (s *Store) SetCondition(id manifest.NamedResource, cond Condition) {
+	s.mu.Lock()
+	prev := s.conditions[id]
+	prevInfo, _ := statusInfoFromConditions(prev)
+
+	updated := make([]Condition, 0, len(prev)+1)
+	replaced := false
+	for _, c := range prev {
+		if c.Type == cond.Type {
+			if conditionEqual(c, cond) {
+				// Identical condition — nothing to do, including no event.
+				s.mu.Unlock()
+				return
+			}
+			updated = append(updated, cond)
+			replaced = true
+			continue
+		}
+		updated = append(updated, c)
+	}
+	if !replaced {
+		updated = append(updated, cond)
+	}
+	s.conditions[id] = updated
+
+	newInfo, _ := statusInfoFromConditions(updated)
+	s.mu.Unlock()
+
+	if cond.Type == ConditionReady && prevInfo != newInfo {
+		s.fire(EventStatusUpdated, id, newInfo)
+	}
+}
+
+// GetStatus returns the Ready-derived StatusInfo for id and whether
+// a Ready condition was present.
 func (s *Store) GetStatus(id manifest.NamedResource) (StatusInfo, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	info, ok := s.status[id]
-	return info, ok
+	return statusInfoFromConditions(s.conditions[id])
+}
+
+// GetConditions returns a copy of id's condition list. Empty for
+// unknown ids.
+func (s *Store) GetConditions(id manifest.NamedResource) []Condition {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	conds := s.conditions[id]
+	if len(conds) == 0 {
+		return nil
+	}
+	out := make([]Condition, len(conds))
+	copy(out, conds)
+	return out
+}
+
+// conditionEqual reports whether two conditions carry the same
+// observable state. LastTransitionTime is intentionally ignored — it
+// is reset on every transition by the controller-runtime libraries
+// and would otherwise prevent the no-op short-circuit from firing.
+func conditionEqual(a, b Condition) bool {
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message &&
+		a.ObservedGeneration == b.ObservedGeneration
 }
 
 // SetArtifact stores an artifact for id and dispatches an
@@ -184,12 +241,12 @@ func (s *Store) GetArtifact(id manifest.NamedResource) Artifact {
 	return s.artifacts[id]
 }
 
-// HasFailedResources reports whether any tracked status is Failed.
+// HasFailedResources reports whether any tracked Ready condition is False.
 func (s *Store) HasFailedResources() bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for _, info := range s.status {
-		if info.Status == StatusFailed {
+	for _, conds := range s.conditions {
+		if info, ok := statusInfoFromConditions(conds); ok && info.Status == StatusFailed {
 			return true
 		}
 	}
@@ -201,8 +258,8 @@ func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make(map[manifest.NamedResource]StatusInfo)
-	for id, info := range s.status {
-		if info.Status == StatusFailed {
+	for id, conds := range s.conditions {
+		if info, ok := statusInfoFromConditions(conds); ok && info.Status == StatusFailed {
 			out[id] = info
 		}
 	}
@@ -240,8 +297,12 @@ func (s *Store) replayInto(event EventKind, fn Listener) {
 		}
 	case EventStatusUpdated:
 		s.mu.RLock()
-		snap := make(map[manifest.NamedResource]StatusInfo, len(s.status))
-		maps.Copy(snap, s.status)
+		snap := make(map[manifest.NamedResource]StatusInfo, len(s.conditions))
+		for id, conds := range s.conditions {
+			if info, ok := statusInfoFromConditions(conds); ok {
+				snap[id] = info
+			}
+		}
 		s.mu.RUnlock()
 		for id, info := range snap {
 			fn(id, info)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -266,7 +266,7 @@ func TestStore_AddListener_Unsubscribe(t *testing.T) {
 func TestStore_SetArtifact(t *testing.T) {
 	s := New()
 	id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}
-	art := &GitArtifact{URL: "https://example", LocalPath: "/tmp/x"}
+	art := &SourceArtifact{Kind: "GitRepository", URL: "https://example", LocalPath: "/tmp/x"}
 
 	count := 0
 	s.AddListener(EventArtifactUpdated, func(_ manifest.NamedResource, _ any) {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -65,6 +67,59 @@ func TestStore_UpdateStatus_Idempotent(t *testing.T) {
 	info, ok := s.GetStatus(id)
 	if !ok || info.Status != StatusReady {
 		t.Errorf("status: %+v ok=%v", info, ok)
+	}
+}
+
+func TestStore_SetCondition_NonReadyDoesNotFireStatusEvent(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
+	s.UpdateStatus(id, StatusPending, "starting")
+	statusEvents := 0
+	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, _ any) {
+		statusEvents++
+	}, false)
+	// A non-Ready condition should land silently.
+	s.SetCondition(id, Condition{Type: ConditionHealthy, Status: metav1.ConditionTrue, Reason: "Healthy"})
+	if statusEvents != 0 {
+		t.Errorf("non-Ready SetCondition fired StatusUpdated event %d times", statusEvents)
+	}
+	got := s.GetConditions(id)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 conditions, got %d", len(got))
+	}
+}
+
+func TestStore_SetCondition_ReadyFiresStatusEvent(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
+	statusEvents := 0
+	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, payload any) {
+		statusEvents++
+		info, ok := payload.(StatusInfo)
+		if !ok || info.Status != StatusReady {
+			t.Errorf("expected Ready payload, got %+v", payload)
+		}
+	}, false)
+	s.SetCondition(id, Condition{
+		Type: ConditionReady, Status: metav1.ConditionTrue,
+		Reason: ReasonSucceeded, Message: "ok",
+	})
+	if statusEvents != 1 {
+		t.Errorf("Ready SetCondition fired %d events; want 1", statusEvents)
+	}
+}
+
+func TestStore_SetCondition_IdenticalIsNoOp(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
+	statusEvents := 0
+	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, _ any) { statusEvents++ }, false)
+
+	cond := Condition{Type: ConditionReady, Status: metav1.ConditionTrue, Reason: ReasonSucceeded}
+	s.SetCondition(id, cond)
+	s.SetCondition(id, cond)
+	if statusEvents != 1 {
+		t.Errorf("identical SetCondition fired %d events; want 1", statusEvents)
 	}
 }
 

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -163,6 +163,6 @@ func (s *Store) WatchAdded(ctx context.Context, kind string, bufSize int) <-chan
 func (s *Store) String() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return fmt.Sprintf("Store{objects:%d, status:%d, artifacts:%d}",
-		len(s.objects), len(s.status), len(s.artifacts))
+	return fmt.Sprintf("Store{objects:%d, conditions:%d, artifacts:%d}",
+		len(s.objects), len(s.conditions), len(s.artifacts))
 }


### PR DESCRIPTION
## Summary

Phase 2 of the Flux-fidelity push, **final piece**. Lays the foundation for adding **Bucket** and **ExternalArtifact** cleanly without per-touchpoint type-switch growth.

**Stacked on #28 (\`refactor/status-conditions\`).** Merge order: #26 → #27 → #28 → this.

Three coordinated changes, all in the source layer.

## 1. Unified \`SourceArtifact\` replaces \`GitArtifact\`/\`OCIArtifact\`

One struct in \`pkg/store/artifact.go\` mirrors Flux's \`meta.Artifact\` contract:

\`\`\`go
type SourceArtifact struct {
    Kind      string
    URL       string
    LocalPath string
    Revision  string
    Digest    string
    Size      int64
    Metadata  map[string]string
}
\`\`\`

Consumers that care which kind produced an artifact (the helmrelease controller's local-git registration is the only one today) filter on \`Kind\`. Everyone else just reads \`LocalPath\`. The kustomization controller's \`resolveSourceRoot\` collapses from a two-arm type-switch to a single \`*store.SourceArtifact\` assertion.

## 2. \`Fetcher\` interface + per-kind implementations

\`pkg/source/source.go\` introduces:

\`\`\`go
type Fetcher interface {
    Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error)
}

type Suspendable interface {
    Suspended() bool
}
\`\`\`

\`GitFetcher\` and \`OCIFetcher\` are thin implementations that wrap the existing \`FetchGit\`/\`FetchOCI\` functions. \`Suspended() bool\` methods on \`GitRepository\` / \`OCIRepository\` let the controller short-circuit suspend uniformly via the \`Suspendable\` interface.

## 3. Source controller dispatches via a Fetchers map

The per-kind \`switch id.Kind\` is gone. The controller now holds:

\`\`\`go
Fetchers map[string]src.Fetcher  // keyed by id.Kind
\`\`\`

The orchestrator constructs the map and registers \`GitFetcher\` unconditionally + \`OCIFetcher\` when \`cfg.EnableOCI\`. **Disabling a source kind is now \"omit it from the map\"** rather than a special \`Controller.EnableOCI\` field (which is gone).

## What this unblocks

Adding **Bucket** (planned): one new file \`pkg/source/bucket.go\` with \`type BucketFetcher\` implementing \`Fetcher\`, one new constant in \`manifest/constants.go\`, one new line in the orchestrator. Per-provider auth (s3/gcs/azure/generic) lives inside \`BucketFetcher\`.

Adding **ExternalArtifact**: the Fetcher is effectively a no-op — the artifact is published by a third-party controller; flate just relays the upstream URL/digest. Same one-line registration shape.

The agent's full architectural roadmap (\`pkg/source/{git,oci,bucket,external}/\` per-kind subpackages) is intentionally deferred — it's a pure file-move that can land alongside the first new kind, when the dep tree of the new provider's SDK justifies the isolation.

## Bonus

OCI revisions now follow source-controller's \`\"<tag>@<digest>\"\` convention via the new \`ociRevision\` helper. The descriptor's Size is captured into the artifact, useful for the future Flux-status \`Artifact.Size\` field.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (manifest, orchestrator, source, store, helm, e2e — all packages)
- [x] \`go vet ./...\` clean

## Test deltas

- \`TestStore_SetArtifact\` migrated from \`&GitArtifact{}\` to \`&SourceArtifact{Kind: \"GitRepository\"}\`.
- \`TestTemplate\` in helm package migrated likewise.
- Every controller/orchestrator/e2e test passes unchanged — the type unification was non-breaking at the consumer surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)