### PR TITLE
feat(source/oci): certSecretRef (mTLS) + spec.insecure

### DIFF
--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -125,13 +125,15 @@ func (r OCIRepositoryRef) IsEmpty() bool { return r == OCIRepositoryRef{} }
 
 // OCIRepository is the Flux OCIRepository CRD.
 type OCIRepository struct {
-	Name      string                `json:"name" yaml:"name"`
-	Namespace string                `json:"namespace" yaml:"namespace"`
-	URL       string                `json:"url" yaml:"url"`
-	Ref       OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Provider  string                `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	Suspend   bool                  `json:"-" yaml:"-"`
+	Name          string                `json:"name" yaml:"name"`
+	Namespace     string                `json:"namespace" yaml:"namespace"`
+	URL           string                `json:"url" yaml:"url"`
+	Ref           OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Provider      string                `json:"provider,omitempty" yaml:"provider,omitempty"`
+	SecretRef     *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	CertSecretRef *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
+	Insecure      bool                  `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	Suspend       bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the OCIRepository.
@@ -204,7 +206,11 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		Namespace: cr.Namespace,
 		URL:       cr.Spec.URL,
 		Provider:  provider,
+		Insecure:  cr.Spec.Insecure,
 		Suspend:   cr.Spec.Suspend,
+	}
+	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
+		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
 	}
 	if r := cr.Spec.Reference; r != nil {
 		out.Ref = OCIRepositoryRef{

--- a/pkg/source/oci/auth_test.go
+++ b/pkg/source/oci/auth_test.go
@@ -2,12 +2,135 @@ package oci
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
+
+func TestFetcher_ResolveTLS_NoCertSecretIsNil(t *testing.T) {
+	f := &Fetcher{}
+	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns"}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil TLS config when no CertSecretRef + Insecure=false")
+	}
+}
+
+func TestFetcher_ResolveTLS_Insecure(t *testing.T) {
+	f := &Fetcher{}
+	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns", Insecure: true}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg == nil || !cfg.InsecureSkipVerify {
+		t.Errorf("expected Insecure to set InsecureSkipVerify: %+v", cfg)
+	}
+}
+
+// TestFetcher_ResolveTLS_FromSecret uses a real ephemeral cert/key
+// pair — tls.X509KeyPair actually parses it so we can't hardcode.
+func TestFetcher_ResolveTLS_FromSecret(t *testing.T) {
+	certPEM, keyPEM := generateSelfSignedCert(t)
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{
+				StringData: map[string]any{
+					"tls.crt": certPEM,
+					"tls.key": keyPEM,
+					"ca.crt":  certPEM,
+				},
+			}
+		},
+	}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg == nil {
+		t.Fatalf("expected non-nil TLS config")
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("expected 1 client certificate, got %d", len(cfg.Certificates))
+	}
+	if cfg.RootCAs == nil {
+		t.Errorf("expected RootCAs populated from ca.crt")
+	}
+}
+
+func TestFetcher_ResolveTLS_PartialCertKey(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"tls.crt": "-only-cert-"}}
+		},
+	}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	_, err := f.resolveTLS(repo)
+	if err == nil || !strings.Contains(err.Error(), "must provide both") {
+		t.Errorf("expected partial cert/key error; got %v", err)
+	}
+}
+
+func TestFetcher_ResolveTLS_AllKeysMissing(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"unrelated": "x"}}
+		},
+	}
+	repo := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	_, err := f.resolveTLS(repo)
+	if err == nil || !strings.Contains(err.Error(), "tls.crt") {
+		t.Errorf("expected missing-keys error; got %v", err)
+	}
+}
+
+func generateSelfSignedCert(t *testing.T) (string, string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "flate-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}))
+	return certPEM, keyPEM
+}
 
 func TestFetcher_NonGenericProvider(t *testing.T) {
 	f := &Fetcher{}

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -5,8 +5,11 @@ package oci
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -19,6 +22,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/retry"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
@@ -54,7 +58,64 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		return nil, err
 	}
 	defer cleanup()
