### PR TITLE
fix(kustomization): emit render output before SOPS abort + dispatch child events

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -132,18 +132,14 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
+	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
+	var sopsRefs []string
 	for _, doc := range docs {
 		if manifest.IsEncryptedSecret(doc) {
 			name, ns := manifest.DocMetadata(doc)
-			return fmt.Errorf(
-				"SOPS-encrypted %s %s/%s in rendered output: flate does not implement spec.decryption — "+
-					"render against pre-decrypted manifests or remove the encrypted resource",
-				manifest.DocKind(doc), ns, name,
-			)
+			sopsRefs = append(sopsRefs, fmt.Sprintf("%s %s/%s", manifest.DocKind(doc), ns, name))
+			continue
 		}
-	}
-	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
-	for _, doc := range docs {
 		obj, err := manifest.ParseDoc(doc, opts)
 		if err != nil {
 			// Don't fail on parse errors of inline resources — they may
@@ -152,7 +148,27 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 			slog.Debug("kustomization: skipped doc", "id", id.String(), "err", err)
 			continue
 		}
-		c.Store.AddRendered(obj)
+		// When a parent Kustomization renders a Flux resource that has
+		// its own controller (child Kustomization, HelmRelease, sources),
+		// route through AddObject so the rendered version (with patches,
+		// commonMetadata, targetNamespace, etc. applied) supersedes any
+		// statically-loaded copy and triggers a fresh reconcile.
+		// Non-reconcilable leaves keep the cheaper AddRendered path.
+		if shouldDispatchAsObject(obj) {
+			c.Store.AddObject(obj)
+		} else {
+			c.Store.AddRendered(obj)
+		}
+	}
+	if len(sopsRefs) > 0 {
+		// Surface SOPS docs as the Kustomization's failure reason but
+		// keep the non-SOPS docs in the store so downstream consumers
+		// can still reconcile against the parts flate could render.
+		return fmt.Errorf(
+			"SOPS-encrypted resource(s) in rendered output: %s — flate does not implement spec.decryption; "+
+				"render against pre-decrypted manifests or remove the encrypted resource",
+			strings.Join(sopsRefs, ", "),
+		)
 	}
 
 	c.Store.SetArtifact(id, &store.KustomizationArtifact{
@@ -160,6 +176,30 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		Manifests: docs,
 	})
 	return nil
+}
+
+// shouldDispatchAsObject reports whether a render-emitted Flux
+// resource needs to fire EventObjectAdded so its own controller picks
+// it up. The pattern is: parent Kustomization renders → emits a
+// child Flux resource (e.g. another Kustomization with parent patches
+// applied, a HelmRelease, an OCIRepository fanned out from a kustomize
+// component) → that child's controller must reconcile the patched
+// version, not the statically-loaded one.
+func shouldDispatchAsObject(obj manifest.BaseManifest) bool {
+	switch obj.(type) {
+	case *manifest.Kustomization,
+		*manifest.HelmRelease,
+		*manifest.HelmRepository,
+		*manifest.OCIRepository,
+		*manifest.GitRepository,
+		*manifest.Bucket,
+		*manifest.HelmChartSource,
+		*manifest.ExternalArtifact,
+		*manifest.ConfigMap,
+		*manifest.Secret:
+		return true
+	}
+	return false
 }
 
 // collectDeps assembles the dependency refs whose readiness must

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -223,6 +223,56 @@ func TestE2E_NonSharedChangeDoesNotPropagate(t *testing.T) {
 	}
 }
 
