### PR TITLE
test: unit tests for kustomization dispatch + WatchReady multi-flip + orphans

### DIFF
--- a/pkg/controllers/kustomization/dispatch_test.go
+++ b/pkg/controllers/kustomization/dispatch_test.go
@@ -1,0 +1,102 @@
+package kustomization
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestShouldDispatchAsObject_KnownKinds documents which kinds the
+// parent Kustomization controller routes through AddObject vs.
+// AddRendered. Pinning this matrix prevents a future contributor
+// from accidentally widening or narrowing the set — a regression
+// here would either re-introduce the two-phase emission race (by
+// excluding a data kind) or trigger spurious reconciles on
+// non-reconcilable kinds.
+func TestShouldDispatchAsObject_KnownKinds(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  manifest.BaseManifest
+		want bool
+	}{
+		{"Kustomization", &manifest.Kustomization{}, true},
+		{"HelmRelease", &manifest.HelmRelease{}, true},
+		{"HelmRepository", &manifest.HelmRepository{}, true},
+		{"OCIRepository", &manifest.OCIRepository{}, true},
+		{"GitRepository", &manifest.GitRepository{}, true},
+		{"Bucket", &manifest.Bucket{}, true},
+		{"HelmChartSource", &manifest.HelmChartSource{}, true},
+		{"ExternalArtifact", &manifest.ExternalArtifact{}, true},
+		{"ConfigMap", &manifest.ConfigMap{}, true},
+		{"Secret", &manifest.Secret{}, true},
+		{"RawObject falls through", &manifest.RawObject{Kind: "Service"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldDispatchAsObject(tc.obj); got != tc.want {
+				t.Errorf("shouldDispatchAsObject(%T) = %v, want %v", tc.obj, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsLeafReconcilable defines the pass-1 vs pass-2 split. Only
+// Kustomization and HelmRelease are "leaf reconcilables" — their
+// controllers fire AS SOON AS AddObject lands and immediately try
+// to expand substituteFrom / resolve chart sources, so they must be
+// emitted in pass 2 (after ConfigMap / Secret / sources from pass 1
+// are already in the store).
+func TestIsLeafReconcilable(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  manifest.BaseManifest
+		want bool
+	}{
+		// Pass 2 — wait for pass-1 data first.
+		{"Kustomization is leaf", &manifest.Kustomization{}, true},
+		{"HelmRelease is leaf", &manifest.HelmRelease{}, true},
+
+		// Pass 1 — supply data that pass-2 leaves consume.
+		{"ConfigMap is data, not leaf", &manifest.ConfigMap{}, false},
+		{"Secret is data, not leaf", &manifest.Secret{}, false},
+		{"HelmRepository is source, not leaf", &manifest.HelmRepository{}, false},
+		{"OCIRepository is source, not leaf", &manifest.OCIRepository{}, false},
+		{"GitRepository is source, not leaf", &manifest.GitRepository{}, false},
+		{"Bucket is source, not leaf", &manifest.Bucket{}, false},
+		{"HelmChartSource is source, not leaf", &manifest.HelmChartSource{}, false},
+		{"ExternalArtifact is source, not leaf", &manifest.ExternalArtifact{}, false},
+		{"RawObject is neither", &manifest.RawObject{}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isLeafReconcilable(tc.obj); got != tc.want {
+				t.Errorf("isLeafReconcilable(%T) = %v, want %v", tc.obj, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPass1Vs Pass2Categories — the two helpers must agree on the
+// pass-1-vs-pass-2 contract. Every leaf reconcilable must also be
+// dispatch-as-object (otherwise it'd be silently swallowed by
+// AddRendered). Non-leaf reconcilables can be either.
+func TestPass1Pass2Categories(t *testing.T) {
+	kinds := []manifest.BaseManifest{
+		&manifest.Kustomization{},
+		&manifest.HelmRelease{},
+		&manifest.HelmRepository{},
+		&manifest.OCIRepository{},
+		&manifest.GitRepository{},
+		&manifest.Bucket{},
+		&manifest.HelmChartSource{},
+		&manifest.ExternalArtifact{},
+		&manifest.ConfigMap{},
+		&manifest.Secret{},
+		&manifest.RawObject{},
+	}
+	for _, k := range kinds {
+		if isLeafReconcilable(k) && !shouldDispatchAsObject(k) {
+			t.Errorf("%T is a leaf reconcilable but not dispatch-as-object", k)
+		}
+	}
+}

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -6,7 +6,101 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
+
+// TestDetectOrphans drives the orphan-detection logic in isolation —
+// no controllers, just the store / sourceFiles wiring the orchestrator
+// builds during Bootstrap. Three scenarios:
+//
+//   1. Truly orphaned child (file under parent path, never emitted by
+//      parent's render): downgraded.
+//   2. Root-level resource (no covering parent): NOT downgraded.
+//   3. Child re-emitted by parent (WasRendered set): NOT downgraded.
+func TestDetectOrphans(t *testing.T) {
+	parent := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		Path: "./kubernetes/apps",
+	}
+	orphan := &manifest.Kustomization{
+		Name: "orphan", Namespace: "flux-system",
+		Path: "./kubernetes/apps/orphan/app",
+	}
+	emittedChild := &manifest.Kustomization{
+		Name: "wired", Namespace: "flux-system",
+		Path: "./kubernetes/apps/wired/app",
+	}
+	root := &manifest.Kustomization{
+		Name: "another-root", Namespace: "flux-system",
+		Path: "./standalone",
+	}
+
+	o := &Orchestrator{
+		store: store.New(),
+		sourceFiles: map[manifest.NamedResource]string{
+			parent.Named():       "kubernetes/flux/cluster/ks.yaml",
+			orphan.Named():       "kubernetes/apps/orphan/ks.yaml",
+			emittedChild.Named(): "kubernetes/apps/wired/ks.yaml",
+			root.Named():         "kubernetes/standalone/ks.yaml",
+		},
+	}
+	for _, ks := range []*manifest.Kustomization{parent, orphan, emittedChild, root} {
+		o.store.AddObject(ks)
+	}
+	// Mark emittedChild as rendered by its parent — simulates the
+	// AddObject + MarkRendered call cluster-apps's render would make.
+	o.store.MarkRendered(emittedChild.Named())
+
+	failed := map[manifest.NamedResource]store.StatusInfo{
+		orphan.Named():       {Status: store.StatusFailed, Message: "TIMEZONE undefined"},
+		emittedChild.Named(): {Status: store.StatusFailed, Message: "TIMEZONE undefined"},
+		root.Named():         {Status: store.StatusFailed, Message: "broken"},
+	}
+
+	orphans := o.detectOrphans(failed)
+
+	if _, ok := orphans[orphan.Named()]; !ok {
+		t.Errorf("expected orphan to be detected")
+	}
+	if _, ok := orphans[emittedChild.Named()]; ok {
+		t.Errorf("re-emitted child is not an orphan: parent's render covered it")
+	}
+	if _, ok := orphans[root.Named()]; ok {
+		t.Errorf("root resource with no covering parent is not an orphan")
+	}
+	if got := len(orphans); got != 1 {
+		t.Errorf("expected exactly 1 orphan, got %d: %+v", got, orphans)
+	}
+}
+
+// TestDetectOrphans_NonReconcilableKindsIgnored — ConfigMaps and
+// Secrets that fail (they can't fail in practice but the failure
+// map is permissive) are never reported as orphans; orphan
+// detection only applies to Kustomization + HelmRelease.
+func TestDetectOrphans_NonReconcilableKindsIgnored(t *testing.T) {
+	parent := &manifest.Kustomization{
+		Name: "p", Namespace: "ns", Path: "./apps",
+	}
+	cm := &manifest.ConfigMap{Name: "stuck", Namespace: "ns"}
+
+	o := &Orchestrator{
+		store: store.New(),
+		sourceFiles: map[manifest.NamedResource]string{
+			parent.Named(): "ks.yaml",
+			cm.Named():     "apps/stuck/cm.yaml",
+		},
+	}
+	o.store.AddObject(parent)
+	o.store.AddObject(cm)
+
+	failed := map[manifest.NamedResource]store.StatusInfo{
+		cm.Named(): {Status: store.StatusFailed, Message: "bogus"},
+	}
+	orphans := o.detectOrphans(failed)
+	if len(orphans) != 0 {
+		t.Errorf("orphan detection should skip non-reconcilable kinds; got %+v", orphans)
+	}
+}
 
 func TestOrchestrator_SimpleCluster(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -243,6 +243,63 @@ func TestStore_WatchReady_FailedFlipsBeforeGrace(t *testing.T) {
 	}
 }
 
+// TestStore_WatchReady_FailedFailedReady verifies multi-Failed-then-Ready:
+// the grace timer arms on the first Failed and persists through subsequent
+// Failed updates (does NOT reset). If Ready arrives before the original
+// timer expires, dependents see Ready and proceed. Guards an invariant
+// the grace-period comment in pkg/store/watch.go calls out.
+func TestStore_WatchReady_FailedFailedReady(t *testing.T) {
+	withFailedGrace(t, 300*time.Millisecond)
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Namespace: "ns", Name: "k"}
+	s.UpdateStatus(id, StatusFailed, "first failure")
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		s.UpdateStatus(id, StatusFailed, "second failure")
+		time.Sleep(50 * time.Millisecond)
+		s.UpdateStatus(id, StatusReady, "")
+	}()
+
+	info, err := s.WatchReady(context.Background(), id)
+	if err != nil {
+		t.Fatalf("expected nil err after Failed→Failed→Ready flip, got %v", err)
+	}
+	if info.Status != StatusReady {
+		t.Errorf("status = %v, want Ready", info.Status)
+	}
+}
+
+// TestStore_WatchReady_GraceExpiresOnSustainedFailed verifies the
+// opposite: when Ready never arrives, the original grace window
+// expires and WatchReady returns the most-recently-observed Failed.
+func TestStore_WatchReady_GraceExpiresOnSustainedFailed(t *testing.T) {
+	withFailedGrace(t, 50*time.Millisecond)
+	s := New()
+	id := manifest.NamedResource{Kind: "Kustomization", Namespace: "ns", Name: "k"}
+	s.UpdateStatus(id, StatusFailed, "first")
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		s.UpdateStatus(id, StatusFailed, "second")
+	}()
+
+	info, err := s.WatchReady(context.Background(), id)
+	if err == nil {
+		t.Fatalf("expected ResourceFailedError after grace expiration")
+	}
+	var rfe *manifest.ResourceFailedError
+	if !errors.As(err, &rfe) {
+		t.Fatalf("expected *ResourceFailedError, got %T", err)
+	}
+	if info.Status != StatusFailed {
+		t.Errorf("status = %v, want Failed", info.Status)
+	}
+	// The latest reason should be reported, not the first.
+	if rfe.Reason != "second" {
+		t.Errorf("reason = %q, want %q (latest observed failure)", rfe.Reason, "second")
+	}
+}
+
 // withFailedGrace temporarily shrinks FailedGrace for a single test
 // and restores it on cleanup. Keeps unit-test wall time bounded
 // without leaking the shorter value into other tests.


### PR DESCRIPTION
## Summary

Closes three gaps the test-coverage review flagged — places where shipped bugs landed without a unit-test guard. Added as white-box tests so regressions catch locally rather than surfacing only in integration runs.

### Coverage added

- **\`shouldDispatchAsObject\` / \`isLeafReconcilable\`** — pins the matrix of pass-1 (data) vs. pass-2 (reconcilable leaves) kinds. A future contributor accidentally widening or narrowing the set would re-introduce the two-phase emission race.
- **\`WatchReady\` Failed→Failed→Ready** — the grace timer arms on the FIRST Failed and persists through subsequent Failed updates; if Ready arrives before the original timer expires, dependents see Ready. Also covers the inverse: sustained Failed → grace expires → caller sees the LATEST reason, not the first.
- **\`detectOrphans\`** — pure-function tests on the orphan-downgrade logic: orphaned child downgrades, re-emitted child does not, root with no covering parent does not, non-reconcilable kinds are skipped.

## Test plan
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)