### PR TITLE
feat(kustomize): inject Flux owner labels on rendered children

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -129,6 +129,9 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, subPath st
 	if err := applyCommonMetadata(rm, rawSpec); err != nil {
 		return nil, fmt.Errorf("apply commonMetadata %s: %w", subPath, err)
 	}
+	if err := applyOwnerLabels(rm, rawSpec); err != nil {
+		return nil, fmt.Errorf("apply owner labels %s: %w", subPath, err)
+	}
 	out, err := rm.AsYaml()
 	if err != nil {
 		return nil, fmt.Errorf("kustomize render %s: %w", subPath, err)
@@ -168,6 +171,43 @@ func applyCommonMetadata(rm resmap.ResMap, rawSpec map[string]any) error {
 			if err := r.SetAnnotations(merged); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+// applyOwnerLabels stamps every rendered resource with the parent's
+// "kustomize.toolkit.fluxcd.io/name" + "/namespace" labels — matching
+// what kustomize-controller injects via ssa.ResourceManager.SetOwnerLabels
+// before apply. These labels are how real Flux tracks ownership for
+// pruning + selection (kubectl get -l kustomize.toolkit.fluxcd.io/name=...).
+//
+// Inject during render so flate's output matches what lands in-cluster
+// rather than what's on disk.
+func applyOwnerLabels(rm resmap.ResMap, rawSpec map[string]any) error {
+	md, _ := rawSpec["metadata"].(map[string]any)
+	name, _ := md["name"].(string)
+	if name == "" {
+		return nil
+	}
+	namespace, _ := md["namespace"].(string)
+	const group = "kustomize.toolkit.fluxcd.io"
+	owner := map[string]string{
+		group + "/name":      name,
+		group + "/namespace": namespace,
+	}
+	for _, r := range rm.Resources() {
+		merged := maps.Clone(r.GetLabels())
+		if merged == nil {
+			merged = map[string]string{}
+		}
+		for k, v := range owner {
+			if v != "" {
+				merged[k] = v
+			}
+		}
+		if err := r.SetLabels(merged); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -186,4 +186,56 @@ func TestRenderFlux_HonorsCommonMetadata(t *testing.T) {
 	if annotations["note"] != "y" {
 		t.Errorf("existing annotations dropped: %v", annotations)
 	}
+	// applyOwnerLabels: every rendered resource should carry the parent
+	// Kustomization's name + namespace under kustomize.toolkit.fluxcd.io/*.
+	if labels["kustomize.toolkit.fluxcd.io/name"] != "k" {
+		t.Errorf("owner name label missing: %v", labels)
+	}
+	if labels["kustomize.toolkit.fluxcd.io/namespace"] != "ns" {
+		t.Errorf("owner namespace label missing: %v", labels)
+	}
+}
+
+// TestRenderFlux_InjectsOwnerLabels guards that
+// kustomize.toolkit.fluxcd.io/{name,namespace} land on rendered
+// resources even without spec.commonMetadata.
+func TestRenderFlux_InjectsOwnerLabels(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "cm.yaml"), []byte(
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\ndata:\n  k: v\n",
+	), 0o600); err != nil {
+		t.Fatalf("write cm: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "kustomization.yaml"), []byte(
+		"resources:\n- cm.yaml\n",
+	), 0o600); err != nil {
+		t.Fatalf("write kustomization: %v", err)
+	}
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	out, err := RenderFlux(context.Background(), cache, src, ".", map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "infra", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "./"},
+	})
+	if err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+	var got map[string]any
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out)
+	}
+	md, _ := got["metadata"].(map[string]any)
+	labels, _ := md["labels"].(map[string]any)
+	if labels["kustomize.toolkit.fluxcd.io/name"] != "infra" {
+		t.Errorf("owner name label = %v, want infra", labels["kustomize.toolkit.fluxcd.io/name"])
+	}
+	if labels["kustomize.toolkit.fluxcd.io/namespace"] != "flux-system" {
+		t.Errorf("owner namespace label = %v, want flux-system", labels["kustomize.toolkit.fluxcd.io/namespace"])
+	}
 }


### PR DESCRIPTION
## Summary
Real kustomize-controller stamps every applied resource with \`kustomize.toolkit.fluxcd.io/name\` and \`/namespace\` labels referencing the parent Kustomization (via \`ssa.ResourceManager.SetOwnerLabels\`). These are how Flux tracks ownership for pruning + selection (\`kubectl get -l kustomize.toolkit.fluxcd.io/name=infra\`). flate previously skipped this — diffs against a live cluster showed every resource missing two labels.

\`applyOwnerLabels\` runs after \`applyCommonMetadata\` in \`RenderFlux\`, walking \`rm.Resources()\` and merging the two labels from the rawSpec's metadata. Empty namespace omitted (cluster-scoped Kustomization or fallback).

## Why
Found during architectural review. The agent flagged this as HIGH impact for diff-against-cluster workflows.

## Test
\`TestRenderFlux_InjectsOwnerLabels\` covers the no-commonMetadata path. The existing commonMetadata test now also asserts owner labels coexist with user-supplied labels.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)