### PR TITLE
feat(helm): HelmRepository certSecretRef (mTLS)

### DIFF
--- a/pkg/helm/auth_test.go
+++ b/pkg/helm/auth_test.go
@@ -7,6 +7,86 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+func TestHelmRepoTLS_NoCertSecretIsNoOp(t *testing.T) {
+	c, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	r := &manifest.HelmRepository{Name: "r", Namespace: "ns", URL: "https://charts.example"}
+	opts, cleanup, err := c.helmRepoTLSOptions(r)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("helmRepoTLSOptions: %v", err)
+	}
+	if opts != nil {
+		t.Errorf("expected nil opts when no CertSecretRef; got %v", opts)
+	}
+}
+
+func TestHelmRepoTLS_FromSecret(t *testing.T) {
+	c, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.SetSecretGetter(func(_, _ string) *manifest.Secret {
+		return &manifest.Secret{
+			StringData: map[string]any{
+				"tls.crt": "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+				"tls.key": "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+				"ca.crt":  "-----BEGIN CERTIFICATE-----\nca\n-----END CERTIFICATE-----\n",
+			},
+		}
+	})
+	r := &manifest.HelmRepository{
+		Name: "r", Namespace: "ns", URL: "https://charts.example",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls-creds"},
+	}
+	opts, cleanup, err := c.helmRepoTLSOptions(r)
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("helmRepoTLSOptions: %v", err)
+	}
+	if len(opts) == 0 {
+		t.Errorf("expected non-empty TLS opts when cert/key/ca present")
+	}
+}
+
+func TestHelmRepoTLS_AllKeysMissing(t *testing.T) {
+	c, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.SetSecretGetter(func(_, _ string) *manifest.Secret {
+		return &manifest.Secret{StringData: map[string]any{"unrelated": "x"}}
+	})
+	r := &manifest.HelmRepository{
+		Name: "r", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "wrong-shape"},
+	}
+	_, cleanup, err := c.helmRepoTLSOptions(r)
+	cleanup()
+	if err == nil || !strings.Contains(err.Error(), "tls.crt") {
+		t.Errorf("expected error mentioning expected keys; got %v", err)
+	}
+}
+
+func TestHelmRepoTLS_CertSecretNotFound(t *testing.T) {
+	c, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.SetSecretGetter(func(_, _ string) *manifest.Secret { return nil })
+	r := &manifest.HelmRepository{
+		Name: "r", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
+	}
+	_, cleanup, err := c.helmRepoTLSOptions(r)
+	cleanup()
+	if err == nil || !strings.Contains(err.Error(), "cert secret ns/missing not found") {
+		t.Errorf("expected secret-not-found error; got %v", err)
+	}
+}
+
 func TestHelmRepoAuth_NoSecretIsAnonymous(t *testing.T) {
 	c, err := NewClient(t.TempDir(), t.TempDir())
 	if err != nil {

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -105,9 +105,15 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	if err != nil {
 		return "", err
 	}
+	tlsOpts, cleanup, err := c.helmRepoTLSOptions(r)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	allOpts := append(authOpts, tlsOpts...)
 
 	indexURL := strings.TrimSuffix(r.URL, "/") + "/index.yaml"
-	idx, err := c.fetchIndex(indexURL, authOpts)
+	idx, err := c.fetchIndex(indexURL, allOpts)
 	if err != nil {
 		return "", err
 	}
@@ -137,7 +143,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	if err != nil {
 		return "", err
 	}
-	buf, err := g.Get(chartURL, authOpts...)
+	buf, err := g.Get(chartURL, allOpts...)
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", chartURL, err)
 	}
@@ -179,6 +185,81 @@ func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Optio
 		opts = append(opts, getter.WithPassCredentialsAll(true))
 	}
 	return opts, nil
