### PR TITLE
feat(source): honor spec.ignore on Git/OCI/Bucket sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/fluxcd/pkg/apis/meta v1.25.1
 	github.com/fluxcd/pkg/envsubst v1.7.0
 	github.com/fluxcd/pkg/kustomize v1.32.0
+	github.com/fluxcd/pkg/sourceignore v0.18.0
 	github.com/fluxcd/source-controller/api v1.8.5
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/cel-go v0.28.1
@@ -60,7 +61,6 @@ require (
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fluxcd/cli-utils v1.2.0 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
-	github.com/fluxcd/pkg/sourceignore v0.18.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -86,6 +86,10 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		_ = f.Cache.Reset(slot)
 		return nil, fmt.Errorf("bucket %s/%s walk: %w", b.Namespace, b.Name, err)
 	}
+	if err := source.ApplyIgnore(slot, b.Ignore); err != nil {
+		_ = f.Cache.Reset(slot)
+		return nil, fmt.Errorf("bucket %s/%s: %w", b.Namespace, b.Name, err)
+	}
 
 	return &store.SourceArtifact{
 		Kind:      manifest.KindBucket,

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -96,6 +96,9 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 			return nil, err
 		}
 	}
+	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+	}
 	return art, nil
 }
 

--- a/pkg/source/ignore.go
+++ b/pkg/source/ignore.go
@@ -1,0 +1,73 @@
+package source
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fluxcd/pkg/sourceignore"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+)
+
+// ApplyIgnore deletes every file under root that matches the gitignore-
+// style patterns in ignore, mirroring source-controller's spec.ignore
+// behavior. Empty/nil ignore is a no-op.
+//
+// flate intentionally applies ONLY user-supplied patterns from
+// spec.ignore — source-controller's default VCS/extension excludes are
+// skipped so repos that never set spec.ignore see no behavior change.
+// Files that real Flux would have excluded by default remain visible
+// in the staged artifact; users wanting full fidelity should set
+// spec.ignore explicitly.
+func ApplyIgnore(root string, ignore *string) error {
+	if ignore == nil || strings.TrimSpace(*ignore) == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("sourceignore abs: %w", err)
+	}
+	domain := strings.Split(abs, string(filepath.Separator))
+	patterns := sourceignore.ReadPatterns(strings.NewReader(*ignore), domain)
+	if len(patterns) == 0 {
+		return nil
+	}
+	matcher := sourceignore.NewMatcher(patterns)
+	return walkAndDelete(abs, domain, matcher)
+}
+
+func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) error {
+	var toRemove []string
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		// gitignore.Matcher expects path segments relative to the
+		// scope root, combined with the absolute domain.
+		segments := append(append([]string{}, domain...), strings.Split(rel, string(filepath.Separator))...)
+		if matcher.Match(segments, d.IsDir()) {
+			toRemove = append(toRemove, p)
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("sourceignore walk: %w", err)
+	}
+	for _, p := range toRemove {
+		if err := os.RemoveAll(p); err != nil {
+			return fmt.Errorf("sourceignore remove %s: %w", p, err)
+		}
+	}
+	return nil
+}

