### PR TITLE
fix: three correctness bugs from post-merge architecture review

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -57,6 +57,7 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	inst.EnableDNS = opts.EnableDNS
 	inst.Replace = true
 	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
+	inst.SkipSchemaValidation = hr.DisableSchemaValidation
 	// spec.postRenderers — pipe rendered output through one or more
 	// kustomize patch+image transforms. helm-controller does this via
 	// the same postrenderer.PostRenderer hook.

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -40,22 +40,18 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource) (Stat
 		return info, nil
 	}
 
-	// Subscribe and then re-check (avoids the gap between GetStatus and
-	// AddListener).
-	ch := make(chan StatusInfo, 1)
-	unsub := s.AddListener(EventStatusUpdated, func(other manifest.NamedResource, payload any) {
+	// Subscribe with a wake-only signal — the actual status is read
+	// back from the store on every wake. Carrying StatusInfo through
+	// the channel directly would lose Failed→Ready transitions when
+	// the buffer-1 channel drops on a default-send.
+	wake := make(chan struct{}, 1)
+	unsub := s.AddListener(EventStatusUpdated, func(other manifest.NamedResource, _ any) {
 		if other != id {
 			return
 		}
-		info, ok := payload.(StatusInfo)
-		if !ok {
-			return
-		}
-		if info.Status == StatusReady || info.Status == StatusFailed {
-			select {
-			case ch <- info:
-			default:
-			}
+		select {
+		case wake <- struct{}{}:
+		default:
 		}
 	}, false)
 	defer unsub()
@@ -81,17 +77,20 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource) (Stat
 
 	for {
 		select {
-		case info := <-ch:
-			if info.Status == StatusReady {
-				return info, nil
+		case <-wake:
+			info, ok := s.GetStatus(id)
+			if !ok {
+				continue
 			}
-			// Another Failed update — track the latest reason but
-			// don't reset the grace timer (the resource is still
-			// failing; we don't want to wait forever).
-			f := info
-			currentFailed = &f
-			if graceCh == nil {
-				graceCh = time.After(FailedGrace)
+			switch info.Status {
+			case StatusReady:
+				return info, nil
+			case StatusFailed:
+				f := info
+				currentFailed = &f
+				if graceCh == nil {
+					graceCh = time.After(FailedGrace)
+				}
 			}
 		case <-graceCh:
 			return *currentFailed, &manifest.ResourceFailedError{

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -87,6 +87,11 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 // MUST be called only from inside a body launched by Service.Go —
 // calling from outside corrupts the semaphore accounting.
 //
+// The re-acquire is deferred so a panic inside fn still restores the
+// slot count; otherwise Service.Go's outer `defer <-s.sem` would drain
+// a phantom slot on unwind, eventually hanging another goroutine that
+// did own a slot legitimately.
+//
 // On an unbounded Service (New or NewBounded(<=0)), fn runs unchanged.
 func (s *Service) YieldSlot(fn func()) {
 	if s.sem == nil {
@@ -94,8 +99,8 @@ func (s *Service) YieldSlot(fn func()) {
 		return
 	}
 	<-s.sem
+	defer func() { s.sem <- struct{}{} }()
 	fn()
-	s.sem <- struct{}{}
 }
 
 // ActiveCount returns the number of currently active tasks.

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -251,3 +251,34 @@ func TestYieldSlot_UnboundedIsNoOp(t *testing.T) {
 	}
 }
 
+// TestYieldSlot_PanicRestoresSlot guards against a phantom-slot drain
+// when fn panics: without the deferred re-acquire, Service.Go's outer
+// `defer <-s.sem` would consume an extra token on unwind, eventually
+// hanging another goroutine that legitimately holds a slot.
+func TestYieldSlot_PanicRestoresSlot(t *testing.T) {
+	s := NewBounded(1)
+
+	// Run a panicking YieldSlot inside a real Service.Go goroutine so
+	// the outer defer chain actually fires; Service.Go's own recover
+	// absorbs the panic.
+	s.Go(context.Background(), "boom", func(_ context.Context) {
+		func() {
+			defer func() { _ = recover() }()
+			s.YieldSlot(func() { panic("boom") })
+		}()
+	})
+	s.BlockTillDone()
+
+	// After the panicked run, a fresh Go must still acquire a slot
+	// promptly. Without the fix the buffered semaphore would have
+	// been drained by one token and this second body would hang.
+	ran := make(chan struct{})
+	s.Go(context.Background(), "next", func(_ context.Context) { close(ran) })
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker pool drained after YieldSlot panic — subsequent task could not acquire a slot")
+	}
+	s.BlockTillDone()
+}
+


### PR DESCRIPTION
## Summary
Three independent bugs surfaced by the post-merge review of the embed refactor (#83/#85):

### 1. YieldSlot panic-unsafety — \`pkg/task/task.go:91-99\`
Before:
\`\`\`go
<-s.sem
fn()
s.sem <- struct{}{}
\`\`\`
If \`fn\` panics the re-acquire is skipped, but \`Service.Go\`'s outer \`defer <-s.sem\` still drains a token on unwind — net one extra token consumed from the buffered semaphore, eventually hanging another goroutine that legitimately owned a slot. Latent today because all current call sites are wrapped in \`base.RunWithStatus\`'s \`defer Recover\` (panic absorbed before unwind), but a one-line defer is cheap insurance. New \`TestYieldSlot_PanicRestoresSlot\` covers the path.

### 2. WatchReady drop race — \`pkg/store/watch.go:42-58\`
The buffer-1 status channel used \`default\` drop on send. If a \`Failed\` landed, was buffered, then \`Ready\` fired before the consumer drained, \`Ready\` was silently lost — consumer read stale \`Failed\`, grace expired, function returned Failed for a recovered dep. Misclassifies a healthy dep as failed.

Fix: switch to a wake-only signal (\`chan struct{}\`) and re-read \`s.GetStatus(id)\` on every wake. Mirrors the correct pattern already used in \`pkg/depwait/depwait.go\`'s \`watchReadyExpr\`. Existing WatchReady tests (7 of them) all still pass.

### 3. SkipSchemaValidation dropped — \`pkg/helm/template.go:59\`
\`hr.DisableSchemaValidation\` was parsed from \`spec.install.disableSchemaValidation\` / \`spec.upgrade.disableSchemaValidation\` but never applied to the helm action. helm v4 calls this field \`SkipSchemaValidation\` (separate from \`DisableOpenAPIValidation\`). Charts with intentionally non-conforming \`values.schema.json\` failed to render under flate while succeeding under real helm-controller. One-line fix: \`inst.SkipSchemaValidation = hr.DisableSchemaValidation\`.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)