### PR TITLE
fix: decode YAML the way Flux does; widen change-filter to structural parent

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -122,6 +122,38 @@ func (f *Filter) resolve(objs ObjectLister) {
 		for _, d := range transitiveDeps(objs, queue[head]) {
 			enqueue(d)
 		}
+		// Also walk the structural-parent chain of any Flux
+		// Kustomization in the keep set. A leaf change pulls in its
+		// owner KS (above); that KS's own source file might live under
+		// a parent KS's spec.path (the home-ops cross-tree pattern —
+		// see #103). Without the parent reconciling, namespace-scoped
+		// sources it emits (e.g. components/namespace producing one
+		// OCIRepository per tenant ns) never land in the store, and
+		// the leaf can't resolve its chart ref.
+		if queue[head].Kind != manifest.KindKustomization {
+			continue
+		}
+		src, ok := f.sourceFiles[queue[head]]
+		if !ok {
+			continue
+		}
+		// Pull in whichever KS owns this KS's *source file* — i.e. the
+		// structural parent in the home-ops cross-tree pattern where a
+		// leaf KS in apps/base/ is registered by a parent KS rendering
+		// apps/main/. Use ownersOf so the parent (longest-prefix match
+		// for the source file) gets included; also append ancestorsOf
+		// so deeper chains of meta-Kustomizations get pulled in too.
+		// queue[head] itself owns its OWN spec.path, not its source
+		// file, so the parent never collides with the KS we're walking.
+		for _, owner := range owners.ownersOf(src) {
+			if owner == queue[head] {
+				continue
+			}
+			enqueue(owner)
+		}
+		for _, ancestor := range owners.ancestorsOf(src) {
+			enqueue(ancestor)
+		}
 	}
 	f.keep = keep
 

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -126,6 +126,46 @@ func TestFilter_AncestorKSAlsoKept(t *testing.T) {
 	}
 }
 
