### PR TITLE
feat(source): support spec.proxySecretRef on Git/OCI/Bucket

### DIFF
--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -27,7 +27,11 @@ type Bucket struct {
 	// CertSecretRef points at a Secret with tls.crt + tls.key
 	// (client cert) and/or ca.crt (server CA) for mTLS endpoints.
 	CertSecretRef *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
-	Suspend       bool                  `json:"-" yaml:"-"`
+	// ProxySecretRef points at a Secret carrying an HTTP proxy
+	// configuration (address + optional username/password) used when
+	// reaching the bucket endpoint.
+	ProxySecretRef *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
+	Suspend        bool                  `json:"-" yaml:"-"`
 }
 
 // Named identifies the Bucket.
@@ -77,6 +81,9 @@ func ParseBucket(doc map[string]any) (*Bucket, error) {
 	}
 	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
 		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
+	}
+	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
+		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
 	}
 	return out, nil
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -104,6 +104,67 @@ spec:
 	}
 }
 
+func TestParseGitRepository_ProxySecretRef(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: r, namespace: flux-system}
+spec:
+  url: https://github.com/owner/repo.git
+  proxySecretRef:
+    name: corp-proxy
+  interval: 5m
+`)
+	g, err := ParseGitRepository(doc)
+	if err != nil {
+		t.Fatalf("ParseGitRepository: %v", err)
+	}
+	if g.ProxySecretRef == nil || g.ProxySecretRef.Name != "corp-proxy" {
+		t.Errorf("ProxySecretRef = %+v, want {Name: corp-proxy}", g.ProxySecretRef)
+	}
+}
+
+func TestParseOCIRepository_ProxySecretRef(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata: {name: r, namespace: ns}
+spec:
+  url: oci://ghcr.io/x/y
+  proxySecretRef:
+    name: corp-proxy
+  interval: 5m
+`)
+	o, err := ParseOCIRepository(doc)
+	if err != nil {
+		t.Fatalf("ParseOCIRepository: %v", err)
+	}
+	if o.ProxySecretRef == nil || o.ProxySecretRef.Name != "corp-proxy" {
+		t.Errorf("ProxySecretRef = %+v", o.ProxySecretRef)
+	}
+}
+
+func TestParseBucket_ProxySecretRef(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: Bucket
+metadata: {name: b, namespace: ns}
+spec:
+  bucketName: x
+  endpoint: minio:9000
+  proxySecretRef:
+    name: corp-proxy
+  interval: 5m
+`)
+	b, err := ParseBucket(doc)
+	if err != nil {
+		t.Fatalf("ParseBucket: %v", err)
+	}
+	if b.ProxySecretRef == nil || b.ProxySecretRef.Name != "corp-proxy" {
+		t.Errorf("ProxySecretRef = %+v", b.ProxySecretRef)
+	}
+}
+
 func TestParseGitRepository_SparseCheckout(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -47,6 +47,7 @@ type GitRepository struct {
 	Ref               GitRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
 	Provider          string                `json:"provider,omitempty" yaml:"provider,omitempty"`
 	SecretRef         *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	ProxySecretRef    *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
 	RecurseSubmodules bool                  `json:"recurseSubmodules,omitempty" yaml:"recurseSubmodules,omitempty"`
 	// SparseCheckout limits the checkout to the listed repo-relative
 	// directories. When empty, the full tree is checked out (default).
@@ -109,6 +110,9 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
 		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
 	}
+	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
+		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
+	}
 	return out, nil
 }
 
@@ -125,17 +129,18 @@ func (r OCIRepositoryRef) IsEmpty() bool { return r == OCIRepositoryRef{} }
 
 // OCIRepository is the Flux OCIRepository CRD.
 type OCIRepository struct {
-	Name          string                `json:"name" yaml:"name"`
-	Namespace     string                `json:"namespace" yaml:"namespace"`
-	URL           string                `json:"url" yaml:"url"`
-	Ref           OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Provider      string                `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef     *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	CertSecretRef *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
-	Verify        *OCIRepositoryVerify  `json:"verify,omitempty" yaml:"verify,omitempty"`
-	LayerSelector *OCILayerSelector     `json:"layerSelector,omitempty" yaml:"layerSelector,omitempty"`
-	Insecure      bool                  `json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	Suspend       bool                  `json:"-" yaml:"-"`
+	Name           string                `json:"name" yaml:"name"`
+	Namespace      string                `json:"namespace" yaml:"namespace"`
+	URL            string                `json:"url" yaml:"url"`
+	Ref            OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
+	Provider       string                `json:"provider,omitempty" yaml:"provider,omitempty"`
+	SecretRef      *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+	CertSecretRef  *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
+	ProxySecretRef *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
+	Verify         *OCIRepositoryVerify  `json:"verify,omitempty" yaml:"verify,omitempty"`
+	LayerSelector  *OCILayerSelector     `json:"layerSelector,omitempty" yaml:"layerSelector,omitempty"`
+	Insecure       bool                  `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+	Suspend        bool                  `json:"-" yaml:"-"`
 }
 
 // OCILayerSelector mirrors source-controller's spec.layerSelector.
