### PR TITLE
feat(source): add ExternalArtifact support

### DIFF
--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -17,6 +17,7 @@ const (
 	KindHelmChart                = "HelmChart"
 	KindGitRepository            = "GitRepository"
 	KindOCIRepository            = "OCIRepository"
+	KindExternalArtifact         = "ExternalArtifact"
 	KindConfigMap                = "ConfigMap"
 	KindSecret                   = "Secret"
 	KindCustomResourceDefinition = "CustomResourceDefinition"

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -84,6 +84,43 @@ spec:
 	}
 }
 
+func TestParseExternalArtifact(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: ExternalArtifact
+metadata:
+  name: pulled-tarball
+  namespace: apps
+spec:
+  sourceRef:
+    apiVersion: image.toolkit.fluxcd.io/v1beta2
+    kind: ImageUpdateAutomation
+    name: app-image
+    namespace: apps
+status:
+  artifact:
+    url: file:///cache/ea/pulled-tarball.tar.gz
+    revision: v1.2.3@sha256:abc
+    digest: sha256:abc
+`)
+	ea, err := ParseExternalArtifact(doc)
+	if err != nil {
+		t.Fatalf("ParseExternalArtifact: %v", err)
+	}
+	if ea.Name != "pulled-tarball" || ea.Namespace != "apps" {
+		t.Errorf("identity: %+v", ea)
+	}
+	if ea.SourceRef == nil || ea.SourceRef.Kind != "ImageUpdateAutomation" {
+		t.Errorf("sourceRef: %+v", ea.SourceRef)
+	}
+	if ea.ArtifactURL != "file:///cache/ea/pulled-tarball.tar.gz" {
+		t.Errorf("artifact URL: %q", ea.ArtifactURL)
+	}
+	if ea.Revision != "v1.2.3@sha256:abc" {
+		t.Errorf("revision: %q", ea.Revision)
+	}
+}
+
 func TestParseHelmRelease_DependsOn(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -94,6 +94,8 @@ func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
 		return ParseGitRepository(doc)
 	case kind == KindOCIRepository:
 		return ParseOCIRepository(doc)
+	case kind == KindExternalArtifact && strings.HasPrefix(apiVersion, SourceDomain):
+		return ParseExternalArtifact(doc)
 	case kind == KindConfigMap:
 		return ParseConfigMap(doc)
 	case kind == KindSecret:

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -187,3 +187,75 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	}
 	return out, nil
 }
+
+// ExternalArtifactSourceRef identifies the upstream CR that produces
+// the artifact. Mirrors Flux's meta.NamespacedObjectKindReference.
+type ExternalArtifactSourceRef struct {
+	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind       string `json:"kind" yaml:"kind"`
+	Namespace  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Name       string `json:"name" yaml:"name"`
+}
+
+// ExternalArtifact is the Flux ExternalArtifact CRD
+// (source.toolkit.fluxcd.io/v1). It is the contract a third-party
+// controller uses to publish an on-cluster artifact under Flux's
+// source-controller schema. flate's offline reconcile cannot fetch
+// from a live cluster — if a downstream Kustomization or HelmRelease
+// references an ExternalArtifact via sourceRef.kind=ExternalArtifact,
+// the user must supply status.artifact in the YAML (typical workflow:
+// pre-bake a file:// URL) for flate to resolve a local path.
+type ExternalArtifact struct {
+	Name      string                     `json:"name" yaml:"name"`
+	Namespace string                     `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	SourceRef *ExternalArtifactSourceRef `json:"sourceRef,omitempty" yaml:"sourceRef,omitempty"`
+	// ArtifactURL / Revision / Digest come from status.artifact when
+	// pre-populated in the YAML. Empty otherwise (the normal case for a
+	// freshly-written CR); flate then fails to resolve any consumer.
+	ArtifactURL string `json:"-" yaml:"-"`
+	Revision    string `json:"-" yaml:"-"`
+	Digest      string `json:"-" yaml:"-"`
+}
+
+// Named identifies the ExternalArtifact.
+func (e *ExternalArtifact) Named() NamedResource {
+	return NamedResource{Kind: KindExternalArtifact, Namespace: e.Namespace, Name: e.Name}
+}
+
+// Suspended is always false for ExternalArtifact — the CR has no
+// spec.suspend field per Flux's schema. Defined so the source
+// controller's Suspendable check is uniform.
+func (e *ExternalArtifact) Suspended() bool { return false }
+
+// ParseExternalArtifact decodes an ExternalArtifact CR via the
+// source-controller typed schema.
+func ParseExternalArtifact(doc map[string]any) (*ExternalArtifact, error) {
+	if err := checkAPIVersion(doc, SourceDomain); err != nil {
+		return nil, err
+	}
+	var cr sourcev1.ExternalArtifact
+	if err := decodeTyped(doc, &cr); err != nil {
+		return nil, inputf("ExternalArtifact decode: %v", err)
+	}
+	if cr.Name == "" {
+		return nil, inputf("ExternalArtifact missing metadata.name")
+	}
+	out := &ExternalArtifact{
+		Name:      cr.Name,
+		Namespace: cr.Namespace,
+	}
+	if cr.Spec.SourceRef != nil {
+		out.SourceRef = &ExternalArtifactSourceRef{
+			APIVersion: cr.Spec.SourceRef.APIVersion,
+			Kind:       cr.Spec.SourceRef.Kind,
+			Namespace:  cr.Spec.SourceRef.Namespace,
+			Name:       cr.Spec.SourceRef.Name,
+		}
+	}
+	if a := cr.Status.Artifact; a != nil {
+		out.ArtifactURL = a.URL
+		out.Revision = a.Revision
+		out.Digest = a.Digest
+	}
+	return out, nil
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -104,7 +104,8 @@ func New(cfg Config) (*Orchestrator, error) {
 	ts := task.New()
 	cache := cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources")))
 	fetchers := map[string]source.Fetcher{
-		manifest.KindGitRepository: &source.GitFetcher{Cache: cache},
+		manifest.KindGitRepository:    &source.GitFetcher{Cache: cache},
+		manifest.KindExternalArtifact: &source.ExternalArtifactFetcher{},
 	}
 	if cfg.EnableOCI {
 		fetchers[manifest.KindOCIRepository] = &source.OCIFetcher{

--- a/pkg/source/external.go
+++ b/pkg/source/external.go
@@ -1,0 +1,61 @@
+package source
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// ExternalArtifactFetcher resolves an ExternalArtifact CR into a
+// SourceArtifact. Because ExternalArtifact is the contract a
+// third-party controller uses to publish content into a live cluster,
+// flate (which runs offline) has no general way to fetch from the
+// upstream URL. Two modes are supported:
+//
+//  1. The CR's status.artifact has been pre-populated in the YAML with
+//     a `file://` URL. flate trusts the local path and surfaces it
+//     verbatim as a SourceArtifact so downstream Kustomizations or
+//     HelmReleases referencing the artifact can resolve.
+//
+//  2. status.artifact is unset or its URL is not file://. flate cannot
+//     resolve the content; the fetcher returns an error. Any consumer
+//     that references this ExternalArtifact will fail-loud with a
+//     "source artifact not found" message — preferable to silently
+//     emitting empty output.
+type ExternalArtifactFetcher struct{}
+
+// Fetch implements source.Fetcher for *manifest.ExternalArtifact.
+func (f *ExternalArtifactFetcher) Fetch(_ context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+	ea, ok := obj.(*manifest.ExternalArtifact)
+	if !ok {
+		return nil, fmt.Errorf("%w: ExternalArtifactFetcher: unexpected payload %T", manifest.ErrInput, obj)
+	}
+	if ea.ArtifactURL == "" {
+		return nil, fmt.Errorf(
+			"ExternalArtifact %s/%s requires status.artifact to be populated for offline use — "+
+				"flate cannot fetch from the live source-controller. Pre-fill status.artifact with a file:// URL "+
+				"or suspend the resource",
+			ea.Namespace, ea.Name,
+		)
+	}
+	localPath := ""
+	if rest, ok := strings.CutPrefix(ea.ArtifactURL, "file://"); ok {
+		localPath = rest
+	}
+	if localPath == "" {
+		return nil, fmt.Errorf(
+			"ExternalArtifact %s/%s status.artifact.url %q is not a file:// URL — flate can only resolve local artifacts offline",
+			ea.Namespace, ea.Name, ea.ArtifactURL,
+		)
+	}
+	return &store.SourceArtifact{
+		Kind:      manifest.KindExternalArtifact,
+		URL:       ea.ArtifactURL,
+		LocalPath: localPath,
+		Revision:  ea.Revision,
+		Digest:    ea.Digest,
+	}, nil
+}

--- a/pkg/source/external_test.go
+++ b/pkg/source/external_test.go
@@ -1,0 +1,60 @@
+package source_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+func TestExternalArtifactFetcher_FileURL(t *testing.T) {
+	f := &source.ExternalArtifactFetcher{}
+	ea := &manifest.ExternalArtifact{
+		Name: "ea", Namespace: "apps",
+		ArtifactURL: "file:///cache/x.tar.gz",
+		Revision:    "v1@sha256:abc",
+		Digest:      "sha256:abc",
+	}
+	art, err := f.Fetch(context.Background(), ea)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if art.Kind != manifest.KindExternalArtifact {
+		t.Errorf("Kind = %q, want %q", art.Kind, manifest.KindExternalArtifact)
+	}
+	if art.LocalPath != "/cache/x.tar.gz" {
+		t.Errorf("LocalPath = %q, want /cache/x.tar.gz", art.LocalPath)
+	}
+	if art.Revision != "v1@sha256:abc" {
+		t.Errorf("Revision = %q", art.Revision)
+	}
+}
+
+func TestExternalArtifactFetcher_NoArtifact(t *testing.T) {
+	f := &source.ExternalArtifactFetcher{}
+	ea := &manifest.ExternalArtifact{Name: "ea", Namespace: "apps"}
+	_, err := f.Fetch(context.Background(), ea)
+	if err == nil {
+		t.Fatalf("expected error when ArtifactURL is empty")
+	}
+	if !strings.Contains(err.Error(), "offline use") {
+		t.Errorf("error should explain the offline limitation; got %v", err)
+	}
+}
+
+func TestExternalArtifactFetcher_NonFileURL(t *testing.T) {
+	f := &source.ExternalArtifactFetcher{}
+	ea := &manifest.ExternalArtifact{
+		Name: "ea", Namespace: "apps",
+		ArtifactURL: "http://source-controller.flux-system.svc/x.tar.gz",
+	}
+	_, err := f.Fetch(context.Background(), ea)
+	if err == nil {
+		t.Fatalf("expected error for non-file:// URL")
+	}
+	if !strings.Contains(err.Error(), "not a file://") {
+		t.Errorf("error should call out the URL scheme; got %v", err)
+	}
+}

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -56,7 +56,8 @@ func SupportsStatus(kind string) bool {
 		manifest.KindGitRepository,
 		manifest.KindHelmRelease,
 		manifest.KindHelmRepository,
-		manifest.KindOCIRepository:
+		manifest.KindOCIRepository,
+		manifest.KindExternalArtifact:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

Adds support for the **\`ExternalArtifact\`** Flux source kind (\`source.toolkit.fluxcd.io/v1\`), one of the two missing kinds the deep-review pass flagged.

\`ExternalArtifact\` is the contract a third-party controller uses to publish on-cluster content under Flux's source-controller schema (RFC-0012). Adding it is the smallest validation of the post-Phase-2 architecture: **one Fetcher implementation + one orchestrator registration + one constant.**

## Behavior

ExternalArtifact's content lives at a URL published by an upstream controller into \`status.artifact\`. flate runs offline, so the general case (HTTP URL into a live cluster) is not resolvable. The fetcher honors two modes:

1. **Pre-populated \`status.artifact\` with a \`file://\` URL.** The typical workflow for testing or air-gapped renders, where the artifact is pre-extracted to disk. flate surfaces it verbatim as a \`SourceArtifact\`.
2. **Anything else** (empty status, http/https URL, etc.). The fetcher returns a clear error explaining the limitation; downstream KS/HR references fail-loud at \`resolveSourceRoot\` with \"source artifact not found\" instead of silently emitting empty.

## What changed

- New \`manifest.KindExternalArtifact\` constant.
- New \`manifest.ExternalArtifact\` struct + \`ParseExternalArtifact\` via the existing \`decodeTyped\` JSON-round-trip path. Reads \`spec.sourceRef\` (the upstream CR identifier) and, when present, \`status.artifact.{url,revision,digest}\`.
- \`ParseDoc\` dispatch arm registered.
- \`store.SupportsStatus\` includes the kind so depwait / change-filter handle it like other source CRs.
- New \`source.ExternalArtifactFetcher\` (zero deps).
- Orchestrator registers the fetcher unconditionally (no enable/disable flag — the CR is harmless if no consumer references it).

## Tests

- \`TestParseExternalArtifact\` — full CR with \`sourceRef\` + \`status.artifact\` round-trips correctly.
- \`TestExternalArtifactFetcher_FileURL\` — \`file://\` URL produces a usable SourceArtifact with LocalPath.
- \`TestExternalArtifactFetcher_NoArtifact\` — missing status.artifact returns an error mentioning \"offline use\".
- \`TestExternalArtifactFetcher_NonFileURL\` — http/https URL returns an error mentioning the URL scheme.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (all 18 packages + e2e)
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues

Next: **Bucket** support (P3.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)