### PR TITLE
feat(helmrelease): honor spec.postRenderers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/fluxcd/kustomize-controller/api v1.8.5
+	github.com/fluxcd/pkg/apis/kustomize v1.18.0
 	github.com/fluxcd/pkg/apis/meta v1.25.1
 	github.com/fluxcd/pkg/envsubst v1.7.0
 	github.com/fluxcd/pkg/kustomize v1.32.0
@@ -26,6 +27,7 @@ require (
 	k8s.io/apimachinery v0.36.1
 	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/kustomize/api v0.21.1
+	sigs.k8s.io/kustomize/kyaml v0.21.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -58,7 +60,6 @@ require (
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fluxcd/cli-utils v1.2.0 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
-	github.com/fluxcd/pkg/apis/kustomize v1.18.0 // indirect
 	github.com/fluxcd/pkg/sourceignore v0.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
@@ -161,7 +162,6 @@ require (
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/controller-runtime v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )

--- a/pkg/helm/postrender.go
+++ b/pkg/helm/postrender.go
@@ -1,0 +1,125 @@
+package helm
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/fluxcd/pkg/apis/kustomize"
+	"helm.sh/helm/v4/pkg/postrenderer"
+	"sigs.k8s.io/kustomize/api/krusty"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+// kustomizePostRenderer pipes helm's rendered output through one or
+// more kustomize PostRenderer.Kustomize specs (patches + images),
+// matching helm-controller's behavior. Multiple post-renderers chain:
+// the output of one feeds the next.
+type kustomizePostRenderer struct {
+	renderers []helmv2.PostRenderer
+}
+
+// newPostRenderer returns nil when rs has no usable entries — callers
+// pass nil to action.Install.PostRenderer to mean "no post-render".
+func newPostRenderer(rs []helmv2.PostRenderer) postrenderer.PostRenderer {
+	for _, r := range rs {
+		if r.Kustomize != nil {
+			return &kustomizePostRenderer{renderers: rs}
+		}
+	}
+	return nil
+}
+
+func (k *kustomizePostRenderer) Run(in *bytes.Buffer) (*bytes.Buffer, error) {
+	current := in
+	for _, r := range k.renderers {
+		if r.Kustomize == nil {
+			continue
+		}
+		out, err := runKustomizePostRender(current, r.Kustomize)
+		if err != nil {
+			return nil, err
+		}
+		current = out
+	}
+	return current, nil
+}
+
+func runKustomizePostRender(in *bytes.Buffer, k *helmv2.Kustomize) (*bytes.Buffer, error) {
+	fs := filesys.MakeFsInMemory()
+	const inputFile = "helm-output.yaml"
+	if err := fs.WriteFile(inputFile, in.Bytes()); err != nil {
+		return nil, fmt.Errorf("postRenderer: write helm output: %w", err)
+	}
+
+	cfg := kustypes.Kustomization{
+		TypeMeta: kustypes.TypeMeta{
+			APIVersion: kustypes.KustomizationVersion,
+			Kind:       kustypes.KustomizationKind,
+		},
+		Resources: []string{inputFile},
+		Images:    adaptImages(k.Images),
+	}
+	for _, p := range k.Patches {
+		cfg.Patches = append(cfg.Patches, kustypes.Patch{
+			Patch:  p.Patch,
+			Target: adaptSelector(p.Target),
+		})
+	}
+
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("postRenderer: marshal kustomization: %w", err)
+	}
+	if err := fs.WriteFile("kustomization.yaml", raw); err != nil {
+		return nil, fmt.Errorf("postRenderer: write kustomization: %w", err)
+	}
+
+	opts := &krusty.Options{
+		LoadRestrictions: kustypes.LoadRestrictionsNone,
+		PluginConfig:     kustypes.DisabledPluginConfig(),
+	}
+	rm, err := krusty.MakeKustomizer(opts).Run(fs, ".")
+	if err != nil {
+		return nil, fmt.Errorf("postRenderer: kustomize build: %w", err)
+	}
+	out, err := rm.AsYaml()
+	if err != nil {
+		return nil, fmt.Errorf("postRenderer: marshal output: %w", err)
+	}
+	return bytes.NewBuffer(out), nil
+}
+
+func adaptImages(in []kustomize.Image) []kustypes.Image {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]kustypes.Image, len(in))
+	for i, im := range in {
+		out[i] = kustypes.Image{
+			Name:    im.Name,
+			NewName: im.NewName,
+			NewTag:  im.NewTag,
+			Digest:  im.Digest,
+		}
+	}
+	return out
+}
+
+func adaptSelector(sel *kustomize.Selector) *kustypes.Selector {
+	if sel == nil {
+		return nil
+	}
+	out := &kustypes.Selector{
+		LabelSelector:      sel.LabelSelector,
+		AnnotationSelector: sel.AnnotationSelector,
+	}
+	out.Name = sel.Name
+	out.Namespace = sel.Namespace
+	out.Group = sel.Group
+	out.Kind = sel.Kind
+	out.Version = sel.Version
+	return out
+}