@@ -265,6 +270,9 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
 		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+	}
+	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
+		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
 	}
 	if v := cr.Spec.Verify; v != nil {
 		out.Verify = &OCIRepositoryVerify{Provider: v.Provider}

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -100,14 +100,39 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 }
 
 // resolveTransport builds a custom *http.Transport from
-// spec.certSecretRef when configured. Returns nil to let minio-go
-// use its default transport. The Insecure flag is intentionally
-// applied at the protocol level (normalizeEndpoint) rather than the
-// TLS layer, mirroring Flux's source-controller behavior.
+// spec.certSecretRef and/or spec.proxySecretRef. Returns nil to let
+// minio-go use its default transport. The Insecure flag is
+// intentionally applied at the protocol level (normalizeEndpoint)
+// rather than the TLS layer, mirroring Flux's source-controller
+// behavior.
 func (f *Fetcher) resolveTransport(b *manifest.Bucket) (*http.Transport, error) {
-	if b.CertSecretRef == nil {
+	proxy, err := source.ResolveProxy(f.Secrets, b.Namespace, "Bucket",
+		b.Namespace+"/"+b.Name, b.ProxySecretRef)
+	if err != nil {
+		return nil, err
+	}
+	if b.CertSecretRef == nil && proxy == nil {
 		return nil, nil
 	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if b.CertSecretRef != nil {
+		cfg, terr := f.resolveTLSConfig(b)
+		if terr != nil {
+			return nil, terr
+		}
+		tr.TLSClientConfig = cfg
+	}
+	if proxy != nil {
+		pfn, perr := proxy.HTTPProxyFunc()
+		if perr != nil {
+			return nil, perr
+		}
+		tr.Proxy = pfn
+	}
+	return tr, nil
+}
+
+func (f *Fetcher) resolveTLSConfig(b *manifest.Bucket) (*tls.Config, error) {
 	if f.Secrets == nil {
 		return nil, fmt.Errorf("bucket %s/%s references certSecretRef but no source.SecretGetter is wired",
 			b.Namespace, b.Name)
@@ -145,9 +170,7 @@ func (f *Fetcher) resolveTransport(b *manifest.Bucket) (*http.Transport, error) 
 		}
 		cfg.RootCAs = pool
 	}
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	tr.TLSClientConfig = cfg
-	return tr, nil
+	return cfg, nil
 }
 
 // resolveCredentials picks up accesskey/secretkey from the SecretRef

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -58,14 +58,27 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	if err != nil {
 		return nil, err
 	}
+	proxy, err := source.ResolveProxy(f.Secrets, repo.Namespace, "GitRepository",
+		repo.Namespace+"/"+repo.Name, repo.ProxySecretRef)
+	if err != nil {
+		return nil, err
+	}
 	if tlsCfg != nil {
 		f.httpsMu.Lock()
 		defer f.httpsMu.Unlock()
-		httpsClient := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsCfg}}
+		tr := &http.Transport{TLSClientConfig: tlsCfg}
+		if proxy != nil {
+			pfn, perr := proxy.HTTPProxyFunc()
+			if perr != nil {
+				return nil, perr
+			}
+			tr.Proxy = pfn
+		}
+		httpsClient := &http.Client{Transport: tr}
 		client.InstallProtocol("https", githttp.NewClient(httpsClient))
 		defer client.InstallProtocol("https", githttp.DefaultClient)
 	}