+// TestE2E_ParentPatchesPropagateToChildren reproduces the bjw-s
+// home-ops cluster-apps pattern: a top-level Flux Kustomization with
+// spec.patches that inject postBuild.substituteFrom into every child
+// Kustomization. Children carry only inline substitute.* — they rely
+// on the parent's patches to wire the ConfigMap reference at render
+// time. The fixture's leaf KS references ${MY_VAR}, which only
+// resolves if the parent's render-emitted (patched) child KS
+// supersedes the statically-loaded one and triggers a fresh reconcile.
+//
+// A SOPS-encrypted Secret in the same parent kustomize tree exercises
+// the secondary fix: render must continue past the SOPS doc so the
+// (non-SOPS) patched children still reach the store.
+func TestE2E_ParentPatchesPropagateToChildren(t *testing.T) {
+	src := testdataPath(t, "parent-patches")
+	root := copyTree(t, src)
+
+	// `flate test ks` exits non-zero because cluster-apps reports the
+	// SOPS Secret it could not decrypt — that's the intended fail-loud.
+	// What matters here is that leaf still PASSED.
+	out, _ := runCLIExpectErr(t, "test", "ks", "--path", root)
+
+	if !strings.Contains(out, "Kustomization/flux-system/leaf") {
+		t.Fatalf("leaf KS missing from output:\n%s", out)
+	}
+	leafLine := mustExtractLine(t, out, "Kustomization/flux-system/leaf")
+	if !strings.Contains(leafLine, "PASSED") {
+		t.Errorf("leaf should pass once parent patches inject substituteFrom; got: %s", leafLine)
+	}
+	if strings.Contains(out, `variable "MY_VAR" is undefined`) {
+		t.Errorf("MY_VAR should be resolved via parent-injected substituteFrom:\n%s", out)
+	}
+	// cluster-apps itself stays FAILED so users see the SOPS warning,
+	// but the failure mode is the collected-and-reported one, not the
+	// early-abort that previously dropped all other rendered docs.
+	if !strings.Contains(out, "SOPS-encrypted resource(s)") {
+		t.Errorf("cluster-apps should still surface a SOPS warning:\n%s", out)
+	}
+}
+
+func mustExtractLine(t *testing.T, haystack, needle string) string {
+	t.Helper()
+	for _, line := range strings.Split(haystack, "\n") {
+		if strings.Contains(line, needle) && (strings.Contains(line, "PASSED") || strings.Contains(line, "FAILED")) {
+			return line
+		}
+	}
+	t.Fatalf("status line for %q not found in:\n%s", needle, haystack)
+	return ""
+}
+
 // copyTree shallow-copies src into a fresh tempdir, preserving the
 // relative path layout. Used so each test can mutate its own copy.
 func copyTree(t *testing.T, src string) string {

--- a/testdata/parent-patches/apps/cluster-secrets.sops.yaml
+++ b/testdata/parent-patches/apps/cluster-secrets.sops.yaml
@@ -1,0 +1,14 @@
+# Synthetic SOPS-encrypted Secret. Real cosign/age headers aren't
+# required — flate's IsEncryptedSecret detector only checks for a
+# top-level sops map with a mac/version field.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-secrets
+  namespace: flux-system
+type: Opaque
+data:
+  SECRET_DOMAIN: RU5DW3Rlc3RdCg==
+sops:
+  mac: ENC[AES256_GCM,data:test,iv:test,tag:test,type:str]
+  version: 3.10.0

--- a/testdata/parent-patches/apps/cluster-settings.yaml
+++ b/testdata/parent-patches/apps/cluster-settings.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  MY_VAR: from-cluster-settings

--- a/testdata/parent-patches/apps/kustomization.yaml
+++ b/testdata/parent-patches/apps/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./leaf/ks.yaml
+  - ./cluster-settings.yaml
+  - ./cluster-secrets.sops.yaml

--- a/testdata/parent-patches/apps/leaf/app/cm.yaml
+++ b/testdata/parent-patches/apps/leaf/app/cm.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: leaf-cm
+data:
+  value: ${MY_VAR}
+  app: ${APP}

--- a/testdata/parent-patches/apps/leaf/app/kustomization.yaml
+++ b/testdata/parent-patches/apps/leaf/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cm.yaml

--- a/testdata/parent-patches/apps/leaf/ks.yaml
+++ b/testdata/parent-patches/apps/leaf/ks.yaml
@@ -1,0 +1,24 @@
+---
+# leaf Flux Kustomization deliberately omits postBuild.substituteFrom —
+# it relies on the parent cluster-apps Kustomization's spec.patches to
+# inject the cluster-settings reference at render time.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: leaf
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/leaf/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: leaf
+  # Inline substitute makes the substitution pass active. Without
+  # this, the orchestrator skips Substitute entirely when vars is
+  # empty — so leaf wouldn't actually exercise the "${MY_VAR} comes
+  # from a parent-injected substituteFrom" path.
+  postBuild:
+    substitute:
+      APP: leaf

--- a/testdata/parent-patches/cluster/flux-system.yaml
+++ b/testdata/parent-patches/cluster/flux-system.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+  ref:
+    branch: main
+---
+# cluster-apps mirrors the bjw-s home-ops top-level Flux Kustomization.
+# Its spec.patches inject postBuild.substituteFrom into every child
+# Kustomization CR rendered from ./apps so leaves don't have to
+# repeat the boilerplate.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+        optional: false
+  patches:
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          postBuild:
+            substituteFrom:
+              - kind: ConfigMap
+                name: cluster-settings
+                optional: false
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization


### PR DESCRIPTION
## Summary

Fixes #22. Two coupled defects, both surfaced by the bjw-s home-ops cluster pattern that issue reporter uses.

### Bug 1 — SOPS-encrypted Secret aborted the entire reconcile

A SOPS-encrypted Secret found anywhere in a parent Kustomization's rendered output caused the controller to return on the first match. Every other doc rendered alongside — patched child Kustomization CRs, kustomize-component-fanned-out OCIRepositories / ConfigMaps — was discarded before reaching the store.

Now: SOPS docs are collected into one reported reason while non-SOPS docs continue through `AddObject` (for kinds with controllers) or `AddRendered` (for leaves). The parent Kustomization still reports a loud failure listing every SOPS resource it could not decrypt — that part is unchanged behavior.

### Bug 2 — Render-emitted children didn't trigger child reconciles

When a parent Kustomization's render emitted another Flux resource (a child Kustomization with parent patches applied, a HelmRelease, a fanned-out OCIRepository, etc.), it landed in the store via `AddRendered` which suppresses `EventObjectAdded`. The child's controller had already reconciled the statically-loaded (un-patched) version and never re-ran.

Now: Flux-resource kinds route through `AddObject` so events fire and the controller re-reconciles with the patched payload. `reflect.DeepEqual` dedup in `AddObject` prevents loops when content is unchanged.

## Effect on the reporter's repo

Before (current main):
> HelmRelease/default/searxng: chart source OCIRepository/default/app-template not ready: **dependency not found**
> Kustomization/default/searxng: postBuild: variable "SECRET_DOMAIN" is undefined

After:
> HelmRelease/default/searxng: PASSED
> Kustomization/default/searxng: postBuild: variable "SECRET_DOMAIN" is undefined

The OCIRepository half is resolved (cluster-apps's render now fans the source out to consuming namespaces). The `SECRET_DOMAIN` half is a separate, pre-existing limitation — that value lives in a SOPS-encrypted Secret which flate cannot decrypt offline. Users need to either pre-decrypt their cluster-secrets, or supply the value via inline substitute, or shoulder a future flate-decrypts-SOPS feature.

## Regression fixture

`testdata/parent-patches` strips the bjw-s pattern to its minimum: a top-level Flux Kustomization with `spec.patches` injecting `postBuild.substituteFrom` into every child, plus a SOPS-encrypted Secret alongside the patched leaves. The leaf KS PASSES post-fix; on the pre-fix binary it FAILS with `"MY_VAR" is undefined`.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] New e2e test `TestE2E_ParentPatchesPropagateToChildren` reproduces the bjw-s pattern.
- [x] Verified against the reporter's actual repo (drag0n141/home-ops): searxng HelmRelease moves from FAILED→PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)