### PR TITLE
refactor(source): per-kind subdirectories

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -18,6 +18,10 @@ import (
 	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/bucket"
+	"github.com/home-operations/flate/pkg/source/external"
+	"github.com/home-operations/flate/pkg/source/git"
+	"github.com/home-operations/flate/pkg/source/oci"
 	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/task"
 )
@@ -110,12 +114,12 @@ func New(cfg Config) (*Orchestrator, error) {
 	}
 	helmClient.SetSecretGetter(helm.SecretGetter(secretGet))
 	fetchers := map[string]source.Fetcher{
-		manifest.KindGitRepository:    &source.GitFetcher{Cache: cache, Secrets: secretGet},
-		manifest.KindExternalArtifact: &source.ExternalArtifactFetcher{},
-		manifest.KindBucket:           &source.BucketFetcher{Cache: cache, Secrets: secretGet},
+		manifest.KindGitRepository:    &git.Fetcher{Cache: cache, Secrets: secretGet},
+		manifest.KindExternalArtifact: &external.Fetcher{},
+		manifest.KindBucket:           &bucket.Fetcher{Cache: cache, Secrets: secretGet},
 	}
 	if cfg.EnableOCI {
-		fetchers[manifest.KindOCIRepository] = &source.OCIFetcher{
+		fetchers[manifest.KindOCIRepository] = &oci.Fetcher{
 			Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet,
 		}
 	}

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -1,4 +1,6 @@
-package source
+// Package bucket implements the source.Fetcher for KindBucket
+// (S3-compatible object storage via minio-go).
+package bucket
 
 import (
 	"context"
@@ -17,24 +19,25 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// BucketFetcher pulls a Flux Bucket CR into the on-disk cache. Only
-// the "generic" provider (any S3-API-compatible storage) is wired up
+// Fetcher pulls a Flux Bucket CR into the on-disk cache. Only the
+// "generic" provider (any S3-API-compatible storage) is wired up
 // today via minio-go. The aws/gcp/azure providers parse and route
 // here but return a clear "not implemented" error rather than silently
 // falling back.
-type BucketFetcher struct {
-	Cache   *Cache
-	Secrets SecretGetter
+type Fetcher struct {
+	Cache   *source.Cache
+	Secrets source.SecretGetter
 }
 
 // Fetch implements source.Fetcher for *manifest.Bucket.
-func (f *BucketFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
 	b, ok := obj.(*manifest.Bucket)
 	if !ok {
-		return nil, fmt.Errorf("%w: BucketFetcher: unexpected payload %T", manifest.ErrInput, obj)
+		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
 	}
 	if b.Provider != "" && b.Provider != manifest.BucketProviderGeneric {
 		return nil, fmt.Errorf(
@@ -89,7 +92,7 @@ func (f *BucketFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*
 
 // resolveCredentials picks up accesskey/secretkey from the SecretRef
 // or falls back to anonymous (which is valid for public buckets).
-func (f *BucketFetcher) resolveCredentials(b *manifest.Bucket) (*credentials.Credentials, error) {
+func (f *Fetcher) resolveCredentials(b *manifest.Bucket) (*credentials.Credentials, error) {
 	if b.SecretRef == nil {
 		return credentials.NewStaticV4("", "", ""), nil
 	}
@@ -102,33 +105,13 @@ func (f *BucketFetcher) resolveCredentials(b *manifest.Bucket) (*credentials.Cre
 		return nil, fmt.Errorf("bucket %s/%s: secret %s/%s not found",
 			b.Namespace, b.Name, b.Namespace, b.SecretRef.Name)
 	}
-	access := stringFromSecret(sec, "accesskey")
-	secret := stringFromSecret(sec, "secretkey")
+	access := source.StringFromSecret(sec, "accesskey")
+	secret := source.StringFromSecret(sec, "secretkey")
 	if access == "" || secret == "" {
 		return nil, fmt.Errorf("bucket %s/%s: secret %s/%s missing accesskey/secretkey",
 			b.Namespace, b.Name, b.Namespace, b.SecretRef.Name)
 	}
 	return credentials.NewStaticV4(access, secret, ""), nil
-}
-
-// stringFromSecret looks up a key from either Secret.StringData
-// (plain) or Secret.Data (which may have been wiped to a placeholder
-// by ParseSecret when WipeSecrets=true). A placeholder is treated as
-// empty so the caller surfaces a clear "missing keys" error.
-func stringFromSecret(sec *manifest.Secret, key string) string {
-	if v, ok := sec.StringData[key].(string); ok {
-		if strings.HasPrefix(v, "..PLACEHOLDER_") {
-			return ""
-		}
-		return v
-	}
-	if v, ok := sec.Data[key].(string); ok {
-		if strings.HasPrefix(v, "..PLACEHOLDER_") {
-			return ""
-		}
-		return v
-	}
-	return ""
 }
 
 // normalizeEndpoint splits a Flux-style endpoint into the

--- a/pkg/source/bucket/bucket_test.go
+++ b/pkg/source/bucket/bucket_test.go
@@ -1,4 +1,4 @@
-package source_test
+package bucket_test
 
 import (
 	"context"
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/bucket"
 )
 
-func TestBucketFetcher_NonGenericProviderFailsLoud(t *testing.T) {
-	f := &source.BucketFetcher{}
+func TestFetcher_NonGenericProviderFailsLoud(t *testing.T) {
+	f := &bucket.Fetcher{}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
 		Provider: manifest.BucketProviderAmazon,
@@ -25,8 +25,8 @@ func TestBucketFetcher_NonGenericProviderFailsLoud(t *testing.T) {
 	}
 }
 
-func TestBucketFetcher_SecretRefWithoutGetter(t *testing.T) {
-	f := &source.BucketFetcher{} // no Secrets
+func TestFetcher_SecretRefWithoutGetter(t *testing.T) {
+	f := &bucket.Fetcher{} // no Secrets
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
 		Provider: manifest.BucketProviderGeneric,
@@ -42,8 +42,8 @@ func TestBucketFetcher_SecretRefWithoutGetter(t *testing.T) {
 	}
 }
 
-func TestBucketFetcher_SecretRefMissingKeys(t *testing.T) {
-	f := &source.BucketFetcher{
+func TestFetcher_SecretRefMissingKeys(t *testing.T) {
+	f := &bucket.Fetcher{
 		Secrets: func(ns, name string) *manifest.Secret {
 			return &manifest.Secret{
 				Name: name, Namespace: ns,
@@ -66,8 +66,8 @@ func TestBucketFetcher_SecretRefMissingKeys(t *testing.T) {
 	}
 }
 
-func TestBucketFetcher_SecretRefNotFound(t *testing.T) {
-	f := &source.BucketFetcher{
+func TestFetcher_SecretRefNotFound(t *testing.T) {
+	f := &bucket.Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret { return nil },
 	}
 	b := &manifest.Bucket{

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -1,0 +1,18 @@
+package source
+
+import "testing"
+
+func TestSlugifyRepo(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/owner/cluster.git":                "cluster",
+		"git@github.com:owner/cluster.git":                    "cluster",
+		"https://example.com/long-path/with/slashes/repo.git": "repo",
+		"oci://ghcr.io/stefanprodan/charts/podinfo":           "podinfo",
+		"": "repo",
+	}
+	for in, want := range cases {
+		if got := slugifyRepo(in); got != want {
+			t.Errorf("slugifyRepo(%q) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/pkg/source/external/external.go
+++ b/pkg/source/external/external.go
@@ -1,4 +1,8 @@
-package source
+// Package external implements the source.Fetcher for
+// KindExternalArtifact (third-party-published artifacts under Flux's
+// source-controller schema). Only file:// URLs are resolvable from
+// offline flate; other URL schemes fail-loud.
+package external
 
 import (
 	"context"
@@ -9,7 +13,7 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// ExternalArtifactFetcher resolves an ExternalArtifact CR into a
+// Fetcher resolves an ExternalArtifact CR into a
 // SourceArtifact. Because ExternalArtifact is the contract a
 // third-party controller uses to publish content into a live cluster,
 // flate (which runs offline) has no general way to fetch from the
@@ -25,13 +29,13 @@ import (
 //     that references this ExternalArtifact will fail-loud with a
 //     "source artifact not found" message — preferable to silently
 //     emitting empty output.
-type ExternalArtifactFetcher struct{}
+type Fetcher struct{}
 
 // Fetch implements source.Fetcher for *manifest.ExternalArtifact.
-func (f *ExternalArtifactFetcher) Fetch(_ context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+func (f *Fetcher) Fetch(_ context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
 	ea, ok := obj.(*manifest.ExternalArtifact)
 	if !ok {
-		return nil, fmt.Errorf("%w: ExternalArtifactFetcher: unexpected payload %T", manifest.ErrInput, obj)
+		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
 	}
 	if ea.ArtifactURL == "" {
 		return nil, fmt.Errorf(

--- a/pkg/source/external/external_test.go
+++ b/pkg/source/external/external_test.go
@@ -1,4 +1,4 @@
-package source_test
+package external_test
 
 import (
 	"context"
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/external"
 )
 
-func TestExternalArtifactFetcher_FileURL(t *testing.T) {
-	f := &source.ExternalArtifactFetcher{}
+func TestFetcher_FileURL(t *testing.T) {
+	f := &external.Fetcher{}
 	ea := &manifest.ExternalArtifact{
 		Name: "ea", Namespace: "apps",
 		ArtifactURL: "file:///cache/x.tar.gz",
@@ -32,8 +32,8 @@ func TestExternalArtifactFetcher_FileURL(t *testing.T) {
 	}
 }
 
-func TestExternalArtifactFetcher_NoArtifact(t *testing.T) {
-	f := &source.ExternalArtifactFetcher{}
+func TestFetcher_NoArtifact(t *testing.T) {
+	f := &external.Fetcher{}
 	ea := &manifest.ExternalArtifact{Name: "ea", Namespace: "apps"}
 	_, err := f.Fetch(context.Background(), ea)
 	if err == nil {
@@ -44,8 +44,8 @@ func TestExternalArtifactFetcher_NoArtifact(t *testing.T) {
 	}
 }
 
-func TestExternalArtifactFetcher_NonFileURL(t *testing.T) {
-	f := &source.ExternalArtifactFetcher{}
+func TestFetcher_NonFileURL(t *testing.T) {
+	f := &external.Fetcher{}
 	ea := &manifest.ExternalArtifact{
 		Name: "ea", Namespace: "apps",
 		ArtifactURL: "http://source-controller.flux-system.svc/x.tar.gz",

--- a/pkg/source/git/auth_test.go
+++ b/pkg/source/git/auth_test.go
@@ -1,4 +1,4 @@
-package source
+package git
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-func TestGitFetcher_NonGenericProvider(t *testing.T) {
-	f := &GitFetcher{}
+func TestFetcher_NonGenericProvider(t *testing.T) {
+	f := &Fetcher{}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
 		URL:      "https://github.com/x/y.git",
@@ -26,8 +26,8 @@ func TestGitFetcher_NonGenericProvider(t *testing.T) {
 	}
 }
 
-func TestGitFetcher_HTTPSBasicAuth(t *testing.T) {
-	f := &GitFetcher{
+func TestFetcher_HTTPSBasicAuth(t *testing.T) {
+	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret {
 			return &manifest.Secret{
 				StringData: map[string]any{
@@ -55,8 +55,8 @@ func TestGitFetcher_HTTPSBasicAuth(t *testing.T) {
 	}
 }
 
-func TestGitFetcher_HTTPSBearerWinsOverBasic(t *testing.T) {
-	f := &GitFetcher{
+func TestFetcher_HTTPSBearerWinsOverBasic(t *testing.T) {
+	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret {
 			return &manifest.Secret{
 				StringData: map[string]any{
@@ -84,8 +84,8 @@ func TestGitFetcher_HTTPSBearerWinsOverBasic(t *testing.T) {
 	}
 }
 
-func TestGitFetcher_HTTPSMissingCreds(t *testing.T) {
-	f := &GitFetcher{
+func TestFetcher_HTTPSMissingCreds(t *testing.T) {
+	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret {
 			return &manifest.Secret{StringData: map[string]any{"username": "alice"}}
 		},
@@ -100,8 +100,8 @@ func TestGitFetcher_HTTPSMissingCreds(t *testing.T) {
 	}
 }
 
-func TestGitFetcher_NoSecretIsAnonymous(t *testing.T) {
-	f := &GitFetcher{}
+func TestFetcher_NoSecretIsAnonymous(t *testing.T) {
+	f := &Fetcher{}
 	repo := &manifest.GitRepository{URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns"}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
@@ -112,8 +112,8 @@ func TestGitFetcher_NoSecretIsAnonymous(t *testing.T) {
 	}
 }
 
-func TestGitFetcher_SecretRefMissingGetter(t *testing.T) {
-	f := &GitFetcher{} // no Secrets
+func TestFetcher_SecretRefMissingGetter(t *testing.T) {
+	f := &Fetcher{} // no Secrets
 	repo := &manifest.GitRepository{
 		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
 		SecretRef: &manifest.LocalObjectReference{Name: "creds"},

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -1,4 +1,5 @@
-package source
+// Package git implements the source.Fetcher for KindGitRepository.
+package git
 
 import (
 	"context"
@@ -14,23 +15,24 @@ import (
 	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// GitFetcher is the Fetcher implementation for KindGitRepository.
+// Fetcher is the source.Fetcher implementation for KindGitRepository.
 // It owns a shared Cache so multiple GitRepository CRs writing to the
 // same cache root serialize on slot allocation correctly. Secrets is
 // optional; required when a GitRepository sets spec.secretRef.
-type GitFetcher struct {
-	Cache   *Cache
-	Secrets SecretGetter
+type Fetcher struct {
+	Cache   *source.Cache
+	Secrets source.SecretGetter
 }
 
 // Fetch implements source.Fetcher for *manifest.GitRepository.
-func (f *GitFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
 	repo, ok := obj.(*manifest.GitRepository)
 	if !ok {
-		return nil, fmt.Errorf("%w: GitFetcher: unexpected payload %T", manifest.ErrInput, obj)
+		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
 	}
 	if repo.Provider != "" && repo.Provider != manifest.GitProviderGeneric {
 		return nil, fmt.Errorf(
@@ -42,7 +44,7 @@ func (f *GitFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*sto
 	if err != nil {
 		return nil, err
 	}
-	return FetchGit(ctx, f.Cache, repo, auth)
+	return fetch(ctx, f.Cache, repo, auth)
 }
 
 // resolveAuth turns repo.SecretRef into a go-git AuthMethod. Returns
@@ -50,7 +52,7 @@ func (f *GitFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*sto
 // pre-auth behavior. For HTTPS URLs the secret may carry either
 // (username, password) or (bearerToken); for SSH URLs the secret
 // carries `identity` (PEM private key) and an optional `password`.
-func (f *GitFetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMethod, error) {
+func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMethod, error) {
 	if repo.SecretRef == nil {
 		return nil, nil
 	}
@@ -64,12 +66,12 @@ func (f *GitFetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMe
 			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 	}
 	if isSSHURL(repo.URL) {
-		identity := stringFromSecret(sec, "identity")
+		identity := source.StringFromSecret(sec, "identity")
 		if identity == "" {
 			return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s missing 'identity' for SSH auth",
 				repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 		}
-		password := stringFromSecret(sec, "password")
+		password := source.StringFromSecret(sec, "password")
 		user := sshUserFromURL(repo.URL)
 		auth, err := gitssh.NewPublicKeys(user, []byte(identity), password)
 		if err != nil {
@@ -80,7 +82,7 @@ func (f *GitFetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMe
 		// enforce strict host-key checking; otherwise skip (offline
 		// renders against ephemeral worktrees are the norm). Users who
 		// need strict checks provide `known_hosts` in the Secret.
-		if kh := stringFromSecret(sec, "known_hosts"); kh != "" {
+		if kh := source.StringFromSecret(sec, "known_hosts"); kh != "" {
 			cb, herr := knownHostsCallback([]byte(kh))
 			if herr != nil {
 				return nil, fmt.Errorf("GitRepository %s/%s: parse known_hosts: %w",
@@ -94,11 +96,11 @@ func (f *GitFetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMe
 	}
 	// HTTPS / HTTP: bearerToken takes precedence over basic auth, mirroring
 	// source-controller's docs.
-	if token := stringFromSecret(sec, "bearerToken"); token != "" {
+	if token := source.StringFromSecret(sec, "bearerToken"); token != "" {
 		return &githttp.TokenAuth{Token: token}, nil
 	}
-	username := stringFromSecret(sec, "username")
-	password := stringFromSecret(sec, "password")
+	username := source.StringFromSecret(sec, "username")
+	password := source.StringFromSecret(sec, "password")
 	if username == "" || password == "" {
 		return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s missing username/password (or bearerToken) for HTTPS auth",
 			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
@@ -121,13 +123,14 @@ func sshUserFromURL(url string) string {
 	return "git"
 }
 
-// FetchGit clones the GitRepository referenced by repo into the supplied
-// cache and returns a populated *store.SourceArtifact. If a usable cached
-// copy already exists, it is reused. auth may be nil for anonymous clones.
+// fetch clones the GitRepository referenced by repo into the supplied
+// cache and returns a populated *store.SourceArtifact. If a usable
+// cached copy already exists, it is reused. auth may be nil for
+// anonymous clones.
 //
-// Supported transports: HTTPS (anonymous, basic, bearer), SSH (key from
-// SecretRef or ssh-agent), and file:// URLs.
-func FetchGit(ctx context.Context, cache *Cache, repo *manifest.GitRepository, auth transport.AuthMethod) (*store.SourceArtifact, error) {
+// Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
+// from SecretRef or ssh-agent), and file:// URLs.
+func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepository, auth transport.AuthMethod) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -1,4 +1,4 @@
-package source
+package git
 
 import (
 	"context"
@@ -11,52 +11,40 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 )
 
-func TestFetchGit_LocalFileURL(t *testing.T) {
+func TestFetcher_LocalFileURL(t *testing.T) {
 	src := t.TempDir()
 	mustInitRepo(t, src)
 
-	cache := NewCache(t.TempDir())
+	cache := source.NewCache(t.TempDir())
 	repo := &manifest.GitRepository{
 		Name:      "test",
 		Namespace: "flux-system",
 		URL:       "file://" + src,
 	}
 
-	art, err := FetchGit(context.Background(), cache, repo, nil)
+	f := &Fetcher{Cache: cache}
+	art, err := f.Fetch(context.Background(), repo)
 	if err != nil {
-		t.Fatalf("FetchGit: %v", err)
+		t.Fatalf("Fetch: %v", err)
 	}
-	if art.LocalPath == "" || art.URL == "" {
-		t.Errorf("incomplete artifact: %+v", art)
+	sa := art
+	if sa.LocalPath == "" || sa.URL == "" {
+		t.Errorf("incomplete artifact: %+v", sa)
 	}
-	if _, err := os.Stat(filepath.Join(art.LocalPath, "hello.txt")); err != nil {
+	if _, err := os.Stat(filepath.Join(sa.LocalPath, "hello.txt")); err != nil {
 		t.Errorf("expected checked-out file: %v", err)
 	}
 
 	// Second call should reuse cache.
-	art2, err := FetchGit(context.Background(), cache, repo, nil)
+	art2, err := f.Fetch(context.Background(), repo)
 	if err != nil {
-		t.Fatalf("FetchGit second: %v", err)
+		t.Fatalf("Fetch second: %v", err)
 	}
-	if art2.LocalPath != art.LocalPath {
-		t.Errorf("cache slot changed: %s vs %s", art.LocalPath, art2.LocalPath)
-	}
-}
-
-func TestSlugifyRepo(t *testing.T) {
-	cases := map[string]string{
-		"https://github.com/owner/cluster.git":                "cluster",
-		"git@github.com:owner/cluster.git":                    "cluster",
-		"https://example.com/long-path/with/slashes/repo.git": "repo",
-		"oci://ghcr.io/stefanprodan/charts/podinfo":           "podinfo",
-		"": "repo",
-	}
-	for in, want := range cases {
-		if got := slugifyRepo(in); got != want {
-			t.Errorf("slugifyRepo(%q) = %q want %q", in, got, want)
-		}
+	if art2.LocalPath != sa.LocalPath {
+		t.Errorf("cache slot changed: %s vs %s", sa.LocalPath, art2.LocalPath)
 	}
 }
 

--- a/pkg/source/git/ssh.go
+++ b/pkg/source/git/ssh.go
@@ -1,4 +1,4 @@
-package source
+package git
 
 import (
 	"fmt"

--- a/pkg/source/oci/auth_test.go
+++ b/pkg/source/oci/auth_test.go
@@ -1,4 +1,4 @@
-package source
+package oci
 
 import (
 	"context"
@@ -9,8 +9,8 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-func TestOCIFetcher_NonGenericProvider(t *testing.T) {
-	f := &OCIFetcher{}
+func TestFetcher_NonGenericProvider(t *testing.T) {
+	f := &Fetcher{}
 	repo := &manifest.OCIRepository{
 		Name: "o", Namespace: "ns",
 		URL:      "oci://ghcr.io/x/y",
@@ -25,8 +25,8 @@ func TestOCIFetcher_NonGenericProvider(t *testing.T) {
 	}
 }
 
-func TestOCIFetcher_ResolveConfig_NoSecretFallsBackToGlobal(t *testing.T) {
-	f := &OCIFetcher{RegistryConfig: "/etc/docker/config.json"}
+func TestFetcher_ResolveConfig_NoSecretFallsBackToGlobal(t *testing.T) {
+	f := &Fetcher{RegistryConfig: "/etc/docker/config.json"}
 	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns"}
 	path, cleanup, err := f.resolveRegistryConfig(repo)
 	defer cleanup()
@@ -38,9 +38,9 @@ func TestOCIFetcher_ResolveConfig_NoSecretFallsBackToGlobal(t *testing.T) {
 	}
 }
 
-func TestOCIFetcher_ResolveConfig_SecretWritesTempFile(t *testing.T) {
+func TestFetcher_ResolveConfig_SecretWritesTempFile(t *testing.T) {
 	dockerJSON := `{"auths":{"ghcr.io":{"auth":"YWxpY2U6aHVudGVyMg=="}}}`
-	f := &OCIFetcher{
+	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret {
 			return &manifest.Secret{
 				StringData: map[string]any{".dockerconfigjson": dockerJSON},
@@ -74,8 +74,8 @@ func TestOCIFetcher_ResolveConfig_SecretWritesTempFile(t *testing.T) {
 	}
 }
 
-func TestOCIFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
-	f := &OCIFetcher{
+func TestFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
+	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret {
 			return &manifest.Secret{
 				StringData: map[string]any{"username": "alice"}, // wrong shape
@@ -93,21 +93,21 @@ func TestOCIFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
 	}
 }
 
-func TestOCIFetcher_ResolveConfig_SecretRefWithoutGetter(t *testing.T) {
-	f := &OCIFetcher{} // no Secrets
+func TestFetcher_ResolveConfig_SecretRefWithoutGetter(t *testing.T) {
+	f := &Fetcher{} // no Secrets
 	repo := &manifest.OCIRepository{
 		Name: "o", Namespace: "ns",
 		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	_, cleanup, err := f.resolveRegistryConfig(repo)
 	cleanup()
-	if err == nil || !strings.Contains(err.Error(), "SecretGetter") {
-		t.Errorf("expected SecretGetter error; got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
+		t.Errorf("expected source.SecretGetter error; got %v", err)
 	}
 }
 
-func TestOCIFetcher_ResolveConfig_SecretNotFound(t *testing.T) {
-	f := &OCIFetcher{
+func TestFetcher_ResolveConfig_SecretNotFound(t *testing.T) {
+	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret { return nil },
 	}
 	repo := &manifest.OCIRepository{

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -1,4 +1,7 @@
-package source
+// Package oci implements the source.Fetcher for KindOCIRepository
+// via oras-go. Generic provider only — IRSA / Workload Identity is
+// out of scope for offline flate.
+package oci
 
 import (
 	"context"
@@ -18,26 +21,27 @@ import (
 	"oras.land/oras-go/v2/registry/remote/credentials"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// OCIFetcher is the Fetcher implementation for KindOCIRepository.
+// Fetcher is the Fetcher implementation for KindOCIRepository.
 // RegistryConfig is the global --registry-config docker-style
 // config.json path used when no per-repo SecretRef is set. Secrets is
-// the per-repo SecretGetter (typically the orchestrator-provided
+// the per-repo source.SecretGetter (typically the orchestrator-provided
 // Store.GetByName), required when any OCIRepository has spec.secretRef
 // pointing at a kubernetes.io/dockerconfigjson Secret.
-type OCIFetcher struct {
-	Cache          *Cache
+type Fetcher struct {
+	Cache          *source.Cache
 	RegistryConfig string
-	Secrets        SecretGetter
+	Secrets        source.SecretGetter
 }
 
 // Fetch implements source.Fetcher for *manifest.OCIRepository.
-func (f *OCIFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
 	repo, ok := obj.(*manifest.OCIRepository)
 	if !ok {
-		return nil, fmt.Errorf("%w: OCIFetcher: unexpected payload %T", manifest.ErrInput, obj)
+		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
 	}
 	if repo.Provider != "" && repo.Provider != manifest.OCIProviderGeneric {
 		return nil, fmt.Errorf(
@@ -50,7 +54,7 @@ func (f *OCIFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*sto
 		return nil, err
 	}
 	defer cleanup()
-	return FetchOCI(ctx, f.Cache, repo, configPath)
+	return fetch(ctx, f.Cache, repo, configPath)
 }
 
 // resolveRegistryConfig picks the credential source for a fetch.
@@ -63,13 +67,13 @@ func (f *OCIFetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*sto
 //
 // The cleanup func removes any temp file the SecretRef path created;
 // safe to call when no temp file was made (no-op).
-func (f *OCIFetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, func(), error) {
+func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, func(), error) {
 	noCleanup := func() {}
 	if repo.SecretRef == nil {
 		return f.RegistryConfig, noCleanup, nil
 	}
 	if f.Secrets == nil {
-		return "", noCleanup, fmt.Errorf("OCIRepository %s/%s references secretRef but no SecretGetter is wired",
+		return "", noCleanup, fmt.Errorf("OCIRepository %s/%s references secretRef but no source.SecretGetter is wired",
 			repo.Namespace, repo.Name)
 	}
 	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
@@ -77,7 +81,7 @@ func (f *OCIFetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string
 		return "", noCleanup, fmt.Errorf("OCIRepository %s/%s: secret %s/%s not found",
 			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 	}
-	configJSON := stringFromSecret(sec, ".dockerconfigjson")
+	configJSON := source.StringFromSecret(sec, ".dockerconfigjson")
 	if configJSON == "" {
 		return "", noCleanup, fmt.Errorf(
 			"OCIRepository %s/%s: secret %s/%s missing .dockerconfigjson "+
@@ -101,12 +105,12 @@ func (f *OCIFetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string
 	return tmp.Name(), cleanup, nil
 }
 
-// FetchOCI pulls the OCIRepository artifact into cache. Credentials are
+// fetch pulls the OCIRepository artifact into cache. Credentials are
 // read from a docker-style config.json honored by oras-go's
 // credentials.NewFileStore. When spec.ref.semver is set, the registry
 // is listed and the highest matching tag (filtered by semverFilter, if
 // any) is resolved before pulling.
-func FetchOCI(ctx context.Context, cache *Cache, repo *manifest.OCIRepository, registryConfig string) (*store.SourceArtifact, error) {
+func fetch(ctx context.Context, cache *source.Cache, repo *manifest.OCIRepository, registryConfig string) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
 	}

--- a/pkg/source/secret.go
+++ b/pkg/source/secret.go
@@ -1,0 +1,31 @@
+package source
+
+import (
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// StringFromSecret reads a key from a Secret, preferring StringData
+// over Data. PLACEHOLDER_-wiped values (the result of flate's default
+// --wipe-secrets pre-processing) are reported as empty so callers
+// surface a clear "missing keys" error rather than authenticating
+// with the literal placeholder.
+//
+// Used by per-kind Fetchers (git, oci, bucket) to resolve auth from
+// the Secret a SecretRef points at.
+func StringFromSecret(sec *manifest.Secret, key string) string {
+	if v, ok := sec.StringData[key].(string); ok {
+		if strings.HasPrefix(v, "..PLACEHOLDER_") {
+			return ""
+		}
+		return v
+	}
+	if v, ok := sec.Data[key].(string); ok {
+		if strings.HasPrefix(v, "..PLACEHOLDER_") {
+			return ""
+		}
+		return v
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

Reorganizes \`pkg/source\` into one subpackage per source kind, matching the agent's original audit recommendation. The split was intentionally deferred until at least one new non-generic provider landed; the broader Phase 3 work (ExternalArtifact, Bucket, auth across all kinds, ReadyExpr, SOPS) is enough material to justify the layout now.

## New layout

| Package | Contents |
|---|---|
| \`pkg/source/\` | \`Fetcher\` interface, \`Suspendable\` interface, \`SecretGetter\` type, \`Cache\` (shared on-disk content-addressed slot allocator), \`StringFromSecret\` helper used by every per-kind fetcher. |
| \`pkg/source/git/\` | \`git.Fetcher\` (was \`source.GitFetcher\`), SSH host-key callbacks in \`ssh.go\`. |
| \`pkg/source/oci/\` | \`oci.Fetcher\` (was \`source.OCIFetcher\`). |
| \`pkg/source/bucket/\` | \`bucket.Fetcher\` (was \`source.BucketFetcher\`). |
| \`pkg/source/external/\` | \`external.Fetcher\` (was \`source.ExternalArtifactFetcher\`). |

Each kind's Fetcher type is now just \`Fetcher\` inside its package (Go convention) rather than carrying the kind prefix. The orchestrator imports each subpackage and constructs typed \`&git.Fetcher{...}\` etc.

## Behavior

**Unchanged.** All existing tests pass; no API used outside this PR moves.

## Cross-cutting helpers that moved

- \`StringFromSecret\` → \`pkg/source/secret.go\` (was \`stringFromSecret\` private to \`bucket.go\`; now exported and called by git/oci/bucket).
- \`TestSlugifyRepo\` → \`pkg/source/cache_test.go\` (private to root pkg).

## Tests

Tests follow their respective Fetcher to keep the (Fetcher,test) pair co-located. \`go test ./...\` green; \`golangci-lint run\` 0 issues.

## After this

This finishes the **Phase 3 source-coverage push**. flate now recognizes every Flux source kind with per-kind code organization that scales to future variants (cosign verify, workload-identity providers) without bloating any single file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)