-	return fetch(ctx, f.Cache, repo, auth)
+	return fetch(ctx, f.Cache, repo, auth, proxy)
 }
 
 // resolveTLS builds a *tls.Config from spec.secretRef for HTTPS GitRepositories
@@ -185,11 +198,11 @@ func sshUserFromURL(url string) string {
 // fetch clones the GitRepository referenced by repo into the supplied
 // cache and returns a populated *store.SourceArtifact. If a usable
 // cached copy already exists, it is reused. auth may be nil for
-// anonymous clones.
+// anonymous clones; proxy may be nil for direct connections.
 //
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
-func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepository, auth transport.AuthMethod) (*store.SourceArtifact, error) {
+func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}
@@ -230,6 +243,13 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 	}
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
+	if proxy != nil {
+		cloneOpts.ProxyOptions = transport.ProxyOptions{
+			URL:      proxy.Address,
+			Username: proxy.Username,
+			Password: proxy.Password,
+		}
+	}
 	if repo.RecurseSubmodules {
 		cloneOpts.RecurseSubmodules = git.DefaultSubmoduleRecursionDepth
 	}

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -63,7 +63,12 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	if err != nil {
 		return nil, err
 	}
-	return fetch(ctx, f, repo, configPath, tlsCfg)
+	proxy, err := source.ResolveProxy(f.Secrets, repo.Namespace, "OCIRepository",
+		repo.Namespace+"/"+repo.Name, repo.ProxySecretRef)
+	if err != nil {
+		return nil, err
+	}
+	return fetch(ctx, f, repo, configPath, tlsCfg, proxy)
 }
 
 // resolveTLS builds a *tls.Config from spec.certSecretRef (PEM-encoded
@@ -173,7 +178,7 @@ func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, f
 // is listed and the highest matching tag (filtered by semverFilter, if
 // any) is resolved before pulling. When spec.verify is set, the pulled
 // digest is verified against the trusted public keys before returning.