--- a/pkg/source/ignore_test.go
+++ b/pkg/source/ignore_test.go
@@ -1,0 +1,114 @@
+package source_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/source"
+)
+
+func writeFile(t *testing.T, dir, rel string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+	}
+	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+func exists(t *testing.T, p string) bool {
+	t.Helper()
+	_, err := os.Stat(p)
+	if err == nil {
+		return true
+	}
+	if !os.IsNotExist(err) {
+		t.Fatalf("stat %s: %v", p, err)
+	}
+	return false
+}
+
+func TestApplyIgnore_NilOrEmptyIsNoop(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "keep.yaml")
+	writeFile(t, root, "docs/readme.md")
+
+	for _, ig := range []*string{nil, ptr("")} {
+		if err := source.ApplyIgnore(root, ig); err != nil {
+			t.Fatalf("ApplyIgnore: %v", err)
+		}
+	}
+	for _, rel := range []string{"keep.yaml", "docs/readme.md"} {
+		if !exists(t, filepath.Join(root, rel)) {
+			t.Errorf("expected %s to remain", rel)
+		}
+	}
+}
+
+func TestApplyIgnore_DeletesMatching(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "app/deployment.yaml")
+	writeFile(t, root, "app/values.yaml")
+	writeFile(t, root, "docs/readme.md")
+	writeFile(t, root, "README.md")
+
+	patterns := "*.md\ndocs/\n"
+	if err := source.ApplyIgnore(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	if exists(t, filepath.Join(root, "README.md")) {
+		t.Errorf("*.md should be removed")
+	}
+	if exists(t, filepath.Join(root, "docs")) {
+		t.Errorf("docs/ should be removed as a tree")
+	}
+	if !exists(t, filepath.Join(root, "app/deployment.yaml")) {
+		t.Errorf("unmatched files should remain")
+	}
+	if !exists(t, filepath.Join(root, "app/values.yaml")) {
+		t.Errorf("unmatched files should remain")
+	}
+}
+
+func TestApplyIgnore_GitignoreSyntax(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "infra/vendor/bigfile")
+	writeFile(t, root, "infra/important.yaml")
+	writeFile(t, root, ".git/HEAD")
+
+	patterns := "vendor/\n.git/\n"
+	if err := source.ApplyIgnore(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	if exists(t, filepath.Join(root, "infra/vendor")) {
+		t.Errorf("vendor/ should be removed")
+	}
+	if exists(t, filepath.Join(root, ".git")) {
+		t.Errorf(".git/ should be removed")
+	}
+	if !exists(t, filepath.Join(root, "infra/important.yaml")) {
+		t.Errorf("non-ignored file should remain")
+	}
+}
+
+func TestApplyIgnore_CommentsAndBlankLines(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "a.tmp")
+	writeFile(t, root, "b.yaml")
+
+	patterns := "# strip temp files\n*.tmp\n\n   \n"
+	if err := source.ApplyIgnore(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	if exists(t, filepath.Join(root, "a.tmp")) {
+		t.Errorf("a.tmp should be removed")
+	}
+	if !exists(t, filepath.Join(root, "b.yaml")) {
+		t.Errorf("b.yaml should remain")
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -271,6 +271,10 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		_ = os.RemoveAll(slot)
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
+	if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
+		_ = os.RemoveAll(slot)
+		return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+	}
 	// Persist the resolved digest so a subsequent cache hit can
 	// re-verify against the exact bytes we wrote, even when the spec
 	// pinned only a tag.


### PR DESCRIPTION
## Summary
Real source-controller applies \`spec.ignore\` (gitignore-syntax patterns) when building the artifact tarball; downstream consumers (Kustomization render, HelmChart load) see a tree with those paths excluded. flate previously cloned/pulled the full tree and shipped it through unchanged, so any repo with \`spec.ignore: \"docs/\\n*.md\"\` had those files visible to flate's renderer but absent from what real Flux applies. The highest-severity render-fidelity gap surfaced by the post-embed review.

\`pkg/source/ignore.go\` adds \`ApplyIgnore(localPath, ignore *string)\` which:
- No-ops on nil/empty ignore (preserves existing behavior).
- Parses inline patterns via \`fluxcd/pkg/sourceignore.ReadPatterns\`.
- Walks the artifact tree and deletes matched files; directory matches short-circuit via \`fs.SkipDir\`.

Wired into each fetcher AFTER content materialization, BEFORE the artifact is returned:
- \`pkg/source/git/git.go\` after the verify pass.
- \`pkg/source/oci/oci.go\` after layer select + cosign verify.
- \`pkg/source/bucket/bucket.go\` after \`walkBucket\`.

## Scope decision
flate honors ONLY user-supplied patterns. source-controller's default VCS/extension excludes are intentionally NOT applied here — adding them would change behavior for repos that never set \`spec.ignore\`. Users wanting full upstream-default fidelity should set \`spec.ignore\` explicitly. Future: a CLI flag could opt into the default-excludes layer.

## Tests
Four new tests in \`pkg/source/ignore_test.go\`:
- nil and empty pointer no-ops.
- explicit pattern deletion (\`*.md\`, \`docs/\`).
- gitignore directory syntax (\`vendor/\`, \`.git/\`).
- comment lines and blank lines tolerated.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)