### PR TITLE
docs: prune stale comments and outdated references

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,6 @@ One-file PRs in a 70-Kustomization repo drop reconcile time from seconds to tens
 | `-o` | Effect |
 |---|---|
 | `table` _(default for `get`)_ | Aligned columns. |
-| `wide` | Extra columns (`get` only). |
 | `yaml` | Multi-document YAML. |
 | `json` | One JSON array. |
 | `name` | `<namespace>/<name>` per line — script-friendly. |
@@ -266,7 +265,7 @@ All output is written to stdout — redirect with `> file.yaml` to capture it. L
 | `--path-orig` | _(unset)_ | Baseline path; enables changed-only mode for every command. |
 | `-n`, `--namespace` | _(all)_ | Limit to a single namespace. Auto-scopes to the touched namespaces in changed-only mode. |
 | `-l`, `--selector` | _(none)_ | `key=value` label selector, repeatable. |
-| `-o`, `--output` | `table` | `table` / `wide` / `yaml` / `json` / `name`. |
+| `-o`, `--output` | `table` | `table` / `yaml` / `json` / `name`. |
 | `--skip-crds` | `true` | Drop CRD objects from rendered output. |
 | `--skip-secrets` | `true` | Drop Secret objects from rendered output. |
 | `--skip-kinds` | _(none)_ | Extra kinds to drop, repeatable. |

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -37,7 +37,7 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 	fs.BoolVar(&f.skipCRDs, "skip-crds", true, "exclude CRD objects from rendered output")
 	fs.BoolVar(&f.skipSecrets, "skip-secrets", true, "exclude Secret objects from rendered output")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")
-	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, wide, yaml, json, name")
+	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, yaml, json, name")
 	fs.BoolVar(&f.enableOCI, "enable-oci", true, "reconcile OCIRepository objects")
 	fs.StringVar(&f.registryConfig, "registry-config", "", "docker config.json for OCI authentication")
 	fs.IntVar(&f.concurrency, "concurrency", runtime.NumCPU()*4,

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -35,7 +35,10 @@ type nameKey struct{ kind, name string }
 //     owns it (longest matching spec.path, including spec.components)
 //     is kept — along with every resource whose source file shares
 //     the same owner.
-//  3. BFS over chart sources, sourceRef, and valuesFrom to pull in
+//  3. Ancestor Kustomizations (shorter-prefix spec.path matches) are
+//     also kept so parent-injected patches / postBuild.substituteFrom
+//     land before the leaf renders. See #58.
+//  4. BFS over chart sources, sourceRef, and valuesFrom to pull in
 //     upstream dependencies. dependsOn is intentionally excluded.
 func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister) *Filter {
 	f := &Filter{

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -1,7 +1,8 @@
 // Package kustomization reconciles Flux Kustomizations: wait on
-// dependsOn/sourceRef, resolve postBuild substitutions, run the
-// kustomize SDK, parse the result back into the Store, and publish a
-// KustomizationArtifact. Failures bubble up to the orchestrator.
+// dependsOn / sourceRef / structural parent, resolve postBuild
+// substitutions, run the kustomize SDK, parse the result back into the
+// Store, and publish a KustomizationArtifact. Failures bubble up to
+// the orchestrator.
 package kustomization
 
 import (


### PR DESCRIPTION
The codebase is already well-curated to the "comments explain WHY, not WHAT" rule (#6) — the seven iterative review passes that just landed left almost nothing to strip. What I did find was stale documentation that drifted away from the code:

## Changes

- **\`internal/cli/common.go\` + \`README.md\`**: the \`--output\` help text still advertised the \`wide\` value that #115 removed alongside the unused \`OutputWide\` constant. Drop the references.
- **\`pkg/change/filter.go\` \`NewFilter\` docstring**: described the change filter's keep-set semantics but missed step 3 — ancestor Kustomizations are also kept (added in PR #104 to fix #58). Add the missing paragraph.
- **\`pkg/controllers/kustomization/controller.go\` package doc**: still described the wait set as "dependsOn / sourceRef" but the structural-parent dep (added in #103) is now also in the set. Update.

## What I deliberately did NOT remove

I read every file under \`pkg/\`, \`internal/\`, and \`cmd/\` looking for WHAT-not-WHY comments to strip. The existing comments overwhelmingly carry one of:
- Upstream-reference rationale (helm-controller \`build.go:46\`, kustomize-controller \`controller.go:460\`, etc.).
- Non-obvious edge-case explanations (SOPS placeholder, two-pass emission, parent-render race).
- Immutability / concurrency contracts (Store doc, Coalescer panic recovery).
- Issue-pinning context (#102, #103, #105, #108–#112).

Removing those would degrade the codebase, not improve it. The few \`// Returns the X.\` style hits I found via grep were either required Go doc comments on exported symbols or explained non-trivial semantics. Standard \`gofmt\` is clean; \`go vet\` is clean.

## Test plan
- [x] \`go build ./...\` — clean.
- [x] \`go test ./... -count=1\` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)