### PR TITLE
refactor(manifest): embed upstream Specs into all 8 top-level CRs

### DIFF
--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -4,6 +4,9 @@ import (
 	"slices"
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -52,13 +55,17 @@ func TestFilter_ResolveDirectMatch(t *testing.T) {
 func TestFilter_SharedComponentPropagatesToAllConsumers(t *testing.T) {
 	plex := &manifest.Kustomization{
 		Name: "plex", Namespace: "media",
-		Path:       "apps/media/plex/app",
-		Components: []string{"../../../../components/volsync"},
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path:       "apps/media/plex/app",
+			Components: []string{"../../../../components/volsync"},
+		},
 	}
 	atuin := &manifest.Kustomization{
 		Name: "atuin", Namespace: "default",
-		Path:       "apps/default/atuin/app",
-		Components: []string{"../../../../components/volsync"},
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path:       "apps/default/atuin/app",
+			Components: []string{"../../../../components/volsync"},
+		},
 	}
 	hrPlex := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "media", Name: "plex"}
 	hrAtuin := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "atuin"}
@@ -86,8 +93,14 @@ func TestFilter_SharedComponentPropagatesToAllConsumers(t *testing.T) {
 func TestFilter_LongestPrefixOwnerWins(t *testing.T) {
 	// A meta-KS at apps/ and a specific KS at apps/media/plex/app —
 	// changes inside plex must belong to plex, not the meta-KS.
-	meta := &manifest.Kustomization{Name: "cluster-apps", Namespace: "flux-system", Path: "apps"}
-	plex := &manifest.Kustomization{Name: "plex", Namespace: "media", Path: "apps/media/plex/app"}
+	meta := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps"},
+	}
+	plex := &manifest.Kustomization{
+		Name: "plex", Namespace: "media",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/media/plex/app"},
+	}
 	hrPlex := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "media", Name: "plex"}
 	metaID, plexID := meta.Named(), plex.Named()
 
@@ -140,8 +153,10 @@ func TestFilter_TransitiveDepsHelmRelease(t *testing.T) {
 		Chart: manifest.HelmChart{
 			RepoKind: manifest.KindOCIRepository, RepoName: "app-template", RepoNamespace: "flux-system",
 		},
-		ValuesFrom: []manifest.ValuesReference{
-			{Kind: manifest.KindConfigMap, Name: "plex-values"},
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: manifest.KindConfigMap, Name: "plex-values"},
+			},
 		},
 	}
 	hrID := hr.Named()

--- a/pkg/helm/auth_test.go
+++ b/pkg/helm/auth_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -12,7 +14,10 @@ func TestHelmRepoTLS_NoCertSecretIsNoOp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	r := &manifest.HelmRepository{Name: "r", Namespace: "ns", URL: "https://charts.example"}
+	r := &manifest.HelmRepository{
+		Name: "r", Namespace: "ns",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example"},
+	}
 	opts, cleanup, err := c.helmRepoTLSOptions(r)
 	defer cleanup()
 	if err != nil {
@@ -38,8 +43,11 @@ func TestHelmRepoTLS_FromSecret(t *testing.T) {
 		}
 	})
 	r := &manifest.HelmRepository{
-		Name: "r", Namespace: "ns", URL: "https://charts.example",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls-creds"},
+		Name: "r", Namespace: "ns",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			URL:           "https://charts.example",
+			CertSecretRef: &manifest.LocalObjectReference{Name: "tls-creds"},
+		},
 	}
 	opts, cleanup, err := c.helmRepoTLSOptions(r)
 	defer cleanup()
@@ -61,7 +69,9 @@ func TestHelmRepoTLS_AllKeysMissing(t *testing.T) {
 	})
 	r := &manifest.HelmRepository{
 		Name: "r", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "wrong-shape"},
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "wrong-shape"},
+		},
 	}
 	_, cleanup, err := c.helmRepoTLSOptions(r)
 	cleanup()
@@ -78,7 +88,9 @@ func TestHelmRepoTLS_CertSecretNotFound(t *testing.T) {
 	c.SetSecretGetter(func(_, _ string) *manifest.Secret { return nil })
 	r := &manifest.HelmRepository{
 		Name: "r", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		},
 	}
 	_, cleanup, err := c.helmRepoTLSOptions(r)
 	cleanup()
