### PR TITLE
fix(source,manifest): sourceignore defaults + ResolveChartRef HelmChart hole

### DIFF
--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -246,11 +246,18 @@ func (h *HelmRelease) RepoName() string {
 // NamespacedName is "<namespace>/<name>".
 func (h *HelmRelease) NamespacedName() string { return h.Namespace + "/" + h.Name }
 
-// ResolveChartRef replaces a chartRef placeholder with the resolved source
-// when version was not pinned. helmCharts is keyed by ResourceFullName.
-// When the chartRef resolves to a HelmChart CRD, its spec.valuesFiles +
+// ResolveChartRef replaces a chartRef placeholder with the resolved
+// source. helmCharts is keyed by ResourceFullName. When the chartRef
+// resolves to a HelmChart CRD, its spec.valuesFiles +
 // spec.ignoreMissingValuesFiles propagate onto the HelmRelease so the
 // rendering pipeline can merge them ahead of HR.Values.
+//
+// The chart rewrite is unconditional once we find the source — even
+// when the HelmChart CRD has no spec.version, we need RepoKind to flip
+// from KindHelmChart to the underlying real source (HelmRepository /
+// OCIRepository / GitRepository) so downstream chart loading can
+// dispatch. Without it, LocateChart would see RepoKind=HelmChart and
+// fall through with an "unsupported chart repo kind" error.
 func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) error {
 	if h.Chart.RepoKind != KindHelmChart || h.Chart.Version != "" {
 		return nil
@@ -260,9 +267,7 @@ func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) er
 		return fmt.Errorf("%w: HelmChartSource %s not found for HelmRelease %s",
 			ErrObjectNotFound, h.Chart.RepoFullName(), h.NamespacedName())
 	}
-	if src.Version != "" {
-		h.Chart = HelmChartFromSource(src)
-	}
+	h.Chart = HelmChartFromSource(src)
 	if len(src.ValuesFiles) > 0 {
 		h.ChartValuesFiles = src.ValuesFiles
 		h.IgnoreMissingValuesFiles = src.IgnoreMissingValuesFiles

--- a/pkg/source/ignore.go
+++ b/pkg/source/ignore.go
@@ -11,31 +11,31 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 )
 
-// ApplyIgnore deletes every file under root that matches the gitignore-
-// style patterns in ignore, mirroring source-controller's spec.ignore
-// behavior. Empty/nil ignore is a no-op.
+// ApplyIgnore deletes every file under root that matches the source-
+// controller ignore matcher: VCS + Default excludes (.git/, .github/,
+// *.jpg/png/zip, .sops.yaml, .flux.yaml, ...) PLUS any in-tree
+// .sourceignore files PLUS the user-supplied spec.ignore patterns when
+// non-nil. Mirrors source-controller's artifact-build behavior.
 //
-// flate intentionally applies ONLY user-supplied patterns from
-// spec.ignore — source-controller's default VCS/extension excludes are
-// skipped so repos that never set spec.ignore see no behavior change.
-// Files that real Flux would have excluded by default remain visible
-// in the staged artifact; users wanting full fidelity should set
-// spec.ignore explicitly.
+// nil spec.ignore is NOT a no-op — the VCS + Default patterns still
+// apply, matching what real Flux ships in an artifact tarball.
 func ApplyIgnore(root string, ignore *string) error {
-	if ignore == nil || strings.TrimSpace(*ignore) == "" {
-		return nil
-	}
 	abs, err := filepath.Abs(root)
 	if err != nil {
 		return fmt.Errorf("sourceignore abs: %w", err)
 	}
 	domain := strings.Split(abs, string(filepath.Separator))
-	patterns := sourceignore.ReadPatterns(strings.NewReader(*ignore), domain)
-	if len(patterns) == 0 {
-		return nil
+
+	// Default to VCS + extension excludes + any .sourceignore files
+	// reachable from root, then layer user patterns on top.
+	patterns, err := sourceignore.LoadIgnorePatterns(abs, domain)
+	if err != nil {
+		return fmt.Errorf("sourceignore load: %w", err)
 	}
-	matcher := sourceignore.NewMatcher(patterns)
-	return walkAndDelete(abs, domain, matcher)
+	if ignore != nil && strings.TrimSpace(*ignore) != "" {
+		patterns = append(patterns, sourceignore.ReadPatterns(strings.NewReader(*ignore), domain)...)
+	}
+	return walkAndDelete(abs, domain, sourceignore.NewDefaultMatcher(patterns, domain))
 }
 
 func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) error {
@@ -51,8 +51,6 @@ func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) erro
 		if err != nil {
 			return err
 		}
