### PR TITLE
fix(loader): inherit Flux KS effective namespace onto cross-tree spec.path resources

### DIFF
--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -26,12 +26,17 @@ func ApplyNamespaceInheritance(s *store.Store, sourceFiles map[manifest.NamedRes
 		return
 	}
 
-	// Index #1 — Flux Kustomizations with a targetNamespace.
-	fluxByPath := indexFluxTargetNamespaces(s)
-
-	// Index #2 — kustomize.yaml `namespace:` directives, keyed by
-	// the directory containing the kustomization file.
+	// Index #1 — kustomize.yaml `namespace:` directives, keyed by
+	// the directory containing the kustomization file. Indexed first
+	// because indexFluxByPath consults it to project a Flux KS's
+	// effective namespace before the parent's render fires.
 	kustomizeByDir := indexKustomizeNamespaces(sourceFiles, repoRoot)
+
+	// Index #2 — Flux Kustomizations by spec.path → effective
+	// namespace (targetNamespace if set, otherwise metadata.namespace,
+	// otherwise the kustomize.yaml directive that would patch the KS
+	// itself once the parent renders).
+	fluxByPath := indexFluxByPath(s, sourceFiles, kustomizeByDir)
 
 	type update struct {
 		old, new manifest.NamedResource
@@ -95,20 +100,44 @@ func resolveNamespace(file string, flux, kust []pathEntry) string {
 	return best.ns
 }
 
-// indexFluxTargetNamespaces returns one pathEntry per Flux
-// Kustomization with a non-empty targetNamespace. resolveNamespace
-// already picks the longest-prefix match, so the slice can stay
-// unsorted.
-func indexFluxTargetNamespaces(s *store.Store) []pathEntry {
+// indexFluxByPath returns one pathEntry per Flux Kustomization keyed
+// by spec.path → the KS's effective namespace. Mirrors what real Flux
+// renders into the cluster:
+//   - spec.targetNamespace wins when set (kustomize-controller injects it).
+//   - Otherwise metadata.namespace acts as the apply-context default —
+//     resources rendered by the KS without explicit namespaces land
+//     in the KS's own namespace.
+//   - When metadata.namespace is also empty (i.e. the KS hasn't yet
+//     had a kustomize directive applied at the time of indexing), fall
+//     back to the kustomize.yaml directive that would patch the KS at
+//     parent-render time. This handles the cross-tree base/ pattern,
+//     where the parent's `replacements:` block injects targetNamespace
+//     only at kustomize-build, but flate runs inheritance at load.
+//
+// resolveNamespace picks the longest-prefix match, so the slice can
+// stay unsorted.
+func indexFluxByPath(s *store.Store, sourceFiles map[manifest.NamedResource]string, kust []pathEntry) []pathEntry {
 	var out []pathEntry
 	for _, obj := range s.ListObjects(manifest.KindKustomization) {
 		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.TargetNamespace == "" {
+		if !ok || ks.Path == "" {
+			continue
+		}
+		ns := ks.TargetNamespace
+		if ns == "" {
+			ns = ks.Namespace
+		}
+		if ns == "" {
+			if file, ok := sourceFiles[ks.Named()]; ok {
+				ns = resolveNamespace(file, nil, kust)
+			}
+		}
+		if ns == "" {
 			continue
 		}
 		out = append(out, pathEntry{
 			prefix: normalizePrefix(ks.Path),
-			ns:     ks.TargetNamespace,
+			ns:     ns,
 		})
 	}
 	return out

--- a/pkg/loader/inherit_test.go
+++ b/pkg/loader/inherit_test.go
@@ -125,6 +125,60 @@ func TestReadKustomizeNamespace_AnchoredByRepoRoot(t *testing.T) {
 	}
 }
 
+// TestApplyNamespaceInheritance_CrossTreeBasePattern covers the
+// multi-cluster shared-base layout (e.g. joryirving/home-ops): the
+// parent kustomization.yaml under `main/<ns>/` carries the `namespace:`
+// directive that — at parent-render time — patches the Flux KS itself
+// to namespace=<ns> and (via a replacements: block) injects
+// spec.targetNamespace=<ns>. The Flux KS's spec.path then points at a
+// directory under `base/` that has no local namespace directive.
+//
+// Pre-fix behavior: inheritance only saw the KS's empty
+// targetNamespace, so resources under the cross-tree base/ path stayed
+// at namespace="" and later failed source-ref resolution.
+//
+// Post-fix: the KS's effective namespace (derived from the
+// kustomization.yaml directive on its own file) propagates to
+// resources under spec.path even when both live in different subtrees.
+func TestApplyNamespaceInheritance_CrossTreeBasePattern(t *testing.T) {
+	root := t.TempDir()
+	// Parent kustomize file lives under main/games and carries the
+	// `namespace: games` directive that real Flux's replacements block
+	// would later turn into spec.targetNamespace=games.
+	writeFile(t, root, "apps/main/games/kustomization.yaml", "namespace: games\n")
+
+	s := store.New()
+	// Flux KS lives at apps/main/games/romm.yaml but spec.path crosses
+	// over to apps/base/games/romm. Neither metadata.namespace nor
+	// spec.targetNamespace is set in the source YAML.
+	ks := &manifest.Kustomization{
+		Name: "romm",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "./apps/base/games/romm",
+		},
+	}
+	hr := &manifest.HelmRelease{Name: "romm"}
+	s.AddObject(ks)
+	s.AddObject(hr)
+
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/main/games/romm.yaml",
+		hr.Named(): "apps/base/games/romm/helmrelease.yaml",
+	}
+	ApplyNamespaceInheritance(s, sourceFiles, root)
+
+	// Both the KS and the HR should now be namespace=games — the KS
+	// from the local kustomize.yaml directive, the HR from the KS's
+	// effective namespace projected onto its spec.path.
+	want := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "games", Name: "romm"}
+	if got := s.GetObject(want); got == nil {
+		t.Fatalf("expected cross-tree HR at games/romm; sourceFiles=%v", sourceFiles)
+	}
+	if got := s.GetObject(manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "romm"}); got != nil {
+		t.Errorf("empty-namespace HR should have been removed")
+	}
+}
+
 func TestApplyNamespaceInheritance_HRChartRepoNamespaceTracksHR(t *testing.T) {
 	// When HR.Chart.RepoNamespace is empty, it implicitly tracks the
 	// HR's own namespace. After inheritance fills the HR namespace in,


### PR DESCRIPTION
## Summary
Partial fix for #51 (multi-cluster cross-tree namespace pattern).

\`ApplyNamespaceInheritance\` previously indexed Flux Kustomizations only when their **in-YAML** \`spec.targetNamespace\` was non-empty. Multi-cluster repos like [joryirving/home-ops](https://github.com/joryirving/home-ops) leave \`spec.targetNamespace\` empty in YAML and inject it at parent-render time via a kustomize \`replacements:\` block keyed off the namespace resource produced by a shared component. Because that injection happens **after** flate has loaded all manifests, the inheritance pass missed it — resources loaded under a child KS's \`spec.path\` (in a different subtree like \`apps/base/games/romm\`) stayed at \`namespace=\"\"\` and later failed source-ref resolution (\`OCIRepository/app-template not ready: dependency not found\`).

This PR broadens the per-KS effective-namespace computation:

1. \`spec.targetNamespace\` (in-YAML, unchanged)
2. \`metadata.namespace\` (in-YAML)
3. The \`kustomization.yaml\` \`namespace:\` directive on the KS's own source file — i.e. what the parent would patch the KS to during render.

\`indexFluxTargetNamespaces\` is renamed to \`indexFluxByPath\` to reflect the broader signal it now carries.

## Verification
Built from this branch against \`/tmp/jory-home-ops\`:

\`\`\`bash
flate get hr romm --path ./kubernetes/clusters/main -o yaml
\`\`\`

Before this PR: \`HelmRelease//romm\` AND \`HelmRelease/games/romm\` both stored (one fails dep resolution).

After this PR: the loader-direct \`HelmRelease//romm\` is correctly inherited into \`HelmRelease/games/romm\` during \`ApplyNamespaceInheritance\`.

## Test plan
- [x] \`go test ./pkg/loader -v\` — all 7 inheritance tests green, new \`TestApplyNamespaceInheritance_CrossTreeBasePattern\` added.
- [x] \`go test ./... -count=1\` — full suite green.

## Doesn't close #51
A second bug surfaces in jory's repo: even with this inheritance fix, the kustomization controller renders child KSes **before** the parent's \`replacements\` block has injected \`spec.targetNamespace\`, producing a stale-namespace HR that is never cleaned up by the coalescer's re-render. That requires a separate render-output-diff or parent-wait fix — filing a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)