### PR TITLE
feat(git): support ca.crt / caFile in GitRepository SecretRef

### DIFF
--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -3,14 +3,19 @@ package git
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 
@@ -26,6 +31,11 @@ import (
 type Fetcher struct {
 	Cache   *source.Cache
 	Secrets source.SecretGetter
+	// httpsMu serializes the brief window where a per-CR HTTPS client
+	// is installed as go-git's global transport. go-git v5 does not
+	// expose per-CloneOptions TLS config, so custom-CA fetches must
+	// take this lock for the duration of the clone.
+	httpsMu sync.Mutex
 }
 
 // Fetch implements source.Fetcher for *manifest.GitRepository.
@@ -44,7 +54,56 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	if err != nil {
 		return nil, err
 	}
+	tlsCfg, err := f.resolveTLS(repo)
+	if err != nil {
+		return nil, err
+	}
+	if tlsCfg != nil {
+		f.httpsMu.Lock()
+		defer f.httpsMu.Unlock()
+		httpsClient := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+		client.InstallProtocol("https", githttp.NewClient(httpsClient))
+		defer client.InstallProtocol("https", githttp.DefaultClient)
+	}
 	return fetch(ctx, f.Cache, repo, auth)
+}
+
+// resolveTLS builds a *tls.Config from spec.secretRef for HTTPS GitRepositories
+// using a custom CA. Returns nil when no CA material is present (anonymous /
+// system-CA path). Matches Flux source-controller key conventions:
+// "ca.crt" (preferred) or "caFile" (legacy alias).
+//
+// SSH repositories ignore this — TLS doesn't apply to that transport.
+func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) {
+	if repo.SecretRef == nil {
+		return nil, nil
+	}
+	if isSSHURL(repo.URL) {
+		return nil, nil
+	}
+	if f.Secrets == nil {
+		// resolveAuth already errored if SecretRef && !Secrets, but
+		// guard anyway so this method is safe to call standalone.
+		return nil, nil
+	}
+	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
+	if sec == nil {
+		// resolveAuth reports the missing-secret error first.
+		return nil, nil
+	}
+	ca := source.StringFromSecret(sec, "ca.crt")
+	if ca == "" {
+		ca = source.StringFromSecret(sec, "caFile")
+	}
+	if ca == "" {
+		return nil, nil
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM([]byte(ca)) {
+		return nil, fmt.Errorf("GitRepository %s/%s: ca.crt did not parse as PEM",
+			repo.Namespace, repo.Name)
+	}
+	return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool}, nil
 }
 
 // resolveAuth turns repo.SecretRef into a go-git AuthMethod. Returns

--- a/pkg/source/git/tls_test.go
+++ b/pkg/source/git/tls_test.go
@@ -1,0 +1,147 @@
+package git
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestFetcher_ResolveTLS_NoSecretRefIsNil(t *testing.T) {
+	f := &Fetcher{}
+	repo := &manifest.GitRepository{Name: "g", Namespace: "ns", URL: "https://example.com/x.git"}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil TLS config when no SecretRef")
+	}
+}
+
+func TestFetcher_ResolveTLS_SSHURLIsNil(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"ca.crt": "x"}}
+		},
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "ssh://git@example.com/x.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil TLS config for SSH URL")
+	}
+}
+
+func TestFetcher_ResolveTLS_NoCAKeyInSecretIsNil(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"username": "alice", "password": "p"}}
+		},
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "https://example.com/x.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg != nil {
+		t.Errorf("expected nil TLS config when SecretRef carries no CA")
+	}
+}
+
+func TestFetcher_ResolveTLS_CAFromCACrt(t *testing.T) {
+	caPEM := generateSelfSignedCA(t)
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"ca.crt": caPEM}}
+		},
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "https://example.com/x.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatalf("expected RootCAs populated from ca.crt: %+v", cfg)
+	}
+}
+
+func TestFetcher_ResolveTLS_CAFromCAFileLegacyKey(t *testing.T) {
+	caPEM := generateSelfSignedCA(t)
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"caFile": caPEM}}
+		},
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "https://example.com/x.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg == nil || cfg.RootCAs == nil {
+		t.Fatalf("expected RootCAs populated from caFile: %+v", cfg)
+	}
+}
+
+func TestFetcher_ResolveTLS_InvalidPEM(t *testing.T) {
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"ca.crt": "-----BEGIN CERTIFICATE-----\nnot-pem\n-----END CERTIFICATE-----"}}
+		},
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "https://example.com/x.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	_, err := f.resolveTLS(repo)
+	if err == nil || !strings.Contains(err.Error(), "did not parse as PEM") {
+		t.Errorf("expected PEM parse error; got %v", err)
+	}
+}
+
+func generateSelfSignedCA(t *testing.T) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "flate-test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}


### PR DESCRIPTION
## Summary
- GitRepository over HTTPS to a self-hosted endpoint with a private CA now picks up trust roots from \`spec.secretRef\`.
- Preferred key: \`ca.crt\` (current source-controller convention). Legacy alias \`caFile\` is also accepted.
- SSH URLs short-circuit — TLS doesn't apply there.

## Why a mutex
go-git v5 doesn't accept a per-\`CloneOptions\` TLS config. The custom https client is installed via \`client.InstallProtocol\` under a Fetcher-level mutex and restored to \`githttp.DefaultClient\` after the clone. This serializes only fetches that actually carry a custom CA.

## Test plan
- [x] \`go test ./pkg/source/git/...\`
- [x] \`go test ./...\`
- [x] \`golangci-lint run ./pkg/source/git/...\`
- [x] New tests cover: no SecretRef, SSH URL, secret without CA key, ca.crt success, caFile legacy success, invalid PEM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)