### PR TITLE
feat(manifest): parse HelmRelease.serviceAccountName + HelmChart.reconcileStrategy

### DIFF
--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -107,6 +107,10 @@ type HelmChartSource struct {
 	Suspend                  bool     `json:"-" yaml:"-"`
 	ValuesFiles              []string `json:"-" yaml:"-"`
 	IgnoreMissingValuesFiles bool     `json:"-" yaml:"-"`
+	// ReconcileStrategy is "ChartVersion" (default) or "Revision". Flate
+	// does not re-trigger reconciles; this is parsed for round-tripping
+	// fidelity so consumers can observe the upstream intent.
+	ReconcileStrategy string `json:"-" yaml:"-"`
 }
 
 // Named identifies the chart resource.
@@ -157,6 +161,7 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 		Suspend:                  cr.Spec.Suspend,
 		ValuesFiles:              cr.Spec.ValuesFiles,
 		IgnoreMissingValuesFiles: cr.Spec.IgnoreMissingValuesFiles,
+		ReconcileStrategy:        cr.Spec.ReconcileStrategy,
 	}, nil
 }
 
@@ -197,6 +202,11 @@ type HelmRelease struct {
 	Suspend                  bool              `json:"-" yaml:"-"`
 	DisableSchemaValidation  bool              `json:"-" yaml:"-"`
 	DisableOpenAPIValidation bool              `json:"-" yaml:"-"`
+	// ServiceAccountName is the SA Flux's helm-controller impersonates
+	// when applying the release. Flate renders offline so it has no
+	// effect here, but the field is preserved for fidelity with the
+	// upstream CR and so future render-time policy checks can observe it.
+	ServiceAccountName string `json:"-" yaml:"-"`
 	// ChartValuesFiles are values files baked into the chart that
 	// should be merged BEFORE the HR's own Values overrides. Sourced
 	// from either spec.chart.spec.valuesFiles (inline template) or the
@@ -352,6 +362,7 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		DisableOpenAPIValidation: disableOpenAPI,
 		ChartValuesFiles:         chartValuesFiles,
 		IgnoreMissingValuesFiles: ignoreMissingValuesFiles,
+		ServiceAccountName:       cr.Spec.ServiceAccountName,
 	}, nil
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -64,6 +64,46 @@ spec:
 	}
 }
 
+func TestParseHelmRelease_ServiceAccountName(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  serviceAccountName: privileged-installer
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	hr, err := ParseHelmRelease(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmRelease: %v", err)
+	}
+	if hr.ServiceAccountName != "privileged-installer" {
+		t.Errorf("ServiceAccountName = %q, want %q", hr.ServiceAccountName, "privileged-installer")
+	}
+}
+
+func TestParseHelmChartSource_ReconcileStrategy(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmChart
+metadata: {name: c, namespace: ns}
+spec:
+  chart: nginx
+  reconcileStrategy: Revision
+  sourceRef: {kind: HelmRepository, name: r}
+`)
+	hc, err := ParseHelmChartSource(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmChartSource: %v", err)
+	}
+	if hc.ReconcileStrategy != "Revision" {
+		t.Errorf("ReconcileStrategy = %q, want %q", hc.ReconcileStrategy, "Revision")
+	}
+}
+
 func TestParseGitRepository_SparseCheckout(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: source.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Summary
- Parse \`HelmRelease.spec.serviceAccountName\` onto \`manifest.HelmRelease.ServiceAccountName\`.
- Parse \`HelmChart.spec.reconcileStrategy\` onto \`manifest.HelmChartSource.ReconcileStrategy\`.

Both are pass-through fields — flate's offline render pipeline doesn't consume them. The motivation is round-trip fidelity (diff tooling, future policy hooks) and removing two cosmetic divergences from the upstream Flux model.

## Test plan
- [x] \`go test ./pkg/manifest/...\`
- [x] \`golangci-lint run ./pkg/manifest/...\`
- [x] New parse-through tests for both fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)