### PR TITLE
chore: remove dead code

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -72,14 +72,6 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	return false
 }
 
-// SourceFile returns the file path that produced id, when known.
-func (f *Filter) SourceFile(id manifest.NamedResource) string {
-	if f == nil {
-		return ""
-	}
-	return f.sourceFiles[id]
-}
-
 func (f *Filter) resolve(objs ObjectLister) {
 	keep := make(map[manifest.NamedResource]struct{})
 	var queue []manifest.NamedResource

--- a/pkg/kustomize/doc.go
+++ b/pkg/kustomize/doc.go
@@ -2,8 +2,8 @@
 // flate never invokes the `kustomize` CLI. It provides:
 //
 //   - Build: renders a kustomization directory to YAML documents.
-//   - Filtering helpers (FilterKinds / ExcludeKinds / GrepHelmRelease)
-//     that mirror flux-local's chainable Kustomize wrapper.
+//   - Filtering helpers (FilterKinds / ExcludeKinds) that mirror
+//     flux-local's chainable Kustomize wrapper.
 //   - Variable substitution (envsubst-style "${VAR}" and "${VAR:=default}")
 //     for Flux post-build substitutions.
 //

--- a/pkg/kustomize/filter.go
+++ b/pkg/kustomize/filter.go
@@ -28,21 +28,6 @@ func ExcludeKinds(docs []map[string]any, skip []string) []map[string]any {
 	})
 }
 
