### PR TITLE
feat(helmrelease): honor spec.install.crds / spec.upgrade.crds policy

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -42,6 +42,16 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	inst.ReleaseName = hr.Name
 	inst.Namespace = hr.ReleaseNamespace()
 	inst.IncludeCRDs = !opts.SkipCRDs
+	// HR-scoped policy wins: spec.install.crds / spec.upgrade.crds set
+	// to "Skip" suppresses CRDs even when the CLI requests them.
+	// "Create" / "CreateReplace" force them on. An empty policy lets
+	// the CLI flag decide.
+	switch hr.CRDsPolicy {
+	case "Skip":
+		inst.IncludeCRDs = false
+	case "Create", "CreateReplace":
+		inst.IncludeCRDs = true
+	}
 	inst.DisableHooks = opts.NoHooks
 	inst.IsUpgrade = opts.IsUpgrade
 	inst.EnableDNS = opts.EnableDNS

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -202,6 +202,14 @@ type HelmRelease struct {
 	Suspend                  bool              `json:"-" yaml:"-"`
 	DisableSchemaValidation  bool              `json:"-" yaml:"-"`
 	DisableOpenAPIValidation bool              `json:"-" yaml:"-"`
+	// CRDsPolicy mirrors spec.install.crds / spec.upgrade.crds. One of
+	// "" (chart's helm default), "Skip", "Create", "CreateReplace".
+	// "Skip" suppresses CRDs from the rendered output. "Create" and
+	// "CreateReplace" both include CRDs — they differ only in
+	// cluster-apply semantics which flate doesn't perform.
+	// Upgrade wins over Install when both are set, matching
+	// helm-controller's "upgrade-after-install" model.
+	CRDsPolicy string `json:"-" yaml:"-"`
 	// ServiceAccountName is the SA Flux's helm-controller impersonates
 	// when applying the release. Flate renders offline so it has no
 	// effect here, but the field is preserved for fidelity with the
@@ -324,6 +332,17 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		(cr.Spec.Upgrade != nil && cr.Spec.Upgrade.DisableSchemaValidation)
 	disableOpenAPI := (cr.Spec.Install != nil && cr.Spec.Install.DisableOpenAPIValidation) ||
 		(cr.Spec.Upgrade != nil && cr.Spec.Upgrade.DisableOpenAPIValidation)
+	// Upgrade.CRDs wins over Install.CRDs — helm-controller's
+	// upgrade-after-install model means the upgrade policy is what
+	// the running cluster sees once any release is past its first
+	// install.
+	crdsPolicy := ""
+	if cr.Spec.Install != nil {
+		crdsPolicy = string(cr.Spec.Install.CRDs)
+	}
+	if cr.Spec.Upgrade != nil && cr.Spec.Upgrade.CRDs != "" {
+		crdsPolicy = string(cr.Spec.Upgrade.CRDs)
+	}
 	var dependsOn []DependencyRef
 	for _, dep := range cr.Spec.DependsOn {
 		if dep.Name == "" {
@@ -363,6 +382,7 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		ChartValuesFiles:         chartValuesFiles,
 		IgnoreMissingValuesFiles: ignoreMissingValuesFiles,
 		ServiceAccountName:       cr.Spec.ServiceAccountName,
+		CRDsPolicy:               crdsPolicy,
 	}, nil
 }
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -85,6 +85,86 @@ spec:
 	}
 }
 
+func TestParseHelmRelease_CRDsPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "install only",
+			yaml: `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  install: {crds: Create}
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`,
+			want: "Create",
+		},
+		{
+			name: "upgrade wins over install",
+			yaml: `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  install: {crds: Create}
+  upgrade: {crds: CreateReplace}
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`,
+			want: "CreateReplace",
+		},
+		{
+			name: "skip suppresses",
+			yaml: `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  upgrade: {crds: Skip}
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`,
+			want: "Skip",
+		},
+		{
+			name: "empty when neither set",
+			yaml: `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`,
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hr, err := ParseHelmRelease(mustYAML(t, tc.yaml))
+			if err != nil {
+				t.Fatalf("ParseHelmRelease: %v", err)
+			}
+			if hr.CRDsPolicy != tc.want {
+				t.Errorf("CRDsPolicy = %q, want %q", hr.CRDsPolicy, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseHelmChartSource_ReconcileStrategy(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: source.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Summary

Previously the renderer hardcoded \`inst.IncludeCRDs = !opts.SkipCRDs\` — the per-HR \`spec.install.crds\` / \`spec.upgrade.crds\` policy was silently ignored even though the typed CR unmarshals it. HelmReleases that pin \`Skip\` got CRDs in the output anyway, and ones that pin \`CreateReplace\` had to rely on the user remembering \`--include-crds\` at the CLI.

### Resolution rules (matches helm-controller)
- \`spec.upgrade.crds\` wins over \`spec.install.crds\` (upgrade-after-install model)
- Empty when neither set

### Effect on rendered output
- \`Skip\` → \`IncludeCRDs = false\` (force off, overrides CLI)
- \`Create\` / \`CreateReplace\` → \`IncludeCRDs = true\` (force on)
- \`\"\"\` (unset) → fall through to \`--skip-crds\` CLI flag

\`Create\` and \`CreateReplace\` produce identical offline output — they differ only in cluster-apply semantics flate doesn't perform.

## Test plan
- [x] \`TestParseHelmRelease_CRDsPolicy\` covers all four resolution paths.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)