### PR TITLE
feat(git): support spec.verify (PGP commit/tag verification)

### DIFF
--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -104,6 +104,48 @@ spec:
 	}
 }
 
+func TestParseGitRepository_Verify(t *testing.T) {
+	cases := []struct {
+		name     string
+		modeYAML string
+		want     string
+	}{
+		{"HEAD", "HEAD", "HEAD"},
+		{"head legacy lowercase normalizes", "head", "HEAD"},
+		{"Tag", "Tag", "Tag"},
+		{"TagAndHEAD", "TagAndHEAD", "TagAndHEAD"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustYAML(t, `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: r, namespace: flux-system}
+spec:
+  url: https://github.com/owner/repo.git
+  verify:
+    mode: `+tc.modeYAML+`
+    secretRef:
+      name: trusted-pgp-keys
+  interval: 5m
+`)
+			g, err := ParseGitRepository(doc)
+			if err != nil {
+				t.Fatalf("ParseGitRepository: %v", err)
+			}
+			if g.Verify == nil {
+				t.Fatalf("expected Verify parsed")
+			}
+			if g.Verify.Mode != tc.want {
+				t.Errorf("Mode = %q, want %q", g.Verify.Mode, tc.want)
+			}
+			if g.Verify.SecretRef == nil || g.Verify.SecretRef.Name != "trusted-pgp-keys" {
+				t.Errorf("SecretRef = %+v", g.Verify.SecretRef)
+			}
+		})
+	}
+}
+
 func TestParseGitRepository_ProxySecretRef(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -48,12 +48,32 @@ type GitRepository struct {
 	Provider          string                `json:"provider,omitempty" yaml:"provider,omitempty"`
 	SecretRef         *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
 	ProxySecretRef    *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
+	Verify            *GitRepositoryVerify  `json:"verify,omitempty" yaml:"verify,omitempty"`
 	RecurseSubmodules bool                  `json:"recurseSubmodules,omitempty" yaml:"recurseSubmodules,omitempty"`
 	// SparseCheckout limits the checkout to the listed repo-relative
 	// directories. When empty, the full tree is checked out (default).
 	SparseCheckout []string `json:"sparseCheckout,omitempty" yaml:"sparseCheckout,omitempty"`
 	Suspend        bool     `json:"-" yaml:"-"`
 }
+
+// GitRepositoryVerify mirrors source-controller's GitRepositoryVerification.
+// The Secret named by SecretRef holds one or more PEM-armored PGP
+// public keys (typically "*.asc"); flate concatenates them into a
+// single keyring and verifies the resolved commit/tag signatures
+// against it.
+type GitRepositoryVerify struct {
+	// Mode is "HEAD", "Tag", or "TagAndHEAD". The legacy "head"
+	// alias normalizes to "HEAD" during parse.
+	Mode      string                `json:"mode,omitempty" yaml:"mode,omitempty"`
+	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
+}
+
+// Git verification modes accepted on spec.verify.mode.
+const (
+	GitVerifyModeHEAD       = "HEAD"
+	GitVerifyModeTag        = "Tag"
+	GitVerifyModeTagAndHEAD = "TagAndHEAD"
+)
 
 // Named identifies the GitRepository.
 func (g *GitRepository) Named() NamedResource {
@@ -112,6 +132,16 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 	}
 	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
 		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
+	}
+	if v := cr.Spec.Verification; v != nil {
+		mode := string(v.GetMode())
+		if mode == "head" { // legacy alias
+			mode = GitVerifyModeHEAD
+		}
+		out.Verify = &GitRepositoryVerify{Mode: mode}
+		if v.SecretRef.Name != "" {
+			out.Verify.SecretRef = &LocalObjectReference{Name: v.SecretRef.Name}
+		}
 	}
 	return out, nil
 }

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -78,7 +78,25 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		client.InstallProtocol("https", githttp.NewClient(httpsClient))
 		defer client.InstallProtocol("https", githttp.DefaultClient)
 	}
