### PR TITLE
fix: ctx-aware per-key locks for kustomize render + helm chart cache

### DIFF
--- a/internal/keylock/keylock.go
+++ b/internal/keylock/keylock.go
@@ -1,0 +1,41 @@
+// Package keylock provides per-key mutual-exclusion locks that honor
+// context cancellation. A KeyMap[K] is a process-wide map of locks
+// keyed by K; Acquire returns once the slot is free or ctx fires.
+package keylock
+
+import (
+	"context"
+	"sync"
+)
+
+// KeyMap holds one lock per key value, allocated on first use.
+type KeyMap[K comparable] struct {
+	mu    sync.Mutex
+	locks map[K]chan struct{}
+}
+
+// New constructs an empty KeyMap.
+func New[K comparable]() *KeyMap[K] {
+	return &KeyMap[K]{locks: map[K]chan struct{}{}}
+}
+
+// Acquire blocks until the lock for key is held by the caller, or ctx
+// is done. Returns ctx.Err on cancellation (lock not held). On success
+// returns a release func — call it (typically deferred) to free the
+// lock.
+func (m *KeyMap[K]) Acquire(ctx context.Context, key K) (release func(), err error) {
+	m.mu.Lock()
+	lock, ok := m.locks[key]
+	if !ok {
+		lock = make(chan struct{}, 1)
+		m.locks[key] = lock
+	}
+	m.mu.Unlock()
+
+	select {
+	case lock <- struct{}{}:
+		return func() { <-lock }, nil
+	case <-ctx.Done():
+		return func() {}, ctx.Err()
+	}
+}

--- a/internal/keylock/keylock_test.go
+++ b/internal/keylock/keylock_test.go
@@ -1,0 +1,92 @@
+package keylock
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestKeyMap_SerializesSameKey(t *testing.T) {
+	m := New[string]()
+	var concurrent atomic.Int32
+	var peak atomic.Int32
+	bumpPeak := func() {
+		n := concurrent.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				return
+			}
+		}
+	}
+
+	done := make(chan struct{}, 4)
+	for range 4 {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			release, err := m.Acquire(context.Background(), "k")
+			if err != nil {
+				t.Errorf("Acquire: %v", err)
+				return
+			}
+			defer release()
+			bumpPeak()
+			time.Sleep(10 * time.Millisecond)
+			concurrent.Add(-1)
+		}()
+	}
+	for range 4 {
+		<-done
+	}
+	if got := peak.Load(); got != 1 {
+		t.Errorf("expected peak 1, got %d", got)
+	}
+}
+
+func TestKeyMap_DistinctKeysRunParallel(_ *testing.T) {
+	m := New[string]()
+	a, _ := m.Acquire(context.Background(), "a")
+	defer a()
+	b, _ := m.Acquire(context.Background(), "b")
+	defer b()
+}
+
+func TestKeyMap_CancelledCtxReturnsErr(t *testing.T) {
+	m := New[string]()
+	release1, _ := m.Acquire(context.Background(), "k")
+	defer release1()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	release2, err := m.Acquire(ctx, "k")
+	defer release2()
+	if err == nil {
+		t.Errorf("expected ctx.Err, got nil")
+	}
+}
+
+func TestKeyMap_CancelUnblocksWaiter(t *testing.T) {
+	m := New[string]()
+	first, _ := m.Acquire(context.Background(), "k")
+	defer first()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		release, err := m.Acquire(ctx, "k")
+		defer release()
+		done <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Errorf("expected non-nil err on cancelled acquire")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancel did not unblock waiter")
+	}
+}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -8,33 +8,19 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/getter"
 	repo "helm.sh/helm/v4/pkg/repo/v1"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 )
 
 // chartCacheLocks serializes concurrent fetches of the same cached
 // chart tarball so two reconcilers don't race on the same file.
