### PR TITLE
feat(helmrelease): honor disableHooks, spec.test.enable, spec.commonMetadata

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
@@ -59,6 +60,117 @@ data:
 	}
 	if !strings.Contains(out, "greeting: hello") {
 		t.Errorf("values not applied: %s", out)
+	}
+}
+
+// helmChartFixture stages a tiny chart with a hook, a test hook, and a
+// CM template that the templating tests share.
+func helmChartFixture(t *testing.T) *Client {
+	t.Helper()
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml",
+		"apiVersion: v2\nname: mychart\nversion: 0.1.0\ndescription: t\n")
+	testutil.WriteFile(t, dir, "mychart/templates/configmap.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\ndata:\n  k: v\n")
+	testutil.WriteFile(t, dir, "mychart/templates/pre-install-hook.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-pre\n  annotations:\n    \"helm.sh/hook\": pre-install\ndata:\n  k: v\n")
+	testutil.WriteFile(t, dir, "mychart/templates/test-hook.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-test\n  annotations:\n    \"helm.sh/hook\": test\ndata:\n  k: v\n")
+
+	cli, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	cli.AddLocalGit(LocalGitRepository{
+		Repo: &manifest.GitRepository{
+			Name: "chart-repo", Namespace: "flux-system",
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + dir},
+		},
+		Artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
+	})
+	return cli
+}
+
+func newHR() *manifest.HelmRelease {
+	return &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "chart-repo",
+			RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
+		},
+	}
+}
+
+func TestTemplate_TestHooksSkippedByDefault(t *testing.T) {
+	cli := helmChartFixture(t)
+	hr := newHR()
+
+	out, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+	// pre-install hook should render; test hook should not when
+	// spec.test.enable is unset (default behavior matches helm-controller).
+	if !strings.Contains(out, "demo-pre") {
+		t.Errorf("expected pre-install hook in output: %s", out)
+	}
+	if strings.Contains(out, "demo-test") {
+		t.Errorf("test hook should be skipped by default: %s", out)
+	}
+}
+
+func TestTemplate_TestEnableIncludesTestHook(t *testing.T) {
+	cli := helmChartFixture(t)
+	hr := newHR()
+	hr.Test = &helmv2.Test{Enable: true}
+
+	out, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+	if !strings.Contains(out, "demo-test") {
+		t.Errorf("test hook should render when spec.test.enable=true: %s", out)
+	}
+}
+
+func TestTemplate_HRInstallDisableHooks(t *testing.T) {
+	cli := helmChartFixture(t)
+	hr := newHR()
+	hr.Install = &helmv2.Install{DisableHooks: true}
+
+	out, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+	if strings.Contains(out, "demo-pre") {
+		t.Errorf("HR-scoped spec.install.disableHooks should suppress pre-install hook: %s", out)
+	}
+}
+
+func TestTemplateDocs_AppliesHRCommonMetadata(t *testing.T) {
+	cli := helmChartFixture(t)
+	hr := newHR()
+	hr.CommonMetadata = &helmv2.CommonMetadata{
+		Labels:      map[string]string{"team": "flate", "managed-by": "override"},
+		Annotations: map[string]string{"owner": "platform"},
+	}
+
+	docs, err := cli.TemplateDocs(context.Background(), hr, nil, Options{NoHooks: true})
+	if err != nil {
+		t.Fatalf("TemplateDocs: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one rendered doc")
+	}
+	cm := docs[0]
+	md, _ := cm["metadata"].(map[string]any)
+	labels, _ := md["labels"].(map[string]any)
+	annotations, _ := md["annotations"].(map[string]any)
+	if labels["team"] != "flate" || labels["managed-by"] != "override" {
+		t.Errorf("commonMetadata.labels not merged: %v", labels)
+	}
+	if annotations["owner"] != "platform" {
+		t.Errorf("commonMetadata.annotations not merged: %v", annotations)
 	}
 }
 

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	"helm.sh/helm/v4/pkg/action"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/common"
@@ -52,7 +53,14 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	case "Create", "CreateReplace":
 		inst.IncludeCRDs = true
 	}
-	inst.DisableHooks = opts.NoHooks
+	// HR-scoped install/upgrade.disableHooks OR'd with the CLI flag,
+	// mirroring helm-controller. Either side forces hooks off — and
+	// the same effective flag drives the post-render hook filter at
+	// the bottom of this function so they don't leak into the output.
+	disableHooks := opts.NoHooks ||
+		(hr.Install != nil && hr.Install.DisableHooks) ||
+		(hr.Upgrade != nil && hr.Upgrade.DisableHooks)
+	inst.DisableHooks = disableHooks
 	inst.IsUpgrade = opts.IsUpgrade
 	inst.EnableDNS = opts.EnableDNS
 	inst.Replace = true
