### PR TITLE
feat(task): bounded-concurrency Service via worker-pool semaphore

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -23,6 +24,7 @@ type commonFlags struct {
 	output         string
 	enableOCI      bool
 	registryConfig string
+	concurrency    int
 }
 
 func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
@@ -38,6 +40,8 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, wide, yaml, json, name")
 	fs.BoolVar(&f.enableOCI, "enable-oci", true, "reconcile OCIRepository objects")
 	fs.StringVar(&f.registryConfig, "registry-config", "", "docker config.json for OCI authentication")
+	fs.IntVar(&f.concurrency, "concurrency", runtime.NumCPU()*4,
+		"max parallel reconcile bodies (0 = unbounded)")
 }
 
 // scopedNamespaces returns the namespace filter the command should
@@ -122,6 +126,7 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 		WipeSecrets:    true,
 		EnableOCI:      c.enableOCI,
 		RegistryConfig: c.registryConfig,
+		Concurrency:    c.concurrency,
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -61,6 +61,13 @@ type Config struct {
 	// filter is still built from this set + the loaded SourceFiles
 	// during Bootstrap.
 	ExternalChanges *change.Set
+
+	// Concurrency caps the number of active reconcile bodies running
+	// in parallel. <= 0 means unbounded (every Kustomization / HR
+	// reconciles on its own goroutine). Background watch loops are
+	// unaffected. Sensible default for I/O-bound work is
+	// runtime.NumCPU() * 4.
+	Concurrency int
 }
 
 // Orchestrator wires controllers and drives reconciliation.
@@ -105,7 +112,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	}
 
 	st := store.New()
-	ts := task.New()
+	ts := task.NewBounded(cfg.Concurrency)
 	cache := cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources")))
 	secretGet := func(ns, name string) *manifest.Secret {
 		obj := st.GetByName(manifest.KindSecret, ns, name)

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -33,15 +33,43 @@ type Service struct {
 	// failures is incremented by goroutines that panic; non-zero implies
 	// the run is poisoned.
 	failures atomic.Int64
+
+	// sem bounds the number of concurrent active task BODIES. The
+	// goroutine is launched eagerly but blocks on the semaphore until
+	// a worker slot is free, so callers never block on Go(). Background
+	// tasks are unaffected — they're long-lived stream processors.
+	//
+	// nil = unbounded (every Go runs in parallel). Set via NewBounded.
+	sem chan struct{}
 }
 
-// New constructs a fresh Service.
+// New constructs a fresh Service with unbounded concurrency.
 func New() *Service {
 	return &Service{names: make(map[int64]string)}
 }
 
+// NewBounded constructs a Service that caps the number of concurrently
+// executing active-task bodies at workers. Submitting more does not
+// block — the surplus goroutines exist but wait on an internal
+// semaphore until a slot opens. workers <= 0 disables bounding
+// (equivalent to New).
+//
+// Sized for I/O-bound work: helm template / oras pull / git clone all
+// release the worker briefly while blocked on the network. A sensible
+// default is runtime.NumCPU() * 4, but callers know their workload
+// better than the package does.
+func NewBounded(workers int) *Service {
+	s := New()
+	if workers > 0 {
+		s.sem = make(chan struct{}, workers)
+	}
+	return s
+}
+
 // Go launches an active task. ctx is propagated to fn. Completion is
-// reported via WaitActive / BlockTillDone.
+// reported via WaitActive / BlockTillDone. When the Service is
+// bounded (NewBounded), fn waits on the worker semaphore before it
+// executes — but Go itself never blocks.
 func (s *Service) Go(ctx context.Context, name string, fn func(context.Context)) {
 	id := s.next.Add(1)
 	s.active.Add(1)
@@ -61,6 +89,14 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 				slog.Error("task panicked", "name", name, "panic", r)
 			}
 		}()
+		if s.sem != nil {
+			select {
+			case s.sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-s.sem }()
+		}
 		fn(ctx)
 	}()
 }

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -7,6 +7,55 @@ import (
 	"time"
 )
 
+func TestNewBounded_LimitsConcurrentBodies(t *testing.T) {
+	const workers = 3
+	s := NewBounded(workers)
+
+	var inFlight, peak atomic.Int64
+	gate := make(chan struct{})
+
+	const submits = 12
+	for range submits {
+		s.Go(context.Background(), "w", func(_ context.Context) {
+			n := inFlight.Add(1)
+			for {
+				p := peak.Load()
+				if n <= p || peak.CompareAndSwap(p, n) {
+					break
+				}
+			}
+			<-gate
+			inFlight.Add(-1)
+		})
+	}
+
+	// Give the goroutines a moment to acquire / queue on the semaphore.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && inFlight.Load() < workers {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := inFlight.Load(); got != workers {
+		t.Errorf("expected exactly %d bodies active behind the semaphore, got %d", workers, got)
+	}
+	close(gate)
+	s.BlockTillDone()
+	if got := peak.Load(); got > workers {
+		t.Errorf("peak in-flight = %d, want <= %d", got, workers)
+	}
+}
+
+func TestNewBounded_Unbounded(t *testing.T) {
+	// Workers <= 0 disables bounding; matches New().
+	s := NewBounded(0)
+	if s.sem != nil {
+		t.Errorf("expected nil semaphore for workers=0")
+	}
+	s = NewBounded(-1)
+	if s.sem != nil {
+		t.Errorf("expected nil semaphore for workers=-1")
+	}
+}
+
 func TestService_BlockTillDone(t *testing.T) {
 	s := New()
 	var n atomic.Int64


### PR DESCRIPTION
## Summary

For a repo with 200 HelmReleases, flate would previously spawn 200 concurrent \`helm template\` invocations — each loading a chart, parsing templates, and (often) pulling from a remote OCI registry. The resulting fan-out exhausted DNS connection pools, drove memory into the GBs, and made wall-time worse rather than better.

### Changes

- **\`task.NewBounded(workers int)\`** — Service variant that gates active task bodies on a buffered-channel semaphore. Goroutines spawn eagerly so \`Go()\` never blocks, but they wait their turn to execute. Background tasks (long-lived watch loops) are exempt.
- **\`orchestrator.Config.Concurrency\`** — wired to \`NewBounded\`; \`<= 0\` means unbounded (matches old behavior).
- **\`--concurrency\`** CLI flag, default \`runtime.NumCPU() * 4\` (a sensible floor for I/O-bound work). Available on every command that runs the orchestrator.

### Semantics

- \`Go(ctx, ...)\` returns immediately. The spawned goroutine acquires the semaphore via a \`select\` on \`ctx.Done()\` so a cancelled context aborts before the body runs.
- Coalescer unchanged — its per-key dedup happens above the semaphore.

## Test plan
- [x] \`TestNewBounded_LimitsConcurrentBodies\` asserts peak in-flight never exceeds the configured worker count.
- [x] \`TestNewBounded_Unbounded\` asserts \`workers <= 0\` disables bounding.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)