### PR TITLE
test: pin pass #5 fixes and correct misleading helm precedence comment

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -191,8 +191,10 @@ func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
 
 // applyHRCommonMetadata merges spec.commonMetadata.labels and .annotations
 // onto every rendered doc's metadata, mirroring helm-controller's
-// CommonRenderer pass. commonMetadata wins on conflict, matching
-// controller semantics.
+// CommonRenderer pass. commonMetadata overwrites chart-template defaults
+// but loses to origin labels on collision — applyHROriginLabels runs
+// AFTER this and reasserts the helm.toolkit.fluxcd.io/{name,namespace}
+// keys, matching helm-controller's build.go:46 comment.
 func applyHRCommonMetadata(docs []map[string]any, cm *helmv2.CommonMetadata) {
 	if cm == nil || (len(cm.Labels) == 0 && len(cm.Annotations) == 0) {
 		return

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -196,6 +196,66 @@ func TestRenderFlux_HonorsCommonMetadata(t *testing.T) {
 	}
 }
 
+// TestRenderFlux_CommonMetadataOverridesOwnerLabels pins the
+// kustomize-controller-matching precedence rule: when commonMetadata
+// supplies a key that collides with the owner-label keys
+// (kustomize.toolkit.fluxcd.io/{name,namespace}), commonMetadata wins.
+// Upstream applies SetOwnerLabels at reconcile setup, then
+// SetCommonMetadata at apply time — so a future revert of the
+// applyOwnerLabels/applyCommonMetadata ordering in flux.go would be
+// caught here.
+func TestRenderFlux_CommonMetadataOverridesOwnerLabels(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "cm.yaml"), []byte(
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\ndata:\n  k: v\n",
+	), 0o600); err != nil {
+		t.Fatalf("write cm: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "kustomization.yaml"), []byte(
+		"resources:\n- cm.yaml\n",
+	), 0o600); err != nil {
+		t.Fatalf("write kustomization: %v", err)
+	}
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	out, err := RenderFlux(context.Background(), cache, src, ".", map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "owner-name", "namespace": "owner-ns"},
+		"spec": map[string]any{
+			"path": "./",
+			"commonMetadata": map[string]any{
+				"labels": map[string]any{
+					"kustomize.toolkit.fluxcd.io/name":      "user-override",
+					"kustomize.toolkit.fluxcd.io/namespace": "user-ns-override",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+
+	var got map[string]any
+	if err := yaml.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out)
+	}
+	md, _ := got["metadata"].(map[string]any)
+	labels, _ := md["labels"].(map[string]any)
+	if labels["kustomize.toolkit.fluxcd.io/name"] != "user-override" {
+		t.Errorf("commonMetadata should win on owner-name collision; got %v",
+			labels["kustomize.toolkit.fluxcd.io/name"])
+	}
+	if labels["kustomize.toolkit.fluxcd.io/namespace"] != "user-ns-override" {
+		t.Errorf("commonMetadata should win on owner-namespace collision; got %v",
+			labels["kustomize.toolkit.fluxcd.io/namespace"])
+	}
+}
+
 // TestRenderFlux_InjectsOwnerLabels guards that
 // kustomize.toolkit.fluxcd.io/{name,namespace} land on rendered
 // resources even without spec.commonMetadata.

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -1,6 +1,51 @@
 package source
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
+
+// TestCache_ResetSerializesAgainstSlot exercises the mutex Cache.Reset
+// acquires alongside Cache.Slot. A goroutine race-detector run with
+// many parallel Slot/Reset pairs targeting the same path must complete
+// without -race tripping. A regression that drops the lock from Reset
+// (or removes it from Slot) would fail under `go test -race`.
+func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
+	c := NewCache(t.TempDir())
+	const goroutines = 16
+	const iterations = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				path, _, err := c.Slot("https://shared.example/repo", "main")
+				if err != nil {
+					t.Errorf("Slot: %v", err)
+					return
+				}
+				_ = path
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				path, _, err := c.Slot("https://shared.example/repo", "main")
+				if err != nil {
+					t.Errorf("Slot: %v", err)
+					return
+				}
+				if err := c.Reset(path); err != nil {
+					t.Errorf("Reset: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
 
 func TestSlugifyRepo(t *testing.T) {
 	cases := map[string]string{


### PR DESCRIPTION
Pass #6 of the iterative review loop turned up three real items — all small, but worth landing to keep the loop convergent.

## 1. Misleading docstring in \`applyHRCommonMetadata\`
**Where**: \`pkg/helm/template.go:194\`.

The comment claimed "commonMetadata wins on conflict, matching controller semantics," but the actual (correct) behavior is the opposite: \`applyHROriginLabels\` runs AFTER \`applyHRCommonMetadata\` and reasserts the \`helm.toolkit.fluxcd.io/{name,namespace}\` keys (test \`TestTemplateDocs_OriginLabelsWinOverCommonMetadata\` pins this). Rewrite the doc to match.

## 2. Kustomize precedence regression test
**Where**: \`pkg/kustomize/kustomize_test.go\`.

PR #116 swapped \`applyOwnerLabels\` / \`applyCommonMetadata\` so user-supplied commonMetadata wins on owner-label key collision (matching kustomize-controller's \`SetOwnerLabels\` → \`SetCommonMetadata\` ordering). The behavior wasn't pinned — a future revert would be silent. Add \`TestRenderFlux_CommonMetadataOverridesOwnerLabels\` to lock the collision outcome.

## 3. Cache.Reset mutex regression test
**Where**: \`pkg/source/cache_test.go\`.

PR #116 added \`c.mu\` around \`Reset\` to serialize against \`Slot\` allocation. The fix is invisible to the existing single-goroutine tests. Add \`TestCache_ResetSerializesAgainstSlot\` — 16 goroutines × 32 iterations of Slot+Reset on the same path; removal of the lock fails under \`go test -race\`.

## Pass #6 outcome summary
- **Architecture**: misleading comment (fixed here) + a deeper Cache.Reset-vs-in-flight-clone race the agent flagged. That deeper race is theoretical and requires architectural change (per-slot keylock around fetcher I/O), not a regression from #116; deferred.
- **Concurrency**: clean — \`Cache.Reset\` fix verified complete.
- **Tests**: kustomize precedence + Cache.Reset gaps (filled here).
- **Hygiene**: clean (\`gofmt -l .\` clean, \`go vet ./...\` clean, no untracked stubs).

## Test plan
- [x] \`go test ./... -count=1\` — green.
- [x] \`go test -race ./pkg/source ./pkg/helm ./pkg/kustomize -count=1\` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)