### PR TITLE
fix(depwait): ReadyExpr non-additive default + status event for any condition

### DIFF
--- a/pkg/depwait/cel_test.go
+++ b/pkg/depwait/cel_test.go
@@ -12,40 +12,112 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// TestWaiter_ReadyExprSatisfied: the dep is Ready by the built-in
-// check AND its CEL expression returns true → DepReady.
-func TestWaiter_ReadyExprSatisfied(t *testing.T) {
+// TestReadyExpr_NonAdditive_PassesOnTrue: in the default (Flux)
+// mode, ReadyExpr replaces the built-in check. When the CEL is true
+// against current state, the dep is Ready regardless of the built-in
+// Ready condition. The store carries Ready=False here to prove the
+// replacement.
+func TestReadyExpr_NonAdditive_PassesOnTrue(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
-	s.UpdateStatus(dep, store.StatusReady, "ok")
+	s.UpdateStatus(dep, store.StatusFailed, "still rolling out") // built-in says Failed
 	s.SetCondition(dep, store.Condition{
-		Type:   "InfraInitialized",
+		Type:   "Healthy",
 		Status: metav1.ConditionTrue,
-		Reason: "Done",
+		Reason: "MyCustomCheck",
 	})
 
 	w := &Waiter{Store: s, Timeout: time.Second}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "InfraInitialized" && c.status == "True")`,
+		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
 	if !sum.AllReady() {
-		t.Errorf("expected AllReady: %+v", sum)
+		t.Errorf("non-additive ReadyExpr should override Failed Ready: %+v", sum)
 	}
 }
 
-// TestWaiter_ReadyExprFailsCheck: the dep is Ready by the built-in
-// check but its CEL expression returns false → DepFailed.
-func TestWaiter_ReadyExprFailsCheck(t *testing.T) {
+// TestReadyExpr_NonAdditive_FlipsOnStatusUpdate: when initial state
+// doesn't satisfy the CEL, the Waiter subscribes to status updates
+// and re-evaluates. A later SetCondition that makes the CEL true
+// closes the wait.
+func TestReadyExpr_NonAdditive_FlipsOnStatusUpdate(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
+	// Initial state: no Healthy condition.
+	s.UpdateStatus(dep, store.StatusPending, "reconciling")
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		s.SetCondition(dep, store.Condition{
+			Type: "Healthy", Status: metav1.ConditionTrue, Reason: "AllGood",
+		})
+	}()
+
+	w := &Waiter{Store: s, Timeout: 2 * time.Second}
+	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
+		NamedResource: dep,
+		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+	}}))
+	if !sum.AllReady() {
+		t.Errorf("expected to satisfy after status update: %+v", sum)
+	}
+}
+
+// TestReadyExpr_NonAdditive_TimesOutOnFalse: when the CEL never
+// returns true and no status update flips it, the wait times out
+// with a DepTimeout event (not DepFailed).
+func TestReadyExpr_NonAdditive_TimesOutOnFalse(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
+	s.UpdateStatus(dep, store.StatusReady, "ok") // built-in says Ready, but CEL needs Healthy
+
+	w := &Waiter{Store: s, Timeout: 100 * time.Millisecond}
+	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
+		NamedResource: dep,
+		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+	}}))
+	if sum.AllReady() {
+		t.Fatalf("expected timeout: %+v", sum)
+	}
+	if !strings.Contains(sum.Messages[dep], "readyExpr timeout") {
+		t.Errorf("expected readyExpr-prefixed timeout; got %q", sum.Messages[dep])
+	}
+}
+
+// TestReadyExpr_Additive_BothMustPass: with AdditiveReadyExpr=true,
+// Ready=True AND CEL=true → DepReady.
+func TestReadyExpr_Additive_BothMustPass(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
 	s.UpdateStatus(dep, store.StatusReady, "ok")
-	// No "InfraInitialized" condition.
+	s.SetCondition(dep, store.Condition{
+		Type: "Healthy", Status: metav1.ConditionTrue, Reason: "AllGood",
+	})
 
-	w := &Waiter{Store: s, Timeout: time.Second}
+	w := &Waiter{Store: s, Timeout: time.Second, AdditiveReadyExpr: true}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "InfraInitialized")`,
+		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+	}}))
+	if !sum.AllReady() {
+		t.Errorf("expected AllReady when both checks pass: %+v", sum)
+	}
+}
+
+// TestReadyExpr_Additive_FalseFails: with AdditiveReadyExpr=true,
+// Ready=True but CEL=false → DepFailed immediately (no waiting on
+// status updates — both must agree on the current state).
+func TestReadyExpr_Additive_FalseFails(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
+	s.UpdateStatus(dep, store.StatusReady, "ok")
+	// No Healthy condition.
+
+	w := &Waiter{Store: s, Timeout: time.Second, AdditiveReadyExpr: true}
+	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
+		NamedResource: dep,
+		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy")`,
 	}}))
 	if !sum.AnyFailed() {
 		t.Fatalf("expected failure: %+v", sum)
@@ -55,14 +127,14 @@ func TestWaiter_ReadyExprFailsCheck(t *testing.T) {
 	}
 }
 
