### PR TITLE
feat(kustomize): honor Kustomization spec.commonMetadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/apimachinery v0.36.1
 	oras.land/oras-go/v2 v2.6.0
+	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -160,7 +161,6 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/controller-runtime v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -112,9 +112,6 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering")
-	// Flux's Generator merges spec.patches / spec.images / spec.components /
-	// spec.targetNamespace / spec.commonMetadata into the kustomization.yaml
-	// before krusty runs — none of which the bare kustomize SDK applies.
 	data, err := kustomize.RenderFlux(ctx, c.Staging, sourceRoot, ks.Path, ks.Contents)
 	if err != nil {
 		return err

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
 
 	fluxkustomize "github.com/fluxcd/pkg/kustomize"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/api/resmap"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -38,9 +40,12 @@ func lockPath(path string) *sync.Mutex {
 // using the same library that Flux's kustomize-controller uses
 // (`github.com/fluxcd/pkg/kustomize`).
 //
-// Every spec feature is honored: patches, images, components,
-// targetNamespace, commonMetadata, plus the auto-generation of a
-// kustomization.yaml when one is absent at spec.path.
+// The Generator merges spec.patches / spec.images / spec.components /
+// spec.targetNamespace / spec.namePrefix / spec.nameSuffix into the
+// kustomization.yaml before krusty runs. spec.commonMetadata is
+// applied post-build (see applyCommonMetadata) because the Generator
+// does not handle it — kustomize-controller does it after build via
+// ssautil.SetCommonMetadata.
 //
 // ctx is honored at coarse boundaries — between path validation,
 // after acquiring the per-path lock, and before/after SecureBuild —
@@ -121,11 +126,65 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, subPath st
 	if err != nil {
 		return nil, fmt.Errorf("kustomize build %s: %w", subPath, err)
 	}
+	if err := applyCommonMetadata(rm, rawSpec); err != nil {
+		return nil, fmt.Errorf("apply commonMetadata %s: %w", subPath, err)
+	}
 	out, err := rm.AsYaml()
 	if err != nil {
 		return nil, fmt.Errorf("kustomize render %s: %w", subPath, err)
 	}
 	return out, nil
+}
+
+// applyCommonMetadata merges spec.commonMetadata.labels and
+// spec.commonMetadata.annotations into every rendered resource —
+// mirroring kustomize-controller's ssautil.SetCommonMetadata pass,
+// which fluxcd/pkg/kustomize.Generator does NOT perform.
+func applyCommonMetadata(rm resmap.ResMap, rawSpec map[string]any) error {
+	spec, _ := rawSpec["spec"].(map[string]any)
+	cm, _ := spec["commonMetadata"].(map[string]any)
+	labels := stringMap(cm["labels"])
+	annotations := stringMap(cm["annotations"])
+	if len(labels) == 0 && len(annotations) == 0 {
+		return nil
+	}
+	for _, r := range rm.Resources() {
+		if len(labels) > 0 {
+			merged := maps.Clone(r.GetLabels())
+			if merged == nil {
+				merged = map[string]string{}
+			}
+			maps.Copy(merged, labels)
+			if err := r.SetLabels(merged); err != nil {
+				return err
+			}
+		}
+		if len(annotations) > 0 {
+			merged := maps.Clone(r.GetAnnotations())
+			if merged == nil {
+				merged = map[string]string{}
+			}
+			maps.Copy(merged, annotations)
+			if err := r.SetAnnotations(merged); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func stringMap(v any) map[string]string {
+	m, ok := v.(map[string]any)
+	if !ok || len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m))
+	for k, val := range m {
+		if s, ok := val.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
 }
 
 // restoreKustomizationFile copies the source kustomization.yaml (if

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -3,8 +3,12 @@ package kustomize
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"sigs.k8s.io/yaml"
 )
 
 // TestRenderFlux_RespectsCanceledContext asserts the renderer bails
@@ -120,5 +124,66 @@ func TestSubstitute_BashSubstringRemoval(t *testing.T) {
 	}
 	if string(out) != "host=example.com" {
 		t.Errorf("Substitute = %q, want %q", out, "host=example.com")
+	}
+}
+
+// TestRenderFlux_HonorsCommonMetadata asserts that
+// spec.commonMetadata.labels and spec.commonMetadata.annotations are
+// merged into every rendered resource — kustomize-controller does this
+// via ssautil.SetCommonMetadata after build, fluxcd/pkg/kustomize.Generator
+// itself does not.
+func TestRenderFlux_HonorsCommonMetadata(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "cm.yaml"), []byte(
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\n  labels:\n    app: x\n  annotations:\n    note: y\ndata:\n  k: v\n",
+	), 0o600); err != nil {
+		t.Fatalf("write cm: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "kustomization.yaml"), []byte(
+		"resources:\n- cm.yaml\n",
+	), 0o600); err != nil {
+		t.Fatalf("write kustomization: %v", err)
+	}
+
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	out, err := RenderFlux(context.Background(), cache, src, ".", map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "k", "namespace": "ns"},
+		"spec": map[string]any{
+			"path": "./",
+			"commonMetadata": map[string]any{
+				"labels":      map[string]any{"team": "flate", "app": "override"},
+				"annotations": map[string]any{"managed-by": "flate"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+
+	var got map[string]any
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out)
+	}
+	md, _ := got["metadata"].(map[string]any)
+	labels, _ := md["labels"].(map[string]any)
+	annotations, _ := md["annotations"].(map[string]any)
+	if labels["team"] != "flate" {
+		t.Errorf("commonMetadata.labels not merged: %v", labels)
+	}
+	if labels["app"] != "override" {
+		t.Errorf("commonMetadata.labels did not override existing: %v", labels)
+	}
+	if annotations["managed-by"] != "flate" {
+		t.Errorf("commonMetadata.annotations not merged: %v", annotations)
+	}
+	if annotations["note"] != "y" {
+		t.Errorf("existing annotations dropped: %v", annotations)
 	}
 }


### PR DESCRIPTION
## Summary
\`fluxcd/pkg/kustomize.Generator\` honors patches, images, components, targetNamespace, namePrefix, and nameSuffix — but NOT commonMetadata. Real kustomize-controller applies it as a post-build pass via \`ssautil.SetCommonMetadata\`. flate previously skipped that pass entirely (despite a doc-comment claiming the opposite), so any \`spec.commonMetadata.labels\` / \`spec.commonMetadata.annotations\` silently disappeared from rendered output.

This change:
- After \`SecureBuild\`, walks \`resmap.ResMap\` and merges \`commonMetadata.{labels,annotations}\` into every rendered resource. commonMetadata wins on conflict (matches controller semantics).
- Removes the stale doc-comment.
- Adds \`TestRenderFlux_HonorsCommonMetadata\`: renders a ConfigMap with its own labels/annotations, verifies commonMetadata both merges and overrides.

## Why
Diff fidelity. Real repos use commonMetadata for ownership tagging (\`app.kubernetes.io/part-of\`, etc.) — without honoring it, flate's render diverges from what gets applied to the cluster.

## Scope note
The original audit also mentioned \`spec.ignore\`. \`Kustomization.spec.ignore\` does not exist in \`kustomize-controller/api/v1\` — only \`spec.ignoreMissingComponents\` (which \`fluxcd/pkg/kustomize.Generator\` already handles). No code change needed there.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] New test verifies merge + override semantics

Re-opened after auto-close from squash-merge of #68 (was stacked on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)