### PR TITLE
feat(source): OCIRepository SecretRef auth (dockerconfigjson)

### DIFF
--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -54,6 +54,18 @@ const (
 	GitProviderGitHub  = "github"
 )
 
+// OCIRepository providers as understood by Flux. flate currently
+// supports only "generic" (SecretRef carrying a docker-style
+// dockerconfigjson, or the global --registry-config file). The
+// aws/gcp/azure providers need IRSA / Workload Identity and fail-loud
+// at fetch time.
+const (
+	OCIProviderGeneric = "generic"
+	OCIProviderAmazon  = "aws"
+	OCIProviderGoogle  = "gcp"
+	OCIProviderAzure   = "azure"
+)
+
 // ValuePlaceholderTemplate is the format string used when wiping Secret
 // values. The "{name}" token is replaced with the data key.
 const ValuePlaceholderTemplate = "..PLACEHOLDER_%s.."

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -114,6 +114,7 @@ type OCIRepository struct {
 	Namespace string                `json:"namespace" yaml:"namespace"`
 	URL       string                `json:"url" yaml:"url"`
 	Ref       OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Provider  string                `json:"provider,omitempty" yaml:"provider,omitempty"`
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
 	Suspend   bool                  `json:"-" yaml:"-"`
 }
@@ -179,10 +180,15 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("OCIRepository missing spec.url")
 	}