-// TestWaiter_ReadyExprCompileError: malformed CEL produces a clear
-// readyExpr-prefixed error rather than silently passing.
-func TestWaiter_ReadyExprCompileError(t *testing.T) {
+// TestReadyExpr_CompileError: malformed CEL produces a clear
+// readyExpr-prefixed error in both modes.
+func TestReadyExpr_CompileError(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}
 	s.UpdateStatus(dep, store.StatusReady, "ok")
 
-	w := &Waiter{Store: s, Timeout: time.Second}
+	w := &Waiter{Store: s, Timeout: 100 * time.Millisecond}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
 		ReadyExpr:     `this isn't valid CEL`,
@@ -75,15 +147,14 @@ func TestWaiter_ReadyExprCompileError(t *testing.T) {
 	}
 }
 
-// TestWaiter_ReadyExprNonBoolResult: an expression that returns a
-// non-bool value surfaces a clear type error rather than treating it
-// as truthy.
-func TestWaiter_ReadyExprNonBoolResult(t *testing.T) {
+// TestReadyExpr_NonBoolResult: a non-bool result surfaces a clear
+// type error rather than treating it as truthy.
+func TestReadyExpr_NonBoolResult(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}
 	s.UpdateStatus(dep, store.StatusReady, "ok")
 
-	w := &Waiter{Store: s, Timeout: time.Second}
+	w := &Waiter{Store: s, Timeout: 100 * time.Millisecond}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
 		ReadyExpr:     `object.metadata.name`, // string, not bool
@@ -96,9 +167,9 @@ func TestWaiter_ReadyExprNonBoolResult(t *testing.T) {
 	}
 }
 
-// TestWaiter_NoReadyExprUsesBuiltin: when ReadyExpr is empty the
+// TestReadyExpr_Empty_UsesBuiltin: when ReadyExpr is empty the
 // built-in Ready check is used unchanged (no CEL involvement).
