### PR TITLE
feat(source/git): spec.sparseCheckout

### DIFF
--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -64,6 +64,28 @@ spec:
 	}
 }
 
+func TestParseGitRepository_SparseCheckout(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: monorepo, namespace: flux-system}
+spec:
+  url: https://github.com/owner/big-monorepo.git
+  sparseCheckout:
+    - kubernetes/apps/media
+    - kubernetes/components/shared
+  interval: 5m
+`)
+	g, err := ParseGitRepository(doc)
+	if err != nil {
+		t.Fatalf("ParseGitRepository: %v", err)
+	}
+	wantDirs := []string{"kubernetes/apps/media", "kubernetes/components/shared"}
+	if !slices.Equal(g.SparseCheckout, wantDirs) {
+		t.Errorf("SparseCheckout = %v, want %v", g.SparseCheckout, wantDirs)
+	}
+}
+
 func TestParseGitRepository_RefNameAndSubmodules(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -48,7 +48,10 @@ type GitRepository struct {
 	Provider          string                `json:"provider,omitempty" yaml:"provider,omitempty"`
 	SecretRef         *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
 	RecurseSubmodules bool                  `json:"recurseSubmodules,omitempty" yaml:"recurseSubmodules,omitempty"`
-	Suspend           bool                  `json:"-" yaml:"-"`
+	// SparseCheckout limits the checkout to the listed repo-relative
+	// directories. When empty, the full tree is checked out (default).
+	SparseCheckout []string `json:"sparseCheckout,omitempty" yaml:"sparseCheckout,omitempty"`
+	Suspend        bool     `json:"-" yaml:"-"`
 }
 
 // Named identifies the GitRepository.
@@ -100,6 +103,7 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		Ref:               ref,
 		Provider:          provider,
 		RecurseSubmodules: cr.Spec.RecurseSubmodules,
+		SparseCheckout:    cr.Spec.SparseCheckout,
 		Suspend:           cr.Spec.Suspend,
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -180,7 +180,7 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 		return nil, fmt.Errorf("clone %s: %w", url, err)
 	}
 
-	if err := checkoutRef(cloned, repo.Ref); err != nil {
+	if err := checkoutRef(cloned, repo.Ref, repo.SparseCheckout); err != nil {
 		return nil, fmt.Errorf("checkout %s: %w", refStr, err)
 	}
 	if repo.RecurseSubmodules {
@@ -196,10 +196,25 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 	}, nil
 }
 
-func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef) error {
+func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef, sparse []string) error {
 	wt, err := repo.Worktree()
 	if err != nil {
 		return err
+	}
+	// newOpts builds a CheckoutOptions pre-populated with sparse-checkout
+	// directories when configured. Repeated per call-site because
+	// CheckoutOptions is consumed by each Checkout invocation.
+	newOpts := func() *git.CheckoutOptions {
+		opts := &git.CheckoutOptions{}
+		if len(sparse) > 0 {
+			opts.SparseCheckoutDirectories = append(opts.SparseCheckoutDirectories, sparse...)
+		}
+		return opts
+	}
+	checkout := func(set func(*git.CheckoutOptions)) error {
+		opts := newOpts()
+		set(opts)
+		return wt.Checkout(opts)
 	}
 	switch {
 	case ref.Name != "":
@@ -210,39 +225,35 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef) error {
 		// branches under refs/remotes/origin.
 		rev := plumbing.Revision(ref.Name)
 		if h, err := repo.ResolveRevision(rev); err == nil {
-			return wt.Checkout(&git.CheckoutOptions{Hash: *h})
+			return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
 		}
 		// Fall through: try resolving as a remote-tracking ref. This
 		// handles refs/heads/<branch> by mapping to refs/remotes/origin/<branch>.
 		if rest, ok := strings.CutPrefix(ref.Name, "refs/heads/"); ok {
 			remote := plumbing.NewRemoteReferenceName("origin", rest)
 			if h, err := repo.ResolveRevision(plumbing.Revision(remote)); err == nil {
-				return wt.Checkout(&git.CheckoutOptions{Hash: *h})
+				return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
 			}
 		}
 		return fmt.Errorf("%w: unable to resolve git ref %q", manifest.ErrInput, ref.Name)
 	case ref.Commit != "":
-		return wt.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(ref.Commit)})
+		return checkout(func(o *git.CheckoutOptions) { o.Hash = plumbing.NewHash(ref.Commit) })
 	case ref.Tag != "":
-		// Tags are typically reachable via "refs/tags/<tag>".
 		if h, err := repo.ResolveRevision(plumbing.Revision("refs/tags/" + ref.Tag)); err == nil {
-			return wt.Checkout(&git.CheckoutOptions{Hash: *h})
+			return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
 		}
-		return wt.Checkout(&git.CheckoutOptions{Branch: plumbing.NewTagReferenceName(ref.Tag)})
+		return checkout(func(o *git.CheckoutOptions) { o.Branch = plumbing.NewTagReferenceName(ref.Tag) })
 	case ref.Branch != "":
-		// Default-branch HEAD is already checked out when NoCheckout=false.
-		// With NoCheckout we must resolve the remote branch.
 		remoteRef := plumbing.NewRemoteReferenceName("origin", ref.Branch)
 		if h, err := repo.ResolveRevision(plumbing.Revision(remoteRef)); err == nil {
-			return wt.Checkout(&git.CheckoutOptions{Hash: *h})
+			return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
 		}
-		// Fallback: maybe the repo has a local branch (file:// case).
-		return wt.Checkout(&git.CheckoutOptions{Branch: plumbing.NewBranchReferenceName(ref.Branch)})
+		return checkout(func(o *git.CheckoutOptions) { o.Branch = plumbing.NewBranchReferenceName(ref.Branch) })
 	case ref.Semver != "":
 		return fmt.Errorf("%w: GitRepository semver ref is not supported yet", manifest.ErrInput)
 	}
-	// No ref: just check out HEAD.
-	return wt.Checkout(&git.CheckoutOptions{})
+	// No ref: just check out HEAD (with sparse, if configured).
+	return checkout(func(*git.CheckoutOptions) {})
 }
 
 // updateSubmodules initializes and pulls submodules in the cloned

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -91,6 +91,69 @@ func TestFetcher_RefByName_Unresolvable(t *testing.T) {
 	}
 }
 
+// TestFetcher_SparseCheckout exercises spec.sparseCheckout — when
+// the repo declares specific directories, the worktree contains only
+// those (plus any tree-root metadata go-git keeps).
+func TestFetcher_SparseCheckout(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{
+		"apps/a/manifest.yaml":   "kind: ConfigMap",
+		"apps/b/manifest.yaml":   "kind: ConfigMap",
+		"infra/c/manifest.yaml":  "kind: ConfigMap",
+		"README.md":              "top-level",
+	})
+
+	cache := source.NewCache(t.TempDir())
+	repo := &manifest.GitRepository{
+		Name: "test", Namespace: "flux-system",
+		URL:            "file://" + src,
+		SparseCheckout: []string{"apps/a"},
+	}
+	f := &Fetcher{Cache: cache}
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// apps/a must be present; apps/b must not.
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "apps", "a", "manifest.yaml")); err != nil {
+		t.Errorf("sparse-included file missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "apps", "b", "manifest.yaml")); !os.IsNotExist(err) {
+		t.Errorf("sparse-excluded file should be absent; stat err = %v", err)
+	}
+}
+
+// mustInitRepoWithFiles creates a git repo at dir with the given
+// {path: contents} entries committed as one revision.
+func mustInitRepoWithFiles(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	wt, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	for path, content := range files {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := wt.Add(path); err != nil {
+			t.Fatalf("Add %s: %v", path, err)
+		}
+	}
+	if _, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	}); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+}
+
 // mustTagHEAD creates an annotated tag pointing at the worktree HEAD
 // and returns the tagged commit SHA.
 func mustTagHEAD(t *testing.T, dir, tag string) string {


### PR DESCRIPTION
## Summary

Flux \`GitRepository.spec.sparseCheckout\` limits the checkout to listed repo-relative directories — a real perf optimization for monorepos where flate only needs a slice of the tree (e.g. \`./kubernetes/apps/media\`).

go-git supports the underlying \`CheckoutOptions.SparseCheckoutDirectories\` field. Wiring is straightforward but touches every \`CheckoutOptions\` construction in \`checkoutRef\`, so the refactor consolidates them via a small \`newOpts\`/\`checkout\` closure pair that injects sparse dirs uniformly across the name / commit / tag / branch / HEAD paths.

## What changed

- \`manifest.GitRepository\` gains \`SparseCheckout []string\`. \`ParseGitRepository\` populates from \`cr.Spec.SparseCheckout\`.
- \`pkg/source/git.checkoutRef\` takes the sparse list and applies it to every checkout option through a single closure.

## Tests

- \`TestFetcher_SparseCheckout\` — creates a multi-dir repo, fetches with \`SparseCheckout: [\"apps/a\"]\`, asserts \`apps/a/manifest.yaml\` is on disk and \`apps/b/manifest.yaml\` is NOT.
- \`TestParseGitRepository_SparseCheckout\` — verifies the parser preserves the directory list.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)