### PR TITLE
test: close coverage gaps in source controller, helm hooks, commonMetadata

### DIFF
--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -112,18 +112,31 @@ func TestController_SuspendedShortCircuitsToReady(t *testing.T) {
 }
 
 func TestController_UnregisteredKindIgnored(t *testing.T) {
-	_, st := newController(t, map[string]src.Fetcher{}) // no fetchers
-	repo := &manifest.GitRepository{
+	// Register an OCIRepository fetcher so the controller is alive but
+	// has no entry for KindGitRepository. The AddObject path dispatches
+	// listeners synchronously, so checking status immediately after
+	// AddObject proves the unregistered branch returned without writing
+	// any status — no sleep needed.
+	registered := &fakeFetcher{artifact: &store.SourceArtifact{Kind: manifest.KindOCIRepository}}
+	_, st := newController(t, map[string]src.Fetcher{manifest.KindOCIRepository: registered})
+
+	unregistered := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
 	}
-	st.AddObject(repo)
-
-	// Give the listener a tick — nothing should run, no status set.
-	time.Sleep(20 * time.Millisecond)
-	if _, ok := st.GetStatus(repo.Named()); ok {
+	st.AddObject(unregistered)
+	if _, ok := st.GetStatus(unregistered.Named()); ok {
 		t.Errorf("expected no status update for unregistered kind")
 	}
+
+	// Positive control: a registered kind reaches Ready, proving the
+	// dispatcher is alive and the unregistered skip is targeted.
+	oci := &manifest.OCIRepository{
+		Name: "o", Namespace: "ns",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+	}
+	st.AddObject(oci)
+	waitForStatus(t, st, oci.Named(), store.StatusReady)
 }
 
 func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -145,6 +145,12 @@ func TestTemplate_HRInstallDisableHooks(t *testing.T) {
 	if strings.Contains(out, "demo-pre") {
 		t.Errorf("HR-scoped spec.install.disableHooks should suppress pre-install hook: %s", out)
 	}
+	// Positive control — non-hook resources must still render so we
+	// know the absence of "demo-pre" is hook-suppression, not a broken
+	// render path.
+	if !strings.Contains(out, "demo-cm") {
+		t.Errorf("expected non-hook ConfigMap to still render: %s", out)
+	}
 }
 
 func TestTemplateDocs_AppliesHRCommonMetadata(t *testing.T) {
@@ -171,6 +177,67 @@ func TestTemplateDocs_AppliesHRCommonMetadata(t *testing.T) {
 	}
 	if annotations["owner"] != "platform" {
 		t.Errorf("commonMetadata.annotations not merged: %v", annotations)
+	}
+}
+
+func TestApplyHRCommonMetadata_LabelsOnly(t *testing.T) {
+	docs := []map[string]any{
+		{"metadata": map[string]any{"name": "x"}},
+	}
+	applyHRCommonMetadata(docs, &helmv2.CommonMetadata{
+		Labels: map[string]string{"team": "flate"},
+	})
+	md := docs[0]["metadata"].(map[string]any)
+	labels, _ := md["labels"].(map[string]any)
+	if labels["team"] != "flate" {
+		t.Errorf("labels not merged: %v", labels)
+	}
+	if _, ok := md["annotations"]; ok {
+		t.Errorf("annotations key should not be created when input is empty: %v", md)
+	}
+}
+
+func TestApplyHRCommonMetadata_AnnotationsOnly(t *testing.T) {
+	docs := []map[string]any{
+		{"metadata": map[string]any{"name": "x"}},
+	}
+	applyHRCommonMetadata(docs, &helmv2.CommonMetadata{
+		Annotations: map[string]string{"owner": "platform"},
+	})
+	md := docs[0]["metadata"].(map[string]any)
+	annotations, _ := md["annotations"].(map[string]any)
+	if annotations["owner"] != "platform" {
+		t.Errorf("annotations not merged: %v", annotations)
+	}
+	if _, ok := md["labels"]; ok {
+		t.Errorf("labels key should not be created when input is empty: %v", md)
+	}
+}
+
+func TestApplyHRCommonMetadata_NilOrEmptyIsNoop(t *testing.T) {
+	docs := []map[string]any{
+		{"metadata": map[string]any{"name": "x"}},
+	}
+	original := docs[0]["metadata"].(map[string]any)
+	applyHRCommonMetadata(docs, nil)
+	applyHRCommonMetadata(docs, &helmv2.CommonMetadata{})
+	if len(original) != 1 || original["name"] != "x" {
+		t.Errorf("metadata mutated by nil/empty CommonMetadata: %v", original)
+	}
+}
+
+func TestApplyHRCommonMetadata_CreatesMetadataWhenMissing(t *testing.T) {
+	docs := []map[string]any{{}} // no metadata
+	applyHRCommonMetadata(docs, &helmv2.CommonMetadata{
+		Labels: map[string]string{"team": "flate"},
+	})
+	md, ok := docs[0]["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("metadata not created: %v", docs[0])
+	}
+	labels, _ := md["labels"].(map[string]any)
+	if labels["team"] != "flate" {
+		t.Errorf("labels not merged into newly-created metadata: %v", labels)
 	}
 }
 

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -129,6 +129,42 @@ func TestFetcher_SparseCheckout(t *testing.T) {
 	}
 }
 
