### PR TITLE
fix(cosign): skip keyless verification with warn instead of failing fetch

### DIFF
--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -120,8 +120,8 @@ const (
 
 // OCIRepositoryVerify is the Flux OCIRepositoryVerification from
 // source-controller. Flate implements keyed cosign mode only: keyless
-// (OIDC) and notation parse for round-trip fidelity but are not
-// enforced at Fetch time.
+// (OIDC) parses for round-trip fidelity, logs a warn at Fetch time,
+// and proceeds with rendering. Notation is also unenforced.
 type OCIRepositoryVerify = sourcev1.OCIRepositoryVerification
 
 // Named identifies the OCIRepository.

--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -13,6 +13,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 
 	"github.com/opencontainers/go-digest"
@@ -72,7 +73,13 @@ type signatureManifest struct {
 // Implements the cosign "simple signing" keyed verification path:
 //   - https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md
 //
-// Keyless / Rekor / Notation are out of scope for offline flate.
+// Keyless (Fulcio / Rekor) verification is logged and skipped: real Flux
+// proves the chain via sigstore-go + transparency-log roots, which costs
+// ~100 MB of crypto dependencies and online Fulcio/Rekor calls. flate's
+// purpose is rendering what Flux would render, not gating artifact
+// pulls — so the chart is fetched and rendered, with a warn-level log
+// making the unverified state visible to the user.
+// Notation is also out of scope.
 func (f *Fetcher) verifyCosignSignature(
 	ctx context.Context,
 	repoClient *remote.Repository,
@@ -91,10 +98,13 @@ func (f *Fetcher) verifyCosignSignature(
 			repo.Namespace, repo.Name, provider, "cosign")
 	}
 	if repo.Verify.SecretRef == nil {
-		// Keyless (OIDC) — flate cannot enforce this offline. Surface
-		// the gap as a loud error rather than silently passing.
-		return fmt.Errorf("OCIRepository %s/%s: keyless cosign verification is not implemented; supply spec.verify.secretRef with a public key",
-			repo.Namespace, repo.Name)
+		// Keyless (OIDC) — flate can't reach Fulcio/Rekor offline and
+		// doesn't carry the sigstore trust roots. Log and proceed so the
+		// chart still renders for diff purposes.
+		slog.Warn("cosign keyless verification skipped; rendering unverified artifact",
+			"ociRepository", repo.Namespace+"/"+repo.Name,
+			"digest", pulledDigest)
+		return nil
 	}
 	keys, err := f.loadCosignPublicKeys(repo)
 	if err != nil {

--- a/pkg/source/oci/cosign_test.go
+++ b/pkg/source/oci/cosign_test.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -176,6 +177,29 @@ func TestLoadCosignPublicKeys_ParsesPEM(t *testing.T) {
 	}
 	if len(keys) != 1 {
 		t.Fatalf("expected 1 key, got %d", len(keys))
+	}
+}
+
+// Keyless cosign (matchOIDCIdentity, no secretRef) cannot be enforced
+// offline. Verify that verifyCosignSignature returns nil — the chart
+// still renders for diff purposes — without touching the registry.
+func TestVerifyCosignSignature_KeylessSkipsAndReturnsNil(t *testing.T) {
+	f := &Fetcher{}
+	repo := &manifest.OCIRepository{
+		Name: "app-template", Namespace: "flux-system",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			Verify: &manifest.OCIRepositoryVerify{
+				Provider: "cosign",
+				MatchOIDCIdentity: []sourcev1.OIDCIdentityMatch{
+					{Issuer: "^https://token.actions.githubusercontent.com$",
+						Subject: "^https://github.com/bjw-s-labs/helm-charts.*$"},
+				},
+			},
+		},
+	}
+	// repoClient nil is fine: keyless path returns before any registry call.
+	if err := f.verifyCosignSignature(context.Background(), nil, repo, "sha256:deadbeef"); err != nil {
+		t.Errorf("keyless cosign should be skipped silently; got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Keyless cosign (`matchOIDCIdentity`, no `secretRef`) previously errored in OCIRepository fetch, blocking chart rendering for any keyless-signed chart (e.g. `bjw-s-labs/app-template`)
- Real Flux verifies via `sigstore/cosign` + Fulcio/Rekor — ~100 MB of crypto deps plus online sigstore calls, out of step with flate's offline-first rendering
- Now: `slog.Warn` and skip, so the chart renders and the unverified state stays visible in logs

Closes #96 to the extent that keyless no longer blocks rendering. Full verification can be revisited if there's demand.

## Test plan
- [x] `go test ./...` — all 28 packages pass
- [x] m00nwtchr/homelab-cluster (uses keyless on `app-template`): `failed=2 → failed=0`
- [x] All 7 scopes (bjw-s-labs, buroa, m00nwtchr, drag0n141, jory-main, jory-test, jory-utility): `failed=0`
- [x] New test `TestVerifyCosignSignature_KeylessSkipsAndReturnsNil` covers the regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)