### PR TITLE
refactor(source): hoist cert-secret resolution into ResolveCertSecret

### DIFF
--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -5,7 +5,6 @@ package bucket
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -115,7 +114,8 @@ func (f *Fetcher) resolveTransport(b *manifest.Bucket) (*http.Transport, error) 
 	}
 	tr := http.DefaultTransport.(*http.Transport).Clone()
 	if b.CertSecretRef != nil {
-		cfg, terr := f.resolveTLSConfig(b)
+		cfg, terr := source.ResolveCertSecret(f.Secrets, b.Namespace, "Bucket",
+			b.Namespace+"/"+b.Name, b.CertSecretRef)
 		if terr != nil {
 			return nil, terr
 		}
@@ -129,28 +129,6 @@ func (f *Fetcher) resolveTransport(b *manifest.Bucket) (*http.Transport, error) 
 		tr.Proxy = pfn
 	}
 	return tr, nil
-}
-
-func (f *Fetcher) resolveTLSConfig(b *manifest.Bucket) (*tls.Config, error) {
-	if f.Secrets == nil {
-		return nil, fmt.Errorf("bucket %s/%s references certSecretRef but no source.SecretGetter is wired",
-			b.Namespace, b.Name)
-	}
-	sec := f.Secrets(b.Namespace, b.CertSecretRef.Name)
-	if sec == nil {
-		return nil, fmt.Errorf("bucket %s/%s: cert secret %s/%s not found",
-			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name)
-	}
-	cfg, err := source.BuildTLSConfig(
-		source.StringFromSecret(sec, "tls.crt"),
-		source.StringFromSecret(sec, "tls.key"),
-		source.StringFromSecret(sec, "ca.crt"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("bucket %s/%s: certSecretRef %s/%s: %w",
-			b.Namespace, b.Name, b.Namespace, b.CertSecretRef.Name, err)
-	}
-	return cfg, nil
 }
 
 // resolveCredentials picks up accesskey/secretkey from the SecretRef

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -77,36 +77,16 @@ func (f *Fetcher) resolveTLS(repo *manifest.OCIRepository) (*tls.Config, error) 
 	if repo.CertSecretRef == nil && !repo.Insecure {
 		return nil, nil
 	}
-	cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	cfg, err := source.ResolveCertSecret(f.Secrets, repo.Namespace, "OCIRepository",
+		repo.Namespace+"/"+repo.Name, repo.CertSecretRef)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		cfg = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
 	if repo.Insecure {
 		cfg.InsecureSkipVerify = true //nolint:gosec // honoring user-declared spec.insecure
-	}
-	if repo.CertSecretRef == nil {
-		return cfg, nil
-	}
-	if f.Secrets == nil {
-		return nil, fmt.Errorf("OCIRepository %s/%s references certSecretRef but no source.SecretGetter is wired",
-			repo.Namespace, repo.Name)
-	}
-	sec := f.Secrets(repo.Namespace, repo.CertSecretRef.Name)
-	if sec == nil {
-		return nil, fmt.Errorf("OCIRepository %s/%s: cert secret %s/%s not found",
-			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name)
-	}
-	mtls, err := source.BuildTLSConfig(
-		source.StringFromSecret(sec, "tls.crt"),
-		source.StringFromSecret(sec, "tls.key"),
-		source.StringFromSecret(sec, "ca.crt"),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("OCIRepository %s/%s: certSecretRef %s/%s: %w",
-			repo.Namespace, repo.Name, repo.Namespace, repo.CertSecretRef.Name, err)
-	}
-	if mtls.Certificates != nil {
-		cfg.Certificates = mtls.Certificates
-	}
-	if mtls.RootCAs != nil {
-		cfg.RootCAs = mtls.RootCAs
 	}
 	return cfg, nil
 }

--- a/pkg/source/tls.go
+++ b/pkg/source/tls.go
@@ -5,7 +5,41 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+
+	"github.com/home-operations/flate/pkg/manifest"
 )
+
+// ResolveCertSecret reads ref's Secret and builds a *tls.Config from
+// its tls.crt + tls.key (client cert) and/or ca.crt (server CA) keys —
+// mirroring source-controller's certSecretRef schema.
+//
+// Returns (nil, nil) when ref is nil. Loud errors when ref is set but
+// SecretGetter is unwired or the Secret is missing/unparseable.
+// ownerKind+ownerID are formatted into errors for diagnosability.
+func ResolveCertSecret(secrets SecretGetter, ns, ownerKind, ownerID string, ref *manifest.LocalObjectReference) (*tls.Config, error) {
+	if ref == nil {
+		return nil, nil
+	}
+	if secrets == nil {
+		return nil, fmt.Errorf("%s %s references certSecretRef but no source.SecretGetter is wired",
+			ownerKind, ownerID)
+	}
+	sec := secrets(ns, ref.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("%s %s: cert secret %s/%s not found",
+			ownerKind, ownerID, ns, ref.Name)
+	}
+	cfg, err := BuildTLSConfig(
+		StringFromSecret(sec, "tls.crt"),
+		StringFromSecret(sec, "tls.key"),
+		StringFromSecret(sec, "ca.crt"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: certSecretRef %s/%s: %w",
+			ownerKind, ownerID, ns, ref.Name, err)
+	}
+	return cfg, nil
+}
 
 // BuildTLSConfig assembles a *tls.Config from PEM-armored secret
 // material. Any subset of (client cert + key) and (CA) is acceptable;


### PR DESCRIPTION
## Summary
Two near-identical \"read certSecretRef → BuildTLSConfig\" routines in \`pkg/source/{oci/oci.go, bucket/bucket.go}\` replaced with a single \`source.ResolveCertSecret\` helper mirroring \`source.ResolveProxy\`'s ownerKind / ownerID error formatting.

- OCI keeps its own \`resolveTLS\` wrapper because \`spec.insecure\` is an OCIRepository-only concern that overlays \`InsecureSkipVerify\` on top of the resolved config.
- GitRepository's \`resolveTLS\` is left as-is — it deliberately swallows nil-Secrets / missing-secret cases (\`resolveAuth\` reports them) and only reads \`ca.crt\` + a legacy \`caFile\` alias, which is enough deviation that sharing would obscure both call sites.

## Test plan
- [x] \`go test ./...\` clean (incl. existing tls/auth tests)
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)