### PR TITLE
fix(kustomization): wait for structural parent before child reconcile

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -39,6 +39,15 @@ type Controller struct {
 	// parsing rendered manifests.
 	WipeSecrets bool
 
+	// ParentOf maps each Flux Kustomization to its structural parent —
+	// the enclosing KS whose spec.path contains this one's source
+	// file. Reconcile waits for the parent's Ready before rendering so
+	// any parent-render-time spec mutations (e.g. `replacements:`
+	// injecting spec.targetNamespace) are observable when the child
+	// renders. Nil means "no parent enforcement," matching pre-#102
+	// behavior.
+	ParentOf map[manifest.NamedResource]manifest.NamedResource
+
 	unsub []store.Unsubscribe
 	coal  *task.Coalescer[manifest.NamedResource]
 }
@@ -103,6 +112,15 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 				Failed:  sum.Failed,
 				Reasons: sum.Messages,
 			}
+		}
+		// Refresh the KS — our structural parent may have re-emitted
+		// us with mutated spec (e.g. `replacements:` injecting
+		// spec.targetNamespace) while we were waiting. Without this
+		// re-read the first render would use the stale-spec snapshot
+		// captured by RunWithStatus, producing duplicate renders that
+		// linger in the store with the wrong namespace. See #102.
+		if fresh, ok := c.Store.GetObject(id).(*manifest.Kustomization); ok {
+			ks = fresh
 		}
 	}
 
@@ -279,7 +297,9 @@ func isLeafReconcilable(obj manifest.BaseManifest) bool {
 
 // collectDeps assembles the dependency refs whose readiness must
 // precede this Kustomization: explicit dependsOn entries (carrying any
-// CEL ReadyExpr) + the source ref.
+// CEL ReadyExpr), the source ref, and the implicit structural parent
+// (the enclosing Flux KS that renders us — must finish first so any
+// parent-render-time spec injections land before our reconcile).
 func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.DependencyRef {
 	deps := append([]manifest.DependencyRef(nil), ks.DependsOn...)
 	if ks.SourceKind != "" && ks.SourceName != "" {
@@ -288,6 +308,9 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 				Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
 			},
 		})
+	}
+	if parent, ok := c.ParentOf[ks.Named()]; ok {
+		deps = append(deps, manifest.DependencyRef{NamedResource: parent})
 	}
 	return deps
 }

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -1,0 +1,40 @@
+package kustomization
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestCollectDeps_AppendsStructuralParent locks the contract that
+// when ParentOf records an enclosing KS, that parent is appended to
+// the dependency list so the reconcile waits for the parent's Ready
+// before rendering. See #102.
+func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
+	parent := manifest.NamedResource{
+		Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps",
+	}
+	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
+
+	c := &Controller{ParentOf: map[manifest.NamedResource]manifest.NamedResource{
+		child.Named(): parent,
+	}}
+	deps := c.collectDeps(child)
+	for _, d := range deps {
+		if d.NamedResource == parent {
+			return
+		}
+	}
+	t.Errorf("parent %+v missing from deps %+v", parent, deps)
+}
+
+// TestCollectDeps_NoParentNoExtraDep guards against ParentOf-less
+// controllers (e.g. unit-test setups) panicking on a nil map.
+func TestCollectDeps_NoParentNoExtraDep(t *testing.T) {
+	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
+	c := &Controller{} // ParentOf nil
+	deps := c.collectDeps(child)
+	if len(deps) != 0 {
+		t.Errorf("expected no deps for KS without sourceRef/dependsOn/parent; got %+v", deps)
+	}
+}

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -1,0 +1,68 @@
+package loader
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// BuildParentIndex maps each Flux Kustomization to its structural
+// parent — the Flux Kustomization whose spec.path is the deepest
+// strict ancestor of the child's source file. Excludes self-matches.
+//
+// Real Flux's reconcile chain enforces this naturally: a parent
+// Kustomization renders and applies its child Kustomizations, then
+// the kustomize-controller reconciles each child. flate's controllers
+// fire on AddObject and would otherwise race the parent's render —
+// the controller uses this index to wait for the parent's Ready
+// before reconciling, so any parent-render-time spec mutations
+// (e.g. `replacements:` injecting spec.targetNamespace) are visible
+// to the child's first reconcile.
+//
+// sourceFiles is the orchestrator's NamedResource → repo-relative
+// source-file map; entries without a recorded file are skipped.
+func BuildParentIndex(s *store.Store, sourceFiles map[manifest.NamedResource]string) map[manifest.NamedResource]manifest.NamedResource {
+	type owner struct {
+		prefix string
+		id     manifest.NamedResource
+	}
+	var owners []owner
+	for _, obj := range s.ListObjects(manifest.KindKustomization) {
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok || ks.Path == "" {
+			continue
+		}
+		owners = append(owners, owner{prefix: normalizePrefix(ks.Path), id: ks.Named()})
+	}
+	out := map[manifest.NamedResource]manifest.NamedResource{}
+	for _, obj := range s.ListObjects(manifest.KindKustomization) {
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok {
+			continue
+		}
+		id := ks.Named()
+		file, ok := sourceFiles[id]
+		if !ok {
+			continue
+		}
+		slashFile := filepath.ToSlash(file)
+		var best owner
+		for _, o := range owners {
+			if o.id == id {
+				continue
+			}
+			if !strings.HasPrefix(slashFile, o.prefix) {
+				continue
+			}
+			if len(o.prefix) > len(best.prefix) {
+				best = o
+			}
+		}
+		if best.prefix != "" {
+			out[id] = best.id
+		}
+	}
+	return out
+}