-	return fetch(ctx, f.Cache, repo, configPath)
+	tlsCfg, err := f.resolveTLS(repo)
+	if err != nil {
+		return nil, err
+	}
+	return fetch(ctx, f.Cache, repo, configPath, tlsCfg)
+}
+
+// resolveTLS builds a *tls.Config from spec.certSecretRef (PEM-encoded
+// tls.crt + tls.key + ca.crt — any subset acceptable) and/or
+// spec.insecure. Returns nil when no TLS customization is needed.
+func (f *Fetcher) resolveTLS(repo *manifest.OCIRepository) (*tls.Config, error) {
+	if repo.CertSecretRef == nil && !repo.Insecure {
+		return nil, nil
+	}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if repo.Insecure {
+		cfg.InsecureSkipVerify = true //nolint:gosec // honoring user-declared spec.insecure
+	}
+	if repo.CertSecretRef == nil {
+		return cfg, nil
+	}
+	if f.Secrets == nil {
+		return nil, fmt.Errorf("OCIRepository %s/%s references certSecretRef but no source.SecretGetter is wired",
+			repo.Namespace, repo.Name)
+	}
+	sec := f.Secrets(repo.Namespace, repo.CertSecretRef.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("OCIRepository %s/%s: cert secret %s/%s not found",
+			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
+	}
+	crt := source.StringFromSecret(sec, "tls.crt")
+	key := source.StringFromSecret(sec, "tls.key")
+	ca := source.StringFromSecret(sec, "ca.crt")
+	if crt == "" && key == "" && ca == "" {
+		return nil, fmt.Errorf("OCIRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
+	}
+	if (crt == "") != (key == "") {
+		return nil, fmt.Errorf("OCIRepository %s/%s: certSecretRef %s/%s must provide both tls.crt and tls.key together",
+			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
+	}
+	if crt != "" {
+		cert, err := tls.X509KeyPair([]byte(crt), []byte(key))
+		if err != nil {
+			return nil, fmt.Errorf("OCIRepository %s/%s: parse tls.crt/tls.key: %w",
+				repo.Namespace, repo.Name, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	if ca != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(ca)) {
+			return nil, fmt.Errorf("OCIRepository %s/%s: ca.crt did not parse as PEM",
+				repo.Namespace, repo.Name)
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg, nil
 }
 
 // resolveRegistryConfig picks the credential source for a fetch.
@@ -110,7 +171,7 @@ func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, f
 // credentials.NewFileStore. When spec.ref.semver is set, the registry
 // is listed and the highest matching tag (filtered by semverFilter, if
 // any) is resolved before pulling.
-func fetch(ctx context.Context, cache *source.Cache, repo *manifest.OCIRepository, registryConfig string) (*store.SourceArtifact, error) {
+func fetch(ctx context.Context, cache *source.Cache, repo *manifest.OCIRepository, registryConfig string, tlsCfg *tls.Config) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
 	}
@@ -130,8 +191,24 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.OCIRepositor
 	if err != nil {
 		return nil, err
 	}
+	// Compose the http.Client transport: oras's retry transport over a
+	// (TLS-customized) http.Transport when needed. Without TLS overrides
+	// oras's default is used.
+	var httpClient *http.Client
+	if tlsCfg != nil {
+		baseTransport := http.DefaultTransport.(*http.Transport).Clone()
+		baseTransport.TLSClientConfig = tlsCfg
+		httpClient = &http.Client{Transport: retry.NewTransport(baseTransport)}
+	}
 	if credStore != nil {
-		repoClient.Client = &auth.Client{Credential: credentials.Credential(credStore)}
+		ac := &auth.Client{Credential: credentials.Credential(credStore)}
+		if httpClient != nil {
+			ac.Client = httpClient
+		}
+		repoClient.Client = ac
+	} else if httpClient != nil {
+		// No auth needed but TLS still has to be configured.
+		repoClient.Client = &auth.Client{Client: httpClient}
 	}
 
 	// Resolve spec.ref into a concrete (tag-or-digest) BEFORE choosing


### PR DESCRIPTION
## Summary

Adds mTLS support for private OCI registries (artifactory, harbor, gitea) plus honors \`spec.insecure\` for the rare HTTP-only registry.

Both flow through a single \`*tls.Config\` the fetch path injects into oras-go's \`auth.Client\`. Composition is layered carefully:

| Config | Resulting client |
|---|---|
| TLS overrides only (no creds) | \`auth.Client\` wraps a custom \`http.Client\` (credentials nil) |
| Credentials only (no TLS) | unchanged — \`auth.Client{Credential: ...}\` over oras's default transport |
| Both | \`auth.Client\` with both \`Credential\` and the custom \`http.Client\` |
| Neither | unchanged |

When custom TLS is needed, the transport is built as: \`retry.NewTransport(http.DefaultTransport.Clone() with TLSClientConfig)\`. Oras-go's retry semantics still apply.

## The CertSecretRef Secret

| Key | Purpose |
|---|---|
| \`tls.crt\` + \`tls.key\` | Client certificate (must appear together) |
| \`ca.crt\` | Custom CA bundle for server verification |

A Secret with none of these returns a clear error; partial cert/key returns \`\"must provide both\"\`. \`spec.insecure\` on its own (no certSecretRef) just sets \`InsecureSkipVerify\` — useful for testing against a self-signed local registry.

## Tests

Use a real ephemeral RSA self-signed cert. \`tls.X509KeyPair\` actually parses input, so hardcoded PEM fakes don't work.

- \`TestFetcher_ResolveTLS_NoCertSecretIsNil\` — no overrides → nil config.
- \`TestFetcher_ResolveTLS_Insecure\` — Insecure alone sets InsecureSkipVerify.
- \`TestFetcher_ResolveTLS_FromSecret\` — real cert/key/ca PEMs produce a populated tls.Config.
- \`TestFetcher_ResolveTLS_PartialCertKey\` — cert without key → error.
- \`TestFetcher_ResolveTLS_AllKeysMissing\` — wrong-shape Secret → error naming expected keys.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green
- [x] \`golangci-lint run\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)