-	return fetch(ctx, f.Cache, repo, auth, proxy)
+	art, err := fetch(ctx, f.Cache, repo, auth, proxy)
+	if err != nil {
+		return nil, err
+	}
+	if repo.Verify != nil {
+		cloned, oerr := git.PlainOpen(art.LocalPath)
+		if oerr != nil {
+			return nil, fmt.Errorf("verify: reopen %s: %w", art.LocalPath, oerr)
+		}
+		head, herr := cloned.Head()
+		if herr != nil {
+			return nil, fmt.Errorf("verify: resolve HEAD: %w", herr)
+		}
+		if err := verifySignatures(f.Secrets, repo, cloned, head.Hash()); err != nil {
+			_ = f.Cache.Reset(art.LocalPath)
+			return nil, err
+		}
+	}
+	return art, nil
 }
 
 // resolveTLS builds a *tls.Config from spec.secretRef for HTTPS GitRepositories

--- a/pkg/source/git/verify.go
+++ b/pkg/source/git/verify.go
@@ -1,0 +1,143 @@
+package git
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// verifySignatures applies the PGP verification configured by
+// spec.verify against the freshly-cloned repository. Returns nil
+// when no verification is configured. Fails loud on any failure —
+// missing secret, malformed keys, unsigned/badly-signed object.
+//
+// The Secret named by spec.verify.secretRef may carry multiple
+// ASCII-armored public keys (any *.asc filename); they're
+// concatenated into a single keyring before verification.
+func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository, cloned *git.Repository, resolvedRef plumbing.Hash) error {
+	if repo.Verify == nil {
+		return nil
+	}
+	v := repo.Verify
+	mode := v.Mode
+	if mode == "" {
+		mode = manifest.GitVerifyModeHEAD
+	}
+	if v.SecretRef == nil {
+		return fmt.Errorf("GitRepository %s/%s: spec.verify.secretRef is required",
+			repo.Namespace, repo.Name)
+	}
+	if secrets == nil {
+		return fmt.Errorf("GitRepository %s/%s: spec.verify set but no source.SecretGetter is wired",
+			repo.Namespace, repo.Name)
+	}
+	sec := secrets(repo.Namespace, v.SecretRef.Name)
+	if sec == nil {
+		return fmt.Errorf("GitRepository %s/%s: verify secret %s/%s not found",
+			repo.Namespace, repo.Name, repo.Namespace, v.SecretRef.Name)
+	}
+	keyring, err := buildPGPKeyring(sec)
+	if err != nil {
+		return fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+	}
+
+	if verifyHEAD(mode) {
+		if err := verifyCommit(cloned, resolvedRef, keyring); err != nil {
+			return fmt.Errorf("GitRepository %s/%s: HEAD verify: %w",
+				repo.Namespace, repo.Name, err)
+		}
+	}
+	if verifyTag(mode) {
+		tagName := repo.Ref.Tag
+		if tagName == "" {
+			return fmt.Errorf("GitRepository %s/%s: verify mode %q requires spec.ref.tag",
+				repo.Namespace, repo.Name, mode)
+		}
+		if err := verifyTagObject(cloned, tagName, keyring); err != nil {
+			return fmt.Errorf("GitRepository %s/%s: tag verify: %w",
+				repo.Namespace, repo.Name, err)
+		}
+	}
+	return nil
+}
+
+func verifyHEAD(mode string) bool {
+	return mode == manifest.GitVerifyModeHEAD || mode == manifest.GitVerifyModeTagAndHEAD
+}
+
+func verifyTag(mode string) bool {
+	return mode == manifest.GitVerifyModeTag || mode == manifest.GitVerifyModeTagAndHEAD
+}
+
+// buildPGPKeyring concatenates every string value in the Secret into
+// one armored keyring. Each value is expected to be an armored PGP
+// public key block; flate doesn't validate the shape here — go-git's
+// Commit/Tag .Verify rejects malformed keyrings.
+//
+// Treats source.StringFromSecret's PLACEHOLDER wipe as missing so a
+// --wipe-secrets run doesn't try to verify against a placeholder.
+func buildPGPKeyring(sec *manifest.Secret) (string, error) {
+	var out string
+	for k := range sec.StringData {
+		v := source.StringFromSecret(sec, k)
+		if v == "" {
+			continue
+		}
+		if out != "" && out[len(out)-1] != '\n' {
+			out += "\n"
+		}
+		out += v
+	}
+	for k := range sec.Data {
+		v := source.StringFromSecret(sec, k)
+		if v == "" {
+			continue
+		}
+		if out != "" && out[len(out)-1] != '\n' {
+			out += "\n"
+		}
+		out += v
+	}
+	if out == "" {
+		return "", fmt.Errorf("verify secret carries no PGP public keys")
+	}
+	return out, nil
+}
+
+func verifyCommit(repo *git.Repository, hash plumbing.Hash, keyring string) error {
+	c, err := repo.CommitObject(hash)
+	if err != nil {
+		return fmt.Errorf("read commit %s: %w", hash, err)
+	}
+	if c.PGPSignature == "" {
+		return fmt.Errorf("commit %s is not signed", hash)
+	}
+	if _, err := c.Verify(keyring); err != nil {
+		return fmt.Errorf("commit %s signature: %w", hash, err)
+	}
+	return nil
+}
+
+func verifyTagObject(repo *git.Repository, name, keyring string) error {
+	ref, err := repo.Tag(name)
+	if err != nil {
+		return fmt.Errorf("resolve tag %q: %w", name, err)
+	}
+	tag, err := repo.TagObject(ref.Hash())
+	if err != nil {
+		// Not an annotated tag — only annotated tags carry
+		// PGP signatures.
+		return fmt.Errorf("tag %q is not annotated (no signature to verify)", name)
+	}
+	if tag.PGPSignature == "" {
+		return fmt.Errorf("tag %q is not signed", name)
+	}
+	if _, err := tag.Verify(keyring); err != nil {
+		return fmt.Errorf("tag %q signature: %w", name, err)
+	}
+	return nil
+}

