### PR TITLE
chore(format): drop unused OutputWide constant

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -18,7 +18,6 @@ type Output string
 // Output values understood by the -o flag.
 const (
 	OutputTable Output = "table"
-	OutputWide  Output = "wide"
 	OutputYAML  Output = "yaml"
 	OutputJSON  Output = "json"
 	OutputName  Output = "name"


### PR DESCRIPTION
Pass #4 review caught \`format.OutputWide\` (\`internal/format/format.go:21\`) defined but never referenced — no \`case format.OutputWide:\` in the output switches across \`internal/cli/{get,build,diff}.go\`. A user passing \`-o wide\` would have silently fallen through to the default table render, getting no error and no actual wide rendering.

Drop the unused declaration. If wide-mode output becomes a real need, file an issue and add proper printer support alongside the constant.

## Pass #4 outcome summary

- **Architecture**: clean — no remaining upstream-fidelity gaps.
- **Concurrency**: agent flagged a helm v4 \`registry.Client.Pull\` race. Verified false positive — \`oras-go/v2/registry/remote/auth\` uses a \`sync.Map\` cache documented as "suitable for concurrent invocation" (\`cache.go:62\`), and the helm Client's other fields (\`httpClient\`, etc.) are either immutable post-\`NewClient\` or thread-safe stdlib types.
- **Tests**: this fix + a list of CLI flag-level e2e gaps (deferred — flag coverage breadth is nice-to-have, not actionable on this loop).
- **Hygiene**: clean.

The loop is close to quorum. After this merges, pass #5 starts on a fresh main; if all four reviews come back fully clean I declare convergence and stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)