### PR TITLE
feat(bucket): support certSecretRef for mTLS endpoints

### DIFF
--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -24,7 +24,10 @@ type Bucket struct {
 	// SecretRef points at a Secret carrying accesskey / secretkey
 	// (generic provider) or the provider-specific credential bag.
 	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	Suspend   bool                  `json:"-" yaml:"-"`
+	// CertSecretRef points at a Secret with tls.crt + tls.key
+	// (client cert) and/or ca.crt (server CA) for mTLS endpoints.
+	CertSecretRef *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
+	Suspend       bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the Bucket.
@@ -71,6 +74,9 @@ func ParseBucket(doc map[string]any) (*Bucket, error) {
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
 		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+	}
+	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
+		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
 	}
 	return out, nil
 }

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -5,10 +5,13 @@ package bucket
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -56,10 +59,16 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		return nil, err
 	}
 
+	transport, err := f.resolveTransport(b)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := minio.New(endpoint, &minio.Options{
-		Creds:  creds,
-		Secure: secure,
-		Region: b.Region,
+		Creds:     creds,
+		Secure:    secure,
+		Region:    b.Region,
+		Transport: transport,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("bucket %s/%s: minio client: %w", b.Namespace, b.Name, err)
@@ -88,6 +97,57 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 			"objectCount": fmt.Sprintf("%d", len(keys)),
 		},
 	}, nil
+}
+
+// resolveTransport builds a custom *http.Transport from
+// spec.certSecretRef when configured. Returns nil to let minio-go
+// use its default transport. The Insecure flag is intentionally
+// applied at the protocol level (normalizeEndpoint) rather than the
+// TLS layer, mirroring Flux's source-controller behavior.
+func (f *Fetcher) resolveTransport(b *manifest.Bucket) (*http.Transport, error) {
+	if b.CertSecretRef == nil {
+		return nil, nil
+	}
+	if f.Secrets == nil {
+		return nil, fmt.Errorf("bucket %s/%s references certSecretRef but no source.SecretGetter is wired",
+			b.Namespace, b.Name)
+	}
+	sec := f.Secrets(b.Namespace, b.CertSecretRef.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("bucket %s/%s: cert secret %s/%s not found",
+			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
+	}
+	crt := source.StringFromSecret(sec, "tls.crt")
+	key := source.StringFromSecret(sec, "tls.key")
+	ca := source.StringFromSecret(sec, "ca.crt")
+	if crt == "" && key == "" && ca == "" {
+		return nil, fmt.Errorf("bucket %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
+	}
+	if (crt == "") != (key == "") {
+		return nil, fmt.Errorf("bucket %s/%s: certSecretRef %s/%s must provide both tls.crt and tls.key together",
+			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
+	}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if crt != "" {
+		cert, err := tls.X509KeyPair([]byte(crt), []byte(key))
+		if err != nil {
+			return nil, fmt.Errorf("bucket %s/%s: parse tls.crt/tls.key: %w",
+				b.Namespace, b.Name, err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	if ca != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(ca)) {
+			return nil, fmt.Errorf("bucket %s/%s: ca.crt did not parse as PEM",
+				b.Namespace, b.Name)
+		}
+		cfg.RootCAs = pool
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = cfg
+	return tr, nil
 }
 
 // resolveCredentials picks up accesskey/secretkey from the SecretRef

--- a/pkg/source/bucket/transport_test.go
+++ b/pkg/source/bucket/transport_test.go
@@ -1,0 +1,146 @@
+package bucket
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestFetcher_ResolveTransport_NoCertSecretIsNil(t *testing.T) {
+	f := &Fetcher{}
+	b := &manifest.Bucket{Name: "b", Namespace: "ns"}
+	tr, err := f.resolveTransport(b)
+	if err != nil {
+		t.Fatalf("resolveTransport: %v", err)
+	}
+	if tr != nil {
+		t.Errorf("expected nil transport when no CertSecretRef")
+	}
+}
+
+func TestFetcher_ResolveTransport_FromSecret(t *testing.T) {
+	certPEM, keyPEM := generateSelfSignedCertForBucket(t)
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{
+				StringData: map[string]any{
+					"tls.crt": certPEM,
+					"tls.key": keyPEM,
+					"ca.crt":  certPEM,
+				},
+			}
+		},
+	}
+	b := &manifest.Bucket{
+		Name: "b", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	tr, err := f.resolveTransport(b)
+	if err != nil {
+		t.Fatalf("resolveTransport: %v", err)
+	}
+	if tr == nil {
+		t.Fatalf("expected non-nil transport")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatalf("expected TLSClientConfig set")
+	}
+	if len(tr.TLSClientConfig.Certificates) != 1 {
+		t.Errorf("expected 1 client cert, got %d", len(tr.TLSClientConfig.Certificates))
+	}
+	if tr.TLSClientConfig.RootCAs == nil {
+		t.Errorf("expected RootCAs populated from ca.crt")
+	}
+}
+
+func TestFetcher_ResolveTransport_PartialCertKey(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"tls.crt": "-only-cert-"}}
+		},
+	}
+	b := &manifest.Bucket{
+		Name: "b", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	_, err := f.resolveTransport(b)
+	if err == nil || !strings.Contains(err.Error(), "must provide both") {
+		t.Errorf("expected partial cert/key error; got %v", err)
+	}
+}
+
+func TestFetcher_ResolveTransport_AllKeysMissing(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"unrelated": "x"}}
+		},
+	}
+	b := &manifest.Bucket{
+		Name: "b", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	_, err := f.resolveTransport(b)
+	if err == nil || !strings.Contains(err.Error(), "tls.crt") {
+		t.Errorf("expected missing-keys error; got %v", err)
+	}
+}
+
+func TestFetcher_ResolveTransport_SecretNotFound(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret { return nil },
+	}
+	b := &manifest.Bucket{
+		Name: "b", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
+	}
+	_, err := f.resolveTransport(b)
+	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {
+		t.Errorf("expected secret-not-found error; got %v", err)
+	}
+}
+
+func TestFetcher_ResolveTransport_CertSecretRefWithoutGetter(t *testing.T) {
+	f := &Fetcher{} // no Secrets
+	b := &manifest.Bucket{
+		Name: "b", Namespace: "ns",
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+	}
+	_, err := f.resolveTransport(b)
+	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
+		t.Errorf("expected source.SecretGetter error; got %v", err)
+	}
+}
+
+func generateSelfSignedCertForBucket(t *testing.T) (string, string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "flate-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}))
+	return certPEM, keyPEM
+}


### PR DESCRIPTION
## Summary
- Parse `spec.certSecretRef` on Bucket via the typed source-controller CR.
- Resolve the referenced Secret in `BucketFetcher` and build a `*tls.Config` from any combination of `tls.crt` / `tls.key` (client cert) and `ca.crt` (server CA), threading it to minio-go via `Options.Transport`.
- Fail loud on the surprising shapes (partial cert/key pair, empty Secret, SecretRef set without a SecretGetter, missing Secret) — matches the OCIRepository mTLS contract shipped in #46.
- `Insecure` still controls only protocol selection (http vs https), mirroring Flux source-controller semantics; it does not flip `InsecureSkipVerify`.

## Test plan
- [x] `go test ./pkg/source/bucket/...`
- [x] `go test ./...`
- [x] `golangci-lint run ./pkg/source/bucket/... ./pkg/manifest/...`
- [x] New internal-package tests cover: nil cert ref, full mTLS triple from Secret, partial cert/key, empty Secret, missing Secret, missing SecretGetter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)