### PR TITLE
docs: refresh README + TESTDATA for SOPS placeholder, cosign, fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,9 @@ Every fetch path resolves credentials from a Flux-style `spec.secretRef` pointin
 
 ## SOPS, suspend, dependsOn
 
-**SOPS-encrypted resources fail-loud.** flate doesn't implement `spec.decryption`. When rendered output contains a Secret (or other resource) with a SOPS `sops:` block, the parent Kustomization/HelmRelease is marked `Failed` with a clear pointer at the offending document. Pre-decrypt your manifests, or remove the encrypted resource.
+**SOPS-encrypted resources are wiped to PLACEHOLDER.** flate doesn't implement `spec.decryption`. Instead of failing the whole reconcile, encrypted Secret values get replaced with the literal `..PLACEHOLDER_<key>..` token (the same wipe `--wipe-secrets` performs on cleartext values). Downstream `postBuild.substituteFrom` lookups against a SOPS Secret resolve to the placeholder string rather than failing — so `${SECRET_DOMAIN}` becomes `..PLACEHOLDER_SECRET_DOMAIN..` in rendered output. Pre-decrypt your manifests if you need real values in the diff.
+
+**Per-resource substitution opt-out:** flate honors the `kustomize.toolkit.fluxcd.io/substitute: disabled` label or annotation. Resources carrying it are skipped during the postBuild substitute pass — used in real repos for ConfigMaps that embed shell scripts with bash array expansions (`${ARR[@]}`) that envsubst's parser can't handle.
 
 **`spec.suspend: true` is honored** on every reconcilable CR (Kustomization, HelmRelease, GitRepository, OCIRepository). Suspended resources mark themselves `Ready` with a `"suspended"` message and produce no rendered output — matching cluster behavior.
 
@@ -364,12 +366,19 @@ Tool versions are pinned via [mise](https://mise.jdx.dev) (`mise install`).
 
 Testdata lives in [`testdata/`](testdata/); the [`test/e2e`](test/e2e/) suite runs the cobra command tree in-process via `cli.Run` — no fork/exec, no freshly built binary required.
 
+## Signature verification
+
+| Source kind | Mechanism | Notes |
+| --- | --- | --- |
+| `OCIRepository` | cosign keyed mode | `spec.verify.secretRef` carries one or more PEM-encoded public keys; flate verifies the cosign signature artifact (`sha256-<hex>.sig` tag) using stdlib crypto — no sigstore dep tree. Keyless (Fulcio/Rekor) and `notation` provider fail loud. |
+| `GitRepository` | PGP | `spec.verify` (`mode: HEAD` / `Tag` / `TagAndHEAD`) verifies the resolved commit and/or annotated tag against the keyring in `spec.verify.secretRef`. |
+
 ## Deferred
 
 - `diff --branch-orig <branch>` (auto-worktree)
 - `shell` interactive REPL
 - ResourceSet (Flux Operator)
-- Cosign / notation signature verification (`spec.verify` on GitRepository / OCIRepository / HelmChart)
+- Cosign keyless / Notation (`spec.verify.provider: notation`) on OCIRepository — fail loud rather than silently pass
 - Bucket `aws` / `gcp` / `azure` providers (workload-identity / IRSA — out of scope offline; use `provider: generic` with static creds)
 - HelmRepository OCI-flavored `spec.secretRef` (use a sibling `OCIRepository` instead)
 

--- a/testdata/TESTDATA.md
+++ b/testdata/TESTDATA.md
@@ -5,13 +5,35 @@ integration suite.
 
 ## Layout
 
-- `simple/` — a hand-crafted minimal cluster used by E2E tests. It exercises
+- `simple/` — a hand-crafted minimal cluster used by E2E tests. Exercises
   the Kustomization + HelmRelease pipeline end-to-end without any network
   access.
   - `cluster/` — Flux GitRepository, Kustomization, and HelmRelease objects.
   - `apps/` — kustomize-rendered ConfigMap + Namespace.
   - `charts/mychart/` — a tiny local Helm chart referenced via
     `sourceRef.kind: GitRepository`.
+
+- `components/` — two consumer apps (`app-a`, `app-b`) referencing a shared
+  kustomize component (`components/shared`). Exists to test change-detection
+  propagation: editing the shared component must surface in both consumers'
+  diff output (`TestE2E_ComponentChangePropagatesToAllConsumers`) and an
+  app-local edit must NOT propagate to the sibling
+  (`TestE2E_NonSharedChangeDoesNotPropagate`).
+
+- `parent-patches/` — the stripped-down bjw-s home-ops cluster pattern.
+  A top-level `cluster-apps` Flux Kustomization injects
+  `postBuild.substituteFrom` via `spec.patches` into every child KS rendered
+  from `./apps`. The fixture also ships a SOPS-encrypted Secret alongside the
+  patched leaf to exercise the wipe-to-PLACEHOLDER behavior end-to-end. Used
+  by `TestE2E_ParentPatchesPropagateToChildren`,
+  `TestE2E_SOPSValueWipedToPlaceholder`, and
+  `TestE2E_SubstituteDisabledAnnotation`.
+
+- `orphans/` — a parent kustomize tree that lists only one child
+  Kustomization (`wired`) while a second one (`orphan`) exists on disk but
+  is intentionally NOT referenced. Real Flux would never reconcile the
+  orphan; flate downgrades its failure to a warning and reports
+  `resource orphaned`. Used by `TestE2E_OrphanedKustomizationIsWarning`.
 
 ## Upstream attribution
 


### PR DESCRIPTION
## Summary

Three doc drifts the test-coverage review flagged.

### README

- **SOPS section was stale.** Used to claim encrypted resources fail-loud. PR #53 changed that — values wipe to \`..PLACEHOLDER_<key>..\` and substituteFrom resolves to the placeholder string.
- **No mention of \`kustomize.toolkit.fluxcd.io/substitute: disabled\`** annotation (shipped in #52). Added.
- **Cosign was listed under "Deferred"**, but #50 shipped keyed cosign on OCIRepository and #60 shipped PGP on GitRepository. Moved both into a new "Signature verification" section with a per-kind matrix. Only keyless cosign + notation stay deferred.

### TESTDATA.md

Previously documented only the \`simple/\` fixture. Added entries for \`components/\`, \`parent-patches/\`, and \`orphans/\`, each tagged with the e2e test that exercises it.

## Test plan
- N/A — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)