### PR TITLE
refactor(source): extract BuildTLSConfig helper; delete duplicate secret reader

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -15,6 +15,7 @@ import (
 	repo "helm.sh/helm/v4/pkg/repo/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 )
 
 // chartCacheLocks serializes concurrent fetches of the same cached
@@ -174,8 +175,8 @@ func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Optio
 		return nil, fmt.Errorf("HelmRepository %s/%s: secret %s/%s not found",
 			r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
 	}
-	username := stringFromHelmSecret(sec, "username")
-	password := stringFromHelmSecret(sec, "password")
+	username := source.StringFromSecret(sec, "username")
+	password := source.StringFromSecret(sec, "password")
 	if username == "" || password == "" {
 		return nil, fmt.Errorf("HelmRepository %s/%s: secret %s/%s missing username/password",
 			r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
@@ -213,7 +214,7 @@ func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option
 
 	var tmpFiles []string
 	writeKey := func(key string) (string, error) {
-		v := stringFromHelmSecret(sec, key)
+		v := source.StringFromSecret(sec, key)
 		if v == "" {
 			return "", nil
 		}
@@ -260,26 +261,6 @@ func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option
 			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
 	}
 	return []getter.Option{getter.WithTLSClientConfig(certPath, keyPath, caPath)}, cleanup, nil
-}
-
-// stringFromHelmSecret reads a Secret key, preferring StringData and
-// treating wiped PLACEHOLDER values as missing. Local copy to avoid a
-// cross-package dep on pkg/source.
-func stringFromHelmSecret(sec *manifest.Secret, key string) string {
-	bag := func(m map[string]any) string {
-		v, ok := m[key].(string)
-		if !ok {
-			return ""
-		}
-		if strings.HasPrefix(v, "..PLACEHOLDER_") {
-			return ""
-		}
-		return v
-	}
-	if v := bag(sec.StringData); v != "" {
-		return v
-	}
-	return bag(sec.Data)
 }
 
 // fetchIndex downloads and parses a HelmRepository index.yaml.

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -142,33 +141,14 @@ func (f *Fetcher) resolveTLSConfig(b *manifest.Bucket) (*tls.Config, error) {
 		return nil, fmt.Errorf("bucket %s/%s: cert secret %s/%s not found",
 			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
 	}
-	crt := source.StringFromSecret(sec, "tls.crt")
-	key := source.StringFromSecret(sec, "tls.key")
-	ca := source.StringFromSecret(sec, "ca.crt")
-	if crt == "" && key == "" && ca == "" {
-		return nil, fmt.Errorf("bucket %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
-			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
-	}
-	if (crt == "") != (key == "") {
-		return nil, fmt.Errorf("bucket %s/%s: certSecretRef %s/%s must provide both tls.crt and tls.key together",
-			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
-	}
-	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
-	if crt != "" {
-		cert, err := tls.X509KeyPair([]byte(crt), []byte(key))
-		if err != nil {
-			return nil, fmt.Errorf("bucket %s/%s: parse tls.crt/tls.key: %w",
-				b.Namespace, b.Name, err)
-		}
-		cfg.Certificates = []tls.Certificate{cert}
-	}
-	if ca != "" {
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM([]byte(ca)) {
-			return nil, fmt.Errorf("bucket %s/%s: ca.crt did not parse as PEM",
-				b.Namespace, b.Name)
-		}
-		cfg.RootCAs = pool
+	cfg, err := source.BuildTLSConfig(
+		source.StringFromSecret(sec, "tls.crt"),
+		source.StringFromSecret(sec, "tls.key"),
+		source.StringFromSecret(sec, "ca.crt"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("bucket %s/%s: certSecretRef %s/%s: %w",
+			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name, err)
 	}
 	return cfg, nil
 }

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -4,7 +4,6 @@ package git
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -129,12 +128,12 @@ func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) 
 	if ca == "" {
 		return nil, nil
 	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM([]byte(ca)) {
-		return nil, fmt.Errorf("GitRepository %s/%s: ca.crt did not parse as PEM",
-			repo.Namespace, repo.Name)
+	cfg, err := source.BuildTLSConfig("", "", ca)
+	if err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: secretRef %s/%s: %w",
+			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name, err)
 	}
-	return &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: pool}, nil
+	return cfg, nil
 }
 
 // resolveAuth turns repo.SecretRef into a go-git AuthMethod. Returns

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -6,7 +6,6 @@ package oci
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"net/http"
@@ -94,32 +93,20 @@ func (f *Fetcher) resolveTLS(repo *manifest.OCIRepository) (*tls.Config, error) 
 		return nil, fmt.Errorf("OCIRepository %s/%s: cert secret %s/%s not found",
 			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
 	}
-	crt := source.StringFromSecret(sec, "tls.crt")
-	key := source.StringFromSecret(sec, "tls.key")
-	ca := source.StringFromSecret(sec, "ca.crt")
-	if crt == "" && key == "" && ca == "" {
-		return nil, fmt.Errorf("OCIRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
-			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
+	mtls, err := source.BuildTLSConfig(
+		source.StringFromSecret(sec, "tls.crt"),
+		source.StringFromSecret(sec, "tls.key"),
+		source.StringFromSecret(sec, "ca.crt"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("OCIRepository %s/%s: certSecretRef %s/%s: %w",
+			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name, err)
 	}
-	if (crt == "") != (key == "") {
-		return nil, fmt.Errorf("OCIRepository %s/%s: certSecretRef %s/%s must provide both tls.crt and tls.key together",
-			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
+	if mtls.Certificates != nil {
+		cfg.Certificates = mtls.Certificates
 	}
-	if crt != "" {
-		cert, err := tls.X509KeyPair([]byte(crt), []byte(key))
-		if err != nil {
-			return nil, fmt.Errorf("OCIRepository %s/%s: parse tls.crt/tls.key: %w",
-				repo.Namespace, repo.Name, err)
-		}
-		cfg.Certificates = []tls.Certificate{cert}
-	}
-	if ca != "" {
-		pool := x509.NewCertPool()
-		if !pool.AppendCertsFromPEM([]byte(ca)) {
-			return nil, fmt.Errorf("OCIRepository %s/%s: ca.crt did not parse as PEM",
-				repo.Namespace, repo.Name)
-		}
-		cfg.RootCAs = pool
+	if mtls.RootCAs != nil {
+		cfg.RootCAs = mtls.RootCAs
 	}
 	return cfg, nil
 }

--- a/pkg/source/tls.go
+++ b/pkg/source/tls.go
@@ -1,0 +1,47 @@
+package source
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+)
+
+// BuildTLSConfig assembles a *tls.Config from PEM-armored secret
+// material. Any subset of (client cert + key) and (CA) is acceptable;
+// crt/key must appear together if either is present. Returns an error
+// when all inputs are empty so callers can distinguish "no TLS
+// configured" from "malformed config".
+//
+// MinVersion is pinned to TLS 1.2 to match source-controller's
+// defaults. Callers that need TLS 1.3-only behavior can adjust the
+// returned config.
+//
+// Common Flux Secret keys feeding this helper:
+//
+//	tls.crt / tls.key  → client certificate (mTLS)
+//	ca.crt             → trust roots for the server
+func BuildTLSConfig(crt, key, ca string) (*tls.Config, error) {
+	if crt == "" && key == "" && ca == "" {
+		return nil, errors.New("no TLS material (tls.crt, tls.key, ca.crt) provided")
+	}
+	if (crt == "") != (key == "") {
+		return nil, errors.New("must provide both tls.crt and tls.key together")
+	}
+	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if crt != "" {
+		cert, err := tls.X509KeyPair([]byte(crt), []byte(key))
+		if err != nil {
+			return nil, fmt.Errorf("parse tls.crt/tls.key: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	if ca != "" {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM([]byte(ca)) {
+			return nil, errors.New("ca.crt did not parse as PEM")
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg, nil
+}

--- a/pkg/source/tls_test.go
+++ b/pkg/source/tls_test.go
@@ -1,0 +1,124 @@
+package source
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildTLSConfig_AllEmpty(t *testing.T) {
+	_, err := BuildTLSConfig("", "", "")
+	if err == nil || !strings.Contains(err.Error(), "no TLS material") {
+		t.Errorf("expected no-material error; got %v", err)
+	}
+}
+
+func TestBuildTLSConfig_CertWithoutKey(t *testing.T) {
+	_, err := BuildTLSConfig("-cert-", "", "")
+	if err == nil || !strings.Contains(err.Error(), "must provide both") {
+		t.Errorf("expected paired-creds error; got %v", err)
+	}
+}
+
+func TestBuildTLSConfig_KeyWithoutCert(t *testing.T) {
+	_, err := BuildTLSConfig("", "-key-", "")
+	if err == nil || !strings.Contains(err.Error(), "must provide both") {
+		t.Errorf("expected paired-creds error; got %v", err)
+	}
+}
+
+func TestBuildTLSConfig_CAOnly(t *testing.T) {
+	caPEM := generateSelfSignedCA(t)
+	cfg, err := BuildTLSConfig("", "", caPEM)
+	if err != nil {
+		t.Fatalf("BuildTLSConfig: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Errorf("expected RootCAs populated from ca.crt")
+	}
+	if len(cfg.Certificates) != 0 {
+		t.Errorf("expected no client cert when only ca.crt is supplied")
+	}
+	if cfg.MinVersion != 0x0303 { // TLS 1.2
+		t.Errorf("MinVersion = %v, want TLS 1.2", cfg.MinVersion)
+	}
+}
+
+func TestBuildTLSConfig_FullMaterial(t *testing.T) {
+	certPEM, keyPEM := generateSelfSignedCertKey(t)
+	caPEM := generateSelfSignedCA(t)
+	cfg, err := BuildTLSConfig(certPEM, keyPEM, caPEM)
+	if err != nil {
+		t.Fatalf("BuildTLSConfig: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Errorf("expected 1 client cert, got %d", len(cfg.Certificates))
+	}
+	if cfg.RootCAs == nil {
+		t.Errorf("expected RootCAs populated")
+	}
+}
+
+func TestBuildTLSConfig_InvalidCAPEM(t *testing.T) {
+	_, err := BuildTLSConfig("", "", "-----BEGIN CERTIFICATE-----\nnot-pem\n-----END CERTIFICATE-----")
+	if err == nil || !strings.Contains(err.Error(), "did not parse as PEM") {
+		t.Errorf("expected PEM parse error; got %v", err)
+	}
+}
+
+func TestBuildTLSConfig_InvalidCertKey(t *testing.T) {
+	_, err := BuildTLSConfig("-not-cert-", "-not-key-", "")
+	if err == nil || !strings.Contains(err.Error(), "parse tls.crt/tls.key") {
+		t.Errorf("expected cert/key parse error; got %v", err)
+	}
+}
+
+func generateSelfSignedCA(t *testing.T) string {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "flate-test-ca"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:         true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func generateSelfSignedCertKey(t *testing.T) (string, string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "flate-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	return string(certPEM), string(keyPEM)
+}


### PR DESCRIPTION
## Summary

Two pieces of dup'd code surfaced in the architecture review.

### 1. \`stringFromHelmSecret\` was a verbatim copy of \`source.StringFromSecret\`
The local copy was added with the comment "Local copy to avoid a cross-package dep on pkg/source" — but \`pkg/source\` is the right place for source-shared helpers. Imported the canonical one and deleted the duplicate.

### 2. TLS config plumbing duplicated 3×
\`tls.X509KeyPair\` + \`AppendCertsFromPEM\` + \`tls.Config\` boilerplate was reproduced verbatim in \`pkg/source/{oci,bucket,git}\` — three slightly-different implementations of the same Flux Secret schema (\`tls.crt\` + \`tls.key\` + \`ca.crt\`). Extracted into \`source.BuildTLSConfig(crt, key, ca string)\`. Callers wrap the resulting error with their own resource-id prefix.

### Net diff
~100 LOC of dup'd production code → ~50 LOC of helper + a shared test that covers paired-credential validation, PEM parse, and the empty / partial / full material cases.

### Not in scope
The third cleanup the review flagged — standardizing \`RepoName\` / \`RepoFullName\` / \`ResourceFullName\` on a single method — is a wide rename across types + tests, and the duplication is cosmetic (three names for the same \`<namespace>-<name>\` formula). Left for a follow-up.

## Test plan
- [x] New \`TestBuildTLSConfig_*\` covers all-empty, cert-without-key, key-without-cert, CA-only, full material, invalid PEM, invalid cert/key.
- [x] Existing oci/bucket/git TLS tests pass unchanged (error string wording preserved as "must provide both ...").
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)