### PR TITLE
feat(depwait): project observedGeneration/generation for CEL ReadyExpr

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -92,9 +92,18 @@ func projectObject(s *store.Store, id manifest.NamedResource) map[string]any {
 		"metadata": map[string]any{
 			"name":      id.Name,
 			"namespace": id.Namespace,
+			// flate has no apiserver, so there is no monotonically-
+			// increasing generation count to model. The single-snapshot
+			// render pins both metadata.generation and
+			// status.observedGeneration to the same value so CEL
+			// expressions like
+			//   object.status.observedGeneration == object.metadata.generation
+			// — a common Flux readiness idiom — never spuriously fail.
+			"generation": int64(1),
 		},
 		"status": map[string]any{
-			"conditions": condsAny,
+			"observedGeneration": int64(1),
+			"conditions":         condsAny,
 		},
 	}
 }

--- a/pkg/depwait/cel_test.go
+++ b/pkg/depwait/cel_test.go
@@ -17,6 +17,22 @@ import (
 // against current state, the dep is Ready regardless of the built-in
 // Ready condition. The store carries Ready=False here to prove the
 // replacement.
+func TestReadyExpr_ProjectsObservedGeneration(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
+	s.UpdateStatus(dep, store.StatusReady, "")
+
+	w := &Waiter{Store: s, Timeout: time.Second}
+	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
+		NamedResource: dep,
+		// Common Flux readiness idiom.
+		ReadyExpr: `object.status.observedGeneration == object.metadata.generation`,
+	}}))
+	if !sum.AllReady() {
+		t.Errorf("observedGeneration projection should match metadata.generation: %+v", sum)
+	}
+}
+
 func TestReadyExpr_NonAdditive_PassesOnTrue(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}


### PR DESCRIPTION
## Summary

The common Flux readiness idiom

\`\`\`
object.status.observedGeneration == object.metadata.generation
\`\`\`

checks whether the controller has caught up to the latest spec. flate's CEL projection omitted both fields, so any ReadyExpr using that idiom would silently fail.

### Resolution

flate has no apiserver — no monotonically-increasing generation count. Pinning both fields to \`1\` makes the equality check trivially true, which is the correct semantic for an offline render: every reconcile flate performs IS against the latest snapshot of the spec.

## Test plan
- [x] New \`TestReadyExpr_ProjectsObservedGeneration\` asserts the idiom resolves to true.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)