### PR TITLE
feat(source): GitRepository SecretRef auth (HTTPS basic / bearer / SSH)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
+	golang.org/x/crypto v0.50.0
 	golang.org/x/sync v0.20.0
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/apimachinery v0.36.1
@@ -130,7 +131,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -44,6 +44,16 @@ const (
 	BucketProviderAzure   = "azure"
 )
 
+// GitRepository providers as understood by Flux. flate currently
+// supports only "generic" (SecretRef-based username/password / bearer
+// / SSH identity); azure (Managed Identity) and github (GitHub App)
+// require live cloud-provider auth flows and fail-loud at fetch time.
+const (
+	GitProviderGeneric = "generic"
+	GitProviderAzure   = "azure"
+	GitProviderGitHub  = "github"
+)
+
 // ValuePlaceholderTemplate is the format string used when wiping Secret
 // values. The "{name}" token is replaced with the data key.
 const ValuePlaceholderTemplate = "..PLACEHOLDER_%s.."

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -33,11 +33,13 @@ func (r GitRepositoryRef) IsEmpty() bool { return r == GitRepositoryRef{} }
 
 // GitRepository is the Flux GitRepository CRD.
 type GitRepository struct {
-	Name      string           `json:"name" yaml:"name"`
-	Namespace string           `json:"namespace" yaml:"namespace"`
-	URL       string           `json:"url" yaml:"url"`
-	Ref       GitRepositoryRef `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Suspend   bool             `json:"-" yaml:"-"`
+	Name      string                `json:"name" yaml:"name"`
+	Namespace string                `json:"namespace" yaml:"namespace"`
+	URL       string                `json:"url" yaml:"url"`
+	Ref       GitRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Provider  string                `json:"provider,omitempty" yaml:"provider,omitempty"`
+	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	Suspend   bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the GitRepository.
@@ -77,13 +79,22 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 			Commit: r.Commit,
 		}
 	}
-	return &GitRepository{
+	provider := cr.Spec.Provider
+	if provider == "" {
+		provider = GitProviderGeneric
+	}
+	out := &GitRepository{
 		Name:      cr.Name,
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
 		Ref:       ref,
+		Provider:  provider,
 		Suspend:   cr.Spec.Suspend,
-	}, nil
+	}
+	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
+		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+	}
+	return out, nil
 }
 
 // OCIRepositoryRef points at a specific OCI artifact version.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -109,7 +109,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		return s
 	}
 	fetchers := map[string]source.Fetcher{
-		manifest.KindGitRepository:    &source.GitFetcher{Cache: cache},
+		manifest.KindGitRepository:    &source.GitFetcher{Cache: cache, Secrets: secretGet},
 		manifest.KindExternalArtifact: &source.ExternalArtifactFetcher{},
 		manifest.KindBucket:           &source.BucketFetcher{Cache: cache, Secrets: secretGet},
 	}

--- a/pkg/source/git.go
+++ b/pkg/source/git.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -16,9 +19,11 @@ import (
 
 // GitFetcher is the Fetcher implementation for KindGitRepository.
 // It owns a shared Cache so multiple GitRepository CRs writing to the
-// same cache root serialize on slot allocation correctly.
+// same cache root serialize on slot allocation correctly. Secrets is
+// optional; required when a GitRepository sets spec.secretRef.
 type GitFetcher struct {
-	Cache *Cache
+	Cache   *Cache
+	Secrets SecretGetter
 }
 
 // Fetch implements source.Fetcher for *manifest.GitRepository.
@@ -27,17 +32,102 @@ func (f *GitFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*sto
 	if !ok {
 		return nil, fmt.Errorf("%w: GitFetcher: unexpected payload %T", manifest.ErrInput, obj)
 	}
-	return FetchGit(ctx, f.Cache, repo)
+	if repo.Provider != "" && repo.Provider != manifest.GitProviderGeneric {
+		return nil, fmt.Errorf(
+			"GitRepository %s/%s provider %q is not implemented; flate currently supports only %q (SecretRef-based credentials)",
+			repo.Namespace, repo.Name, repo.Provider, manifest.GitProviderGeneric,
+		)
+	}
+	auth, err := f.resolveAuth(repo)
+	if err != nil {
+		return nil, err
+	}
+	return FetchGit(ctx, f.Cache, repo, auth)
+}
+
+// resolveAuth turns repo.SecretRef into a go-git AuthMethod. Returns
+// nil auth (anonymous) when no secret is configured, matching the
+// pre-auth behavior. For HTTPS URLs the secret may carry either
+// (username, password) or (bearerToken); for SSH URLs the secret
+// carries `identity` (PEM private key) and an optional `password`.
+func (f *GitFetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMethod, error) {
+	if repo.SecretRef == nil {
+		return nil, nil
+	}
+	if f.Secrets == nil {
+		return nil, fmt.Errorf("GitRepository %s/%s references secretRef but no SecretGetter is wired",
+			repo.Namespace, repo.Name)
+	}
+	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s not found",
+			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+	}
+	if isSSHURL(repo.URL) {
+		identity := stringFromSecret(sec, "identity")
+		if identity == "" {
+			return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s missing 'identity' for SSH auth",
+				repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+		}
+		password := stringFromSecret(sec, "password")
+		user := sshUserFromURL(repo.URL)
+		auth, err := gitssh.NewPublicKeys(user, []byte(identity), password)
+		if err != nil {
+			return nil, fmt.Errorf("GitRepository %s/%s: parse SSH identity: %w",
+				repo.Namespace, repo.Name, err)
+		}
+		// Flate has no central known_hosts. If the secret carries one,
+		// enforce strict host-key checking; otherwise skip (offline
+		// renders against ephemeral worktrees are the norm). Users who
+		// need strict checks provide `known_hosts` in the Secret.
+		if kh := stringFromSecret(sec, "known_hosts"); kh != "" {
+			cb, herr := knownHostsCallback([]byte(kh))
+			if herr != nil {
+				return nil, fmt.Errorf("GitRepository %s/%s: parse known_hosts: %w",
+					repo.Namespace, repo.Name, herr)
+			}
+			auth.HostKeyCallback = cb
+		} else {
+			auth.HostKeyCallback = insecureIgnoreHostKey
+		}
+		return auth, nil
+	}
+	// HTTPS / HTTP: bearerToken takes precedence over basic auth, mirroring
+	// source-controller's docs.
+	if token := stringFromSecret(sec, "bearerToken"); token != "" {
+		return &githttp.TokenAuth{Token: token}, nil
+	}
+	username := stringFromSecret(sec, "username")
+	password := stringFromSecret(sec, "password")
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s missing username/password (or bearerToken) for HTTPS auth",
+			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+	}
+	return &githttp.BasicAuth{Username: username, Password: password}, nil
+}
+
+func isSSHURL(url string) bool {
+	return strings.HasPrefix(url, "ssh://") ||
+		(strings.Contains(url, "@") && !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://"))
+}
+
+// sshUserFromURL extracts the SSH user from "user@host:repo" or
+// "ssh://user@host/repo" forms. Defaults to "git" when absent.
+func sshUserFromURL(url string) string {
+	u := strings.TrimPrefix(url, "ssh://")
+	if at := strings.Index(u, "@"); at > 0 {
+		return u[:at]
+	}
+	return "git"
 }
 
 // FetchGit clones the GitRepository referenced by repo into the supplied
 // cache and returns a populated *store.SourceArtifact. If a usable cached
-// copy already exists, it is reused.
+// copy already exists, it is reused. auth may be nil for anonymous clones.
 //
-// Supported transports: public HTTPS, ssh-with-agent (handled by go-git
-// transparently), and file:// URLs. Per-host credential lookups via a
-// Secret reference will be added when a use case demands it.
-func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (*store.SourceArtifact, error) {
+// Supported transports: HTTPS (anonymous, basic, bearer), SSH (key from
+// SecretRef or ssh-agent), and file:// URLs.
+func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository, auth transport.AuthMethod) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}
@@ -77,7 +167,7 @@ func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository) (
 		url = rest
 	}
 
-	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true}
+	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
 	cloned, err := git.PlainCloneContext(ctx, slot, false, cloneOpts)
 	if err != nil {
 		_ = cache.Reset(slot)

--- a/pkg/source/git_auth_test.go
+++ b/pkg/source/git_auth_test.go
@@ -1,0 +1,161 @@
+package source
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestGitFetcher_NonGenericProvider(t *testing.T) {
+	f := &GitFetcher{}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:      "https://github.com/x/y.git",
+		Provider: manifest.GitProviderGitHub,
+	}
+	_, err := f.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatalf("expected error for unimplemented provider")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should say 'not implemented'; got %v", err)
+	}
+}
+
+func TestGitFetcher_HTTPSBasicAuth(t *testing.T) {
+	f := &GitFetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{
+				StringData: map[string]any{
+					"username": "alice",
+					"password": "hunter2",
+				},
+			}
+		},
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "https://github.com/x/y.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	auth, err := f.resolveAuth(repo)
+	if err != nil {
+		t.Fatalf("resolveAuth: %v", err)
+	}
+	basic, ok := auth.(*githttp.BasicAuth)
+	if !ok {
+		t.Fatalf("got %T, want *BasicAuth", auth)
+	}
+	if basic.Username != "alice" || basic.Password != "hunter2" {
+		t.Errorf("credentials lost: %+v", basic)
+	}
+}
+
+func TestGitFetcher_HTTPSBearerWinsOverBasic(t *testing.T) {
+	f := &GitFetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{
+				StringData: map[string]any{
+					"username":    "alice",
+					"password":    "ignored",
+					"bearerToken": "tkn_abc",
+				},
+			}
+		},
+	}
+	repo := &manifest.GitRepository{
+		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	auth, err := f.resolveAuth(repo)
+	if err != nil {
+		t.Fatalf("resolveAuth: %v", err)
+	}
+	tok, ok := auth.(*githttp.TokenAuth)
+	if !ok {
+		t.Fatalf("got %T, want *TokenAuth", auth)
+	}
+	if tok.Token != "tkn_abc" {
+		t.Errorf("token: %q", tok.Token)
+	}
+}
+
+func TestGitFetcher_HTTPSMissingCreds(t *testing.T) {
+	f := &GitFetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"username": "alice"}}
+		},
+	}
+	repo := &manifest.GitRepository{
+		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	_, err := f.resolveAuth(repo)
+	if err == nil || !strings.Contains(err.Error(), "missing username/password") {
+		t.Errorf("expected missing-creds error; got %v", err)
+	}
+}
+
+func TestGitFetcher_NoSecretIsAnonymous(t *testing.T) {
+	f := &GitFetcher{}
+	repo := &manifest.GitRepository{URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns"}
+	auth, err := f.resolveAuth(repo)
+	if err != nil {
+		t.Fatalf("resolveAuth: %v", err)
+	}
+	if auth != nil {
+		t.Errorf("expected nil auth (anonymous); got %T", auth)
+	}
+}
+
+func TestGitFetcher_SecretRefMissingGetter(t *testing.T) {
+	f := &GitFetcher{} // no Secrets
+	repo := &manifest.GitRepository{
+		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	_, err := f.resolveAuth(repo)
+	if err == nil || !strings.Contains(err.Error(), "SecretGetter") {
+		t.Errorf("expected SecretGetter error; got %v", err)
+	}
+}
+
+func TestSshUserFromURL(t *testing.T) {
+	cases := map[string]string{
+		"git@github.com:owner/repo.git":      "git",
+		"ssh://buildbot@example.com/r.git":   "buildbot",
+		"https://github.com/x/y.git":         "git", // not actually SSH, but tests default
+		"":                                   "git",
+	}
+	for url, want := range cases {
+		if got := sshUserFromURL(url); got != want {
+			t.Errorf("sshUserFromURL(%q) = %q, want %q", url, got, want)
+		}
+	}
+}
+
+func TestIsSSHURL(t *testing.T) {
+	yes := []string{
+		"git@github.com:o/r.git",
+		"ssh://git@example.com/r",
+	}
+	no := []string{
+		"https://github.com/o/r.git",
+		"http://example.com/r",
+		"file:///tmp/r",
+	}
+	for _, u := range yes {
+		if !isSSHURL(u) {
+			t.Errorf("isSSHURL(%q) = false, want true", u)
+		}
+	}
+	for _, u := range no {
+		if isSSHURL(u) {
+			t.Errorf("isSSHURL(%q) = true, want false", u)
+		}
+	}
+}

--- a/pkg/source/git_ssh.go
+++ b/pkg/source/git_ssh.go
@@ -1,0 +1,41 @@
+package source
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// insecureIgnoreHostKey is the default SSH host-key callback when a
+// GitRepository SecretRef does NOT include a known_hosts entry. It
+// matches the pre-existing ssh-with-agent behavior; users who want
+// strict host-key checking provide known_hosts in the Secret.
+func insecureIgnoreHostKey(_ string, _ net.Addr, _ ssh.PublicKey) error {
+	return nil
+}
+
+// knownHostsCallback returns an SSH HostKeyCallback that validates
+// against the provided known_hosts data. The data is materialized to
+// a temp file because golang.org/x/crypto/ssh/knownhosts only exposes
+// a file-based New constructor.
+func knownHostsCallback(data []byte) (ssh.HostKeyCallback, error) {
+	f, err := os.CreateTemp("", "flate-known-hosts-*")
+	if err != nil {
+		return nil, fmt.Errorf("temp known_hosts: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return nil, fmt.Errorf("write known_hosts: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return nil, fmt.Errorf("close known_hosts: %w", err)
+	}
+	// Note: the file leaks until process exit. Acceptable for a CLI
+	// run; revisit if flate ever grows a watch mode.
+	return knownhosts.New(f.Name())
+}

--- a/pkg/source/git_test.go
+++ b/pkg/source/git_test.go
@@ -24,7 +24,7 @@ func TestFetchGit_LocalFileURL(t *testing.T) {
 		URL:       "file://" + src,
 	}
 
-	art, err := FetchGit(context.Background(), cache, repo)
+	art, err := FetchGit(context.Background(), cache, repo, nil)
 	if err != nil {
 		t.Fatalf("FetchGit: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestFetchGit_LocalFileURL(t *testing.T) {
 	}
 
 	// Second call should reuse cache.
-	art2, err := FetchGit(context.Background(), cache, repo)
+	art2, err := FetchGit(context.Background(), cache, repo, nil)
 	if err != nil {
 		t.Fatalf("FetchGit second: %v", err)
 	}


### PR DESCRIPTION
## Summary

First of the Phase 3 auth items: Secret-backed authentication for Flux GitRepository.

Mirrors source-controller's \`generic\` provider, supporting:

| Secret keys | Resolved auth |
|---|---|
| \`bearerToken\` | \`http.TokenAuth\` (takes precedence over basic) |
| \`username\` + \`password\` | \`http.BasicAuth\` |
| \`identity\` (PEM) + optional \`password\` | \`ssh.PublicKeys\` (SSH URLs only) |
| \`identity\` + \`known_hosts\` | SSH with strict host-key checking |
| (no \`known_hosts\`) | SSH with \`insecureIgnoreHostKey\` (matches pre-auth ssh-with-agent behavior) |

\`provider: azure\` (Managed Identity) and \`provider: github\` (GitHub App) parse correctly but the Fetcher returns \`\"provider X is not implemented\"\` — those flows require live cloud-side auth that's out of scope for an offline CLI. Anyone using them gets a clear error rather than silent mis-routing.

## What changed

- \`manifest.GitRepository\` gains \`Provider\` + \`SecretRef\` fields (default Provider \`\"generic\"\`).
- \`ParseGitRepository\` populates them.
- New constants: \`GitProviderGeneric\` / \`GitProviderAzure\` / \`GitProviderGitHub\`.
- \`GitFetcher\` gains \`Secrets SecretGetter\` and \`resolveAuth()\`.
- \`FetchGit\` signature now takes \`transport.AuthMethod\`; threaded into \`CloneOptions.Auth\`.
- New \`git_ssh.go\` with \`insecureIgnoreHostKey\` + \`knownHostsCallback\` (materializes Secret \`known_hosts\` bytes to a temp file because \`x/crypto/ssh/knownhosts\` exposes only a file-based \`New\`).
- Orchestrator wires \`Secrets\` into \`GitFetcher\` — same \`SecretGetter\` shape \`BucketFetcher\` uses, so the orchestrator construction stays uniform.

## --wipe-secrets safety

PLACEHOLDER_-wiped Secret values (the default behavior) are treated as missing in \`stringFromSecret\`. Users get a clear \`\"missing username/password\"\` error rather than silently authenticating with the literal placeholder.

## Tests

- \`TestGitFetcher_NonGenericProvider\` — \`provider: github\` returns clear error.
- \`TestGitFetcher_HTTPSBasicAuth\` — username/password → \`*BasicAuth\`.
- \`TestGitFetcher_HTTPSBearerWinsOverBasic\` — bearerToken precedence.
- \`TestGitFetcher_HTTPSMissingCreds\` — partial Secret returns clear error.
- \`TestGitFetcher_NoSecretIsAnonymous\` — no SecretRef → nil auth (anonymous clone).
- \`TestGitFetcher_SecretRefMissingGetter\` — clear error if SecretRef set but no SecretGetter wired.
- \`TestSshUserFromURL\` / \`TestIsSSHURL\` — URL parsing edge cases.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (all 18 packages + e2e)
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues
- [x] \`go mod tidy\` no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)