--- a/pkg/helm/postrender_test.go
+++ b/pkg/helm/postrender_test.go
@@ -1,0 +1,84 @@
+package helm
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/fluxcd/pkg/apis/kustomize"
+)
+
+func TestNewPostRenderer_NilWhenNoKustomize(t *testing.T) {
+	if pr := newPostRenderer(nil); pr != nil {
+		t.Errorf("expected nil for empty list, got %T", pr)
+	}
+	if pr := newPostRenderer([]helmv2.PostRenderer{{}}); pr != nil {
+		t.Errorf("expected nil for postRenderer without Kustomize, got %T", pr)
+	}
+}
+
+func TestKustomizePostRenderer_PatchAppliesToHelmOutput(t *testing.T) {
+	in := bytes.NewBufferString(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app
+  namespace: default
+data:
+  greeting: hello
+`)
+	pr := newPostRenderer([]helmv2.PostRenderer{{
+		Kustomize: &helmv2.Kustomize{
+			Patches: []kustomize.Patch{{
+				Patch: `- op: replace
+  path: /data/greeting
+  value: bonjour`,
+				Target: &kustomize.Selector{
+					Kind: "ConfigMap",
+					Name: "app",
+				},
+			}},
+		},
+	}})
+	if pr == nil {
+		t.Fatal("expected non-nil post renderer")
+	}
+	out, err := pr.Run(in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "greeting: bonjour") {
+		t.Errorf("patch not applied:\n%s", got)
+	}
+}
+
+func TestKustomizePostRenderer_ImageOverride(t *testing.T) {
+	in := bytes.NewBufferString(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - name: c
+        image: nginx:1.19
+`)
+	pr := newPostRenderer([]helmv2.PostRenderer{{
+		Kustomize: &helmv2.Kustomize{
+			Images: []kustomize.Image{{
+				Name:   "nginx",
+				NewTag: "1.25",
+			}},
+		},
+	}})
+	out, err := pr.Run(in)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(out.String(), "nginx:1.25") {
+		t.Errorf("image not overridden:\n%s", out.String())
+	}
+}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -57,6 +57,10 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	inst.EnableDNS = opts.EnableDNS
 	inst.Replace = true
 	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
+	// spec.postRenderers — pipe rendered output through one or more
+	// kustomize patch+image transforms. helm-controller does this via
+	// the same postrenderer.PostRenderer hook.
+	inst.PostRenderer = newPostRenderer(hr.PostRenderers)
 	// action.Install consults its own KubeVersion field for chart
 	// compatibility checks and ignores cfg.Capabilities for that purpose.
 	if opts.KubeVersion != "" {

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -206,6 +206,10 @@ type HelmRelease struct {
 	// IgnoreMissingValuesFiles: when true, missing ChartValuesFiles
 	// entries are skipped instead of erroring.
 	IgnoreMissingValuesFiles bool `json:"-" yaml:"-"`
+	// PostRenderers are the spec.postRenderers entries applied to the
+	// rendered chart output, mirroring helm-controller's behavior. Each
+	// renderer is a kustomize-based patch+image transform.
+	PostRenderers []helmv2.PostRenderer `json:"-" yaml:"-"`
 }
 
 // Named identifies the release.
@@ -352,6 +356,7 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		Namespace:                cr.Namespace,
 		Chart:                    chart,
 		ReleaseNameOverride:      cr.Spec.ReleaseName,
+		PostRenderers:            slices.Clone(cr.Spec.PostRenderers),
 		TargetNamespace:          cr.Spec.TargetNamespace,
 		Values:                   values,
 		ValuesFrom:               vfs,


### PR DESCRIPTION
## Summary
helm-controller pipes rendered chart output through each entry of \`spec.postRenderers\` (kustomize patches + image overrides) as a final step before the resource lands on the cluster. flate previously ignored this — anyone using postRenderers for namespace fixups, image overrides, or SOPS-style post-decryption saw major diff drift.

This change:
- Adds \`manifest.HelmRelease.PostRenderers\` (capturing the typed \`helmv2.PostRenderer\` list).
- Adds \`pkg/helm/postrender.go\` implementing helm SDK's \`postrenderer.PostRenderer\` interface. Each renderer runs the rendered docs through an in-memory kustomize build (krusty + \`filesys.MakeFsInMemory\`) with the spec'd patches/images applied, chaining when multiple are configured. Mirrors \`helm-controller/internal/postrender/kustomize.go\`.
- Wires it into \`pkg/helm/template.go\` via \`inst.PostRenderer\`; nil when the HR has no kustomize-based postRenderers, matching \`action.Install\`'s \"no post-render\" sentinel.

## Why
Found during architectural review. \`spec.postRenderers\` is the standard escape hatch for chart mutation in production GitOps repos.

## Test
Three unit tests cover the nil sentinel, patch application by Kind+Name selector, and image-by-name tag override.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)