-		// gitignore.Matcher expects path segments relative to the
-		// scope root, combined with the absolute domain.
 		segments := append(append([]string{}, domain...), strings.Split(rel, string(filepath.Separator))...)
 		if matcher.Match(segments, d.IsDir()) {
 			toRemove = append(toRemove, p)

--- a/pkg/source/ignore_test.go
+++ b/pkg/source/ignore_test.go
@@ -31,19 +31,30 @@ func exists(t *testing.T, p string) bool {
 	return false
 }
 
-func TestApplyIgnore_NilOrEmptyIsNoop(t *testing.T) {
+// TestApplyIgnore_AppliesDefaultsWhenIgnoreNil asserts the source-
+// controller default exclusions (VCS + ExcludeExt + ExcludeCI +
+// ExcludeExtra) fire even when spec.ignore is nil, matching real
+// Flux's artifact-build behavior.
+func TestApplyIgnore_AppliesDefaultsWhenIgnoreNil(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "keep.yaml")
 	writeFile(t, root, "docs/readme.md")
+	writeFile(t, root, ".git/HEAD")
+	writeFile(t, root, ".github/workflows/ci.yml")
+	writeFile(t, root, "img.png")
+	writeFile(t, root, ".sops.yaml")
 
-	for _, ig := range []*string{nil, ptr("")} {
-		if err := source.ApplyIgnore(root, ig); err != nil {
-			t.Fatalf("ApplyIgnore: %v", err)
+	if err := source.ApplyIgnore(root, nil); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	for _, gone := range []string{".git", ".github", "img.png", ".sops.yaml"} {
+		if exists(t, filepath.Join(root, gone)) {
+			t.Errorf("default exclude should remove %s", gone)
 		}
 	}
-	for _, rel := range []string{"keep.yaml", "docs/readme.md"} {
-		if !exists(t, filepath.Join(root, rel)) {
-			t.Errorf("expected %s to remain", rel)
+	for _, kept := range []string{"keep.yaml", "docs/readme.md"} {
+		if !exists(t, filepath.Join(root, kept)) {
+			t.Errorf("expected %s to remain", kept)
 		}
 	}
 }
@@ -111,4 +122,43 @@ func TestApplyIgnore_CommentsAndBlankLines(t *testing.T) {
 	}
 }
 
-func ptr(s string) *string { return &s }
+func TestApplyIgnore_DoubleStarMatchesAtAnyDepth(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "vendor/lib/x")
+	writeFile(t, root, "apps/a/vendor/lib/x")
+	writeFile(t, root, "apps/b/manifest.yaml")
+
+	patterns := "**/vendor/\n"
+	if err := source.ApplyIgnore(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	if exists(t, filepath.Join(root, "vendor")) {
+		t.Errorf("**/vendor must remove root-level vendor")
+	}
+	if exists(t, filepath.Join(root, "apps/a/vendor")) {
+		t.Errorf("**/vendor must remove nested vendor")
+	}
+	if !exists(t, filepath.Join(root, "apps/b/manifest.yaml")) {
+		t.Errorf("non-matching path should remain")
+	}
+}
+
+func TestApplyIgnore_LeadingSlashAnchorsToRoot(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "config.yaml")
+	writeFile(t, root, "subdir/config.yaml")
+
+	// /config.yaml should match only the root-level file, not the
+	// nested one. gitignore semantics: a leading "/" anchors.
+	patterns := "/config.yaml\n"
+	if err := source.ApplyIgnore(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	if exists(t, filepath.Join(root, "config.yaml")) {
+		t.Errorf("root-anchored /config.yaml must remove root file")
+	}
+	if !exists(t, filepath.Join(root, "subdir/config.yaml")) {
+		t.Errorf("root-anchored /config.yaml must NOT remove nested file")
+	}
+}
+


### PR DESCRIPTION
## Summary
Two correctness gaps from the latest review.

### 1. \`sourceignore\` defaults missing (HIGH fidelity)
Real source-controller ALWAYS applies VCS + Default + Extra excludes (\`.git/\`, \`.github/\`, \`*.jpg/png/zip\`, \`.sops.yaml\`, \`.flux.yaml\`, ...) plus any in-tree \`.sourceignore\`. flate's PR #89 honored ONLY user-supplied \`spec.ignore\` patterns, so every repo shipped these noise files into the staged tree — every diff against a Flux-applied cluster diverged.

\`ApplyIgnore\` now:
- calls \`sourceignore.LoadIgnorePatterns(root, domain)\` to pick up in-tree \`.sourceignore\` files;
- appends user-supplied \`spec.ignore\` patterns when non-nil;
- matches via \`NewDefaultMatcher\` which prepends VCS + Default + Extra.

\`nil spec.ignore\` is no longer a no-op; the defaults still fire — matching real source-controller's artifact-build behavior.

### 2. \`ResolveChartRef\` HelmChart-no-version hole (MEDIUM)
When \`chartRef.kind=HelmChart\` resolved to a HelmChart CRD with empty \`spec.version\`, flate left \`h.Chart.RepoKind == KindHelmChart\` unchanged, which then dead-ended in \`LocateChart\` with \"unsupported chart repo kind HelmChart\". The version gate was wrong: even with no version, \`RepoKind\` must flip to the real underlying source (\`HelmRepository\` / \`OCIRepository\` / \`GitRepository\`) so the loader can dispatch. Rewrite is now unconditional once the source is found.

## Tests
- New \`TestApplyIgnore_AppliesDefaultsWhenIgnoreNil\` covers \`.git\`/\`.github\`/\`*.png\`/\`.sops.yaml\` removal under nil ignore.
- New \`TestApplyIgnore_DoubleStarMatchesAtAnyDepth\` covers \`**/vendor/\`.
- New \`TestApplyIgnore_LeadingSlashAnchorsToRoot\` covers gitignore root-anchor semantics.

## Scope note
The review also flagged \`spec.test.filters\`. After re-reading helm-controller (\`internal/action/test.go\`), Filters only affect runtime test execution at apply time, not render output. flate's render path is already correct for \`spec.test\`. No change needed there.

## Test plan
- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)