--- a/pkg/source/git/verify_test.go
+++ b/pkg/source/git/verify_test.go
@@ -1,0 +1,125 @@
+package git
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestVerifySignatures_NilVerifyIsNoOp(t *testing.T) {
+	repo := &manifest.GitRepository{Name: "r", Namespace: "ns"}
+	if err := verifySignatures(nil, repo, nil, plumbing.ZeroHash); err != nil {
+		t.Errorf("nil Verify should be a no-op, got %v", err)
+	}
+}
+
+func TestVerifySignatures_RequiresSecretRef(t *testing.T) {
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		Verify: &manifest.GitRepositoryVerify{Mode: manifest.GitVerifyModeHEAD},
+	}
+	err := verifySignatures(nil, repo, nil, plumbing.ZeroHash)
+	if err == nil || !strings.Contains(err.Error(), "secretRef is required") {
+		t.Errorf("expected secretRef-required error; got %v", err)
+	}
+}
+
+func TestVerifySignatures_RequiresSecretGetter(t *testing.T) {
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		Verify: &manifest.GitRepositoryVerify{
+			Mode:      manifest.GitVerifyModeHEAD,
+			SecretRef: &manifest.LocalObjectReference{Name: "keys"},
+		},
+	}
+	err := verifySignatures(nil, repo, nil, plumbing.ZeroHash)
+	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
+		t.Errorf("expected SecretGetter error; got %v", err)
+	}
+}
+
+func TestVerifySignatures_SecretNotFound(t *testing.T) {
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		Verify: &manifest.GitRepositoryVerify{
+			Mode:      manifest.GitVerifyModeHEAD,
+			SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		},
+	}
+	getter := func(_, _ string) *manifest.Secret { return nil }
+	err := verifySignatures(getter, repo, nil, plumbing.ZeroHash)
+	if err == nil || !strings.Contains(err.Error(), "verify secret") || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error; got %v", err)
+	}
+}
+
+func TestBuildPGPKeyring(t *testing.T) {
+	cases := []struct {
+		name    string
+		sec     *manifest.Secret
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "single armored key",
+			sec: &manifest.Secret{StringData: map[string]any{
+				"alice.asc": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nfake\n-----END PGP PUBLIC KEY BLOCK-----\n",
+			}},
+			want: "-----BEGIN PGP PUBLIC KEY BLOCK-----\nfake\n-----END PGP PUBLIC KEY BLOCK-----\n",
+		},
+		{
+			name:    "empty secret",
+			sec:     &manifest.Secret{StringData: map[string]any{}},
+			wantErr: true,
+		},
+		{
+			name: "placeholder-wiped keys treated as missing",
+			sec: &manifest.Secret{StringData: map[string]any{
+				"alice.asc": "..PLACEHOLDER_alice.asc..",
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := buildPGPKeyring(tc.sec)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got out=%q", out)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if out != tc.want {
+				t.Errorf("keyring = %q, want %q", out, tc.want)
+			}
+		})
+	}
+}
+
+func TestVerifyHEAD_Tag_HelperMatrix(t *testing.T) {
+	cases := []struct {
+		mode    string
+		wantH   bool
+		wantTag bool
+	}{
+		{manifest.GitVerifyModeHEAD, true, false},
+		{manifest.GitVerifyModeTag, false, true},
+		{manifest.GitVerifyModeTagAndHEAD, true, true},
+		{"", false, false},
+		{"unknown", false, false},
+	}
+	for _, tc := range cases {
+		if got := verifyHEAD(tc.mode); got != tc.wantH {
+			t.Errorf("verifyHEAD(%q) = %v, want %v", tc.mode, got, tc.wantH)
+		}
+		if got := verifyTag(tc.mode); got != tc.wantTag {
+			t.Errorf("verifyTag(%q) = %v, want %v", tc.mode, got, tc.wantTag)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Source-controller's \`GitRepositoryVerification\` gates the artifact on PGP signatures matching trusted public keys in \`spec.verify.secretRef\`. flate silently dropped the field — the fetch returned even when the resolved commit was unsigned or signed by an untrusted key.

### Behavior

- \`manifest.GitRepository.Verify\` with \`Mode\` (\`HEAD\` / \`Tag\` / \`TagAndHEAD\`) and \`SecretRef\`. Legacy lowercase \`head\` normalizes to \`HEAD\`.
- After clone, the Fetcher reopens the repo, resolves HEAD, loads the verify Secret, concatenates every StringData/Data value into an armored PGP keyring, and:
  - Mode includes **HEAD**: \`go-git Commit.Verify(keyring)\` on the resolved commit.
  - Mode includes **Tag**: resolves \`spec.ref.tag\` as an annotated tag object and runs \`Tag.Verify(keyring)\`.
- Fails loud on misconfiguration: missing secretRef, no SecretGetter, missing Secret, no keys, unsigned object, bad signature, non-annotated tag.
- \`--wipe-secrets\` placeholders are treated as missing so a wiped run can't accidentally pass.

### Note on naming

The original review labeled this \"cosign tag verification\". That's wrong — \`GitRepositoryVerification\` is PGP-based (source-controller uses go-git's PGP path). Cosign-based tag verification is a different scheme that only applies to OCIRepository (already shipped in #50).

## Test plan
- [x] Parser test covers HEAD, head→HEAD normalize, Tag, TagAndHEAD.
- [x] \`verifySignatures\` tests cover: nil Verify is no-op, missing secretRef, missing SecretGetter, missing Secret.
- [x] \`buildPGPKeyring\` tests cover: single armored key, empty Secret, placeholder-wiped keys.
- [x] \`verifyHEAD\` / \`verifyTag\` helper matrix.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)