-func TestWaiter_NoReadyExprUsesBuiltin(t *testing.T) {
+func TestReadyExpr_Empty_UsesBuiltin(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}
 	s.UpdateStatus(dep, store.StatusReady, "ok")

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -72,6 +72,15 @@ type Waiter struct {
 	Store   *store.Store
 	Parent  manifest.NamedResource
 	Timeout time.Duration
+
+	// AdditiveReadyExpr toggles Flux's AdditiveCELDependencyCheck
+	// feature gate. When false (the default, matching Flux), a
+	// dep's ReadyExpr REPLACES the built-in Ready check — flate
+	// re-evaluates the expression on every status update for the
+	// dep and treats the dep as Ready when the expression returns
+	// true. When true, the dep must satisfy both the built-in
+	// Ready check AND the ReadyExpr (additive mode).
+	AdditiveReadyExpr bool
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -80,8 +89,9 @@ type Waiter struct {
 //
 // Watch picks WatchReady vs WatchExists per-dep based on
 // store.SupportsStatus. When dep.ReadyExpr is non-empty the built-in
-// Ready check is *replaced* by the CEL evaluation (matching Flux's
-// non-additive default; AdditiveCELDependencyCheck is not implemented).
+// Ready check is *replaced* by the CEL evaluation (Flux's default).
+// Set Waiter.AdditiveReadyExpr=true to require BOTH (Flux's
+// AdditiveCELDependencyCheck=true mode).
 func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-chan Event {
 	out := make(chan Event, len(deps))
 	if len(deps) == 0 {
@@ -139,18 +149,22 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 		return classify(id, err, "")
 	}
 
+	// Non-additive ReadyExpr: ignore the built-in Ready check entirely.
+	// Subscribe to status updates and re-evaluate the CEL on each fire
+	// until it returns true (or the per-dep timeout / parent ctx
+	// expires). Matches Flux's default semantics — the CEL is the
+	// authoritative readiness signal.
+	if dep.ReadyExpr != "" && !w.AdditiveReadyExpr {
+		return w.watchReadyExpr(ctx, id, dep.ReadyExpr)
+	}
+
 	info, err := w.Store.WatchReady(ctx, id)
 	if err != nil {
 		return classify(id, err, info.Message)
 	}
 
-	// Built-in check passed. If the dep specified a ReadyExpr, evaluate
-	// it against the dep's projected status. Per Flux semantics, a
-	// ReadyExpr REPLACES the built-in check — but we already require
-	// the built-in to pass, so this is effectively additive. That
-	// matches what most users want; Flux's non-additive mode would
-	// require failing the built-in then deferring to CEL, which is a
-	// narrow edge case.
+	// Additive mode: built-in Ready check passed AND the CEL must also
+	// agree. Flux's AdditiveCELDependencyCheck=true behavior.
 	if dep.ReadyExpr != "" {
 		ok, evalErr := evaluateReadyExpr(dep.ReadyExpr, w.Store, id)
 		if evalErr != nil {
@@ -161,6 +175,52 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 		}
 	}
 	return Event{Dep: id, Status: DepReady, Reason: info.Message}
+}
+
+// watchReadyExpr evaluates expr against id's projected state and
+// returns DepReady when it produces true. On false / eval error it
+// blocks on the next EventStatusUpdated for id and re-evaluates.
+// Surfaces the parent ctx's timeout/cancel.
+func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, expr string) Event {
+	// Initial evaluation against current state.
+	if ok, err := evaluateReadyExpr(expr, w.Store, id); err != nil {
+		return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}
+	} else if ok {
+		return Event{Dep: id, Status: DepReady, Reason: "readyExpr satisfied"}
+	}
+
+	// Subscribe and re-check after subscribing to close the race window.
+	ch := make(chan struct{}, 1)
+	unsub := w.Store.AddListener(store.EventStatusUpdated, func(other manifest.NamedResource, _ any) {
+		if other != id {
+			return
+		}
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}, false)
+	defer unsub()
+	if ok, err := evaluateReadyExpr(expr, w.Store, id); err != nil {
+		return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}
+	} else if ok {
+		return Event{Dep: id, Status: DepReady, Reason: "readyExpr satisfied"}
+	}
+
+	for {
+		select {
+		case <-ch:
+			ok, err := evaluateReadyExpr(expr, w.Store, id)
+			if err != nil {
+				return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}
+			}
+			if ok {
+				return Event{Dep: id, Status: DepReady, Reason: "readyExpr satisfied"}
+			}
+		case <-ctx.Done():
+			return Event{Dep: id, Status: DepTimeout, Reason: "readyExpr timeout: " + ctx.Err().Error()}
+		}
+	}
 }
 
 // depExists reports whether a dep is known to the store via either an

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -151,12 +151,16 @@ func (s *Store) UpdateStatus(id manifest.NamedResource, status Status, message s
 
 // SetCondition upserts cond into the resource's condition list keyed
 // by cond.Type. Dispatches a StatusUpdated event with the *StatusInfo
-// rollup* (derived from Ready) when the rollup changed — non-Ready
-// conditions land silently to avoid event spam.
+// rollup* (derived from Ready) on every observable condition change,
+// not just Ready transitions. Listeners that only care about Ready
+// can filter on the StatusInfo payload; CEL-based ReadyExpr watchers
+// need the broader notification so a Healthy condition flip (for
+// example) wakes them.
+//
+// An identical re-write of the same condition is a no-op (no event).
 func (s *Store) SetCondition(id manifest.NamedResource, cond Condition) {
 	s.mu.Lock()
 	prev := s.conditions[id]
-	prevInfo, _ := statusInfoFromConditions(prev)
 
 	updated := make([]Condition, 0, len(prev)+1)
 	replaced := false
@@ -177,13 +181,10 @@ func (s *Store) SetCondition(id manifest.NamedResource, cond Condition) {
 		updated = append(updated, cond)
 	}
 	s.conditions[id] = updated
-
 	newInfo, _ := statusInfoFromConditions(updated)
 	s.mu.Unlock()
 
-	if cond.Type == ConditionReady && prevInfo != newInfo {
-		s.fire(EventStatusUpdated, id, newInfo)
-	}
+	s.fire(EventStatusUpdated, id, newInfo)
 }
 
 // GetStatus returns the Ready-derived StatusInfo for id and whether

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -70,7 +70,12 @@ func TestStore_UpdateStatus_Idempotent(t *testing.T) {
 	}
 }
 
