### PR TITLE
refactor(manifest): alias local ref types to fluxcd upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/fluxcd/kustomize-controller/api v1.8.5
+	github.com/fluxcd/pkg/apis/meta v1.25.1
 	github.com/fluxcd/pkg/envsubst v1.7.0
 	github.com/fluxcd/pkg/kustomize v1.32.0
 	github.com/fluxcd/source-controller/api v1.8.5
@@ -57,7 +58,6 @@ require (
 	github.com/fluxcd/cli-utils v1.2.0 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.18.0 // indirect
-	github.com/fluxcd/pkg/apis/meta v1.25.1 // indirect
 	github.com/fluxcd/pkg/sourceignore v0.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect

--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -77,13 +77,13 @@ func ParseBucket(doc map[string]any) (*Bucket, error) {
 		Suspend:    cr.Spec.Suspend,
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+		out.SecretRef = cr.Spec.SecretRef
 	}
 	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
-		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
+		out.CertSecretRef = cr.Spec.CertSecretRef
 	}
 	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
-		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
+		out.ProxySecretRef = cr.Spec.ProxySecretRef
 	}
 	return out, nil
 }

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -165,29 +166,6 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 	}, nil
 }
 
-// ValuesReference points at a ConfigMap or Secret supplying values to a
-// HelmRelease via .spec.valuesFrom.
-type ValuesReference struct {
-	Kind       string `json:"kind" yaml:"kind"`
-	Name       string `json:"name" yaml:"name"`
-	ValuesKey  string `json:"valuesKey,omitempty" yaml:"valuesKey,omitempty"`
-	TargetPath string `json:"targetPath,omitempty" yaml:"targetPath,omitempty"`
-	Optional   bool   `json:"optional,omitempty" yaml:"optional,omitempty"`
-}
-
-// EffectiveValuesKey returns ValuesKey or the default "values.yaml".
-func (v ValuesReference) EffectiveValuesKey() string {
-	if v.ValuesKey == "" {
-		return "values.yaml"
-	}
-	return v.ValuesKey
-}
-
-// LocalObjectReference matches Kubernetes' core/v1 LocalObjectReference.
-type LocalObjectReference struct {
-	Name string `json:"name" yaml:"name"`
-}
-
 // HelmRelease is the Flux HelmRelease CRD.
 type HelmRelease struct {
 	Name                     string            `json:"name" yaml:"name"`
@@ -312,16 +290,7 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 	if err != nil {
 		return nil, err
 	}
-	vfs := make([]ValuesReference, 0, len(cr.Spec.ValuesFrom))
-	for _, ref := range cr.Spec.ValuesFrom {
-		vfs = append(vfs, ValuesReference{
-			Kind:       ref.Kind,
-			Name:       ref.Name,
-			ValuesKey:  ref.ValuesKey,
-			TargetPath: ref.TargetPath,
-			Optional:   ref.Optional,
-		})
-	}
+	vfs := slices.Clone(cr.Spec.ValuesFrom)
 	var values map[string]any
 	if cr.Spec.Values != nil && len(cr.Spec.Values.Raw) > 0 {
 		if err := json.Unmarshal(cr.Spec.Values.Raw, &values); err != nil {
@@ -449,10 +418,10 @@ func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 		Suspend:         cr.Spec.Suspend,
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+		out.SecretRef = cr.Spec.SecretRef
 	}
 	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
-		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
+		out.CertSecretRef = cr.Spec.CertSecretRef
 	}
 	return out, nil
 }

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -8,14 +8,6 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 )
 
-// SubstituteReference contains a reference to a resource supplying the
-// variable name/value pairs used by postBuild.substitute.
-type SubstituteReference struct {
-	Kind     string `json:"kind" yaml:"kind"`
-	Name     string `json:"name" yaml:"name"`
-	Optional bool   `json:"optional,omitempty" yaml:"optional,omitempty"`
-}
-
 // Kustomization is the Flux Kustomization CR. It bundles the path of a
 // local kustomize tree together with the in-cluster materials it produces
 // (HelmReleases, HelmRepositories, ConfigMaps, Secrets, ...).
