### PR TITLE
chore: post-embed cleanup + controller unit tests

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -146,7 +146,6 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
 
-	// Resolve chartRef if applicable.
 	helmCharts := c.gatherHelmChartSources()
 	if err := hr.ResolveChartRef(helmCharts); err != nil {
 		return err

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -1,0 +1,137 @@
+package helmrelease
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store.Store) {
+	t.Helper()
+	st := store.New()
+	ts := task.New()
+	hc, err := helm.NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("helm.NewClient: %v", err)
+	}
+	c := &Controller{Store: st, Tasks: ts, Helm: hc, Filter: filter}
+	c.Start(context.Background())
+	t.Cleanup(func() {
+		c.Close()
+		ts.BlockTillDone()
+	})
+	return c, st
+}
+
+func waitForStatus(t *testing.T, st *store.Store, id manifest.NamedResource, want store.Status) store.StatusInfo {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if info, ok := st.GetStatus(id); ok && info.Status == want {
+			return info
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	info, _ := st.GetStatus(id)
+	t.Fatalf("status %v not reached; last=%+v", want, info)
+	return info
+}
+
+func TestController_SuspendedShortCircuitsToReady(t *testing.T) {
+	_, st := newTestController(t, nil)
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{Suspend: true},
+	}
+	st.AddObject(hr)
+
+	info := waitForStatus(t, st, hr.Named(), store.StatusReady)
+	if info.Message != "suspended" {
+		t.Errorf("expected suspended; got %q", info.Message)
+	}
+}
+
+func TestController_FilterUnchangedShortCircuitsToReady(t *testing.T) {
+	filter := change.NewFilter(
+		change.NewSet(nil),
+		map[manifest.NamedResource]string{},
+		"",
+		mapLister{},
+	)
+	_, st := newTestController(t, filter)
+	hr := &manifest.HelmRelease{Name: "demo", Namespace: "default"}
+	st.AddObject(hr)
+
+	info := waitForStatus(t, st, hr.Named(), store.StatusReady)
+	if info.Message != "unchanged" {
+		t.Errorf("expected unchanged short-circuit; got %q", info.Message)
+	}
+}
+
+func TestController_HelmChartSourceIndexed(t *testing.T) {
+	c, st := newTestController(t, nil)
+	src := &manifest.HelmChartSource{
+		Name: "podinfo", Namespace: "flux-system",
+		HelmChartSpec: sourcev1.HelmChartSpec{
+			Chart:     "podinfo",
+			Version:   "6.3.2",
+			SourceRef: sourcev1.LocalHelmChartSourceReference{Name: "podinfo", Kind: manifest.KindHelmRepository},
+		},
+	}
+	st.AddObject(src)
+
+	// Listener handles AddObject synchronously from the store mu wake;
+	// give the dispatch a tick.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		c.chartSourcesMu.RLock()
+		_, ok := c.chartSources[src.ResourceFullName()]
+		c.chartSourcesMu.RUnlock()
+		if ok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("HelmChartSource was not indexed in chartSources map")
+}
+
+func TestController_CollectHRDepsClone(t *testing.T) {
+	c, _ := newTestController(t, nil)
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		DependsOn: []manifest.DependencyRef{
+			{NamedResource: manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "other"}},
+		},
+	}
+	got := c.collectHRDeps(hr)
+	if len(got) != 1 || got[0].Name != "other" {
+		t.Fatalf("collectHRDeps = %+v", got)
+	}
+	// Mutating the returned slice must not affect hr.DependsOn.
+	got[0].Name = "mutated"
+	if hr.DependsOn[0].Name == "mutated" {
+		t.Errorf("collectHRDeps did not return a defensive copy")
+	}
+}
+
+type mapLister map[manifest.NamedResource]manifest.BaseManifest
+
+func (m mapLister) GetObject(id manifest.NamedResource) manifest.BaseManifest { return m[id] }
+func (m mapLister) ListObjects(kind string) []manifest.BaseManifest {
+	var out []manifest.BaseManifest
+	for id, obj := range m {
+		if id.Kind == kind {
+			out = append(out, obj)
+		}
+	}
+	return out
+}

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -1,0 +1,175 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/manifest"
+	src "github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+type fakeFetcher struct {
+	calls    int
+	artifact *store.SourceArtifact
+	err      error
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*store.SourceArtifact, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.artifact, nil
+}
+
+func newController(t *testing.T, fetchers map[string]src.Fetcher) (*Controller, *store.Store) {
+	t.Helper()
+	st := store.New()
+	ts := task.New()
+	c := &Controller{Store: st, Tasks: ts, Fetchers: fetchers}
+	c.Start(context.Background())
+	t.Cleanup(func() {
+		c.Close()
+		ts.BlockTillDone()
+	})
+	return c, st
+}
+
+func waitForStatus(t *testing.T, st *store.Store, id manifest.NamedResource, want store.Status) store.StatusInfo {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		info, ok := st.GetStatus(id)
+		if ok && info.Status == want {
+			return info
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	info, _ := st.GetStatus(id)
+	t.Fatalf("status %v not reached within deadline; last=%+v", want, info)
+	return info
+}
+
+func TestController_FetchesAndStoresArtifact(t *testing.T) {
+	f := &fakeFetcher{artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "u", LocalPath: "/tmp"}}
+	_, st := newController(t, map[string]src.Fetcher{manifest.KindGitRepository: f})
+
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+	}
+	st.AddObject(repo)
+
+	waitForStatus(t, st, repo.Named(), store.StatusReady)
+	if f.calls != 1 {
+		t.Errorf("expected 1 fetch call, got %d", f.calls)
+	}
+	if art := st.GetArtifact(repo.Named()); art == nil {
+		t.Errorf("expected artifact set")
+	}
+}
+
+func TestController_FetchErrorMarksFailed(t *testing.T) {
+	f := &fakeFetcher{err: errors.New("boom")}
+	_, st := newController(t, map[string]src.Fetcher{manifest.KindGitRepository: f})
+
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+	}
+	st.AddObject(repo)
+
+	info := waitForStatus(t, st, repo.Named(), store.StatusFailed)
+	if info.Message != "boom" {
+		t.Errorf("Failed reason = %q, want %q", info.Message, "boom")
+	}
+}
+
+func TestController_SuspendedShortCircuitsToReady(t *testing.T) {
+	f := &fakeFetcher{}
+	_, st := newController(t, map[string]src.Fetcher{manifest.KindGitRepository: f})
+
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git", Suspend: true},
+	}
+	st.AddObject(repo)
+
+	info := waitForStatus(t, st, repo.Named(), store.StatusReady)
+	if info.Message != "suspended" {
+		t.Errorf("expected suspended message; got %q", info.Message)
+	}
+	if f.calls != 0 {
+		t.Errorf("suspended source must not fetch; calls=%d", f.calls)
+	}
+}
+
+func TestController_UnregisteredKindIgnored(t *testing.T) {
+	_, st := newController(t, map[string]src.Fetcher{}) // no fetchers
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+	}
+	st.AddObject(repo)
+
+	// Give the listener a tick — nothing should run, no status set.
+	time.Sleep(20 * time.Millisecond)
+	if _, ok := st.GetStatus(repo.Named()); ok {
+		t.Errorf("expected no status update for unregistered kind")
+	}
+}
+
+func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
+	f := &fakeFetcher{artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository}}
+
+	st := store.New()
+	ts := task.New()
+	// Filter that marks our repo as "no changes" — should short-circuit
+	// to Ready without fetching.
+	filter := change.NewFilter(
+		change.NewSet(nil), // no changed files
+		map[manifest.NamedResource]string{},
+		"",
+		mapLister{},
+	)
+	c := &Controller{Store: st, Tasks: ts, Fetchers: map[string]src.Fetcher{manifest.KindGitRepository: f}, Filter: filter}
+	c.Start(context.Background())
+	t.Cleanup(func() {
+		c.Close()
+		ts.BlockTillDone()
+	})
+
+	repo := &manifest.GitRepository{
+		Name: "r", Namespace: "ns",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+	}
+	st.AddObject(repo)
+
+	info := waitForStatus(t, st, repo.Named(), store.StatusReady)
+	if info.Message != "unchanged" {
+		t.Errorf("expected unchanged short-circuit; got %q", info.Message)
+	}
+	if f.calls != 0 {
+		t.Errorf("filtered-out source must not fetch; calls=%d", f.calls)
+	}
+}
+
+type mapLister map[manifest.NamedResource]manifest.BaseManifest
+
+func (m mapLister) GetObject(id manifest.NamedResource) manifest.BaseManifest { return m[id] }
+func (m mapLister) ListObjects(kind string) []manifest.BaseManifest {
+	var out []manifest.BaseManifest
+	for id, obj := range m {
+		if id.Kind == kind {
+			out = append(out, obj)
+		}
+	}
+	return out
+}

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -165,12 +165,14 @@ func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 //
 // Several flate-specific projection fields live alongside the
 // embedded Spec:
