### PR TITLE
fix(resourceset): align renderer with upstream flux-operator semantics

### DIFF
--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -99,7 +99,7 @@ func buildInputSets(rs *manifest.ResourceSet) []map[string]any {
 		return nil
 	}
 	out := make([]map[string]any, 0, len(rs.Inputs))
-	for i, in := range rs.Inputs {
+	for _, in := range rs.Inputs {
 		decoded := map[string]any{}
 		for k, v := range in {
 			if v == nil {
@@ -116,7 +116,6 @@ func buildInputSets(rs *manifest.ResourceSet) []map[string]any {
 			}
 			decoded[k] = raw
 		}
-		decoded["id"] = fmt.Sprintf("%s-%d", rs.Name, i)
 		decoded["provider"] = map[string]any{
 			"apiVersion": fluxopv1.GroupVersion.String(),
 			"kind":       manifest.KindResourceSet,
@@ -233,23 +232,15 @@ func execute(tmplStr string, inputSet map[string]any) ([]byte, error) {
 		Delims("<<", ">>").
 		Funcs(sprig.HermeticTxtFuncMap()).
 		Funcs(template.FuncMap{
-			"slugify": slug.Make,
-			"toYaml":  toYAML,
-			"inputs":  func() any { return inputSet },
+			"slugify":    slug.Make,
+			"toYaml":     toYaml,
+			"mustToYaml": mustToYaml,
+			"inputs":     func() any { return inputSet },
 		}).
+		Option("missingkey=error").
 		Parse(tmplStr)
 	if err != nil {
 		return nil, fmt.Errorf("parse template: %w", err)
-	}
-	if inputSet != nil {
-		// Promote inputs.X access by wrapping execution data in a map
-		// with an "inputs" key — slim-sprig's funcs reach `.inputs.X`
-		// via the standard text/template dot-walk.
-		var buf bytes.Buffer
-		if err := tmpl.Execute(&buf, map[string]any{"inputs": inputSet}); err != nil {
-			return nil, fmt.Errorf("execute template: %w", err)
-		}
-		return buf.Bytes(), nil
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, nil); err != nil {
@@ -258,7 +249,21 @@ func execute(tmplStr string, inputSet map[string]any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func toYAML(v any) (string, error) {
+// toYaml mirrors upstream's silent-error variant — encodes v as YAML;
+// any marshal error collapses to "". Templates expect this signature
+// so authors don't have to wrap every call in {{ if }}…{{ end }}.
+func toYaml(v any) string {
+	s, err := mustToYaml(v)
+	if err != nil {
+		return ""
+	}
+	return s
+}
+
+// mustToYaml is the explicit error-returning variant — surfaces a
+// marshal error to the template engine, which aborts execution. Use
+// this when the template is willing to fail loudly on malformed inputs.
+func mustToYaml(v any) (string, error) {
 	out, err := yaml.Marshal(v)
 	if err != nil {
 		return "", err

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -256,6 +256,122 @@ func TestRender_DisabledReconcileAnnotationSkips(t *testing.T) {
 	}
 }
 
+// TestRender_InputsProviderBuiltinField asserts every rendered input
+// carries the built-in inputs.provider block per the upstream
+// flux-operator contract. Templates rely on inputs.provider.kind to
+// distinguish ResourceSet inline inputs from ResourceSetInputProvider
+// inputs once that's supported.
+func TestRender_InputsProviderBuiltinField(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "apps", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			Inputs: []fluxopv1.ResourceSetInput{{"tenant": jsonTmpl(t, `"a"`)}},
+			Resources: []*apix.JSON{
+				jsonTmpl(t, `{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": {"name": "x", "namespace": "flux-system"},
+					"data": {
+						"providerKind":      "<< inputs.provider.kind >>",
+						"providerName":      "<< inputs.provider.name >>",
+						"providerNamespace": "<< inputs.provider.namespace >>"
+					}
+				}`),
+			},
+		},
+	}
+	docs, err := resourceset.Render(rs)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	data := docs[0]["data"].(map[string]any)
+	if data["providerKind"] != "ResourceSet" {
+		t.Errorf("inputs.provider.kind=%v want ResourceSet", data["providerKind"])
+	}
+	if data["providerName"] != "apps" {
+		t.Errorf("inputs.provider.name=%v want apps", data["providerName"])
+	}
+	if data["providerNamespace"] != "flux-system" {
+		t.Errorf("inputs.provider.namespace=%v want flux-system", data["providerNamespace"])
+	}
+}
+
+// TestRender_MissingKeyErrors locks the upstream Option("missingkey=error")
+// behavior — a template referencing an undefined input must fail with a
+// useful error rather than silently rendering "<no value>". Templates
+// that work in flate must also work in real flux-operator and vice versa.
+func TestRender_MissingKeyErrors(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "test", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			Inputs: []fluxopv1.ResourceSetInput{{"tenant": jsonTmpl(t, `"a"`)}},
+			Resources: []*apix.JSON{
+				jsonTmpl(t, `{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": {"name": "<< inputs.nonexistent >>", "namespace": "flux-system"}
+				}`),
+			},
+		},
+	}
+	_, err := resourceset.Render(rs)
+	if err == nil {
+		t.Fatal("expected error for undefined input key, got nil")
+	}
+}
+
+// TestRender_MalformedTemplateErrors surfaces a parse error rather than
+// silently swallowing the broken template.
+func TestRender_MalformedTemplateErrors(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "test", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			Inputs: []fluxopv1.ResourceSetInput{{"name": jsonTmpl(t, `"a"`)}},
+			Resources: []*apix.JSON{
+				jsonTmpl(t, `{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": {"name": "<< inputs.name "}
+				}`), // unterminated template
+			},
+		},
+	}
+	_, err := resourceset.Render(rs)
+	if err == nil {
+		t.Fatal("expected parse error for malformed template, got nil")
+	}
+}
+
+// TestRender_ToYamlNindent covers the canonical upstream pattern
+// `<< value | toYaml | nindent N >>` for embedding nested structs as
+// child YAML. Pins both that toYaml is registered as the silent variant
+// (no error wrapping needed) and that the resulting indentation lines
+// up with the surrounding YAML.
+func TestRender_ToYamlNindent(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "test", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			Inputs: []fluxopv1.ResourceSetInput{
+				{"layerSelector": jsonTmpl(t, `{"mediaType": "x", "operation": "copy"}`)},
+			},
+			ResourcesTemplate: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app
+  namespace: flux-system
+spec:
+  layerSelector: << inputs.layerSelector | toYaml | nindent 4 >>
+`,
+		},
+	}
+	docs, err := resourceset.Render(rs)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	spec := docs[0]["spec"].(map[string]any)
+	sel := spec["layerSelector"].(map[string]any)
+	if sel["mediaType"] != "x" || sel["operation"] != "copy" {
+		t.Errorf("toYaml|nindent did not produce nested map: %v", sel)
+	}
+}
+
 // TestRender_ResourcesTemplate covers spec.resourcesTemplate (multi-doc
 // YAML string variant).
 func TestRender_ResourcesTemplate(t *testing.T) {


### PR DESCRIPTION
Architecture review of #106 against the upstream \`flux-operator/internal/builder/resourceset.go\` reference flagged three fidelity gaps. All three are real (verified against upstream source under \`\$(go env GOPATH)/pkg/mod/github.com/controlplaneio-fluxcd/flux-operator@v0.50.0/internal/\`).

## Fixes

### 1. \`inputs.id\` over-injected in Flatten

Upstream's \`Flattener\` (\`internal/inputs/flattener.go\`) does not add an \`id\` field — only the \`Permuter\` (\`permuter.go:217\`) does, using an Adler32 hash of the permutation components. flate was unconditionally setting \`decoded[\"id\"] = fmt.Sprintf(\"%s-%d\", rs.Name, i)\`. Templates that referenced \`<< inputs.id >>\` against flate would render fine and then silently produce an empty value on a real cluster.

Removed. Permute support is tracked in #109.

### 2. \`toYaml\` signature divergence

Upstream registers two variants (\`internal/builder/resourceset.go:150\`):
- \`toYaml(v) string\` — silent: marshal error → \`\"\"\`.
- \`mustToYaml(v) (string, error)\` — explicit: error surfaces to the template engine.

flate registered only the error-returning variant under the name \`toYaml\`. Templates that compose \`<< value | toYaml | nindent N >>\` (the canonical layerSelector pattern) would fail in flate but work upstream. Register both; \`toYaml\` is now the silent variant, \`mustToYaml\` the explicit one.

### 3. Missing \`Option(\"missingkey=error\")\`

Upstream sets this so a template referencing an undefined input fails fast (\`internal/builder/resourceset.go:151\`). flate would silently render \`<no value>\`, producing invalid YAML that surfaced later as opaque parse errors. Set the option.

Also drops a redundant code path: \`execute()\` had a non-nil-data branch that wasn't reachable — the \`inputs\` template func is the only access route, so matching upstream's \`tp.Execute(b, nil)\` is both simpler and exact.

## Follow-ups filed (per review rule #8)

- **#108** \`spec.inputsFrom\` + \`ResourceSetInputProvider\`.
- **#109** \`spec.inputStrategy: Permute\` (Cartesian product strategy).
- **#110** \`copyFrom\` / \`convertKubeConfigFrom\` / \`checksumFrom\` annotations.

## Test plan
- [x] \`go test ./... -count=1\` — full suite green.
- [x] \`go test ./pkg/resourceset -v\` — 4 new tests added: inputs.provider block, missing-key error, malformed-template error, toYaml | nindent canonical pattern.
- [x] End-to-end sanity on the d2-fleet repo — 7 Kustomizations still expand correctly from the ResourceSets in \`tenants/\`.

## What the review correctly did NOT flag

The concurrency agent flagged a TOCTOU on the \`resolveSourceRoot\` re-read after dep-wait, plus three other "could happen if X" races. I traced \`DeleteObject\` callers and confirmed it's only invoked at load-time (\`ApplyNamespaceInheritance\`), before any controller starts. Those races are not reachable in current code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)