### PR TITLE
fix(task): YieldSlot to break parent/child KS pool deadlock

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -126,10 +126,15 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 
 	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
 	// each dependency reaching Ready before this HR reconciles.
+	// YieldSlot releases the worker-pool slot during the wait so the
+	// dependencies can themselves acquire one.
 	if deps := c.collectHRDeps(hr); len(deps) > 0 {
 		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
-		w := &depwait.Waiter{Store: c.Store, Parent: id}
-		sum := depwait.WaitAll(w.Watch(ctx, deps))
+		var sum depwait.Summary
+		c.Tasks.YieldSlot(func() {
+			w := &depwait.Waiter{Store: c.Store, Parent: id}
+			sum = depwait.WaitAll(w.Watch(ctx, deps))
+		})
 		if sum.AnyFailed() {
 			return &manifest.DependencyFailedError{
 				Parent:  id,
@@ -153,8 +158,11 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	srcID := manifest.NamedResource{
 		Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
 	}
-	w := &depwait.Waiter{Store: c.Store, Parent: id}
-	sum := depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
+	var sum depwait.Summary
+	c.Tasks.YieldSlot(func() {
+		w := &depwait.Waiter{Store: c.Store, Parent: id}
+		sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
+	})
 	if sum.AnyFailed() {
 		return fmt.Errorf("%w: chart source %s not ready: %s",
 			manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -88,8 +88,15 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 
 	deps := c.collectDeps(ks)
 	if len(deps) > 0 {
-		w := &depwait.Waiter{Store: c.Store, Parent: id}
-		sum := depwait.WaitAll(w.Watch(ctx, deps))
+		// Release our worker slot for the duration of the dep wait so
+		// children we depend on can acquire one and make progress.
+		// Without this, N parents on a bounded Service consume all
+		// slots while waiting for children that need a slot to run.
+		var sum depwait.Summary
+		c.Tasks.YieldSlot(func() {
+			w := &depwait.Waiter{Store: c.Store, Parent: id}
+			sum = depwait.WaitAll(w.Watch(ctx, deps))
+		})
 		if sum.AnyFailed() {
 			return &manifest.DependencyFailedError{
 				Parent:  id,

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -101,6 +101,26 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 	}()
 }
 
+// YieldSlot releases the worker-pool slot held by the current goroutine,
+// runs fn, then re-acquires a slot before returning. Use this around
+// blocking waits (e.g. depwait) so queued tasks can make progress while
+// the holder is parked on external state. Without this, N tasks waiting
+// on each other for slot-gated work deadlock under NewBounded(N).
+//
+// MUST be called only from inside a body launched by Service.Go —
+// calling from outside corrupts the semaphore accounting.
+//
+// On an unbounded Service (New or NewBounded(<=0)), fn runs unchanged.
+func (s *Service) YieldSlot(fn func()) {
+	if s.sem == nil {
+		fn()
+		return
+	}
+	<-s.sem
+	fn()
+	s.sem <- struct{}{}
+}
+
 // GoBackground launches a long-lived task whose completion is not
 // counted toward BlockTillDone.
 func (s *Service) GoBackground(ctx context.Context, name string, fn func(context.Context)) {

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -207,6 +207,69 @@ func TestCoalescer_DistinctKeysRunConcurrently(t *testing.T) {
 	s.BlockTillDone()
 }
 
+// TestYieldSlot_AllowsChildrenWhenParentsFillPool simulates the
+// parent/child Kustomization deadlock: two parents each take a slot in
+// a 2-worker pool, then block waiting on a child. Without YieldSlot
+// the children can never acquire a slot and the whole run hangs.
+func TestYieldSlot_AllowsChildrenWhenParentsFillPool(t *testing.T) {
+	s := NewBounded(2)
+	childrenStarted := make(chan struct{}, 2)
+	childrenDone := make(chan struct{})
+
+	// Two children that will run once they get a slot.
+	for range 2 {
+		s.Go(context.Background(), "child", func(_ context.Context) {
+			childrenStarted <- struct{}{}
+			<-childrenDone
+		})
+	}
+
+	// Two parents that occupy the slots and wait for the children.
+	parentsDone := make(chan struct{})
+	for range 2 {
+		s.Go(context.Background(), "parent", func(_ context.Context) {
+			s.YieldSlot(func() {
+				// Wait until both children have started — which can only
+				// happen if YieldSlot actually released our slot.
+				<-childrenStarted
+			})
+		})
+	}
+
+	go func() {
+		s.BlockTillDone()
+		close(parentsDone)
+	}()
+
+	// Both children must have started under YieldSlot.
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatal("children never started — YieldSlot did not release slots")
+	case <-parentsDone:
+		t.Fatal("parents finished before children started — unexpected ordering")
+	default:
+	}
+
+	// Release children; parents should reclaim slots and finish.
+	close(childrenDone)
+	select {
+	case <-parentsDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("parents never finished after children completed")
+	}
+}
+
+// TestYieldSlot_UnboundedIsNoOp asserts the no-pool path runs fn
+// transparently.
+func TestYieldSlot_UnboundedIsNoOp(t *testing.T) {
+	s := New()
+	called := false
+	s.YieldSlot(func() { called = true })
+	if !called {
+		t.Errorf("YieldSlot did not invoke fn on unbounded Service")
+	}
+}
+
 func TestService_ActiveNames(t *testing.T) {
 	s := New()
 	gate := make(chan struct{})


### PR DESCRIPTION
## Summary
Under \`task.NewBounded(N)\`, \`reconcile()\` holds a worker slot for its entire lifetime — including the synchronous \`depwait.WaitAll\` on child Kustomization or HelmRelease readiness. When N parents fill all slots and each waits for a child, the children can never acquire a slot. **The whole run hangs silently** — \`BlockTillDone\` never returns.

Add \`task.Service.YieldSlot(fn)\`: releases the slot for the duration of \`fn\` (the dep wait), then re-acquires before returning. CPU-bound paths (\`RenderFlux\`, \`TemplateDocs\`) still run under the pool budget; only the blocking external-state wait yields.

Wired into:
- \`pkg/controllers/kustomization/controller.go\` — wraps \`depwait.WaitAll(w.Watch(ctx, deps))\`
- \`pkg/controllers/helmrelease/controller.go\` — wraps both \`depwait.WaitAll\` calls (deps + chart-source wait)

## Why
Found during architectural review. Easy to repro with concurrency=2 and any nested-KS layout (e.g. flux-system → infrastructure/apps fan-out). The bug is silent — no panic, no error, just stuck reconcile.

## Test
\`TestYieldSlot_AllowsChildrenWhenParentsFillPool\` reproduces the deadlock: two parents take both slots in a \`NewBounded(2)\` pool and wait on children. Without YieldSlot, children never start. With YieldSlot, children start, parents reclaim, all finish under a 2s deadline.

## Test plan
- [x] \`go test ./...\` clean (incl. new regression test)
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)