### PR TITLE
feat(source/git): RecurseSubmodules + spec.ref.name

### DIFF
--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -64,6 +64,33 @@ spec:
 	}
 }
 
+func TestParseGitRepository_RefNameAndSubmodules(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: pr, namespace: flux-system}
+spec:
+  url: https://github.com/owner/repo.git
+  ref:
+    name: refs/pull/420/head
+  recurseSubmodules: true
+  interval: 5m
+`)
+	g, err := ParseGitRepository(doc)
+	if err != nil {
+		t.Fatalf("ParseGitRepository: %v", err)
+	}
+	if g.Ref.Name != "refs/pull/420/head" {
+		t.Errorf("Ref.Name = %q", g.Ref.Name)
+	}
+	if !g.RecurseSubmodules {
+		t.Errorf("RecurseSubmodules should be true")
+	}
+	if want := "name:refs/pull/420/head"; g.Ref.RefString() != want {
+		t.Errorf("RefString = %q, want %q", g.Ref.RefString(), want)
+	}
+}
+
 func TestParseKustomization_Suspend(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -10,12 +10,20 @@ type GitRepositoryRef struct {
 	Tag    string `json:"tag,omitempty" yaml:"tag,omitempty"`
 	Semver string `json:"semver,omitempty" yaml:"semver,omitempty"`
 	Commit string `json:"commit,omitempty" yaml:"commit,omitempty"`
+	// Name is the full Git reference (e.g. "refs/pull/420/head" or
+	// "refs/tags/v0.1.0"). When set, takes precedence over
+	// Branch/Tag/SemVer and any Commit specified — flate resolves the
+	// remote ref to a commit before checkout.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
-// RefString returns "branch:main", "tag:v1.2.3", etc., or empty when the
-// ref is empty. Precedence: commit > tag > branch > semver.
+// RefString returns "branch:main", "tag:v1.2.3", etc., or empty when
+// the ref is empty. Precedence (matches Flux source-controller):
+// name > commit > tag > branch > semver.
 func (r GitRepositoryRef) RefString() string {
 	switch {
+	case r.Name != "":
+		return "name:" + r.Name
 	case r.Commit != "":
 		return "commit:" + r.Commit
 	case r.Tag != "":
@@ -33,13 +41,14 @@ func (r GitRepositoryRef) IsEmpty() bool { return r == GitRepositoryRef{} }
 
 // GitRepository is the Flux GitRepository CRD.
 type GitRepository struct {
-	Name      string                `json:"name" yaml:"name"`
-	Namespace string                `json:"namespace" yaml:"namespace"`
-	URL       string                `json:"url" yaml:"url"`
-	Ref       GitRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Provider  string                `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	Suspend   bool                  `json:"-" yaml:"-"`
+	Name              string                `json:"name" yaml:"name"`
+	Namespace         string                `json:"namespace" yaml:"namespace"`
+	URL               string                `json:"url" yaml:"url"`
+	Ref               GitRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Provider          string                `json:"provider,omitempty" yaml:"provider,omitempty"`
+	SecretRef         *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	RecurseSubmodules bool                  `json:"recurseSubmodules,omitempty" yaml:"recurseSubmodules,omitempty"`
+	Suspend           bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the GitRepository.
@@ -77,6 +86,7 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 			Tag:    r.Tag,
 			Semver: r.SemVer,
 			Commit: r.Commit,
+			Name:   r.Name,
 		}
 	}
 	provider := cr.Spec.Provider
@@ -84,12 +94,13 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		provider = GitProviderGeneric
 	}
 	out := &GitRepository{
-		Name:      cr.Name,
-		Namespace: cr.Namespace,
-		URL:       cr.Spec.URL,
-		Ref:       ref,
-		Provider:  provider,
-		Suspend:   cr.Spec.Suspend,
+		Name:              cr.Name,
+		Namespace:         cr.Namespace,
+		URL:               cr.Spec.URL,
+		Ref:               ref,
+		Provider:          provider,
+		RecurseSubmodules: cr.Spec.RecurseSubmodules,
+		Suspend:           cr.Spec.Suspend,
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
 		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -171,6 +171,9 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 	}
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
+	if repo.RecurseSubmodules {
+		cloneOpts.RecurseSubmodules = git.DefaultSubmoduleRecursionDepth
+	}
 	cloned, err := git.PlainCloneContext(ctx, slot, false, cloneOpts)
 	if err != nil {
 		_ = cache.Reset(slot)
@@ -179,6 +182,11 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 
 	if err := checkoutRef(cloned, repo.Ref); err != nil {
 		return nil, fmt.Errorf("checkout %s: %w", refStr, err)
+	}
+	if repo.RecurseSubmodules {
+		if err := updateSubmodules(cloned, auth); err != nil {
+			return nil, fmt.Errorf("submodules: %w", err)
+		}
 	}
 
 	rev, _ := readResolvedRevision(slot)
@@ -194,6 +202,25 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef) error {
 		return err
 	}
 	switch {
+	case ref.Name != "":
+		// Full ref name takes precedence (e.g. "refs/pull/420/head",
+		// "refs/tags/v1.2.3"). Resolve against the cloned repo so the
+		// remote-tracking layer (refs/remotes/origin/...) is checked
+		// too — go-git's PlainClone fetches all refs but normalizes
+		// branches under refs/remotes/origin.
+		rev := plumbing.Revision(ref.Name)
+		if h, err := repo.ResolveRevision(rev); err == nil {
+			return wt.Checkout(&git.CheckoutOptions{Hash: *h})
+		}
+		// Fall through: try resolving as a remote-tracking ref. This
+		// handles refs/heads/<branch> by mapping to refs/remotes/origin/<branch>.
+		if rest, ok := strings.CutPrefix(ref.Name, "refs/heads/"); ok {
+			remote := plumbing.NewRemoteReferenceName("origin", rest)
+			if h, err := repo.ResolveRevision(plumbing.Revision(remote)); err == nil {
+				return wt.Checkout(&git.CheckoutOptions{Hash: *h})
+			}
+		}
+		return fmt.Errorf("%w: unable to resolve git ref %q", manifest.ErrInput, ref.Name)
 	case ref.Commit != "":
 		return wt.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(ref.Commit)})
 	case ref.Tag != "":
