### PR TITLE
fix(depwait): recover panics in per-dep watch goroutine

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -6,6 +6,8 @@ package depwait
 import (
 	"context"
 	"errors"
+	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -108,7 +110,10 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 		wg.Add(1)
 		go func(dep manifest.DependencyRef) {
 			defer wg.Done()
-			ev := w.watchOne(ctx, dep, timeout)
+			// Recover from panics in watchOne (e.g. malformed CEL expression
+			// evaluating against an unexpected payload type) so the whole
+			// run isn't killed. The dep is reported failed instead.
+			ev := safeWatchOne(ctx, w, dep, timeout)
 			select {
 			case out <- ev:
 			case <-ctx.Done():
@@ -121,6 +126,23 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 		close(out)
 	}()
 	return out
+}
+
+// safeWatchOne wraps watchOne with panic recovery — a malformed CEL
+// ReadyExpr (or any other internal bug) reports the dep as failed
+// instead of taking the orchestrator down with it.
+func safeWatchOne(ctx context.Context, w *Waiter, dep manifest.DependencyRef, timeout time.Duration) (ev Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("depwait: panic in watchOne", "dep", dep.String(), "panic", r)
+			ev = Event{
+				Dep:    dep.NamedResource,
+				Status: DepFailed,
+				Reason: fmt.Sprintf("depwait panic: %v", r),
+			}
+		}
+	}()
+	return w.watchOne(ctx, dep, timeout)
 }
 
 func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeout time.Duration) Event {

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -2,6 +2,7 @@ package depwait
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,5 +101,20 @@ func TestWaiter_NoDeps(t *testing.T) {
 	sum := WaitAll(w.Watch(context.Background(), nil))
 	if !sum.AllReady() {
 		t.Errorf("expected vacuous ready: %+v", sum)
+	}
+}
+
+// TestWaiter_PanicReportedAsFailed asserts that a panic in watchOne
+// (here triggered by a nil Store) is caught and reported as a failed
+// Event instead of killing the orchestrator.
+func TestWaiter_PanicReportedAsFailed(t *testing.T) {
+	w := &Waiter{} // Store nil — depExists will nil-deref
+	dep := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "x"}
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	if !sum.AnyFailed() {
+		t.Fatalf("expected fail on panic: %+v", sum)
+	}
+	if msg := sum.Messages[dep]; !strings.Contains(msg, "depwait panic:") {
+		t.Errorf("expected 'depwait panic:' prefix, got %q", msg)
 	}
 }


### PR DESCRIPTION
## Summary
\`Waiter.Watch\` spawns a raw \`go func()\` per dep that calls \`watchOne\` with no panic recovery. A malformed CEL ReadyExpr evaluating against a payload of unexpected type — or any other bug — would kill the orchestrator process.

\`safeWatchOne\` wraps the call with \`defer recover\`. A panic is converted to a failed \`Event\` with reason \`\"depwait panic: <msg>\"\`. The parent reconcile sees a \`DependencyFailedError\` as it would for any other unmet dep; the rest of the run continues.

## Why
Found during architectural review. \`task.Service.Go\` already has this recover for tasks routed through it — depwait's per-dep goroutines were the only spawn-without-recover in the codebase.

## Test
\`TestWaiter_PanicReportedAsFailed\` triggers a nil-deref via a Waiter with nil Store and asserts the event carries the \`\"depwait panic:\"\` prefix.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)