### PR TITLE
feat(helmrelease): honor spec.releaseName

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -39,7 +39,7 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 
 	inst := action.NewInstall(cfg)
 	inst.DryRunStrategy = action.DryRunClient
-	inst.ReleaseName = hr.Name
+	inst.ReleaseName = hr.ReleaseName()
 	inst.Namespace = hr.ReleaseNamespace()
 	inst.IncludeCRDs = !opts.SkipCRDs
 	// HR-scoped policy wins: spec.install.crds / spec.upgrade.crds set

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -171,6 +171,10 @@ type HelmRelease struct {
 	Name                     string            `json:"name" yaml:"name"`
 	Namespace                string            `json:"namespace" yaml:"namespace"`
 	Chart                    HelmChart         `json:"chart" yaml:"chart"`
+	// ReleaseNameOverride holds spec.releaseName when set. Empty means
+	// helm-controller defaults to metadata.name. Use ReleaseName() to
+	// resolve.
+	ReleaseNameOverride      string            `json:"-" yaml:"-"`
 	TargetNamespace          string            `json:"-" yaml:"-"`
 	Values                   map[string]any    `json:"-" yaml:"-"`
 	ValuesFrom               []ValuesReference `json:"-" yaml:"-"`
@@ -209,8 +213,15 @@ func (h *HelmRelease) Named() NamedResource {
 	return NamedResource{Kind: KindHelmRelease, Namespace: h.Namespace, Name: h.Name}
 }
 
-// ReleaseName is "<namespace>-<name>" — the canonical id.
-func (h *HelmRelease) ReleaseName() string { return h.Namespace + "-" + h.Name }
+// ReleaseName returns the resolved Helm release name — spec.releaseName
+// when set, otherwise metadata.name. Mirrors helm-controller's behavior
+// at template time. Always non-empty.
+func (h *HelmRelease) ReleaseName() string {
+	if h.ReleaseNameOverride != "" {
+		return h.ReleaseNameOverride
+	}
+	return h.Name
+}
 
 // ReleaseNamespace returns TargetNamespace when set, otherwise Namespace.
 func (h *HelmRelease) ReleaseNamespace() string {
@@ -340,6 +351,7 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		Name:                     cr.Name,
 		Namespace:                cr.Namespace,
 		Chart:                    chart,
+		ReleaseNameOverride:      cr.Spec.ReleaseName,
 		TargetNamespace:          cr.Spec.TargetNamespace,
 		Values:                   values,
 		ValuesFrom:               vfs,

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -549,7 +549,7 @@ spec:
 	}{
 		{"Name", hr.Name, "podinfo"},
 		{"Namespace", hr.Namespace, "podinfo"},
-		{"ReleaseName", hr.ReleaseName(), "podinfo-podinfo"},
+		{"ReleaseName", hr.ReleaseName(), "podinfo"},
 		{"ReleaseNamespace", hr.ReleaseNamespace(), "apps"},
 		{"Chart.Name", hr.Chart.Name, "podinfo"},
 		{"Chart.Version", hr.Chart.Version, "6.3.2"},
@@ -564,6 +564,30 @@ spec:
 				t.Errorf("got %v, want %v", c.got, c.want)
 			}
 		})
+	}
+}
+
+func TestParseHelmRelease_ReleaseNameOverride(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: hr, namespace: ns}
+spec:
+  releaseName: my-explicit-release
+  chart:
+    spec:
+      chart: c
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	hr, err := ParseHelmRelease(doc)
+	if err != nil {
+		t.Fatalf("ParseHelmRelease: %v", err)
+	}
+	if hr.ReleaseNameOverride != "my-explicit-release" {
+		t.Errorf("ReleaseNameOverride = %q, want my-explicit-release", hr.ReleaseNameOverride)
+	}
+	if got := hr.ReleaseName(); got != "my-explicit-release" {
+		t.Errorf("ReleaseName() with override = %q, want my-explicit-release", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Real helm-controller uses \`spec.releaseName\` as \`Install.ReleaseName\` when set, falling back to \`metadata.name\`. flate previously hardcoded \`hr.Name\` everywhere, so any chart templating \`{{ .Release.Name }}\` with a HelmRelease that overrode it diverged from what gets applied.

- Parse \`cr.Spec.ReleaseName\` into \`HelmRelease.ReleaseNameOverride\`.
- Rewrite \`ReleaseName()\` to return the override when set or \`metadata.name\` otherwise.
- Wire \`ReleaseName()\` into \`pkg/helm/template.go\`.

The pre-existing \`ReleaseName()\` returned \`\"<namespace>-<name>\"\` — that was an internal-id formatter with no callers in production (only a unit test). Repurposed it for the correct semantic and updated the test.

## Why
Found during architectural review. Common pattern in production GitOps repos — \`spec.releaseName: foo\` to make the helm release name independent of the HelmRelease CR's metadata.name.

## Test
\`TestParseHelmRelease_ReleaseNameOverride\` asserts parser captures the override and \`ReleaseName()\` returns it.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)