### PR TITLE
refactor(source): unified SourceArtifact + Fetcher interface

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -111,8 +111,8 @@ func (c *Controller) onArtifactUpdated(id manifest.NamedResource, payload any) {
 	if id.Kind != manifest.KindGitRepository {
 		return
 	}
-	gitArt, ok := payload.(*store.GitArtifact)
-	if !ok {
+	gitArt, ok := payload.(*store.SourceArtifact)
+	if !ok || gitArt.Kind != manifest.KindGitRepository {
 		return
 	}
 	repo, _ := c.Store.GetObject(id).(*manifest.GitRepository)

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -191,11 +191,8 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 	if art == nil {
 		return "", fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())
 	}
-	switch a := art.(type) {
-	case *store.GitArtifact:
-		return a.LocalPath, nil
-	case *store.OCIArtifact:
-		return a.LocalPath, nil
+	if sa, ok := art.(*store.SourceArtifact); ok {
+		return sa.LocalPath, nil
 	}
 	return "", fmt.Errorf("unsupported source artifact type %T for %s", art, srcID.String())
 }

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -1,7 +1,12 @@
 // Package source reconciles Flux source CRs (GitRepository,
-// OCIRepository) into on-disk artifacts via the pkg/source SDK adapter,
-// then publishes the result to the Store. It mirrors
+// OCIRepository, future: Bucket, ExternalArtifact, …) into on-disk
+// artifacts via per-kind Fetcher implementations from pkg/source, then
+// publishes the result to the Store. Mirrors
 // pkg/controllers/{kustomization,helmrelease}.
+//
+// The controller does not know about individual source kinds — it
+// dispatches via the Fetchers map keyed by id.Kind, so adding a new
+// kind is a one-line registration at orchestrator-construction time.
 package source
 
 import (
@@ -16,21 +21,21 @@ import (
 	"github.com/home-operations/flate/pkg/task"
 )
 
-// Controller watches the Store for GitRepository and OCIRepository
-// objects, reconciles each into an on-disk artifact, and updates the
+// Controller watches the Store for source-kind objects, fetches each
+// into an on-disk artifact via the matching Fetcher, and updates the
 // Store with the result.
 type Controller struct {
-	Store          *store.Store
-	Tasks          *task.Service
-	Cache          *src.Cache
-	RegistryConfig string
+	Store *store.Store
+	Tasks *task.Service
 	// Filter, when non-nil and enabled, narrows fetches to only
 	// sources referenced by changed resources.
 	Filter *change.Filter
 
-	// EnableOCI controls whether OCIRepository reconciliation is active.
-	// The upstream Python defaults to off so behavior matches.
-	EnableOCI bool
+	// Fetchers maps source CR kind → Fetcher implementation. Source
+	// kinds with no entry are ignored, which is also how a flate caller
+	// disables a kind (e.g. EnableOCI=false simply omits OCIRepository
+	// from the map).
+	Fetchers map[string]src.Fetcher
 
 	unsubscribers []store.Unsubscribe
 }
@@ -53,43 +58,25 @@ func (c *Controller) Close() {
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	return func(id manifest.NamedResource, payload any) {
-		switch id.Kind {
-		case manifest.KindGitRepository:
-			repo, ok := payload.(*manifest.GitRepository)
-			if !ok {
-				return
-			}
-			if repo.Suspend {
-				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
-				return
-			}
-			if c.skip(id) {
-				return
-			}
-			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer base.Recover(c.Store, id, "source")
-				c.reconcileGit(ctx, id, repo)
-			})
-		case manifest.KindOCIRepository:
-			if !c.EnableOCI {
-				return
-			}
-			repo, ok := payload.(*manifest.OCIRepository)
-			if !ok {
-				return
-			}
-			if repo.Suspend {
-				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
-				return
-			}
-			if c.skip(id) {
-				return
-			}
-			c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
-				defer base.Recover(c.Store, id, "source")
-				c.reconcileOCI(ctx, id, repo)
-			})
+		fetcher, registered := c.Fetchers[id.Kind]
+		if !registered {
+			return
 		}
+		obj, ok := payload.(manifest.BaseManifest)
+		if !ok {
+			return
+		}
+		if sus, ok := obj.(src.Suspendable); ok && sus.Suspended() {
+			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+			return
+		}
+		if c.skip(id) {
+			return
+		}
+		c.Tasks.Go(ctx, "source/"+id.String(), func(ctx context.Context) {
+			defer base.Recover(c.Store, id, "source")
+			c.runFetch(ctx, id, obj, fetcher)
+		})
 	}
 }
 
