### PR TITLE
fix(controllers): typed errors with %w wrapping for dependency / source failures

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
-	"strings"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -132,11 +131,11 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		w := &depwait.Waiter{Store: c.Store, Parent: id}
 		sum := depwait.WaitAll(w.Watch(ctx, deps))
 		if sum.AnyFailed() {
-			var msgs []string
-			for _, f := range sum.Failed {
-				msgs = append(msgs, f.String()+": "+sum.Messages[f])
+			return &manifest.DependencyFailedError{
+				Parent:  id,
+				Failed:  sum.Failed,
+				Reasons: sum.Messages,
 			}
-			return fmt.Errorf("dependencies failed: %s", strings.Join(msgs, "; "))
 		}
 	}
 
@@ -157,7 +156,8 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	w := &depwait.Waiter{Store: c.Store, Parent: id}
 	sum := depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
 	if sum.AnyFailed() {
-		return fmt.Errorf("chart source %s not ready: %s", srcID.String(), sum.Messages[srcID])
+		return fmt.Errorf("%w: chart source %s not ready: %s",
+			manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving values")

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -6,11 +6,9 @@ package kustomization
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
-	"strings"
 
 	yaml "go.yaml.in/yaml/v4"
 
@@ -93,11 +91,11 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		w := &depwait.Waiter{Store: c.Store, Parent: id}
 		sum := depwait.WaitAll(w.Watch(ctx, deps))
 		if sum.AnyFailed() {
-			var msgs []string
-			for _, f := range sum.Failed {
-				msgs = append(msgs, f.String()+": "+sum.Messages[f])
+			return &manifest.DependencyFailedError{
+				Parent:  id,
+				Failed:  sum.Failed,
+				Reasons: sum.Messages,
 			}
-			return fmt.Errorf("dependencies failed: %s", strings.Join(msgs, "; "))
 		}
 	}
 
@@ -298,7 +296,8 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 		// No source — use ks.Path directly. This handles bootstrap
 		// kustomizations whose source is implicit.
 		if ks.Path == "" {
-			return "", errors.New("kustomization has no path and no source")
+			return "", fmt.Errorf("%w: kustomization %s has no path and no source",
+				manifest.ErrInput, ks.NamespacedName())
 		}
 		return ks.Path, nil
 	}
@@ -310,5 +309,6 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 	if sa, ok := art.(*store.SourceArtifact); ok {
 		return sa.LocalPath, nil
 	}
-	return "", fmt.Errorf("unsupported source artifact type %T for %s", art, srcID.String())
+	return "", fmt.Errorf("%w: unsupported source artifact type %T for %s",
+		manifest.ErrFlux, art, srcID.String())
 }