@@ -148,11 +140,7 @@ func ParseKustomization(doc map[string]any) (*Kustomization, error) {
 	var substituteFrom []SubstituteReference
 	var subst map[string]any
 	if pb := cr.Spec.PostBuild; pb != nil {
-		for _, ref := range pb.SubstituteFrom {
-			substituteFrom = append(substituteFrom, SubstituteReference{
-				Kind: ref.Kind, Name: ref.Name, Optional: ref.Optional,
-			})
-		}
+		substituteFrom = slices.Clone(pb.SubstituteFrom)
 		if len(pb.Substitute) > 0 {
 			subst = make(map[string]any, len(pb.Substitute))
 			for k, v := range pb.Substitute {

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -128,10 +128,10 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		Suspend:           cr.Spec.Suspend,
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+		out.SecretRef = cr.Spec.SecretRef
 	}
 	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
-		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
+		out.ProxySecretRef = cr.Spec.ProxySecretRef
 	}
 	if v := cr.Spec.Verification; v != nil {
 		mode := string(v.GetMode())
@@ -140,7 +140,8 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		}
 		out.Verify = &GitRepositoryVerify{Mode: mode}
 		if v.SecretRef.Name != "" {
-			out.Verify.SecretRef = &LocalObjectReference{Name: v.SecretRef.Name}
+			ref := v.SecretRef
+			out.Verify.SecretRef = &ref
 		}
 	}
 	return out, nil
@@ -288,7 +289,7 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		Suspend:   cr.Spec.Suspend,
 	}
 	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
-		out.CertSecretRef = &LocalObjectReference{Name: cr.Spec.CertSecretRef.Name}
+		out.CertSecretRef = cr.Spec.CertSecretRef
 	}
 	if r := cr.Spec.Reference; r != nil {
 		out.Ref = OCIRepositoryRef{
@@ -299,15 +300,15 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		}
 	}
 	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = &LocalObjectReference{Name: cr.Spec.SecretRef.Name}
+		out.SecretRef = cr.Spec.SecretRef
 	}
 	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
-		out.ProxySecretRef = &LocalObjectReference{Name: cr.Spec.ProxySecretRef.Name}
+		out.ProxySecretRef = cr.Spec.ProxySecretRef
 	}
 	if v := cr.Spec.Verify; v != nil {
 		out.Verify = &OCIRepositoryVerify{Provider: v.Provider}
 		if v.SecretRef != nil && v.SecretRef.Name != "" {
-			out.Verify.SecretRef = &LocalObjectReference{Name: v.SecretRef.Name}
+			out.Verify.SecretRef = v.SecretRef
 		}
 		for _, m := range v.MatchOIDCIdentity {
 			out.Verify.MatchOIDCIdentity = append(out.Verify.MatchOIDCIdentity,

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -3,7 +3,25 @@ package manifest
 import (
 	"cmp"
 	"strings"
+
+	meta "github.com/fluxcd/pkg/apis/meta"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 )
+
+// LocalObjectReference is a name-only reference to a same-namespace
+// resource (Secret, ConfigMap, ...). Aliased to fluxcd/pkg/apis/meta
+// so flate's structs unmarshal Flux CRs without a field-by-field copy.
+type LocalObjectReference = meta.LocalObjectReference
+
+// ValuesReference is a reference to a values-bearing ConfigMap or
+// Secret on a HelmRelease.spec.valuesFrom. Aliased to upstream meta
+// for the same reason — and to inherit GetValuesKey().
+type ValuesReference = meta.ValuesReference
+
+// SubstituteReference is a postBuild.substituteFrom entry. Aliased to
+// kustomize-controller's own type — flate's parser previously copied
+// the same three fields (Kind, Name, Optional) into a local twin.
+type SubstituteReference = kustomizev1.SubstituteReference
 
 // NamedResource uniquely identifies a Kubernetes resource by kind +
 // namespace + name. Values are comparable and safe to use as map keys.

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -155,7 +155,7 @@ func lookupValueRef(ref manifest.ValuesReference, namespace string, p Provider) 
 		return "", nil
 	}
 
-	key := ref.EffectiveValuesKey()
+	key := ref.GetValuesKey()
 	val, ok := data[key]
 	if !ok {
 		return "", fmt.Errorf("%w: key %q not found in %s/%s",


### PR DESCRIPTION
## Summary
- Replace local \`LocalObjectReference\`, \`ValuesReference\`, and \`SubstituteReference\` with type aliases pointing at \`fluxcd/pkg/apis/meta\` and \`kustomize-controller/api/v1\`. The flate twins were field-for-field copies of the upstream types.
- Drop the per-field copy loops in \`bucket.go\`/\`helm.go\`/\`kustomization.go\`/\`source.go\`: with the aliases in place, \`out.SecretRef = cr.Spec.SecretRef\` and \`slices.Clone(cr.Spec.ValuesFrom)\` work directly because the source and destination are the same type.
- Drop \`EffectiveValuesKey()\` — the meta alias already has \`GetValuesKey()\` with identical semantics; rename the one caller in \`pkg/values/values.go\`.

## Why
Part of the DRY / upstream-types audit. Less code surface to maintain, and parsed values can now flow back into upstream Flux APIs without an intermediate conversion if we ever need that.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean (all packages)
- [x] \`golangci-lint run ./...\` clean
- [x] Spot-check: parsers and consumers of the renamed types compile and behave the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)