+}
+
+// helmRepoTLSOptions resolves spec.certSecretRef into helm getter
+// options. The Secret should carry one or both of (tls.crt, tls.key)
+// for client cert auth, plus optional ca.crt for a custom server CA.
+// Each present file is materialized to a temp file (helm getter v4's
+// WithTLSClientConfig accepts paths, not bytes) and removed by the
+// returned cleanup func — always safe to call.
+func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option, func(), error) {
+	noCleanup := func() {}
+	if r.CertSecretRef == nil {
+		return nil, noCleanup, nil
+	}
+	c.mu.RLock()
+	getSec := c.secrets
+	c.mu.RUnlock()
+	if getSec == nil {
+		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
+			r.Namespace, r.Name)
+	}
+	sec := getSec(r.Namespace, r.CertSecretRef.Name)
+	if sec == nil {
+		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s: cert secret %s/%s not found",
+			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+	}
+
+	var tmpFiles []string
+	writeKey := func(key string) (string, error) {
+		v := stringFromHelmSecret(sec, key)
+		if v == "" {
+			return "", nil
+		}
+		tmp, err := os.CreateTemp(c.tmpDir, "helm-tls-*.pem")
+		if err != nil {
+			return "", fmt.Errorf("temp %s: %w", key, err)
+		}
+		if _, err := tmp.WriteString(v); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return "", fmt.Errorf("write %s: %w", key, err)
+		}
+		if err := tmp.Close(); err != nil {
+			_ = os.Remove(tmp.Name())
+			return "", fmt.Errorf("close %s: %w", key, err)
+		}
+		tmpFiles = append(tmpFiles, tmp.Name())
+		return tmp.Name(), nil
+	}
+	cleanup := func() {
+		for _, p := range tmpFiles {
+			_ = os.Remove(p)
+		}
+	}
+
+	certPath, err := writeKey("tls.crt")
+	if err != nil {
+		cleanup()
+		return nil, noCleanup, err
+	}
+	keyPath, err := writeKey("tls.key")
+	if err != nil {
+		cleanup()
+		return nil, noCleanup, err
+	}
+	caPath, err := writeKey("ca.crt")
+	if err != nil {
+		cleanup()
+		return nil, noCleanup, err
+	}
+	if certPath == "" && keyPath == "" && caPath == "" {
+		cleanup()
+		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+	}
+	return []getter.Option{getter.WithTLSClientConfig(certPath, keyPath, caPath)}, cleanup, nil
 }
 
 // stringFromHelmSecret reads a Secret key, preferring StringData and

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -364,6 +364,7 @@ type HelmRepository struct {
 	RepoType        string                `json:"repoType,omitempty" yaml:"repoType,omitempty"`
 	Provider        string                `json:"provider,omitempty" yaml:"provider,omitempty"`
 	SecretRef       *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	CertSecretRef   *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
 	PassCredentials bool                  `json:"-" yaml:"-"`
 	Insecure        bool                  `json:"-" yaml:"-"`
 	Suspend         bool                  `json:"-" yaml:"-"`
@@ -418,6 +419,9 @@ func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
 		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+	}
+	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
+		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
 	}
 	return out, nil
 }


### PR DESCRIPTION
## Summary

Adds \`spec.certSecretRef\` support for private Helm repositories behind mTLS — enterprise gitea/harbor/artifactory setups where the registry requires a client cert. The Secret carries one or more of:

| Key | Purpose |
|---|---|
| \`tls.crt\` | PEM-encoded client certificate |
| \`tls.key\` | PEM-encoded client private key |
| \`ca.crt\` | PEM-encoded custom CA bundle for server verification |

\`helm.getter.WithTLSClientConfig(certFile, keyFile, caFile)\` expects filesystem paths, not bytes. The fetcher materializes each present key to a temp file under \`c.tmpDir\`, threads the paths to both \`fetchIndex\` and the per-chart \`Get\`, then removes the temps via a deferred cleanup func (always safe to call — no-op when no temps were created).

## Behavior

- Coexists with HTTP basic / bearer auth — TLS opts append to the existing auth opts; both apply to the same request.
- A Secret with **none** of the expected keys produces a clear error rather than silently configuring nothing.
- \`--wipe-secrets\` PLACEHOLDER values are treated as missing via the existing \`stringFromHelmSecret\` helper.

## Tests

- \`TestHelmRepoTLS_NoCertSecretIsNoOp\` — no CertSecretRef → nil opts.
- \`TestHelmRepoTLS_FromSecret\` — populated cert/key/ca → non-empty opts.
- \`TestHelmRepoTLS_AllKeysMissing\` — Secret with unrelated keys → clear error mentioning \`tls.crt\`.
- \`TestHelmRepoTLS_CertSecretNotFound\` — \`cert secret ns/missing not found\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)