@@ -106,30 +93,17 @@ func (c *Controller) skip(id manifest.NamedResource) bool {
 	return true
 }
 
-func (c *Controller) reconcileGit(ctx context.Context, id manifest.NamedResource, repo *manifest.GitRepository) {
+// runFetch invokes the registered Fetcher and translates the result
+// into Store status + artifact writes. Generic over kind: the only
+// per-kind decision (which Fetcher to call) was made above.
+func (c *Controller) runFetch(ctx context.Context, id manifest.NamedResource, obj manifest.BaseManifest, fetcher src.Fetcher) {
 	c.Store.UpdateStatus(id, store.StatusPending, "fetching")
 	if art := c.Store.GetArtifact(id); art != nil {
 		c.Store.UpdateStatus(id, store.StatusReady, "")
 		return
 	}
-	slog.Debug("source: git fetch", "id", id.String(), "url", repo.URL)
-	artifact, err := src.FetchGit(ctx, c.Cache, repo)
-	if err != nil {
-		c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
-		return
-	}
-	c.Store.SetArtifact(id, artifact)
-	c.Store.UpdateStatus(id, store.StatusReady, "")
-}
-
-func (c *Controller) reconcileOCI(ctx context.Context, id manifest.NamedResource, repo *manifest.OCIRepository) {
-	c.Store.UpdateStatus(id, store.StatusPending, "fetching")
-	if art := c.Store.GetArtifact(id); art != nil {
-		c.Store.UpdateStatus(id, store.StatusReady, "")
-		return
-	}
-	slog.Debug("source: oci fetch", "id", id.String(), "url", repo.URL)
-	artifact, err := src.FetchOCI(ctx, c.Cache, repo, c.RegistryConfig)
+	slog.Debug("source: fetch", "id", id.String())
+	artifact, err := fetcher.Fetch(ctx, obj)
 	if err != nil {
 		c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
 		return

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -21,7 +21,7 @@ import (
 // resolve charts whose sourceRef.kind is GitRepository.
 type LocalGitRepository struct {
 	Repo     *manifest.GitRepository
-	Artifact *store.GitArtifact
+	Artifact *store.SourceArtifact
 }
 
 // RepoName mirrors HelmRepository.RepoName for convenience in lookups.

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -35,7 +35,7 @@ data:
 			Name: "chart-repo", Namespace: "flux-system",
 			URL: "file://" + dir,
 		},
-		Artifact: &store.GitArtifact{URL: "file://" + dir, LocalPath: dir},
+		Artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
 	})
 
 	hr := &manifest.HelmRelease{

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -45,6 +45,9 @@ func (g *GitRepository) Named() NamedResource {
 	return NamedResource{Kind: KindGitRepository, Namespace: g.Namespace, Name: g.Name}
 }
 
+// Suspended reports whether reconciliation is paused on this resource.
+func (g *GitRepository) Suspended() bool { return g.Suspend }
+
 // RepoName is "<namespace>-<name>".
 func (g *GitRepository) RepoName() string { return g.Namespace + "-" + g.Name }
 
@@ -108,6 +111,9 @@ type OCIRepository struct {
 func (o *OCIRepository) Named() NamedResource {
 	return NamedResource{Kind: KindOCIRepository, Namespace: o.Namespace, Name: o.Name}
 }
+
+// Suspended reports whether reconciliation is paused on this resource.
+func (o *OCIRepository) Suspended() bool { return o.Suspend }
 
 // RepoName is "<namespace>-<name>".
 func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -102,16 +102,23 @@ func New(cfg Config) (*Orchestrator, error) {
 
 	st := store.New()
 	ts := task.New()
+	cache := cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources")))
+	fetchers := map[string]source.Fetcher{
+		manifest.KindGitRepository: &source.GitFetcher{Cache: cache},
+	}
+	if cfg.EnableOCI {
+		fetchers[manifest.KindOCIRepository] = &source.OCIFetcher{
+			Cache: cache, RegistryConfig: cfg.RegistryConfig,
+		}
+	}
 	o := &Orchestrator{
 		cfg:   cfg,
 		store: st,
 		tasks: ts,
 		src: &sourcectrl.Controller{
-			Store:          st,
-			Tasks:          ts,
-			Cache:          cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources"))),
-			RegistryConfig: cfg.RegistryConfig,
-			EnableOCI:      cfg.EnableOCI,
+			Store:    st,
+			Tasks:    ts,
+			Fetchers: fetchers,
 		},
 		ksc:     &kustomization.Controller{Store: st, Tasks: ts, Staging: staging, WipeSecrets: cfg.WipeSecrets},
 		hrc:     &helmrelease.Controller{Store: st, Tasks: ts, Helm: helmClient, Options: cfg.HelmOptions, WipeSecrets: cfg.WipeSecrets},
@@ -162,7 +169,10 @@ func (o *Orchestrator) seedBootstrapSource() (string, error) {
 	}
 	id := repo.Named()
 	o.store.AddObject(repo)
-	o.store.SetArtifact(id, &store.GitArtifact{URL: repo.URL, LocalPath: root})
+	o.store.SetArtifact(id, &store.SourceArtifact{
+		Kind: manifest.KindGitRepository,
+		URL:  repo.URL, LocalPath: root,
+	})
 	o.store.UpdateStatus(id, store.StatusReady, "bootstrap")
 	return root, nil
 }

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -14,14 +14,30 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// GitFetcher is the Fetcher implementation for KindGitRepository.
+// It owns a shared Cache so multiple GitRepository CRs writing to the
+// same cache root serialize on slot allocation correctly.
+type GitFetcher struct {
+	Cache *Cache
+}
+
+// Fetch implements source.Fetcher for *manifest.GitRepository.
+func (f *GitFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+	repo, ok := obj.(*manifest.GitRepository)
+	if !ok {
+		return nil, fmt.Errorf("%w: GitFetcher: unexpected payload %T", manifest.ErrInput, obj)
+	}
+	return FetchGit(ctx, f.Cache, repo)
+}
+
 // FetchGit clones the GitRepository referenced by repo into the supplied
-// cache and returns a populated *store.GitArtifact. If a usable cached
+// cache and returns a populated *store.SourceArtifact. If a usable cached
 // copy already exists, it is reused.
 //
 // Supported transports: public HTTPS, ssh-with-agent (handled by go-git
 // transparently), and file:// URLs. Per-host credential lookups via a
 // Secret reference will be added when a use case demands it.
-func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (*store.GitArtifact, error) {
+func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}
@@ -43,8 +59,9 @@ func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (
 		// Validate it's a usable repo before reusing.
 		if _, err := git.PlainOpen(slot); err == nil {
 			rev, _ := readResolvedRevision(slot)
-			return &store.GitArtifact{
-				URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Revision: rev,
+			return &store.SourceArtifact{
+				Kind: manifest.KindGitRepository,
+				URL:  repo.URL, LocalPath: slot, Revision: rev,
 			}, nil
 		}
 		// Stale slot — wipe and re-clone.
@@ -72,8 +89,9 @@ func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (
 	}
 
 	rev, _ := readResolvedRevision(slot)
-	return &store.GitArtifact{
-		URL: repo.URL, LocalPath: slot, Ref: repo.Ref, Revision: rev,
+	return &store.SourceArtifact{
+		Kind: manifest.KindGitRepository,
+		URL:  repo.URL, LocalPath: slot, Revision: rev,
 	}, nil
 }
 

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -21,12 +21,27 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// OCIFetcher is the Fetcher implementation for KindOCIRepository.
+type OCIFetcher struct {
+	Cache          *Cache
+	RegistryConfig string
+}
+
+// Fetch implements source.Fetcher for *manifest.OCIRepository.
+func (f *OCIFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+	repo, ok := obj.(*manifest.OCIRepository)
+	if !ok {
+		return nil, fmt.Errorf("%w: OCIFetcher: unexpected payload %T", manifest.ErrInput, obj)
+	}
+	return FetchOCI(ctx, f.Cache, repo, f.RegistryConfig)
+}
+
 // FetchOCI pulls the OCIRepository artifact into cache. Credentials are
 // read from a docker-style config.json honored by oras-go's
 // credentials.NewFileStore. When spec.ref.semver is set, the registry
 // is listed and the highest matching tag (filtered by semverFilter, if
 // any) is resolved before pulling.
-func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.OCIArtifact, error) {
+func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
 	}
@@ -67,7 +82,12 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
 	if exists {
-		return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: ref.Digest}, nil
+		return &store.SourceArtifact{
+			Kind: manifest.KindOCIRepository,
+			URL:  repo.URL, LocalPath: slot,
+			Revision: ociRevision(ref, ref.Digest),
+			Digest:   ref.Digest,
+		}, nil
 	}
 
 	tag := versionTag(ref)
@@ -87,7 +107,32 @@ func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, r
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
-	return &store.OCIArtifact{URL: repo.URL, LocalPath: slot, Ref: ref, Digest: desc.Digest.String()}, nil
+	digest := desc.Digest.String()
+	return &store.SourceArtifact{
+		Kind: manifest.KindOCIRepository,
+		URL:  repo.URL, LocalPath: slot,
+		Revision: ociRevision(ref, digest),
+		Digest:   digest,
+		Size:     desc.Size,
+	}, nil
+}
+
+// ociRevision composes a Flux-style "<tag>@<digest>" revision string.
+// When tag is empty, falls back to bare digest; when digest is empty,
+// returns just the tag. Matches source-controller's ocirepository
+// revision conventions.
+func ociRevision(ref manifest.OCIRepositoryRef, digest string) string {
+	tag := ref.Tag
+	if tag == "" && ref.Digest == "" {
+		tag = "latest"
+	}
+	switch {
+	case tag != "" && digest != "":
+		return tag + "@" + digest
+	case digest != "":
+		return digest
+	}
+	return tag
 }
 
 // versionedURL composes a Flux-style versioned URL from a base + ref.

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -1,0 +1,39 @@
+// Package source is the SDK adapter for Flux's source-controller CRs.
+// It exposes per-kind Fetcher implementations (one per source type)
+// plus a content-addressed disk Cache that all fetchers write into.
+//
+// Adding a new source kind:
+//
+//  1. Implement source.Fetcher for the new kind in a new file (or
+//     subpackage) under pkg/source.
+//  2. Register the fetcher with the orchestrator at construction time.
+//
+// The source controller (pkg/controllers/source) does not know about
+// individual kinds — it dispatches via the Fetchers map keyed by
+// id.Kind, so adding a new kind is one registration call.
+package source
+
+import (
+	"context"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// Fetcher resolves a single source CR into an on-disk artifact. Each
+// kind (GitRepository, OCIRepository, Bucket, …) provides its own
+// implementation; the source controller dispatches by id.Kind.
+//
+// obj is the typed manifest payload (e.g. *manifest.GitRepository).
+// Implementations type-assert and return an InputError on mismatch
+// rather than panic.
+type Fetcher interface {
+	Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error)
+}
+
+// Suspendable is satisfied by source CR types that carry a
+// spec.suspend bool. The source controller short-circuits suspended
+// objects before invoking the Fetcher.
+type Suspendable interface {
+	Suspended() bool
+}

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -1,7 +1,5 @@
 package store
 
-import "github.com/home-operations/flate/pkg/manifest"
-
 // Artifact is a marker interface implemented by every artifact type.
 // Controllers type-assert to the concrete type they expect.
 type Artifact interface {
@@ -17,27 +15,28 @@ type RenderedArtifact interface {
 	RenderedManifests() []map[string]any
 }
 
-// GitArtifact is the working tree produced by SourceController for a
-// GitRepository.
-type GitArtifact struct {
+// SourceArtifact is the unified working-tree artifact produced by
+// source fetchers (GitRepository, OCIRepository, Bucket, ExternalArtifact, …).
+// Kind identifies which CR kind produced it so consumers that care
+// (e.g. the helm-controller's local-git registration) can filter
+// without the previous per-kind type union.
+//
+// Mirrors Flux's meta.Artifact contract: URL is the upstream address,
+// Revision is the human-readable identifier (branch:main, tag:v1.2.3,
+// commit sha), Digest is the content-addressed verification value,
+// Size is the artifact size in bytes when known, and Metadata holds
+// kind-specific annotations (OCI image annotations, bucket ETag…).
+type SourceArtifact struct {
+	Kind      string
 	URL       string
 	LocalPath string
-	Ref       manifest.GitRepositoryRef
-	Revision  string // resolved commit SHA, when known
-}
-
-func (*GitArtifact) artifact() {}
-
-// OCIArtifact is the working tree produced by SourceController for an
-// OCIRepository.
-type OCIArtifact struct {
-	URL       string
-	LocalPath string
-	Ref       manifest.OCIRepositoryRef
+	Revision  string
 	Digest    string
+	Size      int64
+	Metadata  map[string]string
 }
 
-func (*OCIArtifact) artifact() {}
+func (*SourceArtifact) artifact() {}
 
 // KustomizationArtifact is the rendered output of a Kustomization build.
 type KustomizationArtifact struct {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -266,7 +266,7 @@ func TestStore_AddListener_Unsubscribe(t *testing.T) {
 func TestStore_SetArtifact(t *testing.T) {
 	s := New()
 	id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}
-	art := &GitArtifact{URL: "https://example", LocalPath: "/tmp/x"}
+	art := &SourceArtifact{Kind: "GitRepository", URL: "https://example", LocalPath: "/tmp/x"}
 
 	count := 0
 	s.AddListener(EventArtifactUpdated, func(_ manifest.NamedResource, _ any) {


### PR DESCRIPTION
Reopened replacement for #29 (auto-closed when the upstream branch was deleted on merge of #28).

## Summary

Phase 2 of the Flux-fidelity push, **final piece**. Lays the foundation for adding **Bucket** and **ExternalArtifact** cleanly without per-touchpoint type-switch growth.

Three coordinated changes, all in the source layer.

## 1. Unified \`SourceArtifact\` replaces \`GitArtifact\`/\`OCIArtifact\`

One struct in \`pkg/store/artifact.go\` mirrors Flux's \`meta.Artifact\`:

\`\`\`go
type SourceArtifact struct {
    Kind      string
    URL       string
    LocalPath string
    Revision  string
    Digest    string
    Size      int64
    Metadata  map[string]string
}
\`\`\`

Consumers that care which kind produced an artifact (the helmrelease controller's local-git registration is the only one today) filter on \`Kind\`. The kustomization controller's \`resolveSourceRoot\` collapses from a two-arm type-switch to a single \`*store.SourceArtifact\` assertion.

## 2. \`Fetcher\` interface + per-kind implementations

\`pkg/source/source.go\` introduces:

\`\`\`go
type Fetcher interface {
    Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error)
}

type Suspendable interface {
    Suspended() bool
}
\`\`\`

\`GitFetcher\` and \`OCIFetcher\` are thin implementations that wrap the existing \`FetchGit\`/\`FetchOCI\` functions. \`Suspended() bool\` methods on \`GitRepository\` / \`OCIRepository\` let the controller short-circuit suspend uniformly via the \`Suspendable\` interface.

## 3. Source controller dispatches via Fetchers map

The per-kind \`switch id.Kind\` is gone. The controller now holds:

\`\`\`go
Fetchers map[string]src.Fetcher  // keyed by id.Kind
\`\`\`

**Disabling a source kind is now \"omit it from the map\"** rather than the special \`Controller.EnableOCI\` field (which is gone).

## What this unblocks

Adding **Bucket**: one new file with \`type BucketFetcher\` implementing \`Fetcher\`, one new constant in \`manifest/constants.go\`, one new line in the orchestrator. Per-provider auth (s3/gcs/azure/generic) lives inside \`BucketFetcher\`.

Adding **ExternalArtifact**: the Fetcher is effectively a no-op — the artifact is published by a third-party controller; flate just relays the upstream URL/digest. Same one-line registration shape.

## Bonus

OCI revisions now follow source-controller's \`\"<tag>@<digest>\"\` convention via the new \`ociRevision\` helper. The descriptor's Size is captured into the artifact.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)