@@ -99,7 +107,11 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 		return "", fmt.Errorf("helm template %s/%s: unexpected release type %T", hr.Namespace, hr.Name, rel)
 	}
 
-	return releaseManifest(relV1, opts), nil
+	// spec.test.enable defaults to false; tests only land in the
+	// rendered output when the HR explicitly enables them or the
+	// CLI overrides. CLI --skip-tests always wins.
+	skipTests := opts.SkipTests || hr.Test == nil || !hr.Test.Enable
+	return releaseManifest(relV1, opts, disableHooks, skipTests), nil
 }
 
 // mergeChartValuesFiles merges the named values files (relative paths
@@ -142,6 +154,7 @@ func (c *Client) TemplateDocs(ctx context.Context, hr *manifest.HelmRelease, val
 	if err != nil {
 		return nil, err
 	}
+	applyHRCommonMetadata(docs, hr.CommonMetadata)
 	skip := opts.SkipResourceKinds()
 	if len(skip) == 0 {
 		return docs, nil
@@ -151,15 +164,48 @@ func (c *Client) TemplateDocs(ctx context.Context, hr *manifest.HelmRelease, val
 	}), nil
 }
 
+// applyHRCommonMetadata merges spec.commonMetadata.labels and .annotations
+// onto every rendered doc's metadata, mirroring helm-controller's
+// CommonRenderer pass. commonMetadata wins on conflict, matching
+// controller semantics.
+func applyHRCommonMetadata(docs []map[string]any, cm *helmv2.CommonMetadata) {
+	if cm == nil || (len(cm.Labels) == 0 && len(cm.Annotations) == 0) {
+		return
+	}
+	for _, doc := range docs {
+		md, _ := doc["metadata"].(map[string]any)
+		if md == nil {
+			md = map[string]any{}
+			doc["metadata"] = md
+		}
+		mergeStringMap(md, "labels", cm.Labels)
+		mergeStringMap(md, "annotations", cm.Annotations)
+	}
+}
+
+func mergeStringMap(md map[string]any, key string, in map[string]string) {
+	if len(in) == 0 {
+		return
+	}
+	out, _ := md[key].(map[string]any)
+	if out == nil {
+		out = make(map[string]any, len(in))
+	}
+	for k, v := range in {
+		out[k] = v
+	}
+	md[key] = out
+}
+
 // releaseManifest joins rel.Manifest with hooks (when allowed) and
 // returns a single YAML string. ShowOnly filters by template path,
 // mirroring `helm template --show-only`.
-func releaseManifest(rel *release.Release, opts Options) string {
+func releaseManifest(rel *release.Release, opts Options, disableHooks, skipTests bool) string {
 	var b strings.Builder
 	b.WriteString(rel.Manifest)
-	if !opts.NoHooks {
+	if !disableHooks {
 		for _, h := range rel.Hooks {
-			if opts.SkipTests && isTestHook(h) {
+			if skipTests && isTestHook(h) {
 				continue
 			}
 			if !strings.HasSuffix(b.String(), "\n") {


### PR DESCRIPTION
## Summary
Three render-fidelity gaps surfaced by post-embed review. helm-controller applies all three; flate previously ignored them.

### 1. \`spec.install/upgrade.disableHooks\`
OR'd with \`opts.NoHooks\` and propagated to BOTH \`action.Install.DisableHooks\` (suppresses execution) AND the post-render hook filter (suppresses YAML emission). A pre-install hook on an HR with \`spec.install.disableHooks=true\` now matches real-cluster behavior (absent from rendered output).

### 2. \`spec.test.enable\`
Defaults to \`false\`. Real helm-controller only emits test hooks when explicitly enabled; flate previously emitted them unconditionally, relying only on the CLI \`--skip-tests\` flag. Now: \`skipTests = opts.SkipTests || hr.Test == nil || !hr.Test.Enable\`. CLI override still wins.

### 3. \`spec.commonMetadata\` (HR-level)
Labels/annotations applied to every rendered doc's \`metadata\`. Mirrors helm-controller's \`CommonRenderer\`; commonMetadata wins on conflict, matching controller semantics.

## Tests
Four new tests in \`pkg/helm/helm_test.go\`:
- \`TestTemplate_TestHooksSkippedByDefault\` — pre-install renders, test hook does not.
- \`TestTemplate_TestEnableIncludesTestHook\` — \`spec.test.enable=true\` re-includes it.
- \`TestTemplate_HRInstallDisableHooks\` — pre-install suppressed.
- \`TestTemplateDocs_AppliesHRCommonMetadata\` — labels + annotations merge onto rendered doc metadata.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)