### PR TITLE
chore(manifest,store,helm): prune dead code and redundant defensive clones

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -52,11 +52,11 @@ type ChartLoadResult struct {
 // chart lives at <artifact.LocalPath>/<chart.Name>.
 func (c *Client) locateGitChart(hr *manifest.HelmRelease) (string, error) {
 	c.mu.RLock()
-	g, ok := c.gitRepos[hr.RepoName()]
+	g, ok := c.gitRepos[hr.Chart.RepoFullName()]
 	c.mu.RUnlock()
 	if !ok || g.Artifact == nil {
 		return "", fmt.Errorf("%w: GitRepository %s not available for HelmRelease %s",
-			manifest.ErrObjectNotFound, hr.RepoName(), hr.NamespacedName())
+			manifest.ErrObjectNotFound, hr.Chart.RepoFullName(), hr.NamespacedName())
 	}
 	path := filepath.Join(g.Artifact.LocalPath, hr.Chart.Name)
 	if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err != nil {
@@ -71,11 +71,11 @@ func (c *Client) locateGitChart(hr *manifest.HelmRelease) (string, error) {
 // any SecretRef credentials.
 func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
 	c.mu.RLock()
-	r, ok := c.repos[hr.RepoName()]
+	r, ok := c.repos[hr.Chart.RepoFullName()]
 	c.mu.RUnlock()
 	if !ok {
 		return "", fmt.Errorf("%w: HelmRepository %s not registered for HelmRelease %s",
-			manifest.ErrObjectNotFound, hr.RepoName(), hr.NamespacedName())
+			manifest.ErrObjectNotFound, hr.Chart.RepoFullName(), hr.NamespacedName())
 	}
 
 	if r.Type == manifest.RepoTypeOCI || strings.HasPrefix(r.URL, "oci://") {
@@ -287,10 +287,10 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 // short name from the HelmRelease is metadata, not part of the URL.
 func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
 	c.mu.RLock()
-	r, ok := c.ociRepos[hr.RepoName()]
+	r, ok := c.ociRepos[hr.Chart.RepoFullName()]
 	c.mu.RUnlock()
 	if !ok {
-		return "", fmt.Errorf("%w: OCIRepository %s not registered", manifest.ErrObjectNotFound, hr.RepoName())
+		return "", fmt.Errorf("%w: OCIRepository %s not registered", manifest.ErrObjectNotFound, hr.Chart.RepoFullName())
 	}
 	ver, err := r.Version()
 	if err != nil {

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -3,7 +3,6 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -84,11 +83,11 @@ func chartFromHelmRelease(spec *helmv2.HelmReleaseSpec, defaultNamespace string)
 	}, nil
 }
 
-// HelmChartFromSource constructs a HelmChart from a resolved
+// helmChartFromSource constructs a HelmChart from a resolved
 // HelmChartSource. The Repo* fields are read from the embedded
 // SourceRef (which always shares the HelmChart's namespace per Flux
 // schema).
-func HelmChartFromSource(src *HelmChartSource) HelmChart {
+func helmChartFromSource(src *HelmChartSource) HelmChart {
 	kind := src.SourceRef.Kind
 	if kind == "" {
 		kind = KindHelmRepository
@@ -195,8 +194,7 @@ type HelmRelease struct {
 	// ReadyExpr). Shadows the embedded Spec.DependsOn ([]DependencyReference).
 	DependsOn []DependencyRef `json:"-" yaml:"-"`
 
-	Images []string          `json:"images,omitempty" yaml:"images,omitempty"`
-	Labels map[string]string `json:"-"                yaml:"-"`
+	Labels map[string]string `json:"-" yaml:"-"`
 
 	// CRDsPolicy collapses spec.install.crds vs spec.upgrade.crds. One
 	// of "" (chart's helm default), "Skip", "Create", "CreateReplace".
@@ -238,11 +236,6 @@ func (h *HelmRelease) ReleaseNamespace() string {
 	return h.Namespace
 }
 
-// RepoName is the HelmRepository identifier (namespace-name).
-func (h *HelmRelease) RepoName() string {
-	return h.Chart.RepoNamespace + "-" + h.Chart.RepoName
-}
-
 // NamespacedName is "<namespace>/<name>".
 func (h *HelmRelease) NamespacedName() string { return h.Namespace + "/" + h.Name }
 
@@ -267,7 +260,7 @@ func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) er
 		return fmt.Errorf("%w: HelmChartSource %s not found for HelmRelease %s",
 			ErrObjectNotFound, h.Chart.RepoFullName(), h.NamespacedName())
 	}
-	h.Chart = HelmChartFromSource(src)
+	h.Chart = helmChartFromSource(src)
 	if len(src.ValuesFiles) > 0 {
 		h.ChartValuesFiles = src.ValuesFiles
 		h.IgnoreMissingValuesFiles = src.IgnoreMissingValuesFiles
@@ -296,7 +289,6 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 	if err != nil {
 		return nil, err
 	}
-	vfs := slices.Clone(cr.Spec.ValuesFrom)
 	var values map[string]any
 	if cr.Spec.Values != nil && len(cr.Spec.Values.Raw) > 0 {
 		if err := json.Unmarshal(cr.Spec.Values.Raw, &values); err != nil {
@@ -341,11 +333,6 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		chartValuesFiles = cr.Spec.Chart.Spec.ValuesFiles
 		ignoreMissingValuesFiles = cr.Spec.Chart.Spec.IgnoreMissingValuesFiles
 	}
-
-	// Ensure ValuesFrom is a defensive clone — Spec is embedded by
-	// value so this is the only slice that could escape via aliasing.
-	cr.Spec.ValuesFrom = vfs
-	cr.Spec.PostRenderers = slices.Clone(cr.Spec.PostRenderers)
 
 	return &HelmRelease{
 		Name:                     cr.Name,

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -1,9 +1,6 @@
 package manifest
 
 import (
-	"slices"
-
-	meta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
@@ -128,10 +125,6 @@ const (
 // enforced at Fetch time.
 type OCIRepositoryVerify = sourcev1.OCIRepositoryVerification
 
-// OIDCIdentityMatch is the keyless-mode identity matcher. Parsed for
-// fidelity; flate does not perform keyless verification.
-type OIDCIdentityMatch = sourcev1.OIDCIdentityMatch
-
 // Named identifies the OCIRepository.
 func (o *OCIRepository) Named() NamedResource {
 	return NamedResource{Kind: KindOCIRepository, Namespace: o.Namespace, Name: o.Name}
@@ -181,19 +174,12 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	if cr.Spec.Provider == "" {
 		cr.Spec.Provider = sourcev1.GenericOCIProvider
 	}
-	if v := cr.Spec.Verify; v != nil {
-		v.MatchOIDCIdentity = slices.Clone(v.MatchOIDCIdentity)
-	}
 	return &OCIRepository{
 		Name:              cr.Name,
 		Namespace:         cr.Namespace,
 		OCIRepositorySpec: cr.Spec,
 	}, nil
 }
-
-// ExternalArtifactSourceRef identifies the upstream CR that produces
-// the artifact — Flux's meta.NamespacedObjectKindReference.
-type ExternalArtifactSourceRef = meta.NamespacedObjectKindReference
 
 // ExternalArtifact is the Flux ExternalArtifact CRD
 // (source.toolkit.fluxcd.io/v1). It is the contract a third-party

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -351,35 +351,6 @@ func TestStore_WatchExists(t *testing.T) {
 	}
 }
 
-func TestStore_WatchAdded(t *testing.T) {
-	s := New()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ch := s.WatchAdded(ctx, "ConfigMap", 16)
-
-	s.AddObject(newCM("a", "ns"))
-	s.AddObject(newCM("b", "ns"))
-	// A non-CM object should not appear.
-	s.AddObject(&manifest.Secret{Name: "z", Namespace: "ns"})
-
-	got := make(map[string]struct{})
-	timeout := time.After(time.Second)
-	for len(got) < 2 {
-		select {
-		case ev := <-ch:
-			got[ev.ID.Name] = struct{}{}
-		case <-timeout:
-			t.Fatalf("timed out, got %v", got)
-		}
-	}
-	if _, ok := got["a"]; !ok {
-		t.Errorf("missing 'a'")
-	}
-	if _, ok := got["b"]; !ok {
-		t.Errorf("missing 'b'")
-	}
-}
-
 func TestStore_AddListener_Unsubscribe(t *testing.T) {
 	s := New()
 	count := 0

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -142,64 +142,6 @@ func (s *Store) WatchExists(ctx context.Context, id manifest.NamedResource) (man
 	}
 }
 
-// AddedEvent is the value yielded by WatchAdded.
-type AddedEvent struct {
-	ID     manifest.NamedResource
-	Object manifest.BaseManifest
-}
-
-// WatchAdded returns a channel that yields every object of the given
-// kind, starting with everything already in the store. The channel is
-// closed when ctx is cancelled. The channel has buffer size bufSize;
-// values are dropped if the consumer falls behind to keep dispatch
-// non-blocking. Use bufSize generously for slow consumers.
-func (s *Store) WatchAdded(ctx context.Context, kind string, bufSize int) <-chan AddedEvent {
-	if bufSize < 1 {
-		bufSize = 16
-	}
-	out := make(chan AddedEvent, bufSize)
-
-	go func() {
-		defer close(out)
-
-		// Seed with existing objects.
-		for _, obj := range s.ListObjects(kind) {
-			id := obj.Named()
-			select {
-			case out <- AddedEvent{ID: id, Object: obj}:
-			case <-ctx.Done():
-				return
-			}
-		}
-
-		// Subscribe for new objects.
-		seen := make(map[manifest.NamedResource]struct{})
-		for _, obj := range s.ListObjects(kind) {
-			seen[obj.Named()] = struct{}{}
-		}
-
-		unsub := s.AddListener(EventObjectAdded, func(other manifest.NamedResource, payload any) {
-			if kind != "" && other.Kind != kind {
-				return
-			}
-			obj, ok := payload.(manifest.BaseManifest)
-			if !ok {
-				return
-			}
-			select {
-			case out <- AddedEvent{ID: other, Object: obj}:
-			default:
-				// Consumer too slow — drop. Could optionally log here.
-			}
-		}, false)
-		defer unsub()
-
-		<-ctx.Done()
-	}()
-
-	return out
-}
-
 // String formatter is occasionally useful for tests.
 func (s *Store) String() string {
 	s.mu.RLock()


### PR DESCRIPTION
## Summary
- Delete `Store.WatchAdded` + `AddedEvent` (zero production callers; the seeded `AddListener` flow had a ListObjects vs subscribe race that was never wired up).
- Drop redundant `slices.Clone` defensive copies in `pkg/manifest/helm.go` (`ValuesFrom`, `PostRenderers`) and `pkg/manifest/source.go` (`MatchOIDCIdentity`). The JSON unmarshal in \`decodeTyped\` already produces fresh backing arrays for a local \`cr\`; nothing aliased.
- Delete \`HelmRelease.RepoName()\` — duplicates \`Chart.RepoFullName()\`. Rewrite 6 callers in \`pkg/helm/repo.go\` to \`hr.Chart.RepoFullName()\` so the chart-owned identity is the single source of truth.
- Delete unused \`HelmRelease.Images\` field (never written by the parser).
- Delete unreferenced \`OIDCIdentityMatch\` + \`ExternalArtifactSourceRef\` type aliases.
- Unexport \`HelmChartFromSource\` → \`helmChartFromSource\` (only \`ResolveChartRef\` consumes it).

Net: -114 LOC across 5 files, no behavior change.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./... -count=1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)