### PR TITLE
fix(change): keep ancestor Kustomizations in changed-only keep set

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -91,6 +91,15 @@ func (f *Filter) resolve(objs ObjectLister) {
 			ownersHit[owner] = struct{}{}
 			enqueue(owner)
 		}
+		// Also include ancestor/meta Kustomizations whose render
+		// mutates the leaf owner's spec — parent-injected spec.patches
+		// and postBuild.substituteFrom land at parent-render time, so
+		// in changed-only mode the parent has to run too. Ancestors
+		// are NOT added to ownersHit, so the sibling-pull-in below
+		// doesn't drag in everything else they own. See #58.
+		for _, ancestor := range owners.ancestorsOf(file) {
+			enqueue(ancestor)
+		}
 	}
 	for id, src := range f.sourceFiles {
 		if f.changes.Contains(src) {

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -90,9 +90,13 @@ func TestFilter_SharedComponentPropagatesToAllConsumers(t *testing.T) {
 	}
 }
 
-func TestFilter_LongestPrefixOwnerWins(t *testing.T) {
+func TestFilter_AncestorKSAlsoKept(t *testing.T) {
 	// A meta-KS at apps/ and a specific KS at apps/media/plex/app —
-	// changes inside plex must belong to plex, not the meta-KS.
+	// the leaf plex is the deepest owner of the changed file, but the
+	// meta-KS's render (parent-injected spec.patches and
+	// postBuild.substituteFrom) mutates plex's spec. Both must be
+	// kept under changed-only mode so the leaf renders against the
+	// post-mutation spec. See #58.
 	meta := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
 		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps"},
@@ -115,11 +119,56 @@ func TestFilter_LongestPrefixOwnerWins(t *testing.T) {
 		mapLister{metaID: meta, plexID: plex},
 	)
 
-	if !f.ShouldReconcile(plexID) || !f.ShouldReconcile(hrPlex) {
-		t.Errorf("plex tree should be kept: %v", f.KeepNames())
+	for _, id := range []manifest.NamedResource{plexID, hrPlex, metaID} {
+		if !f.ShouldReconcile(id) {
+			t.Errorf("expected %s in keep; keep=%v", id, f.KeepNames())
+		}
 	}
-	if f.ShouldReconcile(metaID) {
-		t.Errorf("meta KS leaked into keep set despite a deeper owner: %v", f.KeepNames())
+}
+
+func TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings(t *testing.T) {
+	// Two leaf KSes under the same meta-KS. Only plex changes. plex
+	// + meta are kept; atuin (an unrelated sibling under the meta-KS)
+	// must NOT be pulled in — keeping the meta-KS reconcile-eligible
+	// does not widen sibling-resource coverage.
+	meta := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps"},
+	}
+	plex := &manifest.Kustomization{
+		Name: "plex", Namespace: "media",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/media/plex/app"},
+	}
+	atuin := &manifest.Kustomization{
+		Name: "atuin", Namespace: "default",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/default/atuin/app"},
+	}
+	metaID, plexID, atuinID := meta.Named(), plex.Named(), atuin.Named()
+	hrAtuin := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "atuin"}
+
+	f := NewFilter(
+		NewSet([]string{"apps/media/plex/app/helmrelease.yaml"}),
+		map[manifest.NamedResource]string{
+			metaID:   "flux/cluster/ks.yaml",
+			plexID:   "apps/media/plex/app/ks.yaml",
+			atuinID:  "apps/default/atuin/app/ks.yaml",
+			hrAtuin:  "apps/default/atuin/app/helmrelease.yaml",
+		},
+		"",
+		mapLister{metaID: meta, plexID: plex, atuinID: atuin},
+	)
+
+	if !f.ShouldReconcile(metaID) {
+		t.Errorf("meta KS must be kept (ancestor of changed file): %v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(plexID) {
+		t.Errorf("plex KS must be kept (owns changed file): %v", f.KeepNames())
+	}
+	if f.ShouldReconcile(atuinID) {
+		t.Errorf("unrelated sibling atuin must not be pulled in: %v", f.KeepNames())
+	}
+	if f.ShouldReconcile(hrAtuin) {
+		t.Errorf("unrelated sibling atuin HR must not be pulled in: %v", f.KeepNames())
 	}
 }
 

--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -112,6 +112,35 @@ func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
 	return owners
 }
 
+// ancestorsOf returns every Kustomization whose claim is a strict
+// prefix of file but shorter than the longest match (so excluding
+// what ownersOf would return). Used by Filter.resolve to keep
+// parent/meta Kustomizations in scope under changed-only mode —
+// their render injects spec.patches and postBuild.substituteFrom
+// onto children, and skipping them produces undefined-${VAR}
+// failures when the leaf renders. See #58.
+func (idx ownershipIndex) ancestorsOf(file string) []manifest.NamedResource {
+	if file == "" {
+		return nil
+	}
+	file = file + "/"
+	var bestLen int
+	var ancestors []manifest.NamedResource
+	for _, c := range idx.claims {
+		if !strings.HasPrefix(file, c.path) {
+			continue
+		}
+		if bestLen == 0 {
+			bestLen = len(c.path) // first (longest) match — skip
+			continue
+		}
+		if len(c.path) < bestLen {
+			ancestors = append(ancestors, c.id)
+		}
+	}
+	return ancestors
+}
+
 // normalizeKSPath strips the conventional `./` prefix and any trailing
 // slash so KS paths can be compared as plain string prefixes.
 func normalizeKSPath(p string) string {


### PR DESCRIPTION
Closes #58.

## Problem

In the common Flux pattern where a meta/parent Kustomization (e.g. \`cluster-apps\` at \`./kubernetes/apps\`) injects \`spec.patches\` and \`postBuild.substituteFrom\` into every child Kustomization at render time, changed-only mode (\`--path-orig\`) would only enqueue the deepest (leaf) owner of a changed file. The parent — whose render mutates the leaf's spec to pull in \`cluster-settings\` etc. — was skipped, so the leaf then failed to render with \`variable X is undefined and has no default\` because the substituteFrom never landed.

## Fix

Add \`ancestorsOf\` to the ownership index (every claim that's a strict prefix of the file but shorter than the longest match), and have \`Filter.resolve\` enqueue ancestors alongside owners. Ancestors are intentionally **not** added to \`ownersHit\`, so the existing sibling-pull-in for shared owners doesn't widen to \"every resource under the meta-KS\" — the parent simply reconciles, emits all children with patched specs into the store, and the kustomization controller's \`Filter\` check then skips the unchanged siblings while the changed leaf renders against the post-patch spec.

Replace \`TestFilter_LongestPrefixOwnerWins\` (which had baked the buggy behavior into the suite) with \`TestFilter_AncestorKSAlsoKept\`, and add \`TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings\` to lock the \"ancestors yes, sibling pull-in no\" boundary.

## Verification

End-to-end against \`testdata/parent-patches\` with a leaf \`cm.yaml\` edit:

**Before (current main):**
\`\`\`
level=WARN msg=\"resource orphaned\" id=Kustomization/flux-system/leaf
  underlying_error=\"postBuild: variable \\\"MY_SECRET\\\" is undefined and has no default\"
(no diff output)
\`\`\`

**After (this PR):**
\`\`\`diff
--- apps/leaf/app Kustomization: flux-system/leaf ConfigMap: leaf/leaf-cm
+++ apps/leaf/app Kustomization: flux-system/leaf ConfigMap: leaf/leaf-cm
@@
 data:
-  app: leaf
+  app: leaf-edited
   secret: ..PLACEHOLDER_MY_SECRET..
   value: from-cluster-settings
\`\`\`

## Test plan
- [x] \`go test ./... -count=1\` — full suite green.
- [x] \`go test ./pkg/change -v\` — new ancestor tests pass; existing sibling-component / transitive-dep tests unchanged.
- [x] End-to-end repro against \`testdata/parent-patches\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)