--- a/pkg/manifest/errors.go
+++ b/pkg/manifest/errors.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Sentinel errors. Callers branch on these with errors.Is. Every error
@@ -42,18 +43,27 @@ func (*ResourceFailedError) Unwrap() error { return ErrFlux }
 // DependencyFailedError signals that a parent resource cannot proceed
 // because one of its dependencies has failed.
 type DependencyFailedError struct {
-	Kustomization string
-	Dependency    string
-	Reason        string
+	// Parent is the resource whose reconcile is being aborted.
+	Parent NamedResource
+	// Failed is the ordered list of dependency IDs that failed.
+	Failed []NamedResource
+	// Reasons maps each failed ID to its underlying message.
+	Reasons map[NamedResource]string
 }
 
 func (e *DependencyFailedError) Error() string {
-	reason := e.Reason
-	if reason == "" {
-		reason = "unknown error"
+	if len(e.Failed) == 0 {
+		return fmt.Sprintf("%s: dependencies failed", e.Parent.String())
 	}
-	return fmt.Sprintf("kustomization %s dependency %s failed: %s",
-		e.Kustomization, e.Dependency, reason)
+	parts := make([]string, 0, len(e.Failed))
+	for _, f := range e.Failed {
+		reason := e.Reasons[f]
+		if reason == "" {
+			reason = "unknown error"
+		}
+		parts = append(parts, f.String()+": "+reason)
+	}
+	return "dependencies failed: " + strings.Join(parts, "; ")
 }
 
 func (*DependencyFailedError) Unwrap() error { return ErrInput }

--- a/pkg/manifest/errors_test.go
+++ b/pkg/manifest/errors_test.go
@@ -1,0 +1,58 @@
+package manifest
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDependencyFailedError_Format(t *testing.T) {
+	parent := NamedResource{Kind: KindKustomization, Namespace: "default", Name: "child"}
+	depA := NamedResource{Kind: KindKustomization, Namespace: "security", Name: "pocket-id-instance"}
+	depB := NamedResource{Kind: KindKustomization, Namespace: "database", Name: "cnpg-cluster"}
+
+	err := &DependencyFailedError{
+		Parent: parent,
+		Failed: []NamedResource{depA, depB},
+		Reasons: map[NamedResource]string{
+			depA: `variable "SECRET_DOMAIN" is undefined and has no default`,
+			depB: "rendering timed out",
+		},
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "dependencies failed:") {
+		t.Errorf("missing prefix: %q", msg)
+	}
+	if !strings.Contains(msg, depA.String()) || !strings.Contains(msg, depB.String()) {
+		t.Errorf("missing dependency IDs: %q", msg)
+	}
+	if !strings.Contains(msg, "SECRET_DOMAIN") || !strings.Contains(msg, "timed out") {
+		t.Errorf("missing reasons: %q", msg)
+	}
+}
+
+func TestDependencyFailedError_Unwraps(t *testing.T) {
+	err := &DependencyFailedError{
+		Parent: NamedResource{Kind: KindKustomization, Name: "x"},
+	}
+	if !errors.Is(err, ErrInput) {
+		t.Errorf("expected errors.Is(err, ErrInput) to be true")
+	}
+	if !errors.Is(err, ErrFlux) {
+		t.Errorf("expected errors.Is(err, ErrFlux) to be true (ErrInput wraps ErrFlux)")
+	}
+
+	var typed *DependencyFailedError
+	if !errors.As(err, &typed) {
+		t.Errorf("errors.As should match *DependencyFailedError")
+	}
+}
+
+func TestDependencyFailedError_EmptyFailedList(t *testing.T) {
+	err := &DependencyFailedError{
+		Parent: NamedResource{Kind: KindKustomization, Namespace: "ns", Name: "k"},
+	}
+	if msg := err.Error(); !strings.Contains(msg, "dependencies failed") {
+		t.Errorf("empty-failed error should still mention dependencies failed: %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Two hot paths in the Kustomization/HelmRelease controllers returned bare \`fmt.Errorf\` strings with no \`%w\` — callers couldn't \`errors.Is\`/\`errors.As\` against them, and the error chain was lost.

### Changes

- \`manifest.DependencyFailedError\` rebuilt with a structured shape:
  - \`Parent NamedResource\` — the resource whose reconcile aborted
  - \`Failed []NamedResource\` — the dependencies that failed (ordered)
  - \`Reasons map[NamedResource]string\` — per-dep underlying messages
  - \`Unwrap()\` still returns \`ErrInput\` (which wraps \`ErrFlux\`)
- Both controllers return \`&manifest.DependencyFailedError{...}\` instead of \`fmt.Errorf("dependencies failed: ...")\`. Output text matches the previous shape so e2e log-scraping tests keep passing.
- \`HelmRelease\` chart-source not-ready now \`%w\`-wraps \`manifest.ErrObjectNotFound\`.
- Kustomization "no path and no source" + "unsupported artifact type" wrap \`manifest.ErrInput\` / \`manifest.ErrFlux\`.

## Test plan
- [x] New \`TestDependencyFailedError_{Format,Unwraps,EmptyFailedList}\` covers the structured error.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)