-// GrepHelmRelease keeps only documents matching the given HelmRelease.
-// Returns docs unchanged when release is nil.
-func GrepHelmRelease(docs []map[string]any, release *manifest.HelmRelease) []map[string]any {
-	if release == nil {
-		return docs
-	}
-	return filter(docs, func(doc map[string]any) bool {
-		if manifest.DocKind(doc) != manifest.KindHelmRelease {
-			return false
-		}
-		name, ns := manifest.DocMetadata(doc)
-		return name == release.Name && ns == release.Namespace
-	})
-}
-
 // filter returns the elements of docs for which pred is true, without
 // mutating the input slice.
 func filter(docs []map[string]any, pred func(map[string]any) bool) []map[string]any {

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -29,13 +29,6 @@ func DocKind(doc map[string]any) string {
 	return k
 }
 
-// DocAPIVersion returns the "apiVersion" field of a manifest document,
-// or "" if absent.
-func DocAPIVersion(doc map[string]any) string {
-	v, _ := doc["apiVersion"].(string)
-	return v
-}
-
 // DocMetadata returns (name, namespace) from a manifest document's
 // metadata block. Both are "" when metadata is absent or unset.
 func DocMetadata(doc map[string]any) (name, namespace string) {

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"cmp"
-	"strings"
 
 	meta "github.com/fluxcd/pkg/apis/meta"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -59,16 +58,6 @@ func (n NamedResource) Compare(other NamedResource) int {
 
 // Less is the sort.Interface-style predicate.
 func (n NamedResource) Less(other NamedResource) bool { return n.Compare(other) < 0 }
-
-// SplitNamespacedName parses "namespace/name". When s has no separator
-// the fallback namespace is used. ok is false when the string is empty
-// or one of its parts is.
-func SplitNamespacedName(s, fallback string) (ns, name string, ok bool) {
-	if before, after, found := strings.Cut(s, "/"); found {
-		return before, after, before != "" && after != ""
-	}
-	return fallback, s, s != ""
-}
 
 // BaseManifest is the marker interface every domain object implements.
 // Concrete handling is done via type assertions in each controller.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -150,9 +150,6 @@ func New(cfg Config) (*Orchestrator, error) {
 // Store returns the underlying object store.
 func (o *Orchestrator) Store() *store.Store { return o.store }
 
-// Tasks returns the task scheduler.
-func (o *Orchestrator) Tasks() *task.Service { return o.tasks }
-
 // Filter returns the change filter (may be nil-but-non-active).
 func (o *Orchestrator) Filter() *change.Filter { return o.filter }
 

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -1,15 +1,8 @@
 // Package task provides a lightweight goroutine lifecycle manager
-// modeled on flux-local's TaskService. It distinguishes two flavors of
-// concurrent work:
-//
-//   - Active tasks are bounded units of work (a single reconciliation, a
-//     dependency wait) whose completion is interesting to the
-//     orchestrator. BlockTillDone waits for these to drain.
-//   - Background tasks are long-lived stream processors (a watch loop)
-//     whose lifetime is bound to the controller, not to the
-//     orchestrator's "is the run complete?" check.
-//
-// A single Service should be associated with one orchestrator run.
+// modeled on flux-local's TaskService. Active tasks are bounded units
+// of work (a single reconciliation, a dependency wait) whose completion
+// is tracked via BlockTillDone. A single Service should be associated
+// with one orchestrator run.
 package task
 
 import (
@@ -19,16 +12,10 @@ import (
 	"sync/atomic"
 )
 
-// Service tracks active and background goroutines.
+// Service tracks active goroutines.
 type Service struct {
 	wgActive sync.WaitGroup
-	wgBack   sync.WaitGroup
 	active   atomic.Int64
-	back     atomic.Int64
-
-	mu    sync.Mutex
-	names map[int64]string
-	next  atomic.Int64
 
 	// failures is incremented by goroutines that panic; non-zero implies
 	// the run is poisoned.
@@ -36,17 +23,14 @@ type Service struct {
 
 	// sem bounds the number of concurrent active task BODIES. The
 	// goroutine is launched eagerly but blocks on the semaphore until
-	// a worker slot is free, so callers never block on Go(). Background
-	// tasks are unaffected — they're long-lived stream processors.
+	// a worker slot is free, so callers never block on Go().
 	//
 	// nil = unbounded (every Go runs in parallel). Set via NewBounded.
 	sem chan struct{}
 }
 
 // New constructs a fresh Service with unbounded concurrency.
-func New() *Service {
-	return &Service{names: make(map[int64]string)}
-}
+func New() *Service { return &Service{} }
 
 // NewBounded constructs a Service that caps the number of concurrently
 // executing active-task bodies at workers. Submitting more does not
@@ -71,19 +55,12 @@ func NewBounded(workers int) *Service {
 // bounded (NewBounded), fn waits on the worker semaphore before it
 // executes — but Go itself never blocks.
 func (s *Service) Go(ctx context.Context, name string, fn func(context.Context)) {
-	id := s.next.Add(1)
 	s.active.Add(1)
 	s.wgActive.Add(1)
-	s.mu.Lock()
-	s.names[id] = name
-	s.mu.Unlock()
 	go func() {
 		defer s.wgActive.Done()
 		defer s.active.Add(-1)
 		defer func() {
-			s.mu.Lock()
-			delete(s.names, id)
-			s.mu.Unlock()
 			if r := recover(); r != nil {
 				s.failures.Add(1)
 				slog.Error("task panicked", "name", name, "panic", r)
@@ -121,61 +98,15 @@ func (s *Service) YieldSlot(fn func()) {
 	s.sem <- struct{}{}
 }
 
-// GoBackground launches a long-lived task whose completion is not
-// counted toward BlockTillDone.
-func (s *Service) GoBackground(ctx context.Context, name string, fn func(context.Context)) {
-	id := s.next.Add(1)
-	s.back.Add(1)
-	s.wgBack.Add(1)
-	s.mu.Lock()
-	s.names[id] = "(bg) " + name
-	s.mu.Unlock()
-	go func() {
-		defer s.wgBack.Done()
-		defer s.back.Add(-1)
-		defer func() {
-			s.mu.Lock()
-			delete(s.names, id)
-			s.mu.Unlock()
-			if r := recover(); r != nil {
-				s.failures.Add(1)
-				slog.Error("background task panicked", "name", name, "panic", r)
-			}
-		}()
-		fn(ctx)
-	}()
-}
-
 // ActiveCount returns the number of currently active tasks.
 func (s *Service) ActiveCount() int64 { return s.active.Load() }
-
-// BackgroundCount returns the number of currently running background tasks.
-func (s *Service) BackgroundCount() int64 { return s.back.Load() }
 
 // Failures returns the number of panicked tasks observed.
 func (s *Service) Failures() int64 { return s.failures.Load() }
 
-// ActiveNames returns the names of currently running tasks. Useful for
-// debug logging when the orchestrator stalls.
-func (s *Service) ActiveNames() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	out := make([]string, 0, len(s.names))
-	for _, n := range s.names {
-		out = append(out, n)
-	}
-	return out
-}
-
-// BlockTillDone waits until every active task has finished. Background
-// tasks are ignored. Safe to call concurrently with Go.
+// BlockTillDone waits until every active task has finished. Safe to
+// call concurrently with Go.
 func (s *Service) BlockTillDone() { s.wgActive.Wait() }
-
-// BlockTillAllDone waits for active AND background tasks.
-func (s *Service) BlockTillAllDone() {
-	s.wgActive.Wait()
-	s.wgBack.Wait()
-}
 
 // Coalescer keeps at most one task per key in flight; submits that
 // arrive while a key is running collapse into a single re-run after it

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -74,25 +74,6 @@ func TestService_BlockTillDone(t *testing.T) {
 	}
 }
 
-func TestService_BackgroundDoesNotBlockActive(t *testing.T) {
-	s := New()
-	bgDone := make(chan struct{})
-	defer close(bgDone)
-	s.GoBackground(context.Background(), "bg", func(_ context.Context) {
-		<-bgDone
-	})
-
-	var done atomic.Bool
-	s.Go(context.Background(), "active", func(_ context.Context) { done.Store(true) })
-	s.BlockTillDone()
-	if !done.Load() {
-		t.Errorf("active task didn't run")
-	}
-	if s.BackgroundCount() != 1 {
-		t.Errorf("background should still be running, got %d", s.BackgroundCount())
-	}
-}
-
 func TestService_PanicCountedAndRecovered(t *testing.T) {
 	s := New()
 	s.Go(context.Background(), "boom", func(_ context.Context) {
@@ -270,18 +251,3 @@ func TestYieldSlot_UnboundedIsNoOp(t *testing.T) {
 	}
 }
 
-func TestService_ActiveNames(t *testing.T) {
-	s := New()
-	gate := make(chan struct{})
-	started := make(chan struct{})
-	s.Go(context.Background(), "alpha", func(_ context.Context) {
-		close(started)
-		<-gate
-	})
-	<-started
-	if names := s.ActiveNames(); len(names) != 1 || names[0] != "alpha" {
-		t.Errorf("ActiveNames: %v", names)
-	}
-	close(gate)
-	s.BlockTillDone()
-}


### PR DESCRIPTION
## Summary
Eight items confirmed by grep to have no callers in production code:

- \`orchestrator.Orchestrator.Tasks()\` — zero callers
- \`manifest.SplitNamespacedName\` — zero callers
- \`manifest.DocAPIVersion\` — zero callers
- \`kustomize.GrepHelmRelease\` — zero callers (mentioned in doc.go only)
- \`change.Filter.SourceFile\` — zero callers
- \`task.Service.GoBackground\` — only called from a test of itself
- \`task.Service.BackgroundCount\` — same
- \`task.Service.ActiveNames\` — same
- \`task.Service.BlockTillAllDone\` — same

Removing the background-task subsystem also drops \`wgBack\`/\`back\`/\`names\`/\`mu\`/\`next\` fields on Service since they had no remaining users. Service is now a thin shim over a WaitGroup + atomic counters + optional semaphore. Package doc updated to match.

**Net -147 LOC.**

## Why
Surfaced during architectural review. Tests that exclusively exercise the very functions they're meant to validate are a sign the surface is unused; either the function or the test is load-bearing, not both.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)