@@ -216,6 +243,27 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef) error {
 	}
 	// No ref: just check out HEAD.
 	return wt.Checkout(&git.CheckoutOptions{})
+}
+
+// updateSubmodules initializes and pulls submodules in the cloned
+// worktree. Mirrors `git submodule update --init --recursive`. The
+// parent's auth is reused for each submodule's fetch — Flux's
+// behavior assumes a single credential source per GitRepository CR,
+// even when submodules live on different hosts.
+func updateSubmodules(repo *git.Repository, auth transport.AuthMethod) error {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	subs, err := wt.Submodules()
+	if err != nil {
+		return err
+	}
+	return subs.Update(&git.SubmoduleUpdateOptions{
+		Init:              true,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
+		Auth:              auth,
+	})
 }
 
 // readResolvedRevision returns the current commit SHA at the worktree.

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -48,6 +48,67 @@ func TestFetcher_LocalFileURL(t *testing.T) {
 	}
 }
 
+// TestFetcher_RefByName exercises spec.ref.name handling — flate
+// resolves it to a commit via git.ResolveRevision and checks out the
+// resulting hash.
+func TestFetcher_RefByName(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+	tagged := mustTagHEAD(t, src, "v0.1.0")
+
+	cache := source.NewCache(t.TempDir())
+	repo := &manifest.GitRepository{
+		Name: "test", Namespace: "flux-system",
+		URL: "file://" + src,
+		Ref: manifest.GitRepositoryRef{Name: "refs/tags/v0.1.0"},
+	}
+	f := &Fetcher{Cache: cache}
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch by ref.name: %v", err)
+	}
+	if art.Revision != tagged {
+		t.Errorf("Revision = %q, want %q (tag → commit)", art.Revision, tagged)
+	}
+}
+
+// TestFetcher_RefByName_Unresolvable surfaces a clear error when the
+// ref name can't be resolved.
+func TestFetcher_RefByName_Unresolvable(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+
+	cache := source.NewCache(t.TempDir())
+	repo := &manifest.GitRepository{
+		Name: "test", Namespace: "flux-system",
+		URL: "file://" + src,
+		Ref: manifest.GitRepositoryRef{Name: "refs/heads/does-not-exist"},
+	}
+	f := &Fetcher{Cache: cache}
+	_, err := f.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatalf("expected unresolvable-ref error")
+	}
+}
+
+// mustTagHEAD creates an annotated tag pointing at the worktree HEAD
+// and returns the tagged commit SHA.
+func mustTagHEAD(t *testing.T, dir, tag string) string {
+	t.Helper()
+	r, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	head, err := r.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if _, err := r.CreateTag(tag, head.Hash(), nil); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	return head.Hash().String()
+}
+
 // mustInitRepo creates a minimal git repo at dir with one file and one
 // commit.
 func mustInitRepo(t *testing.T, dir string) {


### PR DESCRIPTION
## Summary

Two GitRepository spec fields the audit flagged as dropped, both with practical home-ops value:

- **\`spec.recurseSubmodules\`** — common in monorepos that vendor charts or shared kustomize bases as submodules. flate previously dropped them silently, leaving consumers with partial trees.
- **\`spec.ref.name\`** — Flux's general-form Git reference (\`refs/pull/420/head\`, \`refs/tags/v0.1.0\`, \`refs/heads/main\`). Takes precedence over \`branch\`/\`tag\`/\`semver\`/\`commit\` per source-controller semantics. Unlocks PR-rendering workflows like \"\`flate diff\` this PR's tip against main.\"

## Implementation

- \`manifest.GitRepositoryRef\` gains \`Name\` field. \`RefString\` precedence is now \`name > commit > tag > branch > semver\` (matches Flux).
- \`manifest.GitRepository\` gains \`RecurseSubmodules\`. \`ParseGitRepository\` populates both from \`sourcev1.GitRepositoryRef.Name\` + \`sourcev1.GitRepositorySpec.RecurseSubmodules\`.
- \`pkg/source/git\` fetch path:
  - \`CloneOptions.RecurseSubmodules = git.DefaultSubmoduleRecursionDepth\` when set.
  - After checkout, runs \`updateSubmodules()\` which calls \`Worktree.Submodules().Update\` with \`Init: true\` and the parent's auth reused for each submodule (mirrors Flux's single-credential model — Flux's source-controller also reuses the parent SecretRef across submodule fetches).
- \`checkoutRef()\` handles \`ref.Name\` via \`repo.ResolveRevision\`. Falls through to \`refs/remotes/origin/<branch>\` for \`refs/heads/<branch>\` forms that haven't been promoted to local branch refs.

## Tests

- \`TestParseGitRepository_RefNameAndSubmodules\` — parser populates both fields; RefString returns \`name:refs/pull/420/head\`.
- \`TestFetcher_RefByName\` — \`refs/tags/v0.1.0\` resolves to the tagged commit SHA.
- \`TestFetcher_RefByName_Unresolvable\` — bad ref name produces a clear error.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)