### PR TITLE
fix(kustomization): fall back to bootstrap source when sourceRef is empty

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -315,20 +315,32 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 	return deps
 }
 
+// bootstrapSourceID is the synthetic GitRepository the orchestrator
+// seeds for the user's working tree. Children that inherit sourceRef
+// only from a parent's render patches (a common onedr0p-style pattern)
+// look empty until the parent reconciles, so resolveSourceRoot uses
+// this as the fallback rather than mis-joining ks.Path against itself.
+var bootstrapSourceID = manifest.NamedResource{
+	Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "flux-system",
+}
+
 // resolveSourceRoot returns the on-disk root the kustomization should
 // be built from — i.e. the source artifact's local path. The Flux
 // renderer then joins ks.Path onto this root.
 func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, error) {
+	srcID := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
 	if ks.SourceKind == "" || ks.SourceName == "" {
-		// No source — use ks.Path directly. This handles bootstrap
-		// kustomizations whose source is implicit.
+		// Child Kustomizations that inherit sourceRef from a parent's
+		// render patches show empty here until that parent reconciles.
+		// Fall back to the seeded bootstrap GitRepository (the user's
+		// working tree) so the first reconcile resolves to the repo
+		// root instead of doubling ks.Path against itself (#105).
 		if ks.Path == "" {
 			return "", fmt.Errorf("%w: kustomization %s has no path and no source",
 				manifest.ErrInput, ks.NamespacedName())
 		}
-		return ks.Path, nil
+		srcID = bootstrapSourceID
 	}
-	srcID := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
 	art := c.Store.GetArtifact(srcID)
 	if art == nil {
 		return "", fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())

--- a/pkg/controllers/kustomization/source_root_test.go
+++ b/pkg/controllers/kustomization/source_root_test.go
@@ -1,0 +1,104 @@
+package kustomization
+
+import (
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestResolveSourceRoot_FallsBackToBootstrapWhenSourceRefEmpty covers
+// the #105 path: child Kustomizations whose YAML declares no sourceRef
+// (relying on a parent KS's render-time patches to inject one) used to
+// have resolveSourceRoot return ks.Path itself, which RenderFlux then
+// joined against ks.Path again — producing the X/X doubled path.
+//
+// With the seeded bootstrap GitRepository in the store, the fallback
+// now returns the working-tree root so the first reconcile resolves
+// correctly even before any parent render lands.
+func TestResolveSourceRoot_FallsBackToBootstrapWhenSourceRefEmpty(t *testing.T) {
+	s := store.New()
+	bootstrap := &manifest.GitRepository{
+		Name: "flux-system", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file:///repo"},
+	}
+	s.AddObject(bootstrap)
+	s.SetArtifact(bootstrap.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file:///repo", LocalPath: "/repo",
+	})
+
+	c := &Controller{Store: s}
+	ks := &manifest.Kustomization{
+		Name: "foo", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "./kubernetes/apps/foo/app",
+			// SourceRef intentionally absent — modelling onedr0p-style
+			// children whose sourceRef is injected only by the parent
+			// render's `patches:` block.
+		},
+	}
+	got, err := c.resolveSourceRoot(ks)
+	if err != nil {
+		t.Fatalf("resolveSourceRoot: %v", err)
+	}
+	if got != "/repo" {
+		t.Errorf("resolveSourceRoot=%q, want %q (bootstrap LocalPath)", got, "/repo")
+	}
+}
+
+// TestResolveSourceRoot_ExplicitSourceRefUnchanged guards against the
+// fallback accidentally overriding an explicit sourceRef.
+func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
+	s := store.New()
+	gitrepo := &manifest.GitRepository{
+		Name: "external", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file:///external"},
+	}
+	s.AddObject(gitrepo)
+	s.SetArtifact(gitrepo.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file:///external", LocalPath: "/external",
+	})
+	// Seed bootstrap too — the fallback must not preempt the explicit ref.
+	bootstrap := &manifest.GitRepository{
+		Name: "flux-system", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file:///repo"},
+	}
+	s.AddObject(bootstrap)
+	s.SetArtifact(bootstrap.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file:///repo", LocalPath: "/repo",
+	})
+
+	c := &Controller{Store: s}
+	ks := &manifest.Kustomization{
+		Name: "foo", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
+		SourceKind:        manifest.KindGitRepository,
+		SourceName:        "external",
+		SourceNamespace:   "flux-system",
+	}
+	got, err := c.resolveSourceRoot(ks)
+	if err != nil {
+		t.Fatalf("resolveSourceRoot: %v", err)
+	}
+	if got != "/external" {
+		t.Errorf("resolveSourceRoot=%q, want %q (explicit ref)", got, "/external")
+	}
+}
+
+// TestResolveSourceRoot_NoBootstrapNoSourceRefErrors keeps the safety
+// net for setups that genuinely have neither — error rather than mis-
+// resolve.
+func TestResolveSourceRoot_NoBootstrapNoSourceRefErrors(t *testing.T) {
+	c := &Controller{Store: store.New()}
+	ks := &manifest.Kustomization{
+		Name: "foo", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
+	}
+	_, err := c.resolveSourceRoot(ks)
+	if err == nil {
+		t.Fatalf("expected error when bootstrap source is absent")
+	}
+}


### PR DESCRIPTION
Closes #105.

## Root cause

Child Kustomizations whose YAML declares no \`spec.sourceRef\` (a common onedr0p-style pattern where the parent's \`spec.patches\` inject the ref at render time) were taking \`resolveSourceRoot\`'s \"no source\" branch, which returned \`ks.Path\` itself as the source root. \`RenderFlux\` then joined \`ks.Path\` onto \`ks.Path\`, producing the doubled \`X/X\` path the bug report shows:

\`\`\`
kustomization path does not exist: kubernetes/apps/foo/app/kubernetes/apps/foo/app
\`\`\`

The kustomization controller's parent-wait (#103) gates the first reconcile on the parent's Ready status, but the parent's render only injects \`sourceRef\` onto children when its \`patches:\` block does so — which is not universal across home-ops layouts. When the parent doesn't patch sourceRef (or there is no parent), the child renders with an empty sourceRef forever, and \`resolveSourceRoot\`'s old fallback fired every time.

## Fix

The orchestrator already seeds a synthetic GitRepository at \`flux-system/flux-system\` with \`LocalPath\` pointing at the working tree root. Route the empty-sourceRef fallback through that artifact instead of \`ks.Path\` — the first reconcile now resolves to the repo root, matching real Flux's apply-time behavior.

## Verification

End-to-end against a minimal repro (single child KS with no sourceRef):

**Before:**
\`\`\`
Kustomization/foo  FAILED (flux error: input error: kustomization path does not exist:
                          kubernetes/apps/foo/app/kubernetes/apps/foo/app)
\`\`\`

**After:**
\`\`\`
Kustomization/foo  PASSED
Kustomization/flux-system/foo  PASSED
\`\`\`

Regression checks against the canonical layouts the project tracks:
- \`onedr0p/home-ops\`: 73 PASSED → 73 PASSED.
- \`joryirving/home-ops\`: 145 PASSED → 145 PASSED.

## Test plan
- [x] \`go test ./... -count=1\` — full suite green.
- [x] \`go test ./pkg/controllers/kustomization -run TestResolveSourceRoot -v\` — 3 new tests cover the fallback, explicit-sourceRef preservation, and the genuine-no-source error path.
- [x] End-to-end repro repository transitions from FAILED → PASSED.
- [x] onedr0p + joryirving repos unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)