-//   - Chart is the union of spec.chart and spec.chartRef (the
-//     upstream's Spec.Chart and Spec.ChartRef are dropped via
-//     shadowing — accessible via h.HelmReleaseSpec.Chart if needed).
+//   - Chart is the union of spec.chart and spec.chartRef. Shadows the
+//     embedded Spec.Chart (*HelmChartTemplate) — Spec.ChartRef is
+//     untouched and still accessible if a consumer needs the raw ref.
 //   - Values is the decoded form of spec.values (map[string]any) so
-//     consumers don't have to JSON-decode on every access.
+//     consumers don't have to JSON-decode on every access. Shadows
+//     the embedded Spec.Values (*apiextensionsv1.JSON).
 //   - DependsOn is normalized to []DependencyRef (with ReadyExpr).
+//     Shadows the embedded Spec.DependsOn ([]DependencyReference).
 //   - CRDsPolicy collapses spec.install.crds vs spec.upgrade.crds.
 //   - DisableSchema/OpenAPIValidation collapse Install vs Upgrade.
 //   - ChartValuesFiles + IgnoreMissingValuesFiles are sourced from
@@ -243,23 +245,6 @@ func (h *HelmRelease) RepoName() string {
 
 // NamespacedName is "<namespace>/<name>".
 func (h *HelmRelease) NamespacedName() string { return h.Namespace + "/" + h.Name }
-
-// ResourceDependencies returns the resources whose readiness gates this
-// HelmRelease's reconciliation: the release itself, its chart repo, and
-// any valuesFrom references.
-func (h *HelmRelease) ResourceDependencies() []NamedResource {
-	deps := []NamedResource{h.Named()}
-	deps = append(deps, NamedResource{Kind: h.Chart.RepoKind, Namespace: h.Chart.RepoNamespace, Name: h.Chart.RepoName})
-	seen := make(map[string]struct{})
-	for _, ref := range h.ValuesFrom {
-		if _, ok := seen[ref.Name]; ok {
-			continue
-		}
-		seen[ref.Name] = struct{}{}
-		deps = append(deps, NamedResource{Kind: ref.Kind, Namespace: h.Namespace, Name: ref.Name})
-	}
-	return deps
-}
 
 // ResolveChartRef replaces a chartRef placeholder with the resolved source
 // when version was not pinned. helmCharts is keyed by ResourceFullName.
@@ -391,15 +376,6 @@ func (h *HelmRepository) Named() NamedResource {
 
 // RepoName is "<namespace>-<name>".
 func (h *HelmRepository) RepoName() string { return h.Namespace + "-" + h.Name }
-
-// HelmChartName returns the chart ref used with the helm SDK. For OCI
-// repos the chart name is appended to the URL.
-func (h *HelmRepository) HelmChartName(chart HelmChart) string {
-	if h.Type == RepoTypeOCI {
-		return h.URL + "/" + chart.Name
-	}
-	return chart.ChartName()
-}
 
 // ParseHelmRepository decodes a HelmRepository CR via the
 // source-controller typed schema.

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -654,9 +654,6 @@ spec:
 	if r.Type != "oci" {
 		t.Errorf("RepoType = %q", r.Type)
 	}
-	if got, want := r.HelmChartName(HelmChart{Name: "podinfo"}), "oci://ghcr.io/stefanprodan/charts/podinfo"; got != want {
-		t.Errorf("HelmChartName = %q, want %q", got, want)
-	}
 }
 
 func TestParseGitRepository_Ref(t *testing.T) {
@@ -680,44 +677,6 @@ spec:
 	}
 	if got, want := GitRefString(*g.Reference), "tag:v1.2.3"; got != want {
 		t.Errorf("RefString = %q, want %q", got, want)
-	}
-}
-
-func TestParseOCIRepository_VersionedURL(t *testing.T) {
-	cases := []struct {
-		name string
-		yaml string
-		want string
-	}{
-		{"tag", `
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata: {name: x, namespace: ns}
-spec: {url: oci://example/x, ref: {tag: v1}}
-`, "oci://example/x:v1"},
-		{"digest", `
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata: {name: x, namespace: ns}
-spec: {url: oci://example/x, ref: {digest: sha256:abc}}
-`, "oci://example/x@sha256:abc"},
-		{"no-ref", `
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: OCIRepository
-metadata: {name: x, namespace: ns}
-spec: {url: oci://example/x}
-`, "oci://example/x"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r, err := ParseOCIRepository(mustYAML(t, tc.yaml))
-			if err != nil {
-				t.Fatalf("ParseOCIRepository: %v", err)
-			}
-			if got := r.VersionedURL(); got != tc.want {
-				t.Errorf("VersionedURL = %q, want %q", got, tc.want)
-			}
-		})
 	}
 }
 