-func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, registryConfig string, tlsCfg *tls.Config) (*store.SourceArtifact, error) {
+func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, registryConfig string, tlsCfg *tls.Config, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
 	cache := f.Cache
 	if repo == nil {
 		return nil, errors.New("oci repository is nil")
@@ -195,12 +200,21 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		return nil, err
 	}
 	// Compose the http.Client transport: oras's retry transport over a
-	// (TLS-customized) http.Transport when needed. Without TLS overrides
-	// oras's default is used.
+	// customized http.Transport when TLS or proxy is configured. Without
+	// either, oras's default is used.
 	var httpClient *http.Client
-	if tlsCfg != nil {
+	if tlsCfg != nil || proxy != nil {
 		baseTransport := http.DefaultTransport.(*http.Transport).Clone()
-		baseTransport.TLSClientConfig = tlsCfg
+		if tlsCfg != nil {
+			baseTransport.TLSClientConfig = tlsCfg
+		}
+		if proxy != nil {
+			pfn, perr := proxy.HTTPProxyFunc()
+			if perr != nil {
+				return nil, perr
+			}
+			baseTransport.Proxy = pfn
+		}
 		httpClient = &http.Client{Transport: retry.NewTransport(baseTransport)}
 	}
 	if credStore != nil {

--- a/pkg/source/proxy.go
+++ b/pkg/source/proxy.go
@@ -1,0 +1,72 @@
+package source
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// ProxyConfig is the resolved view of a Flux spec.proxySecretRef.
+// Matches source-controller's Secret schema: data.address (required),
+// data.username + data.password (optional, basic-auth).
+type ProxyConfig struct {
+	Address  string
+	Username string
+	Password string
+}
+
+// URL parses Address into a *url.URL. The caller pre-validated
+// non-empty by checking the return of ResolveProxy.
+func (p *ProxyConfig) URL() (*url.URL, error) {
+	u, err := url.Parse(p.Address)
+	if err != nil {
+		return nil, fmt.Errorf("parse proxy address %q: %w", p.Address, err)
+	}
+	if p.Username != "" {
+		u.User = url.UserPassword(p.Username, p.Password)
+	}
+	return u, nil
+}
+
+// HTTPProxyFunc returns a net/http.Transport.Proxy function pinned to
+// this proxy. Use when configuring an http.Transport for the OCI,
+// Bucket, or HTTP-Git transports.
+func (p *ProxyConfig) HTTPProxyFunc() (func(*http.Request) (*url.URL, error), error) {
+	u, err := p.URL()
+	if err != nil {
+		return nil, err
+	}
+	return http.ProxyURL(u), nil
+}
+
+// ResolveProxy reads ref's Secret via secrets and decodes it into a
+// ProxyConfig. Returns (nil, nil) when ref is nil — proxy is opt-in.
+// Surfaces a loud error when ref is set but the Secret is missing or
+// lacks the required address key, matching source-controller's
+// fail-loud behavior.
+func ResolveProxy(secrets SecretGetter, ns, ownerKind, ownerID string, ref *manifest.LocalObjectReference) (*ProxyConfig, error) {
+	if ref == nil {
+		return nil, nil
+	}
+	if secrets == nil {
+		return nil, fmt.Errorf("%s %s references proxySecretRef but no source.SecretGetter is wired",
+			ownerKind, ownerID)
+	}
+	sec := secrets(ns, ref.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("%s %s: proxy secret %s/%s not found",
+			ownerKind, ownerID, ns, ref.Name)
+	}
+	addr := StringFromSecret(sec, "address")
+	if addr == "" {
+		return nil, fmt.Errorf("%s %s: proxy secret %s/%s missing required 'address' key",
+			ownerKind, ownerID, ns, ref.Name)
+	}
+	return &ProxyConfig{
+		Address:  addr,
+		Username: StringFromSecret(sec, "username"),
+		Password: StringFromSecret(sec, "password"),
+	}, nil
+}

--- a/pkg/source/proxy_test.go
+++ b/pkg/source/proxy_test.go
@@ -1,0 +1,100 @@
+package source
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestResolveProxy_NilRef(t *testing.T) {
+	p, err := ResolveProxy(nil, "ns", "GitRepository", "ns/r", nil)
+	if err != nil {
+		t.Fatalf("ResolveProxy: %v", err)
+	}
+	if p != nil {
+		t.Errorf("expected nil ProxyConfig for nil ref")
+	}
+}
+
+func TestResolveProxy_NoGetter(t *testing.T) {
+	_, err := ResolveProxy(nil, "ns", "GitRepository", "ns/r",
+		&manifest.LocalObjectReference{Name: "px"})
+	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
+		t.Errorf("expected SecretGetter error; got %v", err)
+	}
+}
+
+func TestResolveProxy_SecretNotFound(t *testing.T) {
+	_, err := ResolveProxy(
+		func(_, _ string) *manifest.Secret { return nil },
+		"ns", "OCIRepository", "ns/r",
+		&manifest.LocalObjectReference{Name: "px"})
+	if err == nil || !strings.Contains(err.Error(), "proxy secret ns/px not found") {
+		t.Errorf("expected not-found error; got %v", err)
+	}
+}
+
+func TestResolveProxy_MissingAddress(t *testing.T) {
+	getter := func(_, _ string) *manifest.Secret {
+		return &manifest.Secret{StringData: map[string]any{"username": "alice"}}
+	}
+	_, err := ResolveProxy(getter, "ns", "Bucket", "ns/b",
+		&manifest.LocalObjectReference{Name: "px"})
+	if err == nil || !strings.Contains(err.Error(), "missing required 'address' key") {
+		t.Errorf("expected missing-address error; got %v", err)
+	}
+}
+
+func TestResolveProxy_FullSecret(t *testing.T) {
+	getter := func(_, _ string) *manifest.Secret {
+		return &manifest.Secret{StringData: map[string]any{
+			"address":  "http://proxy.example.com:8080",
+			"username": "alice",
+			"password": "hunter2",
+		}}
+	}
+	p, err := ResolveProxy(getter, "ns", "GitRepository", "ns/r",
+		&manifest.LocalObjectReference{Name: "px"})
+	if err != nil {
+		t.Fatalf("ResolveProxy: %v", err)
+	}
+	if p.Address != "http://proxy.example.com:8080" {
+		t.Errorf("Address = %q", p.Address)
+	}
+	if p.Username != "alice" || p.Password != "hunter2" { //nolint:gosec // test fixture
+		t.Errorf("creds = %q/%q", p.Username, p.Password)
+	}
+}
+
+func TestProxyConfig_URL_BasicAuth(t *testing.T) {
+	p := &ProxyConfig{
+		Address:  "http://proxy.example.com:8080",
+		Username: "alice",
+		Password: "hunter2", //nolint:gosec // test fixture
+	}
+	u, err := p.URL()
+	if err != nil {
+		t.Fatalf("URL: %v", err)
+	}
+	if u.User == nil {
+		t.Fatalf("expected userinfo in URL")
+	}
+	if u.User.Username() != "alice" {
+		t.Errorf("Username = %q", u.User.Username())
+	}
+	if pw, _ := u.User.Password(); pw != "hunter2" {
+		t.Errorf("Password = %q", pw)
+	}
+	if u.Host != "proxy.example.com:8080" {
+		t.Errorf("Host = %q", u.Host)
+	}
+}
+
+func TestProxyConfig_URL_InvalidAddress(t *testing.T) {
+	p := &ProxyConfig{Address: "://broken"}
+	_, err := p.URL()
+	if err == nil {
+		t.Errorf("expected parse error")
+	}
+}


### PR DESCRIPTION
## Summary

Source-controller v1 lets GitRepository, OCIRepository, and Bucket route through an HTTP proxy via \`spec.proxySecretRef\`. flate silently dropped the field, so corporate-proxy users had no way to fetch.

The Secret schema source-controller publishes:

\`\`\`
data:
  address:  http://proxy.example.com:8080  # required
  username: alice                           # optional
  password: hunter2                         # optional
\`\`\`

This PR adds:
- \`manifest.{GitRepository,OCIRepository,Bucket}.ProxySecretRef\` parsing
- \`source.ResolveProxy\` / \`source.ProxyConfig\` — one resolver across all three kinds so the Secret schema and error shape are consistent
- OCI: \`http.Transport.Proxy\` folded into the oras auth.Client
- Bucket: same transport fed to minio-go via \`Options.Transport\`
- Git: \`transport.ProxyOptions\` into go-git's \`CloneOptions\`

HelmRepository does not have \`spec.proxySecretRef\` in source-controller v1 (proxy for helm repos lives at the cluster network layer), so it's intentionally not touched.

## Test plan
- [x] \`source.ResolveProxy\` covered: nil ref, no getter, secret-not-found, missing address, full secret with basic-auth.
- [x] \`ProxyConfig.URL\` round-trips userinfo correctly and rejects malformed addresses.
- [x] Parser round-trip tests for all three CRs.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)