-var (
-	chartCacheLocksMu sync.Mutex
-	chartCacheLocks   = map[string]*sync.Mutex{}
-)
-
-func lockChartPath(p string) *sync.Mutex {
-	chartCacheLocksMu.Lock()
-	defer chartCacheLocksMu.Unlock()
-	if l, ok := chartCacheLocks[p]; ok {
-		return l
-	}
-	l := &sync.Mutex{}
-	chartCacheLocks[p] = l
-	return l
-}
+var chartCacheLocks = keylock.New[string]()
 
 // writeAtomic writes data to path via a temp file + rename so partial
 // writes never appear at the target path to concurrent readers.
@@ -133,9 +119,11 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	cacheKey := safeName(hr.Chart.Name) + "-" + cv.Version + ".tgz"
 	target := filepath.Join(c.cacheDir, cacheKey)
 
-	lock := lockChartPath(target)
-	lock.Lock()
-	defer lock.Unlock()
+	release, err := chartCacheLocks.Acquire(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	defer release()
 
 	if _, err := os.Stat(target); err == nil {
 		return target, nil
@@ -318,9 +306,11 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 	}
 	target := filepath.Join(c.cacheDir, safeName(filepath.Base(ref))+"-"+version+".tgz")
 
-	lock := lockChartPath(target)
-	lock.Lock()
-	defer lock.Unlock()
+	release, err := chartCacheLocks.Acquire(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	defer release()
 
 	if _, err := os.Stat(target); err == nil {
 		return target, nil

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -8,33 +8,19 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"sync"
 
 	fluxkustomize "github.com/fluxcd/pkg/kustomize"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/kustomize/api/resmap"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
 // pathLocks serialize concurrent renders against the same staged path —
 // Flux's Generator mutates kustomization.yaml in place, so parallel
 // builds against the same path race.
-var (
-	pathLocksMu sync.Mutex
-	pathLocks   = map[string]*sync.Mutex{}
-)
-
-func lockPath(path string) *sync.Mutex {
-	pathLocksMu.Lock()
-	defer pathLocksMu.Unlock()
-	if l, ok := pathLocks[path]; ok {
-		return l
-	}
-	l := &sync.Mutex{}
-	pathLocks[path] = l
-	return l
-}
+var pathLocks = keylock.New[string]()
 
 // RenderFlux renders a Flux kustomize.toolkit.fluxcd.io Kustomization
 // using the same library that Flux's kustomize-controller uses
@@ -96,14 +82,12 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, subPath st
 	// Generator merges patches / images / components into the
 	// kustomization file at the staged path — restoring the source
 	// baseline + writing the Generator output must happen atomically
-	// per Kustomization.
-	lock := lockPath(stagedSub)
-	lock.Lock()
-	defer lock.Unlock()
-
-	if err := ctx.Err(); err != nil {
+	// per Kustomization. ctx cancellation interrupts the acquire.
+	release, err := pathLocks.Acquire(ctx, stagedSub)
+	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	// Restore the source kustomization.yaml before each Generator
 	// run so repeat reconciles (e.g. when a parent renders and


### PR DESCRIPTION
## Summary
Replace the \`sync.Mutex\` pools in \`pkg/kustomize/flux.go\` (\`pathLocks\`) and \`pkg/helm/repo.go\` (\`chartCacheLocks\`) with channel-based locks that honor \`context.Context\` cancellation.

With \`sync.Mutex\`, \`Lock()\` is uninterruptible — cancelling the orchestrator ctx left waiters parked on a mutex held by a slow \`SecureBuild\` or \`registry.Pull\`, deferring shutdown by tens of seconds.

\`internal/keylock.KeyMap[K]\` holds a \`chan struct{}\` of size 1 per key. \`Acquire(ctx, k)\` returns ctx.Err if cancelled while waiting, and a release func on success. Call sites become:

\`\`\`go
release, err := pathLocks.Acquire(ctx, key)
if err != nil { return ... }
defer release()
\`\`\`

## Why
Found during architectural review. Slow Ctrl-C / cancel signature: orchestrator goroutines waiting on the same path or chart cache slot couldn't be interrupted, only the holder could finish first.

## Test
Four unit tests in \`internal/keylock\`:
- Serializes within same key
- Parallel across distinct keys
- Pre-cancelled ctx returns err
- Cancel mid-wait unblocks the waiter under 1s

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)