--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -1,0 +1,133 @@
+package loader
+
+import (
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func TestBuildParentIndex_CrossTreeBasePattern(t *testing.T) {
+	// cluster-apps is the root with spec.path=./kubernetes/apps/main.
+	// karma lives at apps/main/observability/karma.yaml — under
+	// cluster-apps's spec.path — so cluster-apps is its parent. karma's
+	// own spec.path crosses over to apps/base/ but that's irrelevant
+	// for THIS index (which is about source-file-vs-spec.path).
+	s := store.New()
+	clusterApps := &manifest.Kustomization{
+		Name:      "cluster-apps",
+		Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "./kubernetes/apps/main",
+		},
+	}
+	karma := &manifest.Kustomization{
+		Name:      "karma",
+		Namespace: "observability",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "./kubernetes/apps/base/observability/karma",
+		},
+	}
+	s.AddObject(clusterApps)
+	s.AddObject(karma)
+
+	sourceFiles := map[manifest.NamedResource]string{
+		clusterApps.Named(): "kubernetes/clusters/main/apps.yaml",
+		karma.Named():       "kubernetes/apps/main/observability/karma.yaml",
+	}
+	parents := BuildParentIndex(s, sourceFiles)
+
+	if got, want := parents[karma.Named()], clusterApps.Named(); got != want {
+		t.Errorf("karma.parent = %+v; want %+v", got, want)
+	}
+	if _, ok := parents[clusterApps.Named()]; ok {
+		t.Errorf("cluster-apps should be parentless (root)")
+	}
+}
+
+func TestBuildParentIndex_DeepestPrefixWins(t *testing.T) {
+	// Outer spec.path is a strict prefix of inner spec.path; both
+	// contain the grandchild's source file. The inner KS should win as
+	// the structural parent.
+	s := store.New()
+	outer := &manifest.Kustomization{
+		Name:              "outer",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	inner := &manifest.Kustomization{
+		Name:              "inner",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/media"},
+	}
+	grandchild := &manifest.Kustomization{
+		Name:              "plex",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/media/plex/app"},
+	}
+	s.AddObject(outer)
+	s.AddObject(inner)
+	s.AddObject(grandchild)
+
+	sourceFiles := map[manifest.NamedResource]string{
+		outer.Named():      "clusters/main/apps.yaml",
+		inner.Named():      "apps/media/kustomization.yaml",
+		grandchild.Named(): "apps/media/plex/ks.yaml",
+	}
+	parents := BuildParentIndex(s, sourceFiles)
+
+	if got, want := parents[grandchild.Named()], inner.Named(); got != want {
+		t.Errorf("grandchild.parent = %+v; want %+v (deepest prefix)", got, want)
+	}
+	if got, want := parents[inner.Named()], outer.Named(); got != want {
+		t.Errorf("inner.parent = %+v; want %+v", got, want)
+	}
+}
+
+func TestBuildParentIndex_NoSelfMatch(t *testing.T) {
+	// A KS whose own source file lives under its spec.path must NOT
+	// match itself as parent. Edge case for in-place trees.
+	s := store.New()
+	ks := &manifest.Kustomization{
+		Name:              "self",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/self/ks.yaml",
+	}
+	parents := BuildParentIndex(s, sourceFiles)
+	if _, ok := parents[ks.Named()]; ok {
+		t.Errorf("KS must not be its own parent: %v", parents)
+	}
+}
+
+func TestBuildParentIndex_NoSourceFileSkipped(t *testing.T) {
+	// A KS without a recorded source file (e.g. lifted purely from a
+	// parent's render output, no annotation propagated to the orchestrator)
+	// has no detectable file — skip rather than blow up.
+	s := store.New()
+	parent := &manifest.Kustomization{
+		Name:              "parent",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	orphan := &manifest.Kustomization{
+		Name:              "orphan",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/orphan/app"},
+	}
+	s.AddObject(parent)
+	s.AddObject(orphan)
+	sourceFiles := map[manifest.NamedResource]string{
+		parent.Named(): "clusters/main/apps.yaml",
+		// orphan deliberately absent.
+	}
+	parents := BuildParentIndex(s, sourceFiles)
+	if _, ok := parents[orphan.Named()]; ok {
+		t.Errorf("KS without source file must not appear in parent index: %v", parents)
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -263,6 +263,10 @@ func (o *Orchestrator) loadManifests(ctx context.Context, repoRoot string) error
 	slog.Debug("orchestrator: loaded objects", "count", total, "scan", scanRoot, "source-root", repoRoot)
 
 	loader.ApplyNamespaceInheritance(o.store, o.sourceFiles, repoRoot)
+	// Build the parent index after namespace inheritance so the
+	// recorded child→parent ids reflect the canonical (post-rewrite)
+	// NamedResources the controller will see.
+	o.ksc.ParentOf = loader.BuildParentIndex(o.store, o.sourceFiles)
 	return nil
 }
 


### PR DESCRIPTION
Closes #102. Also closes #51 (combined with #101).

## Problem

Multi-cluster cross-tree layouts (e.g. [joryirving/home-ops](https://github.com/joryirving/home-ops)) inject \`spec.targetNamespace\` onto child Flux Kustomizations via a parent-level kustomize \`replacements:\` block — meaning the injection happens **during the parent's kustomize-build**, not statically in the child's YAML.

Before this change, flate's kustomization controller dispatched the child's first reconcile as soon as the loader staged it, racing the parent's render. The first render used the stale (un-injected) spec, producing an \`HelmRelease\` with \`namespace=\"\"\`; the coalescer's re-run later produced the correctly-namespaced HR, but the stale one was never cleaned up. Result on jory's repo: 78 spurious \`OCIRepository/app-template not ready: dependency not found\` failures.

## Fix

Add an implicit structural parent dependency:

- **\`pkg/loader/parent.go\`**: \`BuildParentIndex\` returns \`map[child]→parent\` for every Flux KS whose source file lives under another KS's \`spec.path\` (deepest enclosing wins, self-matches excluded).
- **\`pkg/controllers/kustomization\`**: \`collectDeps\` appends the parent to the dependency wait list; \`reconcile\` re-reads the KS from the store after depwait succeeds so any parent-render-time spec injections land before the render proceeds.
- **\`pkg/orchestrator\`**: builds the parent index after \`ApplyNamespaceInheritance\` (so ids reflect post-rewrite namespaces) and wires it into the kustomization controller.

The re-read inside \`reconcile\` is the key piece — without it, the first reconcile would wait for the parent but then proceed with the stale \`ks\` snapshot captured by \`RunWithStatus\`, defeating the fix.

## Verification

\`\`\`bash
git clone --depth 1 https://github.com/joryirving/home-ops /tmp/jory-home-ops
go build -o /tmp/flate ./cmd/flate
/tmp/flate test ks --path /tmp/jory-home-ops/kubernetes/clusters/main
\`\`\`

- Before: \`0 passed, 0 skipped, 145 failed\` (78 distinct \`app-template\` dep failures).
- After: \`145 passed, 0 skipped, 0 failed\`.

\`flate get hr romm -o yaml\` and \`flate get hr karma -o yaml\` now each show a single HR entry with the correct namespace; the empty-namespace duplicates are gone.

## Test plan
- [x] \`go test ./... -count=1\` — full suite green.
- [x] \`go test ./pkg/loader -run TestBuildParentIndex -v\` — 4 new tests covering cross-tree, deepest-prefix, self-exclusion, missing-source-file.
- [x] \`go test ./pkg/controllers/kustomization -run TestCollectDeps -v\` — 2 new tests covering collectDeps with/without ParentOf.
- [x] End-to-end against jory's repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)