### PR TITLE
fix(task): reset Coalescer slot when fn panics

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -195,6 +195,19 @@ func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(c
 	c.mu.Unlock()
 
 	c.svc.Go(ctx, name, func(ctx context.Context) {
+		// On panic, Service.Go's recover catches it; we still need to
+		// clear running so a future Submit on this key is dispatched
+		// instead of silently coalescing into a slot that no longer
+		// has a runner.
+		defer func() {
+			if r := recover(); r != nil {
+				c.mu.Lock()
+				s.running = false
+				s.pending = false
+				c.mu.Unlock()
+				panic(r)
+			}
+		}()
 		for {
 			fn(ctx)
 			c.mu.Lock()

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -104,6 +104,39 @@ func TestService_PanicCountedAndRecovered(t *testing.T) {
 	}
 }
 
+// TestCoalescer_RecoversSlotAfterPanic guards a stuck-slot bug: if
+// fn(ctx) panicked, the Service-level recover absorbed the panic but
+// the per-key slot stayed running=true forever, so every subsequent
+// Submit on that key would mark pending and exit without ever
+// re-running. The recover in Coalescer.Submit now resets the slot
+// before re-raising for the Service-level logger to catch.
+func TestCoalescer_RecoversSlotAfterPanic(t *testing.T) {
+	s := New()
+	c := NewCoalescer[string](s)
+
+	var calls atomic.Int64
+	c.Submit(context.Background(), "boom", "k", func(_ context.Context) {
+		calls.Add(1)
+		panic("boom")
+	})
+	s.BlockTillDone()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("panicking call: expected 1 run, got %d", got)
+	}
+	if got := s.Failures(); got != 1 {
+		t.Errorf("Service.Failures: expected 1, got %d", got)
+	}
+
+	// Slot must be unlocked: a fresh Submit on the same key runs.
+	c.Submit(context.Background(), "recovery", "k", func(_ context.Context) {
+		calls.Add(1)
+	})
+	s.BlockTillDone()
+	if got := calls.Load(); got != 2 {
+		t.Errorf("post-panic Submit blocked: expected 2 runs total, got %d", got)
+	}
+}
+
 func TestCoalescer_SerializesPerKey(t *testing.T) {
 	s := New()
 	c := NewCoalescer[string](s)


### PR DESCRIPTION
## Summary

The Coalescer's per-key goroutine owned the slot's \`running\`/\`pending\` flags but had no panic recovery of its own. If \`fn(ctx)\` panicked mid-execution:

1. The panic propagated up through the goroutine body.
2. The Service-level \`recover\` absorbed it (so the program didn't crash) and bumped \`Service.Failures\`.
3. **The inner reset never ran**. \`s.running\` stayed \`true\` forever.
4. Every subsequent \`Submit\` on that key marked \`pending\` and exited without dispatching anything.

In practice: one reconcile panics → downstream controllers wait on the panicked resource → the panicked resource never recovers → orchestrator deadlocks until \`ctx\` cancellation.

## Fix

Register a defer at the top of the coalescer goroutine that, on panic:
- Takes \`c.mu\`,
- Resets \`running=false\` / \`pending=false\`,
- **Re-raises** so \`Service.Go\`'s existing recover + failure counter still see it.

## Test plan
- [x] New \`TestCoalescer_RecoversSlotAfterPanic\` verifies (a) the panic is counted in \`Service.Failures\` and (b) a subsequent \`Submit\` on the same key dispatches normally instead of being silently swallowed.
- [x] \`go test ./...\` + \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)