### PR TITLE
fix(store): document immutability contract; clone-then-add at mutation sites

### DIFF
--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -55,15 +55,14 @@ func ApplyNamespaceInheritance(s *store.Store, sourceFiles map[manifest.NamedRes
 		if obj == nil {
 			continue
 		}
-		setNamespace(obj, u.new.Namespace)
-		if hr, ok := obj.(*manifest.HelmRelease); ok && hr.Chart.RepoNamespace == "" {
-			// chartRef.namespace wasn't explicit in the YAML so it
-			// implicitly tracks the HR's namespace; carry the new
-			// namespace through.
-			hr.Chart.RepoNamespace = u.new.Namespace
+		// Store immutability contract (pkg/store doc): clone before
+		// mutating, then DeleteObject(old) + AddObject(new).
+		updated := cloneWithNamespace(obj, u.new.Namespace)
+		if updated == nil {
+			continue
 		}
 		s.DeleteObject(u.old)
-		s.AddObject(obj)
+		s.AddObject(updated)
 		delete(sourceFiles, u.old)
 		sourceFiles[u.new] = u.file
 	}
@@ -165,23 +164,50 @@ func normalizePrefix(p string) string {
 	return strings.TrimSuffix(p, "/") + "/"
 }
 
-func setNamespace(obj manifest.BaseManifest, ns string) {
+// cloneWithNamespace returns a shallow copy of obj with metadata.namespace
+// (and HelmRelease.Chart.RepoNamespace, when implicit) rewritten to ns.
+// Returns nil for kinds the loader doesn't reposition. Honors the Store
+// immutability contract — the caller AddObjects the returned pointer
+// rather than mutating the stored object in place.
+func cloneWithNamespace(obj manifest.BaseManifest, ns string) manifest.BaseManifest {
 	switch o := obj.(type) {
 	case *manifest.Kustomization:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	case *manifest.HelmRelease:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		if c.Chart.RepoNamespace == "" {
+			// chartRef.namespace wasn't explicit in the YAML so it
+			// implicitly tracks the HR's namespace.
+			c.Chart.RepoNamespace = ns
+		}
+		return &c
 	case *manifest.HelmRepository:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	case *manifest.OCIRepository:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	case *manifest.GitRepository:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	case *manifest.HelmChartSource:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	case *manifest.ConfigMap:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	case *manifest.Secret:
-		o.Namespace = ns
+		c := *o
+		c.Namespace = ns
+		return &c
 	}
+	return nil
 }

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -62,17 +62,25 @@ func (k *Kustomization) IDName() string { return k.Path }
 // NamespacedName is "<namespace>/<name>".
 func (k *Kustomization) NamespacedName() string { return k.Namespace + "/" + k.Name }
 
-// ValidateDependsOn drops any dependency that is not present in allKS.
-// allKS is a set of "namespace/name" identifiers.
-func (k *Kustomization) ValidateDependsOn(allKS map[string]struct{}) {
+// FilterDependsOn returns a copy of k.DependsOn with any entries
+// whose target is not present in allKS removed. allKS is a set of
+// "namespace/name" identifiers. The second return value is the count
+// of entries that were dropped.
+//
+// Pure function — does not mutate k. Callers wanting to update a
+// stored Kustomization should follow the Store's immutability
+// contract: shallow-copy k, set the new DependsOn on the copy, then
+// re-AddObject the copy.
+func (k *Kustomization) FilterDependsOn(allKS map[string]struct{}) ([]DependencyRef, int) {
 	if len(k.DependsOn) == 0 {
-		return
+		return k.DependsOn, 0
 	}
 	kept := slices.DeleteFunc(slices.Clone(k.DependsOn), func(dep DependencyRef) bool {
 		_, ok := allKS[dep.NamespacedName()]
 		return !ok
 	})
-	if missing := len(k.DependsOn) - len(kept); missing > 0 {
+	dropped := len(k.DependsOn) - len(kept)
+	if dropped > 0 {
 		// Demoted to Debug: dependsOn references often dangle in a
 		// statically-loaded view because parent-Kustomization
 		// targetNamespace inheritance happens lazily. Real Flux resolves
@@ -80,9 +88,9 @@ func (k *Kustomization) ValidateDependsOn(allKS map[string]struct{}) {
 		// wait order during flate's reconcile.
 		slog.Debug("kustomization dependsOn entries dropped",
 			"kustomization", k.NamespacedName(),
-			"dropped", missing, "kept", len(kept))
+			"dropped", dropped, "kept", len(kept))
 	}
-	k.DependsOn = kept
+	return kept, dropped
 }
 
 // UpdatePostBuildSubstitutions merges the given map into the substitution

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -550,9 +550,12 @@ spec:
 		t.Errorf("substitute = %+v", k.PostBuildSubstitute)
 	}
 
-	k.ValidateDependsOn(map[string]struct{}{"flux-system/infra": {}})
-	if len(k.DependsOn) != 1 || k.DependsOn[0].NamespacedName() != "flux-system/infra" {
-		t.Errorf("ValidateDependsOn left %v", k.DependsOn)
+	kept, dropped := k.FilterDependsOn(map[string]struct{}{"flux-system/infra": {}})
+	if len(kept) != 1 || kept[0].NamespacedName() != "flux-system/infra" {
+		t.Errorf("FilterDependsOn kept = %v", kept)
+	}
+	if dropped == 0 {
+		t.Errorf("expected at least one dropped entry")
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -290,9 +290,21 @@ func (o *Orchestrator) validateDependsOn() {
 		}
 	}
 	for _, obj := range ksList {
-		if ks, ok := obj.(*manifest.Kustomization); ok {
-			ks.ValidateDependsOn(known)
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok {
+			continue
 		}
+		kept, dropped := ks.FilterDependsOn(known)
+		if dropped == 0 {
+			continue
+		}
+		// Store immutability contract: clone the struct, set the new
+		// slice on the clone, then re-AddObject so listeners see the
+		// transition cleanly and the existing pointer stays valid for
+		// any in-flight readers.
+		clone := *ks
+		clone.DependsOn = kept
+		o.store.AddObject(&clone)
 	}
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -10,6 +10,29 @@ import (
 )
 
 // Store is the central in-memory state container.
+//
+// # Immutability contract
+//
+// Objects passed to AddObject (and returned by GetObject / GetByName /
+// ListObjects) are treated as IMMUTABLE after insertion. The store
+// returns shared pointers rather than defensive copies for performance:
+// rendering pipelines read millions of fields per reconcile, and
+// cloning the full manifest tree on every read would dominate CPU.
+//
+// Callers that need to "modify" a stored object must:
+//
+//  1. Shallow-copy the struct (most manifest types are flat enough
+//     that *clone := *orig works).
+//  2. Mutate the copy's fields.
+//  3. Re-AddObject the modified copy. AddObject's reflect.DeepEqual
+//     dedup avoids spurious events, and the second-pass dispatch
+//     reaches downstream controllers.
+//
+// Mutating an object after AddObject is a bug — concurrent readers
+// will see torn state and AddObject's dedup will compare against
+// a moving target. The loader (pkg/loader/inherit.go) and
+// orchestrator (pkg/orchestrator/orchestrator.go) follow the
+// clone-then-AddObject pattern; any new mutation site should too.
 type Store struct {
 	mu         sync.RWMutex
 	objects    map[manifest.NamedResource]manifest.BaseManifest

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -36,6 +36,39 @@ func TestStore_AddObjectIdempotent(t *testing.T) {
 	}
 }
 
+// TestStore_AddObject_CloneTriggersUpdate guards the immutability
+// contract: callers that need to "mutate" a stored object must clone
+// it, mutate the clone, and re-AddObject. The store's reflect.DeepEqual
+// dedup recognizes the clone as different and fires EventObjectAdded.
+func TestStore_AddObject_CloneTriggersUpdate(t *testing.T) {
+	s := New()
+	cm := newCM("a", "ns")
+	id := cm.Named()
+
+	var seen int
+	s.AddListener(EventObjectAdded, func(other manifest.NamedResource, _ any) {
+		if other == id {
+			seen++
+		}
+	}, false)
+
+	s.AddObject(cm)
+	clone := *cm
+	clone.Data = map[string]any{"k": "v"}
+	s.AddObject(&clone)
+
+	if seen != 2 {
+		t.Errorf("expected two AddObject events (initial + clone), got %d", seen)
+	}
+	got, ok := s.GetObject(id).(*manifest.ConfigMap)
+	if !ok {
+		t.Fatalf("expected *manifest.ConfigMap, got %T", s.GetObject(id))
+	}
+	if got.Data["k"] != "v" {
+		t.Errorf("store did not pick up the cloned value: %+v", got.Data)
+	}
+}
+
 func TestStore_AddListener_Flush(t *testing.T) {
 	s := New()
 	s.AddObject(newCM("a", "ns"))


### PR DESCRIPTION
## Summary

The architecture review found that \`Store.{GetObject,GetByName,ListObjects}\` return shared pointers without a defensive copy. Two pre-existing call sites then mutated those pointers in place — safe today (both run single-threaded during Bootstrap) but a latent race the moment a future caller invokes them concurrently with the reconcile fan-out.

### Mutation sites fixed
- **\`orchestrator.validateDependsOn\`** called \`ks.ValidateDependsOn()\` which rewrote \`DependsOn\` in-place on the stored Kustomization.
- **\`loader.ApplyNamespaceInheritance\`** mutated \`obj.Namespace\` on the live store pointer before \`DeleteObject\`.

Both now follow the **clone-then-AddObject** pattern. Refactors:
- \`Kustomization.ValidateDependsOn\` → \`Kustomization.FilterDependsOn\` returning \`(newSlice, dropped)\`. Orchestrator clones the struct, sets the new slice on the clone, AddObjects.
- \`loader.setNamespace\` → \`loader.cloneWithNamespace\` returning a new \`*manifest.Foo\` with namespace rewritten.

### Documentation
The Store now carries an explicit immutability contract in its doc comment, explaining the rationale (rendering reads millions of fields; defensive copy on every read would dominate CPU) and the required pattern.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] New \`TestStore_AddObject_CloneTriggersUpdate\` asserts clone-then-AddObject fires EventObjectAdded (the behavior callers rely on).
- [x] Existing test for old \`ValidateDependsOn\` was migrated to \`FilterDependsOn\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)