+	provider := cr.Spec.Provider
+	if provider == "" {
+		provider = OCIProviderGeneric
+	}
 	out := &OCIRepository{
 		Name:      cr.Name,
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
+		Provider:  provider,
 		Suspend:   cr.Spec.Suspend,
 	}
 	if r := cr.Spec.Reference; r != nil {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -115,7 +115,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	}
 	if cfg.EnableOCI {
 		fetchers[manifest.KindOCIRepository] = &source.OCIFetcher{
-			Cache: cache, RegistryConfig: cfg.RegistryConfig,
+			Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet,
 		}
 	}
 	o := &Orchestrator{

--- a/pkg/source/oci.go
+++ b/pkg/source/oci.go
@@ -22,9 +22,15 @@ import (
 )
 
 // OCIFetcher is the Fetcher implementation for KindOCIRepository.
+// RegistryConfig is the global --registry-config docker-style
+// config.json path used when no per-repo SecretRef is set. Secrets is
+// the per-repo SecretGetter (typically the orchestrator-provided
+// Store.GetByName), required when any OCIRepository has spec.secretRef
+// pointing at a kubernetes.io/dockerconfigjson Secret.
 type OCIFetcher struct {
 	Cache          *Cache
 	RegistryConfig string
+	Secrets        SecretGetter
 }
 
 // Fetch implements source.Fetcher for *manifest.OCIRepository.
@@ -33,7 +39,66 @@ func (f *OCIFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*sto
 	if !ok {
 		return nil, fmt.Errorf("%w: OCIFetcher: unexpected payload %T", manifest.ErrInput, obj)
 	}
-	return FetchOCI(ctx, f.Cache, repo, f.RegistryConfig)
+	if repo.Provider != "" && repo.Provider != manifest.OCIProviderGeneric {
+		return nil, fmt.Errorf(
+			"OCIRepository %s/%s provider %q is not implemented; flate currently supports only %q (SecretRef or --registry-config credentials)",
+			repo.Namespace, repo.Name, repo.Provider, manifest.OCIProviderGeneric,
+		)
+	}
+	configPath, cleanup, err := f.resolveRegistryConfig(repo)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+	return FetchOCI(ctx, f.Cache, repo, configPath)
+}
+
+// resolveRegistryConfig picks the credential source for a fetch.
+// Precedence:
+//  1. per-OCIRepository spec.secretRef (a kubernetes.io/dockerconfigjson
+//     Secret materialized to a temp file).
+//  2. global --registry-config path (f.RegistryConfig).
+//  3. docker's default lookup (~/.docker/config.json), handled inside
+//     loadCredentials when configPath is empty.
+//
+// The cleanup func removes any temp file the SecretRef path created;
+// safe to call when no temp file was made (no-op).
+func (f *OCIFetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, func(), error) {
+	noCleanup := func() {}
+	if repo.SecretRef == nil {
+		return f.RegistryConfig, noCleanup, nil
+	}
+	if f.Secrets == nil {
+		return "", noCleanup, fmt.Errorf("OCIRepository %s/%s references secretRef but no SecretGetter is wired",
+			repo.Namespace, repo.Name)
+	}
+	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
+	if sec == nil {
+		return "", noCleanup, fmt.Errorf("OCIRepository %s/%s: secret %s/%s not found",
+			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+	}
+	configJSON := stringFromSecret(sec, ".dockerconfigjson")
+	if configJSON == "" {
+		return "", noCleanup, fmt.Errorf(
+			"OCIRepository %s/%s: secret %s/%s missing .dockerconfigjson "+
+				"(must be type kubernetes.io/dockerconfigjson)",
+			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+	}
+	tmp, err := os.CreateTemp("", "flate-oci-creds-*.json")
+	if err != nil {
+		return "", noCleanup, fmt.Errorf("temp docker config: %w", err)
+	}
+	if _, err := tmp.WriteString(configJSON); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return "", noCleanup, fmt.Errorf("write temp docker config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return "", noCleanup, fmt.Errorf("close temp docker config: %w", err)
+	}
+	cleanup := func() { _ = os.Remove(tmp.Name()) }
+	return tmp.Name(), cleanup, nil
 }
 
 // FetchOCI pulls the OCIRepository artifact into cache. Credentials are

--- a/pkg/source/oci_auth_test.go
+++ b/pkg/source/oci_auth_test.go
@@ -1,0 +1,122 @@
+package source
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestOCIFetcher_NonGenericProvider(t *testing.T) {
+	f := &OCIFetcher{}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		URL:      "oci://ghcr.io/x/y",
+		Provider: manifest.OCIProviderAmazon,
+	}
+	_, err := f.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatalf("expected error for unimplemented provider")
+	}
+	if !strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("error should say 'not implemented'; got %v", err)
+	}
+}
+
+func TestOCIFetcher_ResolveConfig_NoSecretFallsBackToGlobal(t *testing.T) {
+	f := &OCIFetcher{RegistryConfig: "/etc/docker/config.json"}
+	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns"}
+	path, cleanup, err := f.resolveRegistryConfig(repo)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("resolveRegistryConfig: %v", err)
+	}
+	if path != "/etc/docker/config.json" {
+		t.Errorf("path = %q, want /etc/docker/config.json", path)
+	}
+}
+
+func TestOCIFetcher_ResolveConfig_SecretWritesTempFile(t *testing.T) {
+	dockerJSON := `{"auths":{"ghcr.io":{"auth":"YWxpY2U6aHVudGVyMg=="}}}`
+	f := &OCIFetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{
+				StringData: map[string]any{".dockerconfigjson": dockerJSON},
+			}
+		},
+	}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		URL:       "oci://ghcr.io/x/y",
+		SecretRef: &manifest.LocalObjectReference{Name: "ghcr-creds"},
+	}
+	path, cleanup, err := f.resolveRegistryConfig(repo)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("resolveRegistryConfig: %v", err)
+	}
+	if path == "" {
+		t.Fatalf("expected temp file path, got empty")
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is a temp file produced by the fetcher under test
+	if err != nil {
+		t.Fatalf("read temp file: %v", err)
+	}
+	if string(data) != dockerJSON {
+		t.Errorf("temp file content mismatch")
+	}
+	// cleanup should remove the file.
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("temp file not removed by cleanup: stat err = %v", err)
+	}
+}
+
+func TestOCIFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
+	f := &OCIFetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{
+				StringData: map[string]any{"username": "alice"}, // wrong shape
+			}
+		},
+	}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		SecretRef: &manifest.LocalObjectReference{Name: "wrong-shape"},
+	}
+	_, cleanup, err := f.resolveRegistryConfig(repo)
+	cleanup()
+	if err == nil || !strings.Contains(err.Error(), ".dockerconfigjson") {
+		t.Errorf("expected missing-.dockerconfigjson error; got %v", err)
+	}
+}
+
+func TestOCIFetcher_ResolveConfig_SecretRefWithoutGetter(t *testing.T) {
+	f := &OCIFetcher{} // no Secrets
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	_, cleanup, err := f.resolveRegistryConfig(repo)
+	cleanup()
+	if err == nil || !strings.Contains(err.Error(), "SecretGetter") {
+		t.Errorf("expected SecretGetter error; got %v", err)
+	}
+}
+
+func TestOCIFetcher_ResolveConfig_SecretNotFound(t *testing.T) {
+	f := &OCIFetcher{
+		Secrets: func(_, _ string) *manifest.Secret { return nil },
+	}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+	}
+	_, cleanup, err := f.resolveRegistryConfig(repo)
+	cleanup()
+	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {
+		t.Errorf("expected secret-not-found error; got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 auth, second item: per-OCIRepository credentials via \`spec.secretRef\` pointing at a \`kubernetes.io/dockerconfigjson\` Secret.

Previously only \`--registry-config\` (a global file path) was honored, which doesn't scale when a single flate run pulls from multiple registries each with their own credentials. Now each \`OCIRepository\` can carry its own SecretRef.

## Precedence

1. per-OCIRepository \`spec.secretRef\` (kubernetes.io/dockerconfigjson Secret)
2. global \`--registry-config\` file
3. docker default lookup (\`~/.docker/config.json\`)

## How it works

\`OCIFetcher.resolveRegistryConfig()\` materializes the Secret's \`.dockerconfigjson\` value to a temp file (oras-go's \`credentials.NewFileStore\` only accepts a path) and returns a cleanup func that's deferred per-Fetch. The temp file is wiped after each fetch.

\`Provider != \"generic\"\` (aws / gcp / azure — IRSA / Workload Identity) fails-loud at fetch time. Cloud-side workload-identity providers can land later as focused PRs without changing the registration surface.

## What changed

- \`manifest.OCIRepository\` gains \`Provider\` field (parsed, default \`\"generic\"\`).
- \`OCIProviderGeneric\` / \`Amazon\` / \`Google\` / \`Azure\` constants.
- \`OCIFetcher\` gains \`Secrets SecretGetter\` — same shape Bucket / Git use.
- Orchestrator threads \`Secrets\` into the OCIFetcher construction.
- PLACEHOLDER_-wiped Secret values are treated as missing so \`--wipe-secrets\` users get a clear \`\"missing .dockerconfigjson\"\` error instead of authenticating with the literal placeholder.

## Tests

- \`TestOCIFetcher_NonGenericProvider\` — \`provider: aws\` returns clear error.
- \`TestOCIFetcher_ResolveConfig_NoSecretFallsBackToGlobal\` — no SecretRef → global \`--registry-config\` path used.
- \`TestOCIFetcher_ResolveConfig_SecretWritesTempFile\` — SecretRef materialized to a temp file with correct contents; cleanup removes it.
- \`TestOCIFetcher_ResolveConfig_SecretMissingDockerConfigJSON\` — wrong-shape Secret (e.g. username/password without .dockerconfigjson) returns clear error.
- \`TestOCIFetcher_ResolveConfig_SecretRefWithoutGetter\` — SecretRef set but no SecretGetter wired.
- \`TestOCIFetcher_ResolveConfig_SecretNotFound\` — Secret missing from the store.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (all 18 packages + e2e)
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)