-func TestStore_SetCondition_NonReadyDoesNotFireStatusEvent(t *testing.T) {
+func TestStore_SetCondition_NonReadyFiresStatusEvent(t *testing.T) {
+	// Non-Ready conditions DO fire EventStatusUpdated so CEL-based
+	// ReadyExpr waiters can react to Healthy / per-target health
+	// transitions. The Ready-derived StatusInfo payload doesn't change,
+	// but listeners that need finer granularity (depwait's CEL path)
+	// re-query GetConditions to see the change.
 	s := New()
 	id := manifest.NamedResource{Kind: "Kustomization", Name: "k", Namespace: "ns"}
 	s.UpdateStatus(id, StatusPending, "starting")
@@ -78,10 +83,9 @@ func TestStore_SetCondition_NonReadyDoesNotFireStatusEvent(t *testing.T) {
 	s.AddListener(EventStatusUpdated, func(_ manifest.NamedResource, _ any) {
 		statusEvents++
 	}, false)
-	// A non-Ready condition should land silently.
 	s.SetCondition(id, Condition{Type: ConditionHealthy, Status: metav1.ConditionTrue, Reason: "Healthy"})
-	if statusEvents != 0 {
-		t.Errorf("non-Ready SetCondition fired StatusUpdated event %d times", statusEvents)
+	if statusEvents != 1 {
+		t.Errorf("non-Ready SetCondition fired %d events; want 1", statusEvents)
 	}
 	got := s.GetConditions(id)
 	if len(got) != 2 {


### PR DESCRIPTION
## Summary

Two coupled changes that fix a divergence from Flux's actual ReadyExpr semantics that #39 shipped.

**The divergence:** #39 made ReadyExpr additive-by-default — both the built-in Ready check AND the CEL had to pass. Flux's default is **non-additive**: ReadyExpr REPLACES the built-in check. (Flux's \`AdditiveCELDependencyCheck\` feature gate is the opt-in to the additive mode flate had as the default.)

## What changed

### \`Waiter.AdditiveReadyExpr bool\`

Toggles between modes. Default \`false\` matches Flux. Set \`true\` for AdditiveCELDependencyCheck behavior.

### Non-additive path (new default)

- Skip the built-in \`WatchReady\`.
- Evaluate CEL against current state; if true → \`DepReady\`.
- Otherwise subscribe to \`EventStatusUpdated\` for the dep id, re-evaluate on each fire until the CEL passes or the per-dep timeout / parent ctx expires.
- Timeout surfaces as \`DepTimeout\` with a \`\"readyExpr timeout: ...\"\` reason rather than \`DepFailed\`.

### Additive path (\`AdditiveReadyExpr=true\`)

Unchanged from #39: built-in Ready must pass AND CEL must return true. False CEL → immediate \`DepFailed\`.

### \`Store.SetCondition\` now fires on every observable condition change

The previous behavior suppressed events for non-\`Ready\` conditions to avoid spam. That suppression was overly conservative — it blocked CEL waiters from reacting to \`Healthy\` / per-target condition flips, which is the whole point of having \`ReadyExpr\`. Identical re-writes still short-circuit (no event). Existing listeners that only care about Ready filter the \`StatusInfo\` payload themselves; no behavior change for them in practice.

## Tests

- \`TestReadyExpr_NonAdditive_PassesOnTrue\` — CEL=true overrides a \`Ready=False\` built-in.
- \`TestReadyExpr_NonAdditive_FlipsOnStatusUpdate\` — initial false; goroutine sets the expected condition after 50ms; waiter wakes via the new event flow and resolves.
- \`TestReadyExpr_NonAdditive_TimesOutOnFalse\` — never flips → \`DepTimeout\` with the prefixed reason.
- \`TestReadyExpr_Additive_BothMustPass\` + \`TestReadyExpr_Additive_FalseFails\` — additive mode kept.
- \`TestReadyExpr_CompileError\` / \`TestReadyExpr_NonBoolResult\` — mode-independent, unchanged.
- \`TestReadyExpr_Empty_UsesBuiltin\` — empty ReadyExpr still goes through \`WatchReady\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)