### PR TITLE
chore(lint): drop unused ctx/obj parameters in base_test

### DIFF
--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -18,7 +18,7 @@ func TestRunWithStatus_Success(t *testing.T) {
 	id := hr.Named()
 
 	base.RunWithStatus(t.Context(), s, id, "helmrelease",
-		func(ctx context.Context, obj *manifest.HelmRelease) error {
+		func(_ context.Context, obj *manifest.HelmRelease) error {
 			if obj.Name != "app" {
 				t.Errorf("re-read got %q, want app", obj.Name)
 			}
@@ -38,7 +38,7 @@ func TestRunWithStatus_Failure(t *testing.T) {
 	id := hr.Named()
 
 	base.RunWithStatus(t.Context(), s, id, "helmrelease",
-		func(ctx context.Context, obj *manifest.HelmRelease) error {
+		func(_ context.Context, _ *manifest.HelmRelease) error {
 			return errors.New("render failed")
 		},
 	)
@@ -59,7 +59,7 @@ func TestRunWithStatus_Panic(t *testing.T) {
 
 	// Panic must be caught and converted into StatusFailed; no re-panic.
 	base.RunWithStatus(t.Context(), s, id, "helmrelease",
-		func(ctx context.Context, obj *manifest.HelmRelease) error {
+		func(_ context.Context, _ *manifest.HelmRelease) error {
 			panic("kaboom")
 		},
 	)
@@ -77,7 +77,7 @@ func TestRunWithStatus_MissingObject(t *testing.T) {
 	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "ghost"}
 	called := false
 	base.RunWithStatus(t.Context(), s, id, "helmrelease",
-		func(ctx context.Context, obj *manifest.HelmRelease) error {
+		func(_ context.Context, _ *manifest.HelmRelease) error {
 			called = true
 			return nil
 		},


### PR DESCRIPTION
Three `revive: unused-parameter` warnings introduced by #30. Renames `ctx` / `obj` to `_` in four callbacks. No behavior change.

`golangci-lint run` clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)