+// TestFetcher_AppliesSpecIgnore exercises the spec.ignore wiring: a
+// staged tree containing a tracked file matching the user-supplied
+// gitignore pattern must have that file deleted post-checkout.
+func TestFetcher_AppliesSpecIgnore(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{
+		"apps/deployment.yaml": "kind: Deployment",
+		"apps/scratch.tmp":     "noise",
+		"docs/notes.md":        "drop-me",
+	})
+
+	patterns := "*.tmp\ndocs/\n"
+	cache := source.NewCache(t.TempDir())
+	repo := &manifest.GitRepository{
+		Name: "test", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:    "file://" + src,
+			Ignore: &patterns,
+		},
+	}
+	f := &Fetcher{Cache: cache}
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "apps", "scratch.tmp")); !os.IsNotExist(err) {
+		t.Errorf("expected *.tmp to be removed by spec.ignore; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "docs")); !os.IsNotExist(err) {
+		t.Errorf("expected docs/ to be removed by spec.ignore; stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "apps", "deployment.yaml")); err != nil {
+		t.Errorf("non-ignored file should remain: %v", err)
+	}
+}
+
 // mustInitRepoWithFiles creates a git repo at dir with the given
 // {path: contents} entries committed as one revision.
 func mustInitRepoWithFiles(t *testing.T, dir string, files map[string]string) {


### PR DESCRIPTION
## Summary
Spot-fixes for thin tests flagged during the review pass:

- **pkg/controllers/source**: drop the 20ms sleep in \`TestController_UnregisteredKindIgnored\` — \`Store.AddObject\` dispatches listeners on the calling goroutine, so the ignore branch returns before any task is scheduled and the immediate \`GetStatus\` check is sound. Add a positive-control OCIRepository that reaches Ready, proving the dispatcher is alive and the skip targets only the unregistered kind.
- **pkg/helm**: \`TestTemplate_HRInstallDisableHooks\` now asserts the non-hook ConfigMap still renders, so the absence of \`demo-pre\` is unambiguously hook-suppression rather than a broken render.
- **pkg/helm**: add labels-only / annotations-only / nil-empty / missing-metadata branch tests for \`applyHRCommonMetadata\`. Covers the empty-input no-op path (no \`labels\`/\`annotations\` key created on the doc) and the path that creates \`metadata\` when it's absent.
- **pkg/source/git**: add \`TestFetcher_AppliesSpecIgnore\` end-to-end — commit a tracked \`.tmp\` and a \`docs/\` tree, set \`spec.ignore\`, fetch, assert the staged artifact has them removed and other files untouched. The bucket and oci fetchers call \`source.ApplyIgnore\` with the same shape; their integration tests would require fake S3/registry backends, deferring until that infra justifies its own cost.

## Test plan
- [x] \`go test ./... -count=1\`
- [x] \`go test ./pkg/source/git -run TestFetcher_AppliesSpecIgnore\`
- [x] \`go test ./pkg/controllers/source -run TestController_UnregisteredKindIgnored\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)