--- a/pkg/manifest/sops.go
+++ b/pkg/manifest/sops.go
@@ -7,10 +7,11 @@ package manifest
 // field is the unambiguous signal.
 //
 // flate runs offline and cannot decrypt; the kustomization and
-// helmrelease controllers call this to fail-loud when their rendered
-// output still contains encrypted content, mirroring Flux's
-// kustomize-controller refusal to apply un-decrypted Secrets when
-// spec.decryption is absent.
+// helmrelease controllers call this to log the encrypted resource
+// then wipe its data fields to ValuePlaceholderTemplate via
+// ParseSecret, mirroring the --wipe-secrets cleartext behavior.
+// flate ignores spec.decryption entirely — there is no path that
+// reads the decryption Secret.
 func IsEncryptedSecret(doc map[string]any) bool {
 	sops, ok := doc["sops"].(map[string]any)
 	if !ok {

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -30,7 +30,6 @@ func GitRefString(r GitRepositoryRef) string {
 }
 
 
-// GitRepository is the Flux GitRepository CRD.
 // GitRepository is the Flux GitRepository CRD. The embedded
 // sourcev1.GitRepositorySpec promotes URL, Reference, Verification,
 // Provider, SecretRef, ProxySecretRef, RecurseSubmodules,
@@ -99,9 +98,6 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 // OCIRepositoryRef is the Flux OCIRepositoryRef from source-controller.
 type OCIRepositoryRef = sourcev1.OCIRepositoryRef
 
-// OCIRefIsEmpty reports whether the ref is empty.
-func OCIRefIsEmpty(r OCIRepositoryRef) bool { return r == OCIRepositoryRef{} }
-
 // OCIRepository is the Flux OCIRepository CRD. The embedded
 // sourcev1.OCIRepositorySpec promotes URL, Reference, LayerSelector,
 // Provider, SecretRef, CertSecretRef, ProxySecretRef, Verify, Insecure,
@@ -166,23 +162,6 @@ func (o *OCIRepository) Version() (string, error) {
 	return "", nil
 }
 
-// VersionedURL appends the version with the correct separator: "@" for
-// digests, ":" for tags and semver.
-func (o *OCIRepository) VersionedURL() string {
-	r := o.Reference
-	if r == nil {
-		return o.URL
-	}
-	switch {
-	case r.Digest != "":
-		return o.URL + "@" + r.Digest
-	case r.Tag != "":
-		return o.URL + ":" + r.Tag
-	case r.SemVer != "":
-		return o.URL + ":" + r.SemVer
-	}
-	return o.URL
-}
 
 // ParseOCIRepository decodes an OCIRepository CR.
 func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {


### PR DESCRIPTION
## Summary

### Cleanup
- Delete dead \`manifest.OCIRefIsEmpty\` (zero callers).
- Delete dead \`(*HelmRelease).ResourceDependencies\` (zero callers).
- Delete \`(*HelmRepository).HelmChartName\` + \`(*OCIRepository).VersionedURL\` — both were test-only public API. Removed their tests too; they verified methods nothing exercised in real flows.
- Fix doc-block duplication at \`pkg/manifest/source.go\` (two stacked GitRepository one-liners).
- Correct misleading shadow-comment on HelmRelease: claimed \"Spec.Chart and Spec.ChartRef are dropped via shadowing\" but only \`Chart\` is shadowed.
- Rewrite \`pkg/manifest/sops.go\` \`IsEncryptedSecret\` doc — claimed fail-loud but actual behavior is wipe-to-PLACEHOLDER + log.Debug; \`spec.decryption\` is ignored.
- Drop superfluous \`// Resolve chartRef if applicable.\` what-comment in \`helmrelease/controller.go\`.

### Tests
- \`pkg/controllers/source/controller_test.go\` — 5 tests: fetch success, fetch error→Failed, suspend→Ready short-circuit, unknown kind ignored, change-filter short-circuits to Ready (\"unchanged\").
- \`pkg/controllers/helmrelease/controller_test.go\` — 4 tests: suspend→Ready, filter-unchanged→Ready, HelmChartSource indexing into the chartSources map, \`collectHRDeps\` defensive-copy behavior.

Both controllers previously had zero unit tests (only e2e coverage).

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] Net **-97/+323 LOC** (most of the gain is the new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)