### PR TITLE
feat(controllers): fail-loud on SOPS-encrypted rendered output

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -173,6 +173,16 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
+	for _, doc := range docs {
+		if manifest.IsEncryptedSecret(doc) {
+			name, ns := manifest.DocMetadata(doc)
+			return fmt.Errorf(
+				"SOPS-encrypted %s %s/%s in rendered chart output: flate does not implement spec.decryption — "+
+					"render against pre-decrypted manifests or remove the encrypted resource",
+				manifest.DocKind(doc), ns, name,
+			)
+		}
+	}
 	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
 	for _, doc := range docs {
 		obj, err := manifest.ParseDoc(doc, opts)

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -132,6 +132,16 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
+	for _, doc := range docs {
+		if manifest.IsEncryptedSecret(doc) {
+			name, ns := manifest.DocMetadata(doc)
+			return fmt.Errorf(
+				"SOPS-encrypted %s %s/%s in rendered output: flate does not implement spec.decryption — "+
+					"render against pre-decrypted manifests or remove the encrypted resource",
+				manifest.DocKind(doc), ns, name,
+			)
+		}
+	}
 	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
 	for _, doc := range docs {
 		obj, err := manifest.ParseDoc(doc, opts)

--- a/pkg/manifest/sops.go
+++ b/pkg/manifest/sops.go
@@ -1,0 +1,26 @@
+package manifest
+
+// IsEncryptedSecret reports whether doc looks like a SOPS-encrypted
+// Kubernetes resource. SOPS appends a top-level `sops` map containing
+// its metadata (mac, kms/age/pgp blocks, version) after encrypting the
+// document's body; presence of that map with a `mac` or `version`
+// field is the unambiguous signal.
+//
+// flate runs offline and cannot decrypt; the kustomization and
+// helmrelease controllers call this to fail-loud when their rendered
+// output still contains encrypted content, mirroring Flux's
+// kustomize-controller refusal to apply un-decrypted Secrets when
+// spec.decryption is absent.
+func IsEncryptedSecret(doc map[string]any) bool {
+	sops, ok := doc["sops"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if _, ok := sops["mac"]; ok {
+		return true
+	}
+	if _, ok := sops["version"]; ok {
+		return true
+	}
+	return false
+}

--- a/pkg/manifest/sops_test.go
+++ b/pkg/manifest/sops_test.go
@@ -1,0 +1,64 @@
+package manifest
+
+import "testing"
+
+func TestIsEncryptedSecret(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  map[string]any
+		want bool
+	}{
+		{
+			name: "encrypted Secret with mac",
+			doc: map[string]any{
+				"apiVersion": "v1", "kind": "Secret",
+				"metadata": map[string]any{"name": "s", "namespace": "ns"},
+				"data":     map[string]any{"key": "ENC[AES256_GCM,data:...]"},
+				"sops": map[string]any{
+					"mac":     "ENC[AES256_GCM,data:...]",
+					"version": "3.7.3",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "encrypted with version but no mac",
+			doc: map[string]any{
+				"kind": "Secret",
+				"sops": map[string]any{"version": "3.7.3"},
+			},
+			want: true,
+		},
+		{
+			name: "plain Secret (no sops block)",
+			doc: map[string]any{
+				"apiVersion": "v1", "kind": "Secret",
+				"data": map[string]any{"key": "Zm9v"},
+			},
+			want: false,
+		},
+		{
+			name: "user-authored top-level 'sops' without mac/version",
+			doc: map[string]any{
+				"kind": "ConfigMap",
+				"sops": map[string]any{"description": "not encrypted"},
+			},
+			want: false,
+		},
+		{
+			name: "non-map 'sops' field is ignored",
+			doc: map[string]any{
+				"kind": "Secret",
+				"sops": "stringly",
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsEncryptedSecret(tc.doc); got != tc.want {
+				t.Errorf("IsEncryptedSecret = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3, fifth item: detect SOPS-encrypted resources in rendered output and fail-loud. flate runs offline and cannot implement \`spec.decryption\` — until this PR it silently emitted SOPS-encrypted Secrets through as if they were rendered content. The deep-review pass flagged this as MEDIUM correctness (\"flate will silently emit encrypted SOPS payloads as if they were rendered manifests\").

Now mirrors Flux's kustomize-controller refusal to apply un-decrypted Secrets when no decryption provider is configured.

## Behavior

Both reconcile bodies (Kustomization, HelmRelease) walk their rendered docs and return an error when any carries a top-level \`sops\` block with the canonical SOPS metadata. The resource is marked \`StatusFailed\` with a message naming the offending document and suggesting either pre-decrypted rendering or removal:

\`\`\`
SOPS-encrypted Secret media/myapp-creds in rendered output: flate does not implement
spec.decryption — render against pre-decrypted manifests or remove the encrypted resource
\`\`\`

The HelmRelease check covers the rare case where a chart commits a SOPS-encrypted resource directly in its templates.

## Detection

\`manifest.IsEncryptedSecret(doc)\` is structural:

1. Top-level \`sops\` key must be a map (rules out user-authored \`sops: \"some comment\"\`).
2. The map must contain a SOPS-specific field — \`mac\` or \`version\`.

Both conditions are required to avoid false positives on user-authored \`sops\` fields that happen to be map-shaped.

## Tests

Table-driven coverage in \`sops_test.go\`:

- Encrypted Secret with \`mac\` → true
- Encrypted with \`version\` only → true
- Plain Secret (no \`sops\` block) → false
- User-authored \`sops\` map without mac/version → false
- Malformed \`sops\` (string instead of map) → false

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues

## After this

Phase 3 status:
- ExternalArtifact (#33) ✅
- Bucket — generic provider (#34) ✅
- GitRepository auth (#35) ✅
- OCIRepository auth (#36) ✅
- HelmRepository auth — HTTP (#37) ✅
- **SOPS detection (this PR)** ✅
- \`dependsOn\` ReadyExpr CEL
- Bucket aws/gcp/azure providers
- OCI cosign / notation verify
- Per-kind \`pkg/source/\` subdirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)