### PR TITLE
test(helm): defensive type assertions in origin-labels precedence test

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -225,8 +225,8 @@ func TestTemplateDocs_OriginLabelsWinOverCommonMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TemplateDocs: %v", err)
 	}
-	md := docs[0]["metadata"].(map[string]any)
-	labels := md["labels"].(map[string]any)
+	md, _ := docs[0]["metadata"].(map[string]any)
+	labels, _ := md["labels"].(map[string]any)
 	if labels["helm.toolkit.fluxcd.io/name"] != hr.Name {
 		t.Errorf("origin label should win; got %v", labels["helm.toolkit.fluxcd.io/name"])
 	}


### PR DESCRIPTION
Pass #3 of the iterative review loop caught \`TestTemplateDocs_OriginLabelsWinOverCommonMetadata\` using unchecked \`.(map[string]any)\` assertions on \`docs[0][\"metadata\"]\` and \`md[\"labels\"]\`. The sibling tests in the same file (\`TestTemplateDocs_StampsOriginLabels\`, \`TestTemplateDocs_AppliesHRCommonMetadata\`) use the comma-ok pattern. Bring this one in line so the suite stays uniform and a fixture/renderer refactor that leaves a nil intermediate fails the assertion cleanly instead of panicking.

## Pass #3 outcome summary

- **Concurrency** review: clean — verified that the new \`applyHROriginLabels\` pass, depwait state machine, cache slot mutex, and Bootstrap listener-flush sequence are all safe. No actionable findings.
- **Architecture** review: one minor duplication noted (\`mergeStringMap\` in \`pkg/helm/template.go\` + \`pkg/resourceset/render.go\`). Deferred — two callers don't yet justify extracting a shared utility per the project's "no premature abstraction" rule; revisit if a third appears.
- **Hygiene** review: surfaced finding was a false positive — #95 already tracks the \`pkg/helm/repo.go:84\` OCI SecretRef stub the agent flagged.
- **Test** review: this fix.

The loop is converging. Pass #4 starts on a fresh main after this merges.

## Test plan
- [x] \`go test ./pkg/helm -count=1\` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)