@@ -92,7 +104,10 @@ func TestHelmRepoAuth_NoSecretIsAnonymous(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	r := &manifest.HelmRepository{Name: "r", Namespace: "ns", URL: "https://charts.example"}
+	r := &manifest.HelmRepository{
+		Name: "r", Namespace: "ns",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example"},
+	}
 	opts, err := c.helmRepoAuthOptions(r)
 	if err != nil {
 		t.Fatalf("helmRepoAuthOptions: %v", err)
@@ -116,8 +131,11 @@ func TestHelmRepoAuth_BasicAuthFromSecret(t *testing.T) {
 		}
 	})
 	r := &manifest.HelmRepository{
-		Name: "r", Namespace: "ns", URL: "https://charts.example",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		Name: "r", Namespace: "ns",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			URL:       "https://charts.example",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	opts, err := c.helmRepoAuthOptions(r)
 	if err != nil {
@@ -140,7 +158,9 @@ func TestHelmRepoAuth_MissingCreds(t *testing.T) {
 	})
 	r := &manifest.HelmRepository{
 		Name: "r", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err = c.helmRepoAuthOptions(r)
 	if err == nil || !strings.Contains(err.Error(), "missing username/password") {
@@ -163,7 +183,9 @@ func TestHelmRepoAuth_SecretWipedTreatedAsMissing(t *testing.T) {
 	})
 	r := &manifest.HelmRepository{
 		Name: "r", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err = c.helmRepoAuthOptions(r)
 	if err == nil || !strings.Contains(err.Error(), "missing username/password") {
@@ -178,7 +200,9 @@ func TestHelmRepoAuth_NoGetter(t *testing.T) {
 	}
 	r := &manifest.HelmRepository{
 		Name: "r", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err = c.helmRepoAuthOptions(r)
 	if err == nil || !strings.Contains(err.Error(), "SecretGetter") {
@@ -194,7 +218,9 @@ func TestHelmRepoAuth_SecretNotFound(t *testing.T) {
 	c.SetSecretGetter(func(_, _ string) *manifest.Secret { return nil })
 	r := &manifest.HelmRepository{
 		Name: "r", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		},
 	}
 	_, err = c.helmRepoAuthOptions(r)
 	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -33,7 +35,7 @@ data:
 	cli.AddLocalGit(LocalGitRepository{
 		Repo: &manifest.GitRepository{
 			Name: "chart-repo", Namespace: "flux-system",
-			URL: "file://" + dir,
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + dir},
 		},
 		Artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
 	})

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -78,7 +78,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 			manifest.ErrObjectNotFound, hr.RepoName(), hr.NamespacedName())
 	}
 
-	if r.RepoType == manifest.RepoTypeOCI || strings.HasPrefix(r.URL, "oci://") {
+	if r.Type == manifest.RepoTypeOCI || strings.HasPrefix(r.URL, "oci://") {
 		if r.SecretRef != nil {
 			return "", fmt.Errorf(
 				"HelmRepository %s/%s: SecretRef on OCI HelmRepositories is not yet implemented; "+

--- a/pkg/loader/inherit_test.go
+++ b/pkg/loader/inherit_test.go
@@ -3,6 +3,8 @@ package loader
 import (
 	"testing"
 
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -16,10 +18,12 @@ func TestApplyNamespaceInheritance_FluxTargetNamespaceWins(t *testing.T) {
 
 	s := store.New()
 	parent := &manifest.Kustomization{
-		Name:            "plex",
-		Namespace:       "flux-system",
-		Path:            "apps/plex",
-		TargetNamespace: "media",
+		Name:      "plex",
+		Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path:            "apps/plex",
+			TargetNamespace: "media",
+		},
 	}
 	hr := &manifest.HelmRelease{
 		Name:      "plex",

--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -13,25 +13,13 @@ import (
 // via minio-go). The aws/gcp/azure providers parse correctly but the
 // Fetcher returns a clear "provider X not implemented" error.
 type Bucket struct {
-	Name       string `json:"name" yaml:"name"`
-	Namespace  string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Provider   string `json:"provider,omitempty" yaml:"provider,omitempty"`
-	BucketName string `json:"bucketName" yaml:"bucketName"`
-	Endpoint   string `json:"endpoint" yaml:"endpoint"`
-	Region     string `json:"region,omitempty" yaml:"region,omitempty"`
-	Prefix     string `json:"prefix,omitempty" yaml:"prefix,omitempty"`
-	Insecure   bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	// SecretRef points at a Secret carrying accesskey / secretkey
-	// (generic provider) or the provider-specific credential bag.
-	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	// CertSecretRef points at a Secret with tls.crt + tls.key
-	// (client cert) and/or ca.crt (server CA) for mTLS endpoints.
-	CertSecretRef *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
-	// ProxySecretRef points at a Secret carrying an HTTP proxy
-	// configuration (address + optional username/password) used when
-	// reaching the bucket endpoint.
-	ProxySecretRef *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
-	Suspend        bool                  `json:"-" yaml:"-"`
+	Name      string `json:"name"                yaml:"name"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	// BucketSpec is the embedded upstream sourcev1.BucketSpec — all
+	// fields (Provider, BucketName, Endpoint, Region, Prefix, Insecure,
+	// SecretRef, CertSecretRef, ProxySecretRef, Suspend, ...) are
+	// promoted to the top level for ergonomic access (b.Endpoint, etc.).
+	sourcev1.BucketSpec `json:",inline" yaml:",inline"`
 }
 
 // Named identifies the Bucket.
@@ -61,29 +49,12 @@ func ParseBucket(doc map[string]any) (*Bucket, error) {
 	if cr.Spec.Endpoint == "" {
 		return nil, inputf("Bucket %s/%s missing spec.endpoint", cr.Namespace, cr.Name)
 	}
-	provider := cr.Spec.Provider
-	if provider == "" {
-		provider = sourcev1.BucketProviderGeneric
+	if cr.Spec.Provider == "" {
+		cr.Spec.Provider = sourcev1.BucketProviderGeneric
 	}
-	out := &Bucket{
+	return &Bucket{
 		Name:       cr.Name,
 		Namespace:  cr.Namespace,
-		Provider:   provider,
-		BucketName: cr.Spec.BucketName,
-		Endpoint:   cr.Spec.Endpoint,
-		Region:     cr.Spec.Region,
-		Prefix:     cr.Spec.Prefix,
-		Insecure:   cr.Spec.Insecure,
-		Suspend:    cr.Spec.Suspend,
-	}
-	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = cr.Spec.SecretRef
-	}
-	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
-		out.CertSecretRef = cr.Spec.CertSecretRef
-	}
-	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
-		out.ProxySecretRef = cr.Spec.ProxySecretRef
-	}
-	return out, nil
+		BucketSpec: cr.Spec,
+	}, nil
 }

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -372,19 +372,15 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 	}, nil
 }
 
-// HelmRepository is the Flux HelmRepository CRD.
+// HelmRepository is the Flux HelmRepository CRD. The embedded
+// sourcev1.HelmRepositorySpec promotes URL, Type, Provider, SecretRef,
+// CertSecretRef, PassCredentials, Insecure, Suspend, etc. to the top
+// level so consumers write h.URL / h.Type rather than h.Spec.URL.
 type HelmRepository struct {
-	Name      string `json:"name" yaml:"name"`
+	Name      string `json:"name"      yaml:"name"`
 	Namespace string `json:"namespace" yaml:"namespace"`
-	URL       string `json:"url" yaml:"url"`
-	// RepoType is "default" or "oci".
-	RepoType        string                `json:"repoType,omitempty" yaml:"repoType,omitempty"`
-	Provider        string                `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef       *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	CertSecretRef   *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
-	PassCredentials bool                  `json:"-" yaml:"-"`
-	Insecure        bool                  `json:"-" yaml:"-"`
-	Suspend         bool                  `json:"-" yaml:"-"`
+
+	sourcev1.HelmRepositorySpec `json:",inline" yaml:",inline"`
 }
 
 // Named identifies the repo.
@@ -398,7 +394,7 @@ func (h *HelmRepository) RepoName() string { return h.Namespace + "-" + h.Name }
 // HelmChartName returns the chart ref used with the helm SDK. For OCI
 // repos the chart name is appended to the URL.
 func (h *HelmRepository) HelmChartName(chart HelmChart) string {
-	if h.RepoType == RepoTypeOCI {
+	if h.Type == RepoTypeOCI {
 		return h.URL + "/" + chart.Name
 	}
 	return chart.ChartName()
@@ -420,25 +416,12 @@ func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("HelmRepository missing spec.url")
 	}
-	repoType := cr.Spec.Type
-	if repoType == "" {
-		repoType = RepoTypeDefault
+	if cr.Spec.Type == "" {
+		cr.Spec.Type = RepoTypeDefault
 	}
-	out := &HelmRepository{
-		Name:            cr.Name,
-		Namespace:       cr.Namespace,
-		URL:             cr.Spec.URL,
-		RepoType:        repoType,
-		Provider:        cr.Spec.Provider,
-		PassCredentials: cr.Spec.PassCredentials,
-		Insecure:        cr.Spec.Insecure,
-		Suspend:         cr.Spec.Suspend,
-	}
-	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = cr.Spec.SecretRef
-	}
-	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
-		out.CertSecretRef = cr.Spec.CertSecretRef
-	}
-	return out, nil
+	return &HelmRepository{
+		Name:               cr.Name,
+		Namespace:          cr.Namespace,
+		HelmRepositorySpec: cr.Spec,
+	}, nil
 }

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -157,50 +157,60 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 	}, nil
 }
 
-// HelmRelease is the Flux HelmRelease CRD.
+// HelmRelease is the Flux HelmRelease CRD. The embedded
+// helmv2.HelmReleaseSpec promotes Suspend, TargetNamespace,
+// ServiceAccountName, StorageNamespace, ReleaseName (as a field),
+// Install, Upgrade, ValuesFrom, PostRenderers, KubeConfig,
+// MaxHistory, etc. to the top level.
+//
+// Several flate-specific projection fields live alongside the
+// embedded Spec:
+//   - Chart is the union of spec.chart and spec.chartRef (the
+//     upstream's Spec.Chart and Spec.ChartRef are dropped via
+//     shadowing — accessible via h.HelmReleaseSpec.Chart if needed).
+//   - Values is the decoded form of spec.values (map[string]any) so
+//     consumers don't have to JSON-decode on every access.
+//   - DependsOn is normalized to []DependencyRef (with ReadyExpr).
+//   - CRDsPolicy collapses spec.install.crds vs spec.upgrade.crds.
+//   - DisableSchema/OpenAPIValidation collapse Install vs Upgrade.
+//   - ChartValuesFiles + IgnoreMissingValuesFiles are sourced from
+//     spec.chart.spec.valuesFiles OR the referenced HelmChart CRD.
 type HelmRelease struct {
-	Name                     string            `json:"name" yaml:"name"`
-	Namespace                string            `json:"namespace" yaml:"namespace"`
-	Chart                    HelmChart         `json:"chart" yaml:"chart"`
-	// ReleaseNameOverride holds spec.releaseName when set. Empty means
-	// helm-controller defaults to metadata.name. Use ReleaseName() to
-	// resolve.
-	ReleaseNameOverride      string            `json:"-" yaml:"-"`
-	TargetNamespace          string            `json:"-" yaml:"-"`
-	Values                   map[string]any    `json:"-" yaml:"-"`
-	ValuesFrom               []ValuesReference `json:"-" yaml:"-"`
-	Images                   []string          `json:"images,omitempty" yaml:"images,omitempty"`
-	Labels                   map[string]string `json:"-" yaml:"-"`
-	DependsOn                []DependencyRef   `json:"-" yaml:"-"`
-	Suspend                  bool              `json:"-" yaml:"-"`
-	DisableSchemaValidation  bool              `json:"-" yaml:"-"`
-	DisableOpenAPIValidation bool              `json:"-" yaml:"-"`
-	// CRDsPolicy mirrors spec.install.crds / spec.upgrade.crds. One of
-	// "" (chart's helm default), "Skip", "Create", "CreateReplace".
-	// "Skip" suppresses CRDs from the rendered output. "Create" and
-	// "CreateReplace" both include CRDs — they differ only in
-	// cluster-apply semantics which flate doesn't perform.
+	Name      string `json:"name"      yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+
+	helmv2.HelmReleaseSpec `json:",inline" yaml:",inline"`
+
+	// Chart is the resolved chart reference, unifying spec.chart and
+	// spec.chartRef into one shape. Shadows the embedded Spec.Chart.
+	Chart HelmChart `json:"chart" yaml:"chart"`
+
+	// Values is the decoded form of spec.values. Shadows the embedded
+	// Spec.Values (*apiextensionsv1.JSON).
+	Values map[string]any `json:"-" yaml:"-"`
+
+	// DependsOn is the normalized form of spec.dependsOn (carrying any
+	// ReadyExpr). Shadows the embedded Spec.DependsOn ([]DependencyReference).
+	DependsOn []DependencyRef `json:"-" yaml:"-"`
+
+	Images []string          `json:"images,omitempty" yaml:"images,omitempty"`
+	Labels map[string]string `json:"-"                yaml:"-"`
+
+	// CRDsPolicy collapses spec.install.crds vs spec.upgrade.crds. One
+	// of "" (chart's helm default), "Skip", "Create", "CreateReplace".
 	// Upgrade wins over Install when both are set, matching
 	// helm-controller's "upgrade-after-install" model.
 	CRDsPolicy string `json:"-" yaml:"-"`
-	// ServiceAccountName is the SA Flux's helm-controller impersonates
-	// when applying the release. Flate renders offline so it has no
-	// effect here, but the field is preserved for fidelity with the
-	// upstream CR and so future render-time policy checks can observe it.
-	ServiceAccountName string `json:"-" yaml:"-"`
+
+	// DisableSchemaValidation / DisableOpenAPIValidation collapse the
+	// install vs upgrade equivalents into single flags.
+	DisableSchemaValidation  bool `json:"-" yaml:"-"`
+	DisableOpenAPIValidation bool `json:"-" yaml:"-"`
+
 	// ChartValuesFiles are values files baked into the chart that
-	// should be merged BEFORE the HR's own Values overrides. Sourced
-	// from either spec.chart.spec.valuesFiles (inline template) or the
-	// referenced HelmChart CRD's spec.valuesFiles (when chartRef is
-	// used; populated by ResolveChartRef).
-	ChartValuesFiles []string `json:"-" yaml:"-"`
-	// IgnoreMissingValuesFiles: when true, missing ChartValuesFiles
-	// entries are skipped instead of erroring.
-	IgnoreMissingValuesFiles bool `json:"-" yaml:"-"`
-	// PostRenderers are the spec.postRenderers entries applied to the
-	// rendered chart output, mirroring helm-controller's behavior. Each
-	// renderer is a kustomize-based patch+image transform.
-	PostRenderers []helmv2.PostRenderer `json:"-" yaml:"-"`
+	// should be merged BEFORE the HR's own Values overrides.
+	ChartValuesFiles         []string `json:"-" yaml:"-"`
+	IgnoreMissingValuesFiles bool     `json:"-" yaml:"-"`
 }
 
 // Named identifies the release.
@@ -212,8 +222,8 @@ func (h *HelmRelease) Named() NamedResource {
 // when set, otherwise metadata.name. Mirrors helm-controller's behavior
 // at template time. Always non-empty.
 func (h *HelmRelease) ReleaseName() string {
-	if h.ReleaseNameOverride != "" {
-		return h.ReleaseNameOverride
+	if h.HelmReleaseSpec.ReleaseName != "" {
+		return h.HelmReleaseSpec.ReleaseName
 	}
 	return h.Name
 }
@@ -342,23 +352,23 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		ignoreMissingValuesFiles = cr.Spec.Chart.Spec.IgnoreMissingValuesFiles
 	}
 
+	// Ensure ValuesFrom is a defensive clone — Spec is embedded by
+	// value so this is the only slice that could escape via aliasing.
+	cr.Spec.ValuesFrom = vfs
+	cr.Spec.PostRenderers = slices.Clone(cr.Spec.PostRenderers)
+
 	return &HelmRelease{
 		Name:                     cr.Name,
 		Namespace:                cr.Namespace,
+		HelmReleaseSpec:          cr.Spec,
 		Chart:                    chart,
-		ReleaseNameOverride:      cr.Spec.ReleaseName,
-		PostRenderers:            slices.Clone(cr.Spec.PostRenderers),
-		TargetNamespace:          cr.Spec.TargetNamespace,
 		Values:                   values,
-		ValuesFrom:               vfs,
-		Labels:                   cr.Labels,
 		DependsOn:                dependsOn,
-		Suspend:                  cr.Spec.Suspend,
+		Labels:                   cr.Labels,
 		DisableSchemaValidation:  disableSchema,
 		DisableOpenAPIValidation: disableOpenAPI,
 		ChartValuesFiles:         chartValuesFiles,
 		IgnoreMissingValuesFiles: ignoreMissingValuesFiles,
-		ServiceAccountName:       cr.Spec.ServiceAccountName,
 		CRDsPolicy:               crdsPolicy,
 	}, nil
 }

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -84,34 +84,34 @@ func chartFromHelmRelease(spec *helmv2.HelmReleaseSpec, defaultNamespace string)
 	}, nil
 }
 
-// HelmChartFromSource constructs a HelmChart from a resolved HelmChartSource.
+// HelmChartFromSource constructs a HelmChart from a resolved
+// HelmChartSource. The Repo* fields are read from the embedded
+// SourceRef (which always shares the HelmChart's namespace per Flux
+// schema).
 func HelmChartFromSource(src *HelmChartSource) HelmChart {
+	kind := src.SourceRef.Kind
+	if kind == "" {
+		kind = KindHelmRepository
+	}
 	return HelmChart{
 		Name:          src.Chart,
 		Version:       src.Version,
-		RepoName:      src.RepoName,
-		RepoNamespace: src.RepoNamespace,
-		RepoKind:      src.RepoKind,
+		RepoName:      src.SourceRef.Name,
+		RepoNamespace: src.Namespace,
+		RepoKind:      kind,
 	}
 }
 
 // HelmChartSource is the standalone HelmChart CRD
-// (source.toolkit.fluxcd.io/v1 HelmChart).
+// (source.toolkit.fluxcd.io/v1 HelmChart). The embedded HelmChartSpec
+// promotes Chart, Version, SourceRef, ValuesFiles,
+// IgnoreMissingValuesFiles, ReconcileStrategy, Suspend, Verify to the
+// top level for ergonomic access.
 type HelmChartSource struct {
-	Name                     string   `json:"name" yaml:"name"`
-	Namespace                string   `json:"namespace" yaml:"namespace"`
-	Chart                    string   `json:"chart" yaml:"chart"`
-	Version                  string   `json:"version,omitempty" yaml:"version,omitempty"`
-	RepoName                 string   `json:"repoName" yaml:"repoName"`
-	RepoNamespace            string   `json:"repoNamespace" yaml:"repoNamespace"`
-	RepoKind                 string   `json:"repoKind" yaml:"repoKind"`
-	Suspend                  bool     `json:"-" yaml:"-"`
-	ValuesFiles              []string `json:"-" yaml:"-"`
-	IgnoreMissingValuesFiles bool     `json:"-" yaml:"-"`
-	// ReconcileStrategy is "ChartVersion" (default) or "Revision". Flate
-	// does not re-trigger reconciles; this is parsed for round-tripping
-	// fidelity so consumers can observe the upstream intent.
-	ReconcileStrategy string `json:"-" yaml:"-"`
+	Name      string `json:"name"      yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+
+	sourcev1.HelmChartSpec `json:",inline" yaml:",inline"`
 }
 
 // Named identifies the chart resource.
@@ -147,22 +147,13 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 	if cr.Spec.SourceRef.Name == "" {
 		return nil, inputf("HelmChart missing spec.sourceRef.name")
 	}
-	repoKind := cr.Spec.SourceRef.Kind
-	if repoKind == "" {
-		repoKind = KindHelmRepository
+	if cr.Spec.SourceRef.Kind == "" {
+		cr.Spec.SourceRef.Kind = KindHelmRepository
 	}
 	return &HelmChartSource{
-		Name:                     cr.Name,
-		Namespace:                ns,
-		Chart:                    cr.Spec.Chart,
-		Version:                  cr.Spec.Version,
-		RepoName:                 cr.Spec.SourceRef.Name,
-		RepoNamespace:            ns,
-		RepoKind:                 repoKind,
-		Suspend:                  cr.Spec.Suspend,
-		ValuesFiles:              cr.Spec.ValuesFiles,
-		IgnoreMissingValuesFiles: cr.Spec.IgnoreMissingValuesFiles,
-		ReconcileStrategy:        cr.Spec.ReconcileStrategy,
+		Name:           cr.Name,
+		Namespace:      ns,
+		HelmChartSpec:  cr.Spec,
 	}, nil
 }
 

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -11,36 +11,59 @@ import (
 // Kustomization is the Flux Kustomization CR. It bundles the path of a
 // local kustomize tree together with the in-cluster materials it produces
 // (HelmReleases, HelmRepositories, ConfigMaps, Secrets, ...).
+//
+// The embedded kustomizev1.KustomizationSpec promotes Path, Suspend,
+// TargetNamespace, Components, SourceRef, PostBuild, Patches, Images,
+// CommonMetadata, NamePrefix, NameSuffix, Wait, Prune, Force,
+// HealthChecks, etc. to the top level. Shadowed by flate-only fields
+// where the projected shape differs from the upstream (DependsOn,
+// PostBuildSubstitute, PostBuildSubstituteFrom — see field docs).
 type Kustomization struct {
-	Name      string `json:"name" yaml:"name"`
+	Name      string `json:"name"                yaml:"name"`
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	Path      string `json:"path" yaml:"path"`
 
-	HelmRepos        []*HelmRepository  `json:"helmRepos,omitempty" yaml:"helmRepos,omitempty"`
-	OCIRepos         []*OCIRepository   `json:"ociRepos,omitempty" yaml:"ociRepos,omitempty"`
-	HelmReleases     []*HelmRelease     `json:"helmReleases,omitempty" yaml:"helmReleases,omitempty"`
-	ConfigMaps       []*ConfigMap       `json:"configMaps,omitempty" yaml:"configMaps,omitempty"`
-	Secrets          []*Secret          `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	kustomizev1.KustomizationSpec `json:",inline" yaml:",inline"`
+
+	HelmRepos        []*HelmRepository  `json:"helmRepos,omitempty"        yaml:"helmRepos,omitempty"`
+	OCIRepos         []*OCIRepository   `json:"ociRepos,omitempty"         yaml:"ociRepos,omitempty"`
+	HelmReleases     []*HelmRelease     `json:"helmReleases,omitempty"     yaml:"helmReleases,omitempty"`
+	ConfigMaps       []*ConfigMap       `json:"configMaps,omitempty"       yaml:"configMaps,omitempty"`
+	Secrets          []*Secret          `json:"secrets,omitempty"          yaml:"secrets,omitempty"`
 	HelmChartSources []*HelmChartSource `json:"helmChartSources,omitempty" yaml:"helmChartSources,omitempty"`
 
-	// Internal-only fields (not emitted to YAML output).
-	SourcePath              string                `json:"-" yaml:"-"`
-	SourceKind              string                `json:"-" yaml:"-"`
-	SourceName              string                `json:"-" yaml:"-"`
-	SourceNamespace         string                `json:"-" yaml:"-"`
-	TargetNamespace         string                `json:"-" yaml:"-"`
-	Contents                map[string]any        `json:"-" yaml:"-"`
-	PostBuildSubstitute     map[string]any        `json:"-" yaml:"-"`
-	PostBuildSubstituteFrom []SubstituteReference `json:"-" yaml:"-"`
-	DependsOn               []DependencyRef       `json:"-" yaml:"-"`
-	Labels                  map[string]string     `json:"-" yaml:"-"`
-	// Components is Flux v1's spec.components — paths to kustomize
-	// components injected on top of spec.path at reconcile time.
-	Components []string `json:"-" yaml:"-"`
-	// Suspend mirrors spec.suspend — controllers skip suspended objects.
-	Suspend bool `json:"-" yaml:"-"`
+	// SourcePath is the location on disk this Kustomization was loaded
+	// from (config.kubernetes.io/path annotation).
+	SourcePath string `json:"-" yaml:"-"`
 
-	Images []string `json:"images,omitempty" yaml:"images,omitempty"`
+	// SourceKind / SourceName / SourceNamespace mirror the embedded
+	// Spec.SourceRef with the namespace defaulted to the Kustomization's
+	// own namespace (matching Flux's behavior). The embedded struct's
+	// SourceRef is accessible at k.SourceRef when callers need the raw
+	// upstream typed form.
+	SourceKind      string `json:"-" yaml:"-"`
+	SourceName      string `json:"-" yaml:"-"`
+	SourceNamespace string `json:"-" yaml:"-"`
+
+	// Contents is the raw decoded YAML document. Retained because
+	// RenderFlux still feeds it to fluxcd/pkg/kustomize.NewGenerator
+	// as an unstructured.Unstructured.
+	Contents map[string]any `json:"-" yaml:"-"`
+
+	// PostBuildSubstitute holds the resolved substitution variables
+	// (after evaluating spec.postBuild.substituteFrom against the
+	// store). Shadows the upstream Spec.PostBuild.Substitute (which
+	// holds the spec'd unresolved values).
+	PostBuildSubstitute map[string]any `json:"-" yaml:"-"`
+
+	// PostBuildSubstituteFrom captures the typed substituteFrom refs
+	// from spec.postBuild.
+	PostBuildSubstituteFrom []SubstituteReference `json:"-" yaml:"-"`
+
+	// DependsOn is the normalized form of spec.dependsOn carrying any
+	// ReadyExpr. Shadows the embedded Spec.DependsOn ([]DependencyReference).
+	DependsOn []DependencyRef `json:"-" yaml:"-"`
+
+	Labels map[string]string `json:"-" yaml:"-"`
 }
 
 // Named identifies the Kustomization.
@@ -164,18 +187,15 @@ func ParseKustomization(doc map[string]any) (*Kustomization, error) {
 	return &Kustomization{
 		Name:                    cr.Name,
 		Namespace:               ns,
-		Path:                    cr.Spec.Path,
+		KustomizationSpec:       cr.Spec,
 		SourcePath:              cr.Annotations["config.kubernetes.io/path"],
 		SourceKind:              cr.Spec.SourceRef.Kind,
 		SourceName:              cr.Spec.SourceRef.Name,
 		SourceNamespace:         srcNamespace,
-		TargetNamespace:         cr.Spec.TargetNamespace,
 		Contents:                doc,
 		PostBuildSubstitute:     subst,
 		PostBuildSubstituteFrom: substituteFrom,
 		DependsOn:               dependsOn,
 		Labels:                  cr.Labels,
-		Components:              cr.Spec.Components,
-		Suspend:                 cr.Spec.Suspend,
 	}, nil
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -585,8 +585,8 @@ spec:
 	if err != nil {
 		t.Fatalf("ParseHelmRelease: %v", err)
 	}
-	if hr.ReleaseNameOverride != "my-explicit-release" {
-		t.Errorf("ReleaseNameOverride = %q, want my-explicit-release", hr.ReleaseNameOverride)
+	if hr.HelmReleaseSpec.ReleaseName != "my-explicit-release" {
+		t.Errorf("HelmReleaseSpec.ReleaseName = %q, want my-explicit-release", hr.HelmReleaseSpec.ReleaseName)
 	}
 	if got := hr.ReleaseName(); got != "my-explicit-release" {
 		t.Errorf("ReleaseName() with override = %q, want my-explicit-release", got)

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -646,8 +646,8 @@ spec:
 	if err != nil {
 		t.Fatalf("ParseHelmRepository: %v", err)
 	}
-	if r.RepoType != "oci" {
-		t.Errorf("RepoType = %q", r.RepoType)
+	if r.Type != "oci" {
+		t.Errorf("RepoType = %q", r.Type)
 	}
 	if got, want := r.HelmChartName(HelmChart{Name: "podinfo"}), "oci://ghcr.io/stefanprodan/charts/podinfo"; got != want {
 		t.Errorf("HelmChartName = %q, want %q", got, want)

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
 // mustYAML decodes a single YAML document literal into a generic map.
@@ -213,14 +215,14 @@ spec:
 			if err != nil {
 				t.Fatalf("ParseGitRepository: %v", err)
 			}
-			if g.Verify == nil {
+			if g.Verification == nil {
 				t.Fatalf("expected Verify parsed")
 			}
-			if g.Verify.Mode != tc.want {
-				t.Errorf("Mode = %q, want %q", g.Verify.Mode, tc.want)
+			if string(g.Verification.Mode) != tc.want {
+				t.Errorf("Mode = %q, want %q", g.Verification.Mode, tc.want)
 			}
-			if g.Verify.SecretRef == nil || g.Verify.SecretRef.Name != "trusted-pgp-keys" {
-				t.Errorf("SecretRef = %+v", g.Verify.SecretRef)
+			if g.Verification.SecretRef.Name != "trusted-pgp-keys" {
+				t.Errorf("SecretRef = %+v", g.Verification.SecretRef)
 			}
 		})
 	}
@@ -325,14 +327,14 @@ spec:
 	if err != nil {
 		t.Fatalf("ParseGitRepository: %v", err)
 	}
-	if g.Ref.Name != "refs/pull/420/head" {
-		t.Errorf("Ref.Name = %q", g.Ref.Name)
+	if g.Reference == nil || g.Reference.Name != "refs/pull/420/head" {
+		t.Errorf("Reference.Name = %q", g.Reference)
 	}
 	if !g.RecurseSubmodules {
 		t.Errorf("RecurseSubmodules should be true")
 	}
-	if want := "name:refs/pull/420/head"; GitRefString(g.Ref) != want {
-		t.Errorf("RefString = %q, want %q", GitRefString(g.Ref), want)
+	if want := "name:refs/pull/420/head"; GitRefString(*g.Reference) != want {
+		t.Errorf("RefString = %q, want %q", GitRefString(*g.Reference), want)
 	}
 }
 
@@ -614,9 +616,12 @@ spec:
 
 	src := &HelmChartSource{
 		Name: "my-chart", Namespace: "flux-system",
-		Chart: "podinfo", Version: "6.3.2",
-		RepoName: "podinfo", RepoNamespace: "flux-system",
-		RepoKind: KindHelmRepository,
+		HelmChartSpec: sourcev1.HelmChartSpec{
+			Chart: "podinfo", Version: "6.3.2",
+			SourceRef: sourcev1.LocalHelmChartSourceReference{
+				Name: "podinfo", Kind: KindHelmRepository,
+			},
+		},
 	}
 	if err := hr.ResolveChartRef(map[string]*HelmChartSource{src.ResourceFullName(): src}); err != nil {
 		t.Fatalf("ResolveChartRef: %v", err)
@@ -670,7 +675,10 @@ spec:
 	if err != nil {
 		t.Fatalf("ParseGitRepository: %v", err)
 	}
-	if got, want := GitRefString(g.Ref), "tag:v1.2.3"; got != want {
+	if g.Reference == nil {
+		t.Fatalf("expected Reference parsed")
+	}
+	if got, want := GitRefString(*g.Reference), "tag:v1.2.3"; got != want {
 		t.Errorf("RefString = %q, want %q", got, want)
 	}
 }

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -288,9 +288,13 @@ type ExternalArtifactSourceRef = meta.NamespacedObjectKindReference
 // the user must supply status.artifact in the YAML (typical workflow:
 // pre-bake a file:// URL) for flate to resolve a local path.
 type ExternalArtifact struct {
-	Name      string                     `json:"name" yaml:"name"`
-	Namespace string                     `json:"namespace,omitempty" yaml:"namespace,omitempty"`
-	SourceRef *ExternalArtifactSourceRef `json:"sourceRef,omitempty" yaml:"sourceRef,omitempty"`
+	Name      string `json:"name"                yaml:"name"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+
+	// ExternalArtifactSpec embeds the upstream spec, exposing
+	// SourceRef at the top level.
+	sourcev1.ExternalArtifactSpec `json:",inline" yaml:",inline"`
+
 	// ArtifactURL / Revision / Digest come from status.artifact when
 	// pre-populated in the YAML. Empty otherwise (the normal case for a
 	// freshly-written CR); flate then fails to resolve any consumer.
@@ -323,12 +327,9 @@ func ParseExternalArtifact(doc map[string]any) (*ExternalArtifact, error) {
 		return nil, inputf("ExternalArtifact missing metadata.name")
 	}
 	out := &ExternalArtifact{
-		Name:      cr.Name,
-		Namespace: cr.Namespace,
-	}
-	if cr.Spec.SourceRef != nil {
-		ref := *cr.Spec.SourceRef
-		out.SourceRef = &ref
+		Name:                  cr.Name,
+		Namespace:             cr.Namespace,
+		ExternalArtifactSpec:  cr.Spec,
 	}
 	if a := cr.Status.Artifact; a != nil {
 		out.ArtifactURL = a.URL

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -31,40 +31,25 @@ func GitRefString(r GitRepositoryRef) string {
 
 
 // GitRepository is the Flux GitRepository CRD.
+// GitRepository is the Flux GitRepository CRD. The embedded
+// sourcev1.GitRepositorySpec promotes URL, Reference, Verification,
+// Provider, SecretRef, ProxySecretRef, RecurseSubmodules,
+// SparseCheckout, Suspend etc. to the top level.
 type GitRepository struct {
-	Name              string                `json:"name" yaml:"name"`
-	Namespace         string                `json:"namespace" yaml:"namespace"`
-	URL               string                `json:"url" yaml:"url"`
-	Ref               GitRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Provider          string                `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef         *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	ProxySecretRef    *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
-	Verify            *GitRepositoryVerify  `json:"verify,omitempty" yaml:"verify,omitempty"`
-	RecurseSubmodules bool                  `json:"recurseSubmodules,omitempty" yaml:"recurseSubmodules,omitempty"`
-	// SparseCheckout limits the checkout to the listed repo-relative
-	// directories. When empty, the full tree is checked out (default).
-	SparseCheckout []string `json:"sparseCheckout,omitempty" yaml:"sparseCheckout,omitempty"`
-	Suspend        bool     `json:"-" yaml:"-"`
+	Name      string `json:"name"      yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+
+	sourcev1.GitRepositorySpec `json:",inline" yaml:",inline"`
 }
 
-// GitRepositoryVerify mirrors source-controller's GitRepositoryVerification.
-// The Secret named by SecretRef holds one or more PEM-armored PGP
-// public keys (typically "*.asc"); flate concatenates them into a
-// single keyring and verifies the resolved commit/tag signatures
-// against it.
-type GitRepositoryVerify struct {
-	// Mode is "HEAD", "Tag", or "TagAndHEAD". The legacy "head"
-	// alias normalizes to "HEAD" during parse.
-	Mode      string                `json:"mode,omitempty" yaml:"mode,omitempty"`
-	SecretRef *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-}
+// GitRepositoryVerify is the Flux GitRepositoryVerification type.
+type GitRepositoryVerify = sourcev1.GitRepositoryVerification
 
-// Git verification modes — sourced from sourcev1.GitVerificationMode so
-// flate's bare-string Mode field interops with the typed upstream API.
-var (
-	GitVerifyModeHEAD       = string(sourcev1.ModeGitHEAD)
-	GitVerifyModeTag        = string(sourcev1.ModeGitTag)
-	GitVerifyModeTagAndHEAD = string(sourcev1.ModeGitTagAndHEAD)
+// Git verification modes — typed re-exports of sourcev1.GitVerificationMode.
+const (
+	GitVerifyModeHEAD       = sourcev1.ModeGitHEAD
+	GitVerifyModeTag        = sourcev1.ModeGitTag
+	GitVerifyModeTagAndHEAD = sourcev1.ModeGitTagAndHEAD
 )
 
 // Named identifies the GitRepository.
@@ -95,42 +80,20 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("GitRepository missing spec.url")
 	}
-	var ref GitRepositoryRef
-	if r := cr.Spec.Reference; r != nil {
-		ref = *r
-	}
-	provider := cr.Spec.Provider
-	if provider == "" {
-		provider = sourcev1.GitProviderGeneric
-	}
-	out := &GitRepository{
-		Name:              cr.Name,
-		Namespace:         cr.Namespace,
-		URL:               cr.Spec.URL,
-		Ref:               ref,
-		Provider:          provider,
-		RecurseSubmodules: cr.Spec.RecurseSubmodules,
-		SparseCheckout:    cr.Spec.SparseCheckout,
-		Suspend:           cr.Spec.Suspend,
-	}
-	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = cr.Spec.SecretRef
-	}
-	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
-		out.ProxySecretRef = cr.Spec.ProxySecretRef
+	if cr.Spec.Provider == "" {
+		cr.Spec.Provider = sourcev1.GitProviderGeneric
 	}
 	if v := cr.Spec.Verification; v != nil {
-		mode := string(v.GetMode())
-		if mode == "head" { // legacy alias
-			mode = GitVerifyModeHEAD
-		}
-		out.Verify = &GitRepositoryVerify{Mode: mode}
-		if v.SecretRef.Name != "" {
-			ref := v.SecretRef
-			out.Verify.SecretRef = &ref
-		}
+		// GetMode normalizes the legacy "head" alias to "HEAD" and
+		// applies the schema default. Write it back so consumers see a
+		// canonical mode regardless of source casing.
+		v.Mode = v.GetMode()
 	}
-	return out, nil
+	return &GitRepository{
+		Name:              cr.Name,
+		Namespace:         cr.Namespace,
+		GitRepositorySpec: cr.Spec,
+	}, nil
 }
 
 // OCIRepositoryRef is the Flux OCIRepositoryRef from source-controller.
@@ -139,20 +102,15 @@ type OCIRepositoryRef = sourcev1.OCIRepositoryRef
 // OCIRefIsEmpty reports whether the ref is empty.
 func OCIRefIsEmpty(r OCIRepositoryRef) bool { return r == OCIRepositoryRef{} }
 
-// OCIRepository is the Flux OCIRepository CRD.
+// OCIRepository is the Flux OCIRepository CRD. The embedded
+// sourcev1.OCIRepositorySpec promotes URL, Reference, LayerSelector,
+// Provider, SecretRef, CertSecretRef, ProxySecretRef, Verify, Insecure,
+// Suspend etc. to the top level.
 type OCIRepository struct {
-	Name           string                `json:"name" yaml:"name"`
-	Namespace      string                `json:"namespace" yaml:"namespace"`
-	URL            string                `json:"url" yaml:"url"`
-	Ref            OCIRepositoryRef      `json:"ref,omitzero" yaml:"ref,omitempty"`
-	Provider       string                `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SecretRef      *LocalObjectReference `json:"secretRef,omitempty" yaml:"secretRef,omitempty"`
-	CertSecretRef  *LocalObjectReference `json:"certSecretRef,omitempty" yaml:"certSecretRef,omitempty"`
-	ProxySecretRef *LocalObjectReference `json:"proxySecretRef,omitempty" yaml:"proxySecretRef,omitempty"`
-	Verify         *OCIRepositoryVerify  `json:"verify,omitempty" yaml:"verify,omitempty"`
-	LayerSelector  *OCILayerSelector     `json:"layerSelector,omitempty" yaml:"layerSelector,omitempty"`
-	Insecure       bool                  `json:"insecure,omitempty" yaml:"insecure,omitempty"`
-	Suspend        bool                  `json:"-" yaml:"-"`
+	Name      string `json:"name"      yaml:"name"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+
+	sourcev1.OCIRepositorySpec `json:",inline" yaml:",inline"`
 }
 
 // OCILayerSelector is the Flux OCILayerSelector from source-controller.
@@ -193,16 +151,17 @@ func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }
 // A semver expression is returned verbatim — callers wanting a concrete
 // tag must resolve it against remote tag listing (pkg/source).
 func (o *OCIRepository) Version() (string, error) {
-	if OCIRefIsEmpty(o.Ref) {
+	r := o.Reference
+	if r == nil {
 		return "", nil
 	}
 	switch {
-	case o.Ref.Digest != "":
-		return o.Ref.Digest, nil
-	case o.Ref.Tag != "":
-		return o.Ref.Tag, nil
-	case o.Ref.SemVer != "":
-		return o.Ref.SemVer, nil
+	case r.Digest != "":
+		return r.Digest, nil
+	case r.Tag != "":
+		return r.Tag, nil
+	case r.SemVer != "":
+		return r.SemVer, nil
 	}
 	return "", nil
 }
@@ -210,16 +169,17 @@ func (o *OCIRepository) Version() (string, error) {
 // VersionedURL appends the version with the correct separator: "@" for
 // digests, ":" for tags and semver.
 func (o *OCIRepository) VersionedURL() string {
-	if OCIRefIsEmpty(o.Ref) {
+	r := o.Reference
+	if r == nil {
 		return o.URL
 	}
 	switch {
-	case o.Ref.Digest != "":
-		return o.URL + "@" + o.Ref.Digest
-	case o.Ref.Tag != "":
-		return o.URL + ":" + o.Ref.Tag
-	case o.Ref.SemVer != "":
-		return o.URL + ":" + o.Ref.SemVer
+	case r.Digest != "":
+		return o.URL + "@" + r.Digest
+	case r.Tag != "":
+		return o.URL + ":" + r.Tag
+	case r.SemVer != "":
+		return o.URL + ":" + r.SemVer
 	}
 	return o.URL
 }
@@ -239,40 +199,17 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("OCIRepository missing spec.url")
 	}
-	provider := cr.Spec.Provider
-	if provider == "" {
-		provider = sourcev1.GenericOCIProvider
-	}
-	out := &OCIRepository{
-		Name:      cr.Name,
-		Namespace: cr.Namespace,
-		URL:       cr.Spec.URL,
-		Provider:  provider,
-		Insecure:  cr.Spec.Insecure,
-		Suspend:   cr.Spec.Suspend,
-	}
-	if cr.Spec.CertSecretRef != nil && cr.Spec.CertSecretRef.Name != "" {
-		out.CertSecretRef = cr.Spec.CertSecretRef
-	}
-	if r := cr.Spec.Reference; r != nil {
-		out.Ref = *r
-	}
-	if cr.Spec.SecretRef != nil && cr.Spec.SecretRef.Name != "" {
-		out.SecretRef = cr.Spec.SecretRef
-	}
-	if cr.Spec.ProxySecretRef != nil && cr.Spec.ProxySecretRef.Name != "" {
-		out.ProxySecretRef = cr.Spec.ProxySecretRef
+	if cr.Spec.Provider == "" {
+		cr.Spec.Provider = sourcev1.GenericOCIProvider
 	}
 	if v := cr.Spec.Verify; v != nil {
-		clone := *v
-		clone.MatchOIDCIdentity = slices.Clone(v.MatchOIDCIdentity)
-		out.Verify = &clone
+		v.MatchOIDCIdentity = slices.Clone(v.MatchOIDCIdentity)
 	}
-	if ls := cr.Spec.LayerSelector; ls != nil {
-		clone := *ls
-		out.LayerSelector = &clone
-	}
-	return out, nil
+	return &OCIRepository{
+		Name:              cr.Name,
+		Namespace:         cr.Namespace,
+		OCIRepositorySpec: cr.Spec,
+	}, nil
 }
 
 // ExternalArtifactSourceRef identifies the upstream CR that produces

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/helmrelease"
 	"github.com/home-operations/flate/pkg/controllers/kustomization"
@@ -181,7 +183,7 @@ func (o *Orchestrator) seedBootstrapSource() (string, error) {
 
 	repo := &manifest.GitRepository{
 		Name: "flux-system", Namespace: "flux-system",
-		URL: "file://" + root,
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
 	}
 	id := repo.Named()
 	o.store.AddObject(repo)

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -20,19 +22,19 @@ import (
 func TestDetectOrphans(t *testing.T) {
 	parent := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		Path: "./kubernetes/apps",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
 	}
 	orphan := &manifest.Kustomization{
 		Name: "orphan", Namespace: "flux-system",
-		Path: "./kubernetes/apps/orphan/app",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps/orphan/app"},
 	}
 	emittedChild := &manifest.Kustomization{
 		Name: "wired", Namespace: "flux-system",
-		Path: "./kubernetes/apps/wired/app",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps/wired/app"},
 	}
 	root := &manifest.Kustomization{
 		Name: "another-root", Namespace: "flux-system",
-		Path: "./standalone",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./standalone"},
 	}
 
 	o := &Orchestrator{
@@ -79,7 +81,8 @@ func TestDetectOrphans(t *testing.T) {
 // detection only applies to Kustomization + HelmRelease.
 func TestDetectOrphans_NonReconcilableKindsIgnored(t *testing.T) {
 	parent := &manifest.Kustomization{
-		Name: "p", Namespace: "ns", Path: "./apps",
+		Name: "p", Namespace: "ns",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
 	}
 	cm := &manifest.ConfigMap{Name: "stuck", Namespace: "ns"}
 

--- a/pkg/source/bucket/bucket_test.go
+++ b/pkg/source/bucket/bucket_test.go
@@ -15,8 +15,10 @@ func TestFetcher_NonGenericProviderFailsLoud(t *testing.T) {
 	f := &bucket.Fetcher{}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		Provider: sourcev1.BucketProviderAmazon,
-		BucketName: "x", Endpoint: "s3.amazonaws.com",
+		BucketSpec: sourcev1.BucketSpec{
+			Provider:   sourcev1.BucketProviderAmazon,
+			BucketName: "x", Endpoint: "s3.amazonaws.com",
+		},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {
@@ -31,9 +33,11 @@ func TestFetcher_SecretRefWithoutGetter(t *testing.T) {
 	f := &bucket.Fetcher{} // no Secrets
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		Provider: sourcev1.BucketProviderGeneric,
-		BucketName: "x", Endpoint: "minio:9000",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		BucketSpec: sourcev1.BucketSpec{
+			Provider:   sourcev1.BucketProviderGeneric,
+			BucketName: "x", Endpoint: "minio:9000",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {
@@ -55,9 +59,11 @@ func TestFetcher_SecretRefMissingKeys(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		Provider: sourcev1.BucketProviderGeneric,
-		BucketName: "x", Endpoint: "minio:9000",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		BucketSpec: sourcev1.BucketSpec{
+			Provider:   sourcev1.BucketProviderGeneric,
+			BucketName: "x", Endpoint: "minio:9000",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {
@@ -74,9 +80,11 @@ func TestFetcher_SecretRefNotFound(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		Provider: sourcev1.BucketProviderGeneric,
-		BucketName: "x", Endpoint: "minio:9000",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		BucketSpec: sourcev1.BucketSpec{
+			Provider:   sourcev1.BucketProviderGeneric,
+			BucketName: "x", Endpoint: "minio:9000",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {

--- a/pkg/source/bucket/transport_test.go
+++ b/pkg/source/bucket/transport_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -35,7 +37,9 @@ func TestFetcher_ResolveTransport_FromSecret(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		BucketSpec: sourcev1.BucketSpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		},
 	}
 	tr, err := f.resolveTransport(b)
 	if err != nil {
@@ -63,7 +67,9 @@ func TestFetcher_ResolveTransport_PartialCertKey(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		BucketSpec: sourcev1.BucketSpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "must provide both") {
@@ -79,7 +85,9 @@ func TestFetcher_ResolveTransport_AllKeysMissing(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		BucketSpec: sourcev1.BucketSpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "tls.crt") {
@@ -93,7 +101,9 @@ func TestFetcher_ResolveTransport_SecretNotFound(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		BucketSpec: sourcev1.BucketSpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {
@@ -105,7 +115,9 @@ func TestFetcher_ResolveTransport_CertSecretRefWithoutGetter(t *testing.T) {
 	f := &Fetcher{} // no Secrets
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		BucketSpec: sourcev1.BucketSpec{
+			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
+		},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {

--- a/pkg/source/git/auth_test.go
+++ b/pkg/source/git/auth_test.go
@@ -15,8 +15,10 @@ func TestFetcher_NonGenericProvider(t *testing.T) {
 	f := &Fetcher{}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		URL:      "https://github.com/x/y.git",
-		Provider: sourcev1.GitProviderGitHub,
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:      "https://github.com/x/y.git",
+			Provider: sourcev1.GitProviderGitHub,
+		},
 	}
 	_, err := f.Fetch(context.Background(), repo)
 	if err == nil {
@@ -40,8 +42,10 @@ func TestFetcher_HTTPSBasicAuth(t *testing.T) {
 	}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		URL:       "https://github.com/x/y.git",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "https://github.com/x/y.git",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
@@ -69,8 +73,11 @@ func TestFetcher_HTTPSBearerWinsOverBasic(t *testing.T) {
 		},
 	}
 	repo := &manifest.GitRepository{
-		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		Name: "g", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "https://github.com/x/y.git",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
@@ -92,8 +99,11 @@ func TestFetcher_HTTPSMissingCreds(t *testing.T) {
 		},
 	}
 	repo := &manifest.GitRepository{
-		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		Name: "g", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "https://github.com/x/y.git",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err := f.resolveAuth(repo)
 	if err == nil || !strings.Contains(err.Error(), "missing username/password") {
@@ -103,7 +113,10 @@ func TestFetcher_HTTPSMissingCreds(t *testing.T) {
 
 func TestFetcher_NoSecretIsAnonymous(t *testing.T) {
 	f := &Fetcher{}
-	repo := &manifest.GitRepository{URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns"}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://github.com/x/y.git"},
+	}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
@@ -116,8 +129,11 @@ func TestFetcher_NoSecretIsAnonymous(t *testing.T) {
 func TestFetcher_SecretRefMissingGetter(t *testing.T) {
 	f := &Fetcher{} // no Secrets
 	repo := &manifest.GitRepository{
-		URL: "https://github.com/x/y.git", Name: "g", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		Name: "g", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "https://github.com/x/y.git",
+			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+		},
 	}
 	_, err := f.resolveAuth(repo)
 	if err == nil || !strings.Contains(err.Error(), "SecretGetter") {
@@ -127,10 +143,10 @@ func TestFetcher_SecretRefMissingGetter(t *testing.T) {
 
 func TestSshUserFromURL(t *testing.T) {
 	cases := map[string]string{
-		"git@github.com:owner/repo.git":      "git",
-		"ssh://buildbot@example.com/r.git":   "buildbot",
-		"https://github.com/x/y.git":         "git", // not actually SSH, but tests default
-		"":                                   "git",
+		"git@github.com:owner/repo.git":    "git",
+		"ssh://buildbot@example.com/r.git": "buildbot",
+		"https://github.com/x/y.git":       "git", // not actually SSH, but tests default
+		"":                                 "git",
 	}
 	for url, want := range cases {
 		if got := sshUserFromURL(url); got != want {

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -82,7 +82,7 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	if err != nil {
 		return nil, err
 	}
-	if repo.Verify != nil {
+	if repo.Verification != nil {
 		cloned, oerr := git.PlainOpen(art.LocalPath)
 		if oerr != nil {
 			return nil, fmt.Errorf("verify: reopen %s: %w", art.LocalPath, oerr)
@@ -228,9 +228,11 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 		return nil, fmt.Errorf("%w: GitRepository %s missing url", manifest.ErrInput, repo.RepoName())
 	}
 
-	refStr := manifest.GitRefString(repo.Ref)
-	if refStr == "" {
-		refStr = "HEAD"
+	refStr := "HEAD"
+	if repo.Reference != nil {
+		if s := manifest.GitRefString(*repo.Reference); s != "" {
+			refStr = s
+		}
 	}
 
 	slot, exists, err := cache.Slot(repo.URL, refStr)
@@ -277,7 +279,11 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 		return nil, fmt.Errorf("clone %s: %w", url, err)
 	}
 
-	if err := checkoutRef(cloned, repo.Ref, repo.SparseCheckout); err != nil {
+	var ref manifest.GitRepositoryRef
+	if repo.Reference != nil {
+		ref = *repo.Reference
+	}
+	if err := checkoutRef(cloned, ref, repo.SparseCheckout); err != nil {
 		return nil, fmt.Errorf("checkout %s: %w", refStr, err)
 	}
 	if repo.RecurseSubmodules {

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
@@ -20,9 +21,8 @@ func TestFetcher_LocalFileURL(t *testing.T) {
 
 	cache := source.NewCache(t.TempDir())
 	repo := &manifest.GitRepository{
-		Name:      "test",
-		Namespace: "flux-system",
-		URL:       "file://" + src,
+		Name: "test", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
 	}
 
 	f := &Fetcher{Cache: cache}
@@ -59,8 +59,10 @@ func TestFetcher_RefByName(t *testing.T) {
 	cache := source.NewCache(t.TempDir())
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		URL: "file://" + src,
-		Ref: manifest.GitRepositoryRef{Name: "refs/tags/v0.1.0"},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Name: "refs/tags/v0.1.0"},
+		},
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -81,8 +83,10 @@ func TestFetcher_RefByName_Unresolvable(t *testing.T) {
 	cache := source.NewCache(t.TempDir())
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		URL: "file://" + src,
-		Ref: manifest.GitRepositoryRef{Name: "refs/heads/does-not-exist"},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Name: "refs/heads/does-not-exist"},
+		},
 	}
 	f := &Fetcher{Cache: cache}
 	_, err := f.Fetch(context.Background(), repo)
@@ -106,8 +110,10 @@ func TestFetcher_SparseCheckout(t *testing.T) {
 	cache := source.NewCache(t.TempDir())
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		URL:            "file://" + src,
-		SparseCheckout: []string{"apps/a"},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:            "file://" + src,
+			SparseCheckout: []string{"apps/a"},
+		},
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)

--- a/pkg/source/git/tls_test.go
+++ b/pkg/source/git/tls_test.go
@@ -4,13 +4,26 @@ import (
 	"strings"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+func gitRepoWithSecret(name, url, secretName string) *manifest.GitRepository {
+	repo := &manifest.GitRepository{
+		Name: name, Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: url},
+	}
+	if secretName != "" {
+		repo.SecretRef = &manifest.LocalObjectReference{Name: secretName}
+	}
+	return repo
+}
+
 func TestFetcher_ResolveTLS_NoSecretRefIsNil(t *testing.T) {
 	f := &Fetcher{}
-	repo := &manifest.GitRepository{Name: "g", Namespace: "ns", URL: "https://example.com/x.git"}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "")
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -26,11 +39,7 @@ func TestFetcher_ResolveTLS_SSHURLIsNil(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"ca.crt": "x"}}
 		},
 	}
-	repo := &manifest.GitRepository{
-		Name: "g", Namespace: "ns",
-		URL:       "ssh://git@example.com/x.git",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-	}
+	repo := gitRepoWithSecret("g", "ssh://git@example.com/x.git", "creds")
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -46,11 +55,7 @@ func TestFetcher_ResolveTLS_NoCAKeyInSecretIsNil(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"username": "alice", "password": "p"}}
 		},
 	}
-	repo := &manifest.GitRepository{
-		Name: "g", Namespace: "ns",
-		URL:       "https://example.com/x.git",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-	}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "creds")
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -67,11 +72,7 @@ func TestFetcher_ResolveTLS_CAFromCACrt(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"ca.crt": caPEM}}
 		},
 	}
-	repo := &manifest.GitRepository{
-		Name: "g", Namespace: "ns",
-		URL:       "https://example.com/x.git",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-	}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "creds")
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -88,11 +89,7 @@ func TestFetcher_ResolveTLS_CAFromCAFileLegacyKey(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"caFile": caPEM}}
 		},
 	}
-	repo := &manifest.GitRepository{
-		Name: "g", Namespace: "ns",
-		URL:       "https://example.com/x.git",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-	}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "creds")
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -108,14 +105,9 @@ func TestFetcher_ResolveTLS_InvalidPEM(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"ca.crt": "-----BEGIN CERTIFICATE-----\nnot-pem\n-----END CERTIFICATE-----"}}
 		},
 	}
-	repo := &manifest.GitRepository{
-		Name: "g", Namespace: "ns",
-		URL:       "https://example.com/x.git",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-	}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "creds")
 	_, err := f.resolveTLS(repo)
 	if err == nil || !strings.Contains(err.Error(), "did not parse as PEM") {
 		t.Errorf("expected PEM parse error; got %v", err)
 	}
 }
-

--- a/pkg/source/git/verify.go
+++ b/pkg/source/git/verify.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 
@@ -19,15 +20,12 @@ import (
 // ASCII-armored public keys (any *.asc filename); they're
 // concatenated into a single keyring before verification.
 func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository, cloned *git.Repository, resolvedRef plumbing.Hash) error {
-	if repo.Verify == nil {
+	if repo.Verification == nil {
 		return nil
 	}
-	v := repo.Verify
-	mode := v.Mode
-	if mode == "" {
-		mode = manifest.GitVerifyModeHEAD
-	}
-	if v.SecretRef == nil {
+	v := repo.Verification
+	mode := v.GetMode()
+	if v.SecretRef.Name == "" {
 		return fmt.Errorf("GitRepository %s/%s: spec.verify.secretRef is required",
 			repo.Namespace, repo.Name)
 	}
@@ -52,7 +50,10 @@ func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository,
 		}
 	}
 	if verifyTag(mode) {
-		tagName := repo.Ref.Tag
+		tagName := ""
+		if repo.Reference != nil {
+			tagName = repo.Reference.Tag
+		}
 		if tagName == "" {
 			return fmt.Errorf("GitRepository %s/%s: verify mode %q requires spec.ref.tag",
 				repo.Namespace, repo.Name, mode)
@@ -65,12 +66,12 @@ func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository,
 	return nil
 }
 
-func verifyHEAD(mode string) bool {
-	return mode == manifest.GitVerifyModeHEAD || mode == manifest.GitVerifyModeTagAndHEAD
+func verifyHEAD(mode sourcev1.GitVerificationMode) bool {
+	return mode == sourcev1.ModeGitHEAD || mode == sourcev1.ModeGitTagAndHEAD
 }
 
-func verifyTag(mode string) bool {
-	return mode == manifest.GitVerifyModeTag || mode == manifest.GitVerifyModeTagAndHEAD
+func verifyTag(mode sourcev1.GitVerificationMode) bool {
+	return mode == sourcev1.ModeGitTag || mode == sourcev1.ModeGitTagAndHEAD
 }
 
 // buildPGPKeyring concatenates every string value in the Secret into

--- a/pkg/source/git/verify_test.go
+++ b/pkg/source/git/verify_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -19,7 +20,9 @@ func TestVerifySignatures_NilVerifyIsNoOp(t *testing.T) {
 func TestVerifySignatures_RequiresSecretRef(t *testing.T) {
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		Verify: &manifest.GitRepositoryVerify{Mode: manifest.GitVerifyModeHEAD},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			Verification: &manifest.GitRepositoryVerify{Mode: manifest.GitVerifyModeHEAD},
+		},
 	}
 	err := verifySignatures(nil, repo, nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "secretRef is required") {
@@ -30,9 +33,11 @@ func TestVerifySignatures_RequiresSecretRef(t *testing.T) {
 func TestVerifySignatures_RequiresSecretGetter(t *testing.T) {
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		Verify: &manifest.GitRepositoryVerify{
-			Mode:      manifest.GitVerifyModeHEAD,
-			SecretRef: &manifest.LocalObjectReference{Name: "keys"},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			Verification: &manifest.GitRepositoryVerify{
+				Mode:      manifest.GitVerifyModeHEAD,
+				SecretRef: manifest.LocalObjectReference{Name: "keys"},
+			},
 		},
 	}
 	err := verifySignatures(nil, repo, nil, plumbing.ZeroHash)
@@ -44,9 +49,11 @@ func TestVerifySignatures_RequiresSecretGetter(t *testing.T) {
 func TestVerifySignatures_SecretNotFound(t *testing.T) {
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		Verify: &manifest.GitRepositoryVerify{
-			Mode:      manifest.GitVerifyModeHEAD,
-			SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			Verification: &manifest.GitRepositoryVerify{
+				Mode:      manifest.GitVerifyModeHEAD,
+				SecretRef: manifest.LocalObjectReference{Name: "missing"},
+			},
 		},
 	}
 	getter := func(_, _ string) *manifest.Secret { return nil }
@@ -104,7 +111,7 @@ func TestBuildPGPKeyring(t *testing.T) {
 
 func TestVerifyHEAD_Tag_HelperMatrix(t *testing.T) {
 	cases := []struct {
-		mode    string
+		mode    sourcev1.GitVerificationMode
 		wantH   bool
 		wantTag bool
 	}{

--- a/pkg/source/oci/auth_test.go
+++ b/pkg/source/oci/auth_test.go
@@ -12,9 +12,17 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+func ociRepo(name string, set func(s *sourcev1.OCIRepositorySpec)) *manifest.OCIRepository {
+	r := &manifest.OCIRepository{Name: name, Namespace: "ns"}
+	if set != nil {
+		set(&r.OCIRepositorySpec)
+	}
+	return r
+}
+
 func TestFetcher_ResolveTLS_NoCertSecretIsNil(t *testing.T) {
 	f := &Fetcher{}
-	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns"}
+	repo := ociRepo("o", nil)
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -26,7 +34,7 @@ func TestFetcher_ResolveTLS_NoCertSecretIsNil(t *testing.T) {
 
 func TestFetcher_ResolveTLS_Insecure(t *testing.T) {
 	f := &Fetcher{}
-	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns", Insecure: true}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) { s.Insecure = true })
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -51,10 +59,9 @@ func TestFetcher_ResolveTLS_FromSecret(t *testing.T) {
 			}
 		},
 	}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+	})
 	cfg, err := f.resolveTLS(repo)
 	if err != nil {
 		t.Fatalf("resolveTLS: %v", err)
@@ -76,10 +83,9 @@ func TestFetcher_ResolveTLS_PartialCertKey(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"tls.crt": "-only-cert-"}}
 		},
 	}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+	})
 	_, err := f.resolveTLS(repo)
 	if err == nil || !strings.Contains(err.Error(), "must provide both") {
 		t.Errorf("expected partial cert/key error; got %v", err)
@@ -92,24 +98,21 @@ func TestFetcher_ResolveTLS_AllKeysMissing(t *testing.T) {
 			return &manifest.Secret{StringData: map[string]any{"unrelated": "x"}}
 		},
 	}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+	})
 	_, err := f.resolveTLS(repo)
 	if err == nil || !strings.Contains(err.Error(), "tls.crt") {
 		t.Errorf("expected missing-keys error; got %v", err)
 	}
 }
 
-
 func TestFetcher_NonGenericProvider(t *testing.T) {
 	f := &Fetcher{}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		URL:      "oci://ghcr.io/x/y",
-		Provider: sourcev1.AmazonOCIProvider,
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.URL = "oci://ghcr.io/x/y"
+		s.Provider = sourcev1.AmazonOCIProvider
+	})
 	_, err := f.Fetch(context.Background(), repo)
 	if err == nil {
 		t.Fatalf("expected error for unimplemented provider")
@@ -121,7 +124,7 @@ func TestFetcher_NonGenericProvider(t *testing.T) {
 
 func TestFetcher_ResolveConfig_NoSecretFallsBackToGlobal(t *testing.T) {
 	f := &Fetcher{RegistryConfig: "/etc/docker/config.json"}
-	repo := &manifest.OCIRepository{Name: "o", Namespace: "ns"}
+	repo := ociRepo("o", nil)
 	path, cleanup, err := f.resolveRegistryConfig(repo)
 	defer cleanup()
 	if err != nil {
@@ -141,11 +144,10 @@ func TestFetcher_ResolveConfig_SecretWritesTempFile(t *testing.T) {
 			}
 		},
 	}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		URL:       "oci://ghcr.io/x/y",
-		SecretRef: &manifest.LocalObjectReference{Name: "ghcr-creds"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.URL = "oci://ghcr.io/x/y"
+		s.SecretRef = &manifest.LocalObjectReference{Name: "ghcr-creds"}
+	})
 	path, cleanup, err := f.resolveRegistryConfig(repo)
 	defer cleanup()
 	if err != nil {
@@ -176,10 +178,9 @@ func TestFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
 			}
 		},
 	}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "wrong-shape"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.SecretRef = &manifest.LocalObjectReference{Name: "wrong-shape"}
+	})
 	_, cleanup, err := f.resolveRegistryConfig(repo)
 	cleanup()
 	if err == nil || !strings.Contains(err.Error(), ".dockerconfigjson") {
@@ -189,10 +190,9 @@ func TestFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
 
 func TestFetcher_ResolveConfig_SecretRefWithoutGetter(t *testing.T) {
 	f := &Fetcher{} // no Secrets
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.SecretRef = &manifest.LocalObjectReference{Name: "creds"}
+	})
 	_, cleanup, err := f.resolveRegistryConfig(repo)
 	cleanup()
 	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
@@ -204,10 +204,9 @@ func TestFetcher_ResolveConfig_SecretNotFound(t *testing.T) {
 	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret { return nil },
 	}
-	repo := &manifest.OCIRepository{
-		Name: "o", Namespace: "ns",
-		SecretRef: &manifest.LocalObjectReference{Name: "missing"},
-	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.SecretRef = &manifest.LocalObjectReference{Name: "missing"}
+	})
 	_, cleanup, err := f.resolveRegistryConfig(repo)
 	cleanup()
 	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {

--- a/pkg/source/oci/cosign_test.go
+++ b/pkg/source/oci/cosign_test.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -117,8 +119,10 @@ func TestLoadCosignPublicKeys_NoSecretGetter(t *testing.T) {
 	f := &Fetcher{}
 	repo := &manifest.OCIRepository{
 		Name: "o", Namespace: "ns",
-		Verify: &manifest.OCIRepositoryVerify{
-			SecretRef: &manifest.LocalObjectReference{Name: "keys"},
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			Verify: &manifest.OCIRepositoryVerify{
+				SecretRef: &manifest.LocalObjectReference{Name: "keys"},
+			},
 		},
 	}
 	_, err := f.loadCosignPublicKeys(repo)
@@ -133,8 +137,10 @@ func TestLoadCosignPublicKeys_SecretNotFound(t *testing.T) {
 	}
 	repo := &manifest.OCIRepository{
 		Name: "o", Namespace: "ns",
-		Verify: &manifest.OCIRepositoryVerify{
-			SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			Verify: &manifest.OCIRepositoryVerify{
+				SecretRef: &manifest.LocalObjectReference{Name: "missing"},
+			},
 		},
 	}
 	_, err := f.loadCosignPublicKeys(repo)
@@ -158,8 +164,10 @@ func TestLoadCosignPublicKeys_ParsesPEM(t *testing.T) {
 	}
 	repo := &manifest.OCIRepository{
 		Name: "o", Namespace: "ns",
-		Verify: &manifest.OCIRepositoryVerify{
-			SecretRef: &manifest.LocalObjectReference{Name: "keys"},
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			Verify: &manifest.OCIRepositoryVerify{
+				SecretRef: &manifest.LocalObjectReference{Name: "keys"},
+			},
 		},
 	}
 	keys, err := f.loadCosignPublicKeys(repo)

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -198,7 +198,10 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 
 	// Resolve spec.ref into a concrete (tag-or-digest) BEFORE choosing
 	// the cache slot, so different semver matches don't share a slot.
-	ref := repo.Ref
+	var ref manifest.OCIRepositoryRef
+	if repo.Reference != nil {
+		ref = *repo.Reference
+	}
 	if ref.SemVer != "" {
 		resolved, err := resolveOCISemver(ctx, repoClient, ref.SemVer, ref.SemverFilter)
 		if err != nil {

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -40,8 +42,10 @@ func TestExpandValueReferences_ConfigMap(t *testing.T) {
 	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
-		Values:     map[string]any{"image": map[string]any{"repository": "x"}},
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
+		},
+		Values: map[string]any{"image": map[string]any{"repository": "x"}},
 	}
 	if err := ExpandValueReferences(hr, provider); err != nil {
 		t.Fatalf("ExpandValueReferences: %v", err)
@@ -63,8 +67,10 @@ func TestExpandValueReferences_TargetPath(t *testing.T) {
 	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		ValuesFrom: []manifest.ValuesReference{
-			{Kind: "ConfigMap", Name: "k", ValuesKey: "v", TargetPath: "auth.password"},
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "ConfigMap", Name: "k", ValuesKey: "v", TargetPath: "auth.password"},
+			},
 		},
 	}
 	if err := ExpandValueReferences(hr, provider); err != nil {
@@ -79,8 +85,10 @@ func TestExpandValueReferences_TargetPath(t *testing.T) {
 func TestExpandValueReferences_MissingOptionalTargetPath(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		ValuesFrom: []manifest.ValuesReference{
-			{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k", Optional: true},
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k", Optional: true},
+			},
 		},
 	}
 	provider := &SliceProvider{}


### PR DESCRIPTION
## Summary
All 8 top-level Flux CR types in \`pkg/manifest\` migrated from flate-defined field sets to the upstream Spec embedded inline:

| flate CR | embeds |
| --- | --- |
| \`Bucket\` | \`sourcev1.BucketSpec\` |
| \`HelmRepository\` | \`sourcev1.HelmRepositorySpec\` |
| \`ExternalArtifact\` | \`sourcev1.ExternalArtifactSpec\` |
| \`GitRepository\` | \`sourcev1.GitRepositorySpec\` |
| \`OCIRepository\` | \`sourcev1.OCIRepositorySpec\` |
| \`HelmChartSource\` | \`sourcev1.HelmChartSpec\` |
| \`HelmRelease\` | \`helmv2.HelmReleaseSpec\` |
| \`Kustomization\` | \`kustomizev1.KustomizationSpec\` |

\`Name\`/\`Namespace\` stay as flate top-level fields (kept off ObjectMeta to avoid \`creationTimestamp\` leaks in JSON output). All Spec fields are promoted to the top level for ergonomic access.

## Field rename ripples
- \`HelmRepository.RepoType\` → \`Type\`
- \`GitRepository.Ref\` (value) → \`Reference\` (pointer; nil-check needed)
- \`GitRepository.Verify\` → \`Verification\` + aliased to \`sourcev1.GitRepositoryVerification\`
- \`GitVerifyMode*\` constants now typed \`sourcev1.GitVerificationMode\`
- \`OCIRepository.Ref\` (value) → \`Reference\` (pointer)
- \`HelmChartSource.RepoName\`/\`RepoNamespace\`/\`RepoKind\` removed
- \`HelmRelease.ReleaseNameOverride\` removed — promoted as \`Spec.ReleaseName\`

## HelmRelease + Kustomization
Both retain flate-specific projections alongside the embed because upstream shapes don't match what the renderer needs:

- **HelmRelease**: keeps \`Chart\` (chart/chartRef union), \`Values\` (decoded \`map[string]any\`), \`DependsOn\` (\`[]DependencyRef\` with ReadyExpr), \`CRDsPolicy\` (collapsed Install/Upgrade), \`DisableSchema/OpenAPIValidation\`, \`ChartValuesFiles\`, \`Labels\`, \`Images\`.
- **Kustomization**: keeps \`SourceKind/Name/Namespace\` (denormalized), \`Contents\` (raw doc), \`PostBuildSubstitute\` (resolved table), \`PostBuildSubstituteFrom\`, \`DependsOn\`, \`SourcePath\`, \`Labels\`, plus rendered children.

Net gain: upstream Spec fields flate didn't previously expose are now accessible directly (\`hr.Install\`, \`hr.Upgrade\`, \`hr.KubeConfig\`, \`hr.MaxHistory\`, \`ks.Patches\`, \`ks.NamePrefix\`, \`ks.Wait\`, \`ks.Prune\`, \`ks.HealthChecks\`, etc.) without parser changes.

Re-opened after auto-close from squash-merge of #83.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)