### PR TITLE
feat(cli): broaden get hr/ks structured projection

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -26,13 +26,26 @@ func newGetKSCmd() *cobra.Command {
 	return resourceListCmd("ks", []string{"kustomization", "kustomizations"},
 		"List Kustomizations", manifest.KindKustomization, ksColumns,
 		func(o *manifest.Kustomization) (row map[string]string, doc map[string]any) {
-			return map[string]string{
-					"namespace": o.Namespace, "name": o.Name, "path": o.Path,
+			doc = map[string]any{
+				"kind": manifest.KindKustomization, "namespace": o.Namespace,
+				"name": o.Name, "path": o.Path,
+				"sourceRef": map[string]string{
+					"kind":      o.SourceKind,
+					"name":      o.SourceName,
+					"namespace": o.SourceNamespace,
 				},
-				map[string]any{
-					"kind": manifest.KindKustomization, "namespace": o.Namespace,
-					"name": o.Name, "path": o.Path,
-				}
+				"prune": o.Prune,
+				"wait":  o.Wait,
+			}
+			if o.Suspend {
+				doc["suspend"] = true
+			}
+			if o.TargetNamespace != "" {
+				doc["targetNamespace"] = o.TargetNamespace
+			}
+			return map[string]string{
+				"namespace": o.Namespace, "name": o.Name, "path": o.Path,
+			}, doc
 		},
 	)
 }
@@ -41,16 +54,28 @@ func newGetHRCmd() *cobra.Command {
 	return resourceListCmd("hr", []string{"helmrelease", "helmreleases"},
 		"List HelmReleases", manifest.KindHelmRelease, hrColumns,
 		func(o *manifest.HelmRelease) (row map[string]string, doc map[string]any) {
-			return map[string]string{
-					"namespace": o.Namespace, "name": o.Name,
-					"chart": o.Chart.ChartName(), "version": o.Chart.Version,
-					"source": o.Chart.RepoName,
+			doc = map[string]any{
+				"kind": manifest.KindHelmRelease, "namespace": o.Namespace,
+				"name": o.Name, "chart": o.Chart.ChartName(),
+				"version": o.Chart.Version, "source": o.Chart.RepoName,
+				"sourceRef": map[string]string{
+					"kind":      o.Chart.RepoKind,
+					"name":      o.Chart.RepoName,
+					"namespace": o.Chart.RepoNamespace,
 				},
-				map[string]any{
-					"kind": manifest.KindHelmRelease, "namespace": o.Namespace,
-					"name": o.Name, "chart": o.Chart.ChartName(),
-					"version": o.Chart.Version, "source": o.Chart.RepoName,
-				}
+				"releaseName": o.ReleaseName(),
+			}
+			if o.Suspend {
+				doc["suspend"] = true
+			}
+			if o.TargetNamespace != "" {
+				doc["targetNamespace"] = o.TargetNamespace
+			}
+			return map[string]string{
+				"namespace": o.Namespace, "name": o.Name,
+				"chart": o.Chart.ChartName(), "version": o.Chart.Version,
+				"source": o.Chart.RepoName,
+			}, doc
 		})
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -72,6 +72,28 @@ func TestE2E_GetKS(t *testing.T) {
 	}
 }
 
+func TestE2E_GetKS_YAMLExposesProjectedFields(t *testing.T) {
+	out := runCLI(t, "get", "ks", "--path", testdataPath(t, "simple"), "-o", "yaml")
+	// Asserts the structured projection includes the new fields:
+	// sourceRef block (kind/name/namespace), prune, wait.
+	for _, want := range []string{"sourceRef:", "kind: GitRepository", "prune: true", "wait:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in projected ks YAML:\n%s", want, out)
+		}
+	}
+}
+
+func TestE2E_GetHR_YAMLExposesProjectedFields(t *testing.T) {
+	out := runCLI(t, "get", "hr", "--path", testdataPath(t, "simple"), "-o", "yaml")
+	// HelmRelease projection should carry sourceRef (chart's resolved
+	// ref) and releaseName.
+	for _, want := range []string{"sourceRef:", "releaseName:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in projected hr YAML:\n%s", want, out)
+		}
+	}
+}
+
 func TestE2E_BuildKS(t *testing.T) {
 	out := runCLI(t, "build", "ks", "--path", copyTree(t, testdataPath(t, "simple")))
 	if !strings.Contains(out, "kind: ConfigMap") {


### PR DESCRIPTION
## Summary
The YAML/JSON output of \`flate get ks\` and \`flate get hr\` previously carried only the core identity fields (name, namespace, path/chart/version/source). Operators reaching for \`-o yaml\` to script around the output had to re-parse the source manifests for anything else.

This widens the structured projection to include the fields a Flux operator typically wants when inspecting:

- \`flate get ks\`: adds \`sourceRef\` ({kind, name, namespace}), \`prune\`, \`wait\`, and the optional \`suspend\` + \`targetNamespace\` keys (only emitted when non-default to keep the common-case output tidy).
- \`flate get hr\`: adds the chart's resolved \`sourceRef\` ({kind, name, namespace} — distinct from the existing chart/version/source triple), \`releaseName\` (resolved per helm-controller semantics — \`spec.releaseName\` → \`metadata.name\` fallback), and the same optional \`suspend\` + \`targetNamespace\`.

Table columns are unchanged — terminal width is precious, and detailed inspection is what \`-o yaml\` is for.

## Test plan
- [x] \`go test ./... -count=1\`
- [x] New e2e tests: \`TestE2E_GetKS_YAMLExposesProjectedFields\`, \`TestE2E_GetHR_YAMLExposesProjectedFields\`
- [x] \`flate get ks -o yaml\` and \`flate get hr -o yaml\` against testdata/simple emit the new keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)