+// TestFilter_StructuralParentOfOwnerKSAlsoKept covers the home-ops
+// cross-tree pattern (joryirving-style): a leaf Flux KS in apps/base/
+// is registered by a parent KS rendering apps/main/. The leaf's
+// source file lives under the parent's spec.path, so the parent has
+// to reconcile too — otherwise the namespace-scoped sources it emits
+// (e.g. components/namespace producing one OCIRepository per tenant
+// ns) never land in the store and the leaf can't resolve its chart
+// ref. The changed file itself stays in apps/base/, which the parent
+// does NOT cover via spec.path, so ancestorsOf(file) wouldn't catch
+// the parent — only ownersOf(leaf-KS source file) does.
+func TestFilter_StructuralParentOfOwnerKSAlsoKept(t *testing.T) {
+	parent := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/main"},
+	}
+	leaf := &manifest.Kustomization{
+		Name: "actual", Namespace: "self-hosted",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/base/self-hosted/actual"},
+	}
+	hrActual := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "self-hosted", Name: "actual"}
+	parentID, leafID := parent.Named(), leaf.Named()
+
+	f := NewFilter(
+		NewSet([]string{"apps/base/self-hosted/actual/helmrelease.yaml"}),
+		map[manifest.NamedResource]string{
+			parentID: "clusters/main/apps.yaml",
+			leafID:   "apps/main/self-hosted/actual.yaml",
+			hrActual: "apps/base/self-hosted/actual/helmrelease.yaml",
+		},
+		"",
+		mapLister{parentID: parent, leafID: leaf},
+	)
+
+	for _, id := range []manifest.NamedResource{hrActual, leafID, parentID} {
+		if !f.ShouldReconcile(id) {
+			t.Errorf("expected %s in keep; keep=%v", id, f.KeepNames())
+		}
+	}
+}
+
 func TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings(t *testing.T) {
 	// Two leaf KSes under the same meta-KS. Only plex changes. plex
 	// + meta are kept; atuin (an unrelated sibling under the meta-KS)

--- a/pkg/manifest/io.go
+++ b/pkg/manifest/io.go
@@ -12,26 +12,23 @@ import (
 // DecodeDocs reads zero or more YAML documents from r and returns each
 // as a generic map. Empty / null-scalar documents are skipped.
 //
-// We walk yaml.Node directly instead of routing through a YAML→JSON→Go
-// round-trip — DecodeDocs is on the hot path for every loaded file plus
-// every rendered helm/kustomize output, so skipping the extra
-// marshal/unmarshal makes rendering measurably faster.
+// Decodes directly into map[string]any via the yaml.v4 library — same
+// shape sigs.k8s.io/yaml uses behind real Flux. Letting the library
+// own the walk means YAML 1.2 features (anchors, aliases — including
+// aliases-as-keys, merge keys, tagged scalars) round-trip correctly
+// without a hand-rolled node visitor playing catch-up.
 func DecodeDocs(r io.Reader) ([]map[string]any, error) {
 	dec := yaml.NewDecoder(r)
 	var out []map[string]any
 	for {
-		var node yaml.Node
-		if err := dec.Decode(&node); err != nil {
+		var m map[string]any
+		if err := dec.Decode(&m); err != nil {
 			if errors.Is(err, io.EOF) {
 				return out, nil
 			}
 			return nil, fmt.Errorf("%w: %v", ErrInput, err)
 		}
-		m, err := nodeToMap(&node)
-		if err != nil {
-			return nil, err
-		}
-		if m == nil {
+		if len(m) == 0 {
 			continue
 		}
 		out = append(out, m)
@@ -41,83 +38,4 @@ func DecodeDocs(r io.Reader) ([]map[string]any, error) {
 // SplitDocs is the byte-slice convenience wrapper for DecodeDocs.
 func SplitDocs(data []byte) ([]map[string]any, error) {
 	return DecodeDocs(bytes.NewReader(data))
-}
-
-// nodeToMap walks a yaml.Node and returns the root mapping as
-// map[string]any. A nil / empty / null-scalar root yields (nil, nil) so
-// the caller can skip it; a non-mapping root is an error.
-func nodeToMap(node *yaml.Node) (map[string]any, error) {
-	if node == nil || node.Kind == 0 {
-		return nil, nil
-	}
-	target := node
-	if node.Kind == yaml.DocumentNode {
-		if len(node.Content) == 0 {
-			return nil, nil
-		}
-		target = node.Content[0]
-	}
-	if target.Kind == yaml.ScalarNode && (target.Tag == "!!null" || target.Value == "") {
-		return nil, nil
-	}
-	if target.Kind != yaml.MappingNode {
-		return nil, fmt.Errorf("%w: expected mapping at document root, got %d", ErrInput, target.Kind)
-	}
-	v, err := nodeValue(target)
-	if err != nil {
-		return nil, err
-	}
-	m, _ := v.(map[string]any)
-	if len(m) == 0 {
-		return nil, nil
-	}
-	return m, nil
-}
-
-// nodeValue converts an arbitrary yaml.Node into the equivalent Go
-// value: MappingNode → map[string]any, SequenceNode → []any,
-// ScalarNode → typed scalar (nil, bool, int, float64, or string) per
-// yaml.v4's YAML 1.2 core schema resolution.
-func nodeValue(n *yaml.Node) (any, error) {
-	switch n.Kind {
-	case yaml.MappingNode:
-		m := make(map[string]any, len(n.Content)/2)
-		for i := 0; i+1 < len(n.Content); i += 2 {
-			keyNode, valNode := n.Content[i], n.Content[i+1]
-			if keyNode.Kind != yaml.ScalarNode {
-				return nil, fmt.Errorf("%w: non-scalar mapping key at line %d", ErrInput, keyNode.Line)
-			}
-			val, err := nodeValue(valNode)
-			if err != nil {
-				return nil, err
-			}
-			m[keyNode.Value] = val
-		}
-		return m, nil
-	case yaml.SequenceNode:
-		arr := make([]any, len(n.Content))
-		for i, c := range n.Content {
-			v, err := nodeValue(c)
-			if err != nil {
-				return nil, err
-			}
-			arr[i] = v
-		}
-		return arr, nil
-	case yaml.ScalarNode:
-		// Delegate scalar type resolution to yaml.v4 so untagged values
-		// pick up the YAML 1.2 core schema (true/false, integers,
-		// floats, null) and explicit tags are honored.
-		var v any
-		if err := n.Decode(&v); err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrInput, err)
-		}
-		return v, nil
-	case yaml.AliasNode:
-		if n.Alias == nil {
-			return nil, fmt.Errorf("%w: unresolved alias", ErrInput)
-		}
-		return nodeValue(n.Alias)
-	}
-	return nil, fmt.Errorf("%w: unexpected yaml node kind %d", ErrInput, n.Kind)
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1005,3 +1005,35 @@ metadata: {name: b, namespace: ns}
 		t.Errorf("names = %v", names)
 	}
 }
+
+// TestSplitDocs_AliasAsMapKey pins the home-ops pattern of using a
+// YAML anchor as a mapping key (e.g. `&app sonarr` in metadata.name,
+// referenced later as `*app :` to share the literal across the doc).
+// Sigs/Flux YAML parsers resolve the alias to its underlying scalar
+// before assigning into the map; flate's manual node walk used to
+// reject any non-scalar key kind. See m00nwtchr/homelab-cluster
+// apps/media/sonarr/app/helmrelease.yaml.
+func TestSplitDocs_AliasAsMapKey(t *testing.T) {
+	data := []byte(`
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app sonarr
+spec:
+  values:
+    controllers:
+      *app :
+        replicas: 2
+`)
+	docs, err := SplitDocs(data)
+	if err != nil {
+		t.Fatalf("SplitDocs: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc, got %d", len(docs))
+	}
+	controllers, _ := docs[0]["spec"].(map[string]any)["values"].(map[string]any)["controllers"].(map[string]any)
+	if _, ok := controllers["sonarr"]; !ok {
+		t.Errorf("alias key not resolved to scalar; controllers=%v", controllers)
+	}
+}


### PR DESCRIPTION
Two real fidelity gaps surfaced while running \`flate diff\` against five home-ops repos (bjw-s-labs, buroa, m00nwtchr, drag0n141, joryirving).

## 1. YAML alias-as-map-key

\`m00nwtchr/apps/media/sonarr/app/helmrelease.yaml\` uses:
\`\`\`yaml
metadata:
  name: &app sonarr
spec:
  values:
    controllers:
      *app :   # ← AliasNode used as a map key
        type: statefulset
\`\`\`

A common home-ops pattern to share a literal across the doc. Real Flux's parser (\`sigs.k8s.io/yaml\`) resolves the alias and the key becomes the scalar \`"sonarr"\`. flate's hand-rolled \`yaml.Node\` walker in \`pkg/manifest/io.go\` only accepted \`ScalarNode\` keys — AliasNode-as-key was rejected with \`non-scalar mapping key\`.

**Your question on the previous round was the right one** — *why are we using a manual node walk?* The hand-walk existed for a perf claim no one had measured, and it's exactly the kind of YAML 1.2 corner real Flux gets for free by routing through the standard library. Replace the walker with a direct \`yaml.NewDecoder(r).Decode(&map[string]any)\` call, matching how \`sigs.k8s.io/yaml\` works. ~80 LOC gone, and YAML aliases (including as keys), merge keys, and tagged scalars all round-trip without a custom visitor playing catch-up.

## 2. Structural-parent KS missed by changed-only mode

joryirving-style cross-tree pattern: \`apps/main/<ns>/<app>.yaml\` declares a Flux KS whose \`spec.path\` points at \`apps/base/<ns>/<app>/\`. When a leaf in \`apps/base/\` changes, the leaf's owner KS gets enqueued (pass #58 / #104 logic). But the *parent* of that owner KS — registered in \`apps/main/\` and rendering namespace-scoped sources via \`components/namespace\` — wasn't enqueued, because \`ancestorsOf(file)\` only looks at file-ancestors of the changed file, not of the owner KS's source file.

Walk \`ownersOf\` and \`ancestorsOf\` of each Kustomization-in-queue's source file in the BFS body. The KS's own \`spec.path\` claim doesn't match its source file (different subtrees in the cross-tree case), so this can't self-add — guarded with \`owner == queue[head]\` for safety anyway.

## Results across the 5 repos

| Repo | Before | After |
|---|---|---|
| bjw-s-labs/home-ops | clean | clean |
| buroa/k8s-gitops | clean | clean |
| drag0n141/home-ops | clean | clean |
| m00nwtchr/homelab-cluster | sonarr HR failed to load; 50 failed | sonarr loads; 2 failed (pre-existing #96 keyless-cosign limitation) |
| joryirving/home-ops | clean against single-cluster scope; multi-cluster collision at repo-root scope is a separate ergonomic gap | unchanged |

## Tests
- \`TestSplitDocs_AliasAsMapKey\` pins the home-ops \`*app :\` pattern end-to-end.
- \`TestFilter_StructuralParentOfOwnerKSAlsoKept\` pins the cross-tree parent pull-in.
- \`go test ./... -count=1\` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)