### PR TITLE
feat(oci): honor OCIRepository.spec.layerSelector

### DIFF
--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -125,17 +125,37 @@ func (r OCIRepositoryRef) IsEmpty() bool { return r == OCIRepositoryRef{} }
 
 // OCIRepository is the Flux OCIRepository CRD.
 type OCIRepository struct {
-	Name          string                 `json:"name" yaml:"name"`
-	Namespace     string                 `json:"namespace" yaml:"namespace"`
-	URL           string                 `json:"url" yaml:"url"`
-	Ref           OCIRepositoryRef       `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Provider      string                 `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef     *LocalObjectReference  `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	CertSecretRef *LocalObjectReference  `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
-	Verify        *OCIRepositoryVerify   `json:"verify,omitempty" yaml:"verify,omitempty"`
-	Insecure      bool                   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	Suspend       bool                   `json:"-" yaml:"-"`
+	Name          string                `json:"name" yaml:"name"`
+	Namespace     string                `json:"namespace" yaml:"namespace"`
+	URL           string                `json:"url" yaml:"url"`
+	Ref           OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Provider      string                `json:"provider,omitempty" yaml:"provider,omitempty"`
+	SecretRef     *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	CertSecretRef *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
+	Verify        *OCIRepositoryVerify  `json:"verify,omitempty" yaml:"verify,omitempty"`
+	LayerSelector *OCILayerSelector     `json:"layerSelector,omitempty" yaml:"layerSelector,omitempty"`
+	Insecure      bool                  `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	Suspend       bool                  `json:"-" yaml:"-"`
 }
+
+// OCILayerSelector mirrors source-controller's spec.layerSelector.
+// When set, the fetcher selects the first layer matching MediaType
+// and processes it per Operation:
+//   - "extract" (default): the layer's tarball is unpacked into the
+//     artifact directory.
+//   - "copy": the layer's compressed blob is persisted verbatim,
+//     under the filename "layer.tar.gz".
+type OCILayerSelector struct {
+	MediaType string `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
+	Operation string `json:"operation,omitempty" yaml:"operation,omitempty"`
+}
+
+// OCILayerOperationExtract and OCILayerOperationCopy are the two
+// values source-controller accepts on LayerSelector.Operation.
+const (
+	OCILayerOperationExtract = "extract"
+	OCILayerOperationCopy    = "copy"
+)
 
 // OCIRepositoryVerify mirrors source-controller's spec.verify on
 // OCIRepository. Flate implements keyed mode only:
@@ -254,6 +274,12 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		for _, m := range v.MatchOIDCIdentity {
 			out.Verify.MatchOIDCIdentity = append(out.Verify.MatchOIDCIdentity,
 				OIDCIdentityMatch{Issuer: m.Issuer, Subject: m.Subject})
+		}
+	}
+	if ls := cr.Spec.LayerSelector; ls != nil {
+		out.LayerSelector = &OCILayerSelector{
+			MediaType: ls.MediaType,
+			Operation: ls.Operation,
 		}
 	}
 	return out, nil

--- a/pkg/source/oci/cosign_test.go
+++ b/pkg/source/oci/cosign_test.go
@@ -207,6 +207,36 @@ func TestParseOCIRepository_VerifyCosign(t *testing.T) {
 	}
 }
 
+func TestParseOCIRepository_LayerSelector(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1",
+		"kind":       "OCIRepository",
+		"metadata":   map[string]any{"name": "o", "namespace": "ns"},
+		"spec": map[string]any{
+			"url":      "oci://ghcr.io/x/y",
+			"interval": "5m",
+			"ref":      map[string]any{"tag": "v1"},
+			"layerSelector": map[string]any{
+				"mediaType": "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+				"operation": "copy",
+			},
+		},
+	}
+	repo, err := manifest.ParseOCIRepository(doc)
+	if err != nil {
+		t.Fatalf("ParseOCIRepository: %v", err)
+	}
+	if repo.LayerSelector == nil {
+		t.Fatalf("expected LayerSelector parsed")
+	}
+	if got, want := repo.LayerSelector.MediaType, "application/vnd.cncf.helm.chart.content.v1.tar+gzip"; got != want {
+		t.Errorf("MediaType = %q, want %q", got, want)
+	}
+	if got, want := repo.LayerSelector.Operation, "copy"; got != want {
+		t.Errorf("Operation = %q, want %q", got, want)
+	}
+}
+
 func mustPEMPublicKey(t *testing.T, pub crypto.PublicKey) []byte {
 	t.Helper()
 	der, err := x509.MarshalPKIXPublicKey(pub)

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -1,0 +1,225 @@
+package oci
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/registry/remote"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// copiedLayerFilename is the deterministic name layers are stored
+// under when LayerSelector.Operation is "copy". Downstream consumers
+// (e.g. Kustomization spec.path on an OCIRepository whose artifact
+// is shipped as a tarball) look for this name when they need the
+// raw blob.
+const copiedLayerFilename = "layer.tar.gz"
+
+// applyLayerSelector post-processes an OCI artifact written into
+// slot by oras.Copy. After oras.Copy, the slot contains every blob
+// in the artifact named by its sha256 digest. This function:
+//
+//   - Reads the manifest from the slot to find the layer matching
+//     selector.MediaType (or the first layer when MediaType is empty).
+//   - For Operation = "extract" (Flux's default), untars the layer's
+//     tar.gz blob into the slot root.
+//   - For Operation = "copy", renames the layer blob to layer.tar.gz.
+//   - Cleans up the now-redundant digest-named files.
+//
+// When selector is nil the default extract behavior still applies —
+// matches source-controller's behavior when spec.layerSelector is
+// omitted but the artifact has exactly one tarball layer.
+func applyLayerSelector(
+	_ context.Context,
+	_ *remote.Repository,
+	slot string,
+	manifestDigest string,
+	selector *manifest.OCILayerSelector,
+) error {
+	man, err := readSlotManifest(slot, manifestDigest)
+	if err != nil {
+		// No manifest in slot (e.g. helm registry already pulled
+		// the chart elsewhere) — nothing to do.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	layer, ok := pickLayer(man.Layers, selector)
+	if !ok {
+		if selector != nil && selector.MediaType != "" {
+			return fmt.Errorf("no layer matched mediaType %q (manifest has %d layer(s))",
+				selector.MediaType, len(man.Layers))
+		}
+		return nil
+	}
+
+	op := manifest.OCILayerOperationExtract
+	if selector != nil && selector.Operation != "" {
+		op = selector.Operation
+	}
+
+	layerPath := digestPath(slot, layer.Digest)
+	switch op {
+	case manifest.OCILayerOperationExtract:
+		if err := extractTarGz(layerPath, slot); err != nil {
+			return fmt.Errorf("extract layer: %w", err)
+		}
+	case manifest.OCILayerOperationCopy:
+		dest := filepath.Join(slot, copiedLayerFilename)
+		if err := os.Rename(layerPath, dest); err != nil {
+			return fmt.Errorf("copy layer: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported layer operation %q", op)
+	}
+
+	return cleanupBlobs(slot)
+}
+
+// readSlotManifest finds and decodes the OCI image manifest written
+// by orasfile under the given digest.
+func readSlotManifest(slot, digestStr string) (*ocispec.Manifest, error) {
+	path := digestPath(slot, digest.Digest(digestStr))
+	b, err := os.ReadFile(path) //nolint:gosec // slot is fetcher-owned cache path
+	if err != nil {
+		return nil, err
+	}
+	var m ocispec.Manifest
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("decode manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// pickLayer returns the first layer matching selector.MediaType,
+// or the first layer overall when selector is nil or MediaType is empty.
+func pickLayer(layers []ocispec.Descriptor, selector *manifest.OCILayerSelector) (ocispec.Descriptor, bool) {
+	if len(layers) == 0 {
+		return ocispec.Descriptor{}, false
+	}
+	if selector == nil || selector.MediaType == "" {
+		return layers[0], true
+	}
+	for _, l := range layers {
+		if l.MediaType == selector.MediaType {
+			return l, true
+		}
+	}
+	return ocispec.Descriptor{}, false
+}
+
+// digestPath resolves a digest to its on-disk path inside slot,
+// matching orasfile's layout: "<algorithm>:<hex>" → "<hex>" (the
+// algorithm prefix is stripped, file lives at the slot root).
+func digestPath(slot string, d digest.Digest) string {
+	_, hex, found := strings.Cut(d.String(), ":")
+	if !found {
+		hex = d.String()
+	}
+	return filepath.Join(slot, hex)
+}
+
+// cleanupBlobs removes the digest-named files orasfile wrote — by
+// this point the manifest's selected layer has either been extracted
+// or renamed, so the raw blobs are noise.
+func cleanupBlobs(slot string) error {
+	entries, err := os.ReadDir(slot)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == copiedLayerFilename || e.Name() == cachedDigestFile {
+			continue
+		}
+		// orasfile writes files named by their sha256 hex digest.
+		// Anything that isn't the (already-renamed) layer or sentinel
+		// matches that shape and is safe to drop.
+		if looksLikeDigest(e.Name()) {
+			_ = os.Remove(filepath.Join(slot, e.Name()))
+		}
+	}
+	return nil
+}
+
+func looksLikeDigest(name string) bool {
+	if len(name) != 64 {
+		return false
+	}
+	for _, c := range name {
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// extractTarGz unpacks a gzipped tarball into dst. Refuses path
+// traversal entries (../) so a malicious artifact can't write
+// outside the cache slot.
+func extractTarGz(src, dst string) error {
+	f, err := os.Open(src) //nolint:gosec // src lives under the fetcher's cache slot
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip: %w", err)
+	}
+	defer func() { _ = gz.Close() }()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar: %w", err)
+		}
+		clean := filepath.Clean(hdr.Name)
+		if strings.HasPrefix(clean, "..") || strings.Contains(clean, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("tar entry escapes target directory: %q", hdr.Name)
+		}
+		target := filepath.Join(dst, clean)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o750); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+				return err
+			}
+			out, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // target stays under dst
+			if err != nil {
+				return err
+			}
+			if _, err := io.Copy(out, tr); err != nil { //nolint:gosec // tar.Reader is size-bounded by header
+				_ = out.Close()
+				return err
+			}
+			if err := out.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	if err := os.Remove(src); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/source/oci/layer_test.go
+++ b/pkg/source/oci/layer_test.go
@@ -1,0 +1,262 @@
+package oci
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestPickLayer(t *testing.T) {
+	layers := []ocispec.Descriptor{
+		{MediaType: "application/vnd.unknown"},
+		{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"},
+		{MediaType: "application/octet-stream"},
+	}
+	cases := []struct {
+		name     string
+		selector *manifest.OCILayerSelector
+		wantMT   string
+		wantOK   bool
+	}{
+		{"nil selector picks first", nil, "application/vnd.unknown", true},
+		{"empty mediaType picks first", &manifest.OCILayerSelector{}, "application/vnd.unknown", true},
+		{
+			"matches helm chart",
+			&manifest.OCILayerSelector{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"},
+			"application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			true,
+		},
+		{
+			"unmatched",
+			&manifest.OCILayerSelector{MediaType: "application/missing"},
+			"", false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := pickLayer(layers, tc.selector)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && got.MediaType != tc.wantMT {
+				t.Errorf("mediaType = %q, want %q", got.MediaType, tc.wantMT)
+			}
+		})
+	}
+}
+
+func TestLooksLikeDigest(t *testing.T) {
+	cases := map[string]bool{
+		"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": true,
+		"E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855": false, // uppercase
+		"layer.tar.gz": false,
+		"short":        false,
+		"":             false,
+	}
+	for in, want := range cases {
+		if got := looksLikeDigest(in); got != want {
+			t.Errorf("looksLikeDigest(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestApplyLayerSelector_Extract(t *testing.T) {
+	slot := t.TempDir()
+
+	chartFiles := map[string]string{
+		"Chart.yaml":          "name: example\nversion: 1.0.0\n",
+		"templates/cm.yaml":   "kind: ConfigMap\n",
+		"values.yaml":         "replicas: 1\n",
+	}
+	layerBytes := mustTarGz(t, chartFiles)
+	layerDigest := writeBlob(t, slot, layerBytes)
+
+	manifestBytes, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{
+			MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			Digest:    layerDigest,
+			Size:      int64(len(layerBytes)),
+		},
+	})
+	_ = manifestBytes
+
+	if err := applyLayerSelector(t.Context(), nil, slot, manifestDigest.String(),
+		&manifest.OCILayerSelector{
+			MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			Operation: manifest.OCILayerOperationExtract,
+		}); err != nil {
+		t.Fatalf("applyLayerSelector: %v", err)
+	}
+
+	for name, want := range chartFiles {
+		path := filepath.Join(slot, name)
+		got, err := os.ReadFile(path) //nolint:gosec // path is inside t.TempDir()
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+	// Both blob files should be gone.
+	entries, _ := os.ReadDir(slot)
+	for _, e := range entries {
+		if looksLikeDigest(e.Name()) {
+			t.Errorf("leftover digest-named file: %s", e.Name())
+		}
+	}
+}
+
+func TestApplyLayerSelector_Copy(t *testing.T) {
+	slot := t.TempDir()
+
+	layerBytes := mustTarGz(t, map[string]string{"hello.txt": "world"})
+	layerDigest := writeBlob(t, slot, layerBytes)
+	_, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{
+			MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			Digest:    layerDigest,
+			Size:      int64(len(layerBytes)),
+		},
+	})
+
+	if err := applyLayerSelector(t.Context(), nil, slot, manifestDigest.String(),
+		&manifest.OCILayerSelector{
+			MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			Operation: manifest.OCILayerOperationCopy,
+		}); err != nil {
+		t.Fatalf("applyLayerSelector: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(slot, copiedLayerFilename)) //nolint:gosec // inside t.TempDir()
+	if err != nil {
+		t.Fatalf("read layer.tar.gz: %v", err)
+	}
+	if !bytes.Equal(got, layerBytes) {
+		t.Errorf("copied layer differs from source layer (len got=%d want=%d)", len(got), len(layerBytes))
+	}
+}
+
+func TestApplyLayerSelector_MediaTypeUnmatched(t *testing.T) {
+	slot := t.TempDir()
+	layerBytes := mustTarGz(t, map[string]string{"x": "y"})
+	layerDigest := writeBlob(t, slot, layerBytes)
+	_, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{
+			MediaType: "application/vnd.unknown",
+			Digest:    layerDigest,
+			Size:      int64(len(layerBytes)),
+		},
+	})
+
+	err := applyLayerSelector(t.Context(), nil, slot, manifestDigest.String(),
+		&manifest.OCILayerSelector{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"})
+	if err == nil {
+		t.Fatalf("expected error for unmatched mediaType")
+	}
+}
+
+func TestApplyLayerSelector_TraversalRejected(t *testing.T) {
+	slot := t.TempDir()
+	// Craft a tarball with a ../ entry.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	body := []byte("malicious")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "../escape.txt",
+		Typeflag: tar.TypeReg,
+		Size:     int64(len(body)),
+		Mode:     0o644,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+
+	layerDigest := writeBlob(t, slot, buf.Bytes())
+	_, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{
+			MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			Digest:    layerDigest,
+			Size:      int64(buf.Len()),
+		},
+	})
+
+	err := applyLayerSelector(t.Context(), nil, slot, manifestDigest.String(),
+		&manifest.OCILayerSelector{
+			MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip",
+			Operation: manifest.OCILayerOperationExtract,
+		})
+	if err == nil {
+		t.Fatalf("expected traversal rejection")
+	}
+}
+
+// mustTarGz produces a gzipped tarball with the given files.
+func mustTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, body := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     name,
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(body)),
+			Mode:     0o644,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+// writeBlob writes payload at slot/<sha256-hex> and returns its OCI digest.
+func writeBlob(t *testing.T, slot string, payload []byte) digest.Digest {
+	t.Helper()
+	sum := sha256.Sum256(payload)
+	hexs := hex.EncodeToString(sum[:])
+	if err := os.WriteFile(filepath.Join(slot, hexs), payload, 0o600); err != nil { //nolint:gosec // inside t.TempDir()
+		t.Fatal(err)
+	}
+	return digest.Digest("sha256:" + hexs)
+}
+
+// writeManifest writes an OCI manifest at slot/<sha256-hex> for layers
+// and returns (raw bytes, digest).
+func writeManifest(t *testing.T, slot string, layers []ocispec.Descriptor) ([]byte, digest.Digest) {
+	t.Helper()
+	m := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Layers:    layers,
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b, writeBlob(t, slot, b)
+}

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -282,6 +282,10 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 			return nil, err
 		}
 	}
+	if err := applyLayerSelector(ctx, repoClient, slot, desc.Digest.String(), repo.LayerSelector); err != nil {
+		_ = os.RemoveAll(slot)
+		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
+	}
 	// Persist the resolved digest so a subsequent cache hit can
 	// re-verify against the exact bytes we wrote, even when the spec
 	// pinned only a tag.


### PR DESCRIPTION
## Summary

\`ParseOCIRepository\` dropped \`spec.layerSelector\` silently — the struct existed on \`manifest.OCIRepository\` but no parser populated it. Multi-layer OCI artifacts therefore landed in the cache slot as raw digest-named blob files; downstream consumers got the first blob regardless of the spec.

This PR parses the field and honors the operation per Flux's behavior:
- **\`extract\`** (default): untar+gunzip the selected layer into the slot root.
- **\`copy\`**: rename the layer blob to \`layer.tar.gz\` for downstream tooling.

Path traversal in the tar is rejected so a malicious artifact can't escape the slot.

## Test plan
- [x] Pure-function tests: \`pickLayer\` (mediaType match / unmatched / nil-fallback), \`looksLikeDigest\`.
- [x] \`applyLayerSelector\` end-to-end on synthetic tarballs: extract, copy, unmatched mediaType, traversal-rejected.
- [x] Parser round-trip for \`spec.layerSelector\`.
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)