### PR TITLE
fix(helm): stamp helm.toolkit.fluxcd.io origin labels on rendered docs

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -182,6 +182,59 @@ func TestTemplateDocs_AppliesHRCommonMetadata(t *testing.T) {
 	}
 }
 
+// TestTemplateDocs_StampsOriginLabels locks the helm-controller
+// OriginLabels post-renderer behavior: every rendered resource is
+// stamped with helm.toolkit.fluxcd.io/{name,namespace} so a real Flux
+// would identify it as owned by this HelmRelease.
+func TestTemplateDocs_StampsOriginLabels(t *testing.T) {
+	cli := helmChartFixture(t)
+	hr := newHR()
+	docs, err := cli.TemplateDocs(context.Background(), hr, nil, Options{NoHooks: true})
+	if err != nil {
+		t.Fatalf("TemplateDocs: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatal("expected at least one rendered doc")
+	}
+	for i, doc := range docs {
+		md, _ := doc["metadata"].(map[string]any)
+		labels, _ := md["labels"].(map[string]any)
+		if labels["helm.toolkit.fluxcd.io/name"] != hr.Name {
+			t.Errorf("doc[%d] missing/wrong helm.toolkit.fluxcd.io/name: %v", i, labels)
+		}
+		if labels["helm.toolkit.fluxcd.io/namespace"] != hr.Namespace {
+			t.Errorf("doc[%d] missing/wrong helm.toolkit.fluxcd.io/namespace: %v", i, labels)
+		}
+	}
+}
+
+// TestTemplateDocs_OriginLabelsWinOverCommonMetadata locks the upstream
+// precedence rule: OriginLabels run AFTER CommonRenderer, so an
+// origin-key collision in CommonMetadata is silently overridden by the
+// origin value. Matches helm-controller/internal/postrender/build.go:46.
+func TestTemplateDocs_OriginLabelsWinOverCommonMetadata(t *testing.T) {
+	cli := helmChartFixture(t)
+	hr := newHR()
+	hr.CommonMetadata = &helmv2.CommonMetadata{
+		Labels: map[string]string{
+			"helm.toolkit.fluxcd.io/name": "user-override-should-lose",
+			"team":                        "platform",
+		},
+	}
+	docs, err := cli.TemplateDocs(context.Background(), hr, nil, Options{NoHooks: true})
+	if err != nil {
+		t.Fatalf("TemplateDocs: %v", err)
+	}
+	md := docs[0]["metadata"].(map[string]any)
+	labels := md["labels"].(map[string]any)
+	if labels["helm.toolkit.fluxcd.io/name"] != hr.Name {
+		t.Errorf("origin label should win; got %v", labels["helm.toolkit.fluxcd.io/name"])
+	}
+	if labels["team"] != "platform" {
+		t.Errorf("non-colliding commonMetadata label dropped; got %v", labels["team"])
+	}
+}
+
 func TestApplyHRCommonMetadata_LabelsOnly(t *testing.T) {
 	docs := []map[string]any{
 		{"metadata": map[string]any{"name": "x"}},

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -156,6 +156,7 @@ func (c *Client) TemplateDocs(ctx context.Context, hr *manifest.HelmRelease, val
 		return nil, err
 	}
 	applyHRCommonMetadata(docs, hr.CommonMetadata)
+	applyHROriginLabels(docs, hr)
 	skip := opts.SkipResourceKinds()
 	if len(skip) == 0 {
 		return docs, nil
@@ -163,6 +164,29 @@ func (c *Client) TemplateDocs(ctx context.Context, hr *manifest.HelmRelease, val
 	return slices.DeleteFunc(docs, func(doc map[string]any) bool {
 		return slices.Contains(skip, manifest.DocKind(doc))
 	}), nil
+}
+
+// applyHROriginLabels stamps the helm.toolkit.fluxcd.io/{name,namespace}
+// ownership labels onto every rendered doc, mirroring helm-controller's
+// OriginLabels post-renderer. Real Flux uses these to track which HR
+// owns each in-cluster resource for pruning + selection
+// (`kubectl get -l helm.toolkit.fluxcd.io/name=...`), and they take
+// precedence over CommonMetadata when keys collide — so we apply this
+// pass AFTER applyHRCommonMetadata, matching the upstream order.
+func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
+	group := helmv2.GroupVersion.Group
+	origin := map[string]string{
+		group + "/name":      hr.Name,
+		group + "/namespace": hr.Namespace,
+	}
+	for _, doc := range docs {
+		md, _ := doc["metadata"].(map[string]any)
+		if md == nil {
+			md = map[string]any{}
+			doc["metadata"] = md
+		}
+		mergeStringMap(md, "labels", origin)
+	}
 }
 
 // applyHRCommonMetadata merges spec.commonMetadata.labels and .annotations

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -92,8 +92,10 @@ func Render(rs *manifest.ResourceSet) ([]map[string]any, error) {
 }
 
 // buildInputSets returns the flattened in-YAML input matrix. Each entry
-// is a map[string]any with the built-in inputs.id + inputs.provider
-// fields injected, matching the flux-operator runtime contract.
+// is a map[string]any with the built-in inputs.provider block injected,
+// matching the flux-operator runtime contract. inputs.id is deliberately
+// not set under the Flatten strategy — upstream's Permuter is the only
+// path that synthesizes one (tracked in #109).
 func buildInputSets(rs *manifest.ResourceSet) []map[string]any {
 	if len(rs.Inputs) == 0 {
 		return nil


### PR DESCRIPTION
Pass #2 architecture review caught a missing-fidelity gap against upstream helm-controller.

## What's missing

Every resource a real Flux HelmRelease renders carries two ownership labels:

\`\`\`
helm.toolkit.fluxcd.io/name      = hr.metadata.name
helm.toolkit.fluxcd.io/namespace = hr.metadata.namespace
\`\`\`

helm-controller's \`BuildPostRenderers\` wires this in unconditionally via \`NewOriginLabels\` (\`internal/postrender/build.go:48\`), AFTER the \`CommonRenderer\` pass — so origin keys win on collision with user-supplied \`commonMetadata\`. flate applied only \`commonMetadata\`, leaving rendered output diverging from what would land in a real cluster.

## Fix

Add \`applyHROriginLabels\` alongside \`applyHRCommonMetadata\`, called in the upstream order (common first, origin second). Origin labels override on key collision, matching the upstream comment at \`build.go:46\`.

The matching pass already exists for Kustomization (\`pkg/kustomize/flux.go\` \`applyOwnerLabels\`) — this brings HelmRelease to parity.

## Drift cleanup

- \`pkg/resourceset/render.go:94\` docstring still claimed \`inputs.id\` was injected. #111 removed that; comment updated.

## Test plan
- [x] \`go test ./... -count=1\` — full suite green.
- [x] \`TestTemplateDocs_StampsOriginLabels\` — every rendered doc carries both ownership labels.
- [x] \`TestTemplateDocs_OriginLabelsWinOverCommonMetadata\` — pins the upstream precedence rule (origin overrides colliding commonMetadata; non-colliding commonMetadata keys preserved).

## Filed for follow-up
- **#112** GitRepository \`spec.ref.semver\` support — pass #2 hygiene review spotted the "not supported yet" stub at \`git.go:359\`.

## Pass #2 outcome

3 of 4 agents converged on "no actionable findings" (concurrency clean, hygiene clean once #112 is filed, tests review surfaced nice-to-have additions but no real gaps that aren't already documented limitations). The architecture agent's HelmRelease-origin-labels finding is the only real fix this pass produced. After this PR merges, pass #3 begins on a fresh main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)