### PR TITLE
feat(resourceset): resolve spec.inputsFrom via ResourceSetInputProvider

### DIFF
--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -26,6 +26,7 @@ const (
 	KindSecret                   = "Secret"
 	KindCustomResourceDefinition = "CustomResourceDefinition"
 	KindResourceSet              = "ResourceSet"
+	KindResourceSetInputProvider = "ResourceSetInputProvider"
 )
 
 // DefaultNamespace mirrors Flux's convention of placing top-level resources

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -93,6 +93,8 @@ func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
 		return ParseBucket(doc)
 	case kind == KindResourceSet && strings.HasPrefix(apiVersion, FluxOperatorDomain):
 		return ParseResourceSet(doc)
+	case kind == KindResourceSetInputProvider && strings.HasPrefix(apiVersion, FluxOperatorDomain):
+		return ParseResourceSetInputProvider(doc)
 	case kind == KindConfigMap:
 		return ParseConfigMap(doc)
 	case kind == KindSecret:

--- a/pkg/manifest/resourcesetinputprovider.go
+++ b/pkg/manifest/resourcesetinputprovider.go
@@ -1,0 +1,101 @@
+package manifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+)
+
+// ResourceSetInputProvider is the flux-operator
+// ResourceSetInputProvider CRD (fluxcd.controlplane.io/v1). It supplies
+// inputs to one or more ResourceSets via spec.inputsFrom.
+//
+// flate evaluates the Static type fully — defaultValues becomes a
+// single exported input set. Dynamic types (GitHubBranch, OCIArtifactTag,
+// ExternalService, …) require live API access to remote services and
+// are intentionally treated as empty providers here; the referencing
+// ResourceSet still renders, but with no contribution from that
+// provider.
+type ResourceSetInputProvider struct {
+	Name      string `json:"name"                yaml:"name"`
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+
+	fluxopv1.ResourceSetInputProviderSpec `json:",inline" yaml:",inline"`
+
+	Labels map[string]string `json:"-" yaml:"-"`
+}
+
+// Named identifies the ResourceSetInputProvider.
+func (p *ResourceSetInputProvider) Named() NamedResource {
+	return NamedResource{Kind: KindResourceSetInputProvider, Namespace: p.Namespace, Name: p.Name}
+}
+
+// NamespacedName is "<namespace>/<name>".
+func (p *ResourceSetInputProvider) NamespacedName() string { return p.Namespace + "/" + p.Name }
+
+// ParseResourceSetInputProvider decodes a ResourceSetInputProvider CR.
+func ParseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvider, error) {
+	if err := checkAPIVersion(doc, FluxOperatorDomain); err != nil {
+		return nil, err
+	}
+	var cr fluxopv1.ResourceSetInputProvider
+	if err := decodeTyped(doc, &cr); err != nil {
+		return nil, inputf("ResourceSetInputProvider decode: %v", err)
+	}
+	if cr.Name == "" {
+		return nil, inputf("ResourceSetInputProvider missing metadata.name")
+	}
+	ns := cr.Namespace
+	if ns == "" {
+		ns = DefaultNamespace
+	}
+	return &ResourceSetInputProvider{
+		Name:                                  cr.Name,
+		Namespace:                             ns,
+		ResourceSetInputProviderSpec:          cr.Spec,
+		Labels:                                cr.Labels,
+	}, nil
+}
+
+// ExportedInputs returns the input sets this provider contributes to a
+// referencing ResourceSet. Mirrors the upstream RSIP controller's
+// "exported inputs" semantics for the Static case; dynamic types
+// contribute zero sets here because flate can't query their remote
+// APIs offline. Each returned set is a fresh map[string]any safe for
+// the caller to mutate (e.g. to inject the provider block).
+func (p *ResourceSetInputProvider) ExportedInputs() ([]map[string]any, error) {
+	switch p.Type {
+	case fluxopv1.InputProviderStatic, "":
+		defaults := map[string]any{}
+		for k, v := range p.DefaultValues {
+			if v == nil {
+				defaults[k] = nil
+				continue
+			}
+			var raw any
+			if err := json.Unmarshal(v.Raw, &raw); err != nil {
+				return nil, fmt.Errorf("defaultValues[%s]: %w", k, err)
+			}
+			defaults[k] = raw
+		}
+		// Upstream injects a synthetic "id" derived from the RSIP UID.
+		// flate has no UIDs; a deterministic hash of namespace/name is
+		// stable across runs and still uniquely identifies the input set
+		// when downstream templates reference inputs.id.
+		if _, exists := defaults["id"]; !exists {
+			defaults["id"] = p.derivedID()
+		}
+		return []map[string]any{defaults}, nil
+	}
+	return nil, nil
+}
+
+// derivedID is the placeholder for upstream's UID-derived id field —
+// stable across flate runs because flate has no UIDs.
+func (p *ResourceSetInputProvider) derivedID() string {
+	sum := sha256.Sum256([]byte(p.Namespace + "/" + p.Name))
+	return hex.EncodeToString(sum[:8])
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -320,7 +321,7 @@ func (o *Orchestrator) loadAt(ctx context.Context, l *loader.Loader, dir string,
 // the count of new objects added so the caller can detect a fixed
 // point in the expansion loop.
 func (o *Orchestrator) renderResourceSet(rs *manifest.ResourceSet) (int, error) {
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, o.resolveInputProvider)
 	if err != nil {
 		return 0, err
 	}
@@ -350,6 +351,44 @@ func (o *Orchestrator) renderResourceSet(rs *manifest.ResourceSet) (int, error) 
 		added++
 	}
 	return added, nil
+}
+
+// resolveInputProvider satisfies resourceset.ProviderResolver against
+// the orchestrator's object store. Returns the RSIPs matching a single
+// spec.inputsFrom reference within the given namespace. Name lookups
+// hit a single id; selector matches walk the store's RSIPs in nsScope
+// and filter by metadata.labels.
+func (o *Orchestrator) resolveInputProvider(ref fluxopv1.InputProviderReference, namespace string) ([]*manifest.ResourceSetInputProvider, error) {
+	if ref.Name != "" {
+		id := manifest.NamedResource{
+			Kind:      manifest.KindResourceSetInputProvider,
+			Namespace: namespace,
+			Name:      ref.Name,
+		}
+		obj, _ := o.store.GetObject(id).(*manifest.ResourceSetInputProvider)
+		if obj == nil {
+			return nil, nil
+		}
+		return []*manifest.ResourceSetInputProvider{obj}, nil
+	}
+	if ref.Selector == nil {
+		return nil, nil
+	}
+	var out []*manifest.ResourceSetInputProvider
+	for _, obj := range o.store.ListObjects(manifest.KindResourceSetInputProvider) {
+		p, ok := obj.(*manifest.ResourceSetInputProvider)
+		if !ok || p.Namespace != namespace {
+			continue
+		}
+		match, err := resourceset.MatchSelector(ref.Selector, p.Labels)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			out = append(out, p)
+		}
+	}
+	return out, nil
 }
 
 // validateDependsOn drops dangling dependsOn references so the

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -6,8 +6,12 @@
 // slim-sprig with the `<<  >>` delimiter pair (so ResourceSet templates
 // can sit inside Helm charts without delimiter conflicts).
 //
-// Scope on this first pass:
+// Supported:
 //   - spec.inputs (in-YAML inline inputs)
+//   - spec.inputsFrom (ResourceSetInputProvider, Static type) — resolved
+//     via the ProviderResolver passed to Render. Dynamic providers
+//     (GitHubBranch, OCIArtifactTag, ExternalService, …) need network
+//     access flate doesn't have and contribute zero input sets.
 //   - spec.resources (typed JSON template list)
 //   - spec.resourcesTemplate (multi-document YAML string)
 //   - spec.commonMetadata (labels + annotations applied to every emitted object)
@@ -15,7 +19,6 @@
 //   - Default-namespace fallback to the ResourceSet's own namespace
 //
 // Deferred:
-//   - spec.inputsFrom (ResourceSetInputProvider) — needs a separate CRD type.
 //   - spec.inputStrategy: Permute — start with the implicit Flatten.
 //   - fluxcd.controlplane.io/copyFrom / convertKubeConfigFrom / checksumFrom
 //     annotations — those need live cluster data flate does not have.
@@ -25,6 +28,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -32,10 +37,18 @@ import (
 	sprig "github.com/go-task/slim-sprig/v3"
 	"github.com/gosimple/slug"
 	apix "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/yaml"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
+
+// ProviderResolver returns the ResourceSetInputProviders matching a
+// single spec.inputsFrom reference within the given namespace. Callers
+// implement this against their object store (orchestrator) or pass nil
+// to disable inputsFrom resolution (tests, simple cases).
+type ProviderResolver func(ref fluxopv1.InputProviderReference, namespace string) ([]*manifest.ResourceSetInputProvider, error)
 
 // Render evaluates rs.Spec across rs.Spec.Inputs (flatten strategy) and
 // returns the resulting Kubernetes manifests as decoded YAML documents,
@@ -44,12 +57,19 @@ import (
 //
 // When rs.Spec.Inputs is empty (e.g. d2-fleet's policies.yaml — static
 // resources with no matrix), templates render once with a nil input set.
-func Render(rs *manifest.ResourceSet) ([]map[string]any, error) {
+//
+// resolve is optional: when non-nil, spec.inputsFrom references are
+// resolved and their providers' exported inputs are flattened into the
+// matrix alongside any inline rs.Spec.Inputs.
+func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]any, error) {
 	if rs == nil {
 		return nil, nil
 	}
 
-	inputs := buildInputSets(rs)
+	inputs, err := buildInputSets(rs, resolve)
+	if err != nil {
+		return nil, fmt.Errorf("ResourceSet %s: %w", rs.NamespacedName(), err)
+	}
 	var docs []map[string]any
 	seen := map[string]struct{}{}
 	appendUnique := func(doc map[string]any) {
@@ -91,33 +111,21 @@ func Render(rs *manifest.ResourceSet) ([]map[string]any, error) {
 	return docs, nil
 }
 
-// buildInputSets returns the flattened in-YAML input matrix. Each entry
-// is a map[string]any with the built-in inputs.provider block injected,
-// matching the flux-operator runtime contract. inputs.id is deliberately
-// not set under the Flatten strategy — upstream's Permuter is the only
-// path that synthesizes one (tracked in #109).
-func buildInputSets(rs *manifest.ResourceSet) []map[string]any {
-	if len(rs.Inputs) == 0 {
-		return nil
-	}
-	out := make([]map[string]any, 0, len(rs.Inputs))
+// buildInputSets returns the flattened input matrix. The ResourceSet's
+// own inline spec.inputs come first (with a provider block pointing at
+// the ResourceSet itself), followed by every input set exported by each
+// referenced ResourceSetInputProvider (with a provider block pointing
+// at the RSIP). Matches upstream's Flatten strategy: simple concat,
+// order = rset's inline inputs first, then providers in sorted
+// (kind, namespace, name) order.
+//
+// Permute strategy is not yet implemented (#109). inputs.id is left to
+// the provider when it's a Static RSIP; inline-only inputs see no
+// synthetic id under Flatten.
+func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]any, error) {
+	var out []map[string]any
 	for _, in := range rs.Inputs {
-		decoded := map[string]any{}
-		for k, v := range in {
-			if v == nil {
-				decoded[k] = nil
-				continue
-			}
-			var raw any
-			if err := json.Unmarshal(v.Raw, &raw); err != nil {
-				// flate skips malformed entries silently — the parser
-				// already accepted the document, and at render time we
-				// have no good signaling channel beyond the per-resource
-				// log line a controller would emit.
-				continue
-			}
-			decoded[k] = raw
-		}
+		decoded := decodeInputSet(in)
 		decoded["provider"] = map[string]any{
 			"apiVersion": fluxopv1.GroupVersion.String(),
 			"kind":       manifest.KindResourceSet,
@@ -126,7 +134,91 @@ func buildInputSets(rs *manifest.ResourceSet) []map[string]any {
 		}
 		out = append(out, decoded)
 	}
-	return out
+	if resolve == nil || len(rs.InputsFrom) == 0 {
+		return out, nil
+	}
+
+	seen := make(map[string]struct{})
+	var providers []*manifest.ResourceSetInputProvider
+	for _, ref := range rs.InputsFrom {
+		matches, err := resolve(ref, rs.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("inputsFrom %q: %w", ref.Name, err)
+		}
+		for _, p := range matches {
+			if p == nil {
+				continue
+			}
+			k := p.Namespace + "/" + p.Name
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			providers = append(providers, p)
+		}
+	}
+	// Sort providers by (namespace, name) for deterministic output,
+	// matching upstream's Combine routine ordering.
+	sort.Slice(providers, func(i, j int) bool {
+		if providers[i].Namespace != providers[j].Namespace {
+			return providers[i].Namespace < providers[j].Namespace
+		}
+		return providers[i].Name < providers[j].Name
+	})
+	for _, p := range providers {
+		exported, err := p.ExportedInputs()
+		if err != nil {
+			return nil, fmt.Errorf("ResourceSetInputProvider %s: %w", p.NamespacedName(), err)
+		}
+		if exported == nil && p.Type != "" && p.Type != fluxopv1.InputProviderStatic {
+			slog.Warn("resourceset: dynamic input provider contributes no inputs offline",
+				"resourceSet", rs.NamespacedName(),
+				"provider", p.NamespacedName(),
+				"type", p.Type)
+		}
+		for _, set := range exported {
+			set["provider"] = map[string]any{
+				"apiVersion": fluxopv1.GroupVersion.String(),
+				"kind":       manifest.KindResourceSetInputProvider,
+				"name":       p.Name,
+				"namespace":  p.Namespace,
+			}
+			out = append(out, set)
+		}
+	}
+	return out, nil
+}
+
+func decodeInputSet(in fluxopv1.ResourceSetInput) map[string]any {
+	decoded := map[string]any{}
+	for k, v := range in {
+		if v == nil {
+			decoded[k] = nil
+			continue
+		}
+		var raw any
+		if err := json.Unmarshal(v.Raw, &raw); err != nil {
+			// Malformed entries are skipped silently — the parser
+			// already accepted the document, and there's no good
+			// signaling channel beyond a controller log line.
+			continue
+		}
+		decoded[k] = raw
+	}
+	return decoded
+}
+
+// MatchSelector returns true when sel matches lbls. Helper for
+// ProviderResolver implementations that filter by InputProviderReference.Selector.
+func MatchSelector(sel *metav1.LabelSelector, lbls map[string]string) (bool, error) {
+	if sel == nil {
+		return true, nil
+	}
+	s, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return false, err
+	}
+	return s.Matches(labels.Set(lbls)), nil
 }
 
 // renderResources templates a single spec.resources entry once per

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -35,7 +35,7 @@ func TestRender_InputsExpandTemplates(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -77,7 +77,7 @@ func TestRender_Deduplication(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestRender_NoInputsRendersOnce(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestRender_DefaultsNamespace(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestRender_CommonMetadata(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestRender_SprigFunctions(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestRender_DisabledReconcileAnnotationSkips(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -279,7 +279,7 @@ func TestRender_InputsProviderBuiltinField(t *testing.T) {
 			},
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -312,7 +312,7 @@ func TestRender_MissingKeyErrors(t *testing.T) {
 			},
 		},
 	}
-	_, err := resourceset.Render(rs)
+	_, err := resourceset.Render(rs, nil)
 	if err == nil {
 		t.Fatal("expected error for undefined input key, got nil")
 	}
@@ -333,7 +333,7 @@ func TestRender_MalformedTemplateErrors(t *testing.T) {
 			},
 		},
 	}
-	_, err := resourceset.Render(rs)
+	_, err := resourceset.Render(rs, nil)
 	if err == nil {
 		t.Fatal("expected parse error for malformed template, got nil")
 	}
@@ -361,7 +361,7 @@ spec:
 `,
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}
@@ -369,6 +369,111 @@ spec:
 	sel := spec["layerSelector"].(map[string]any)
 	if sel["mediaType"] != "x" || sel["operation"] != "copy" {
 		t.Errorf("toYaml|nindent did not produce nested map: %v", sel)
+	}
+}
+
+// TestRender_InputsFrom_StaticProvider locks the billimek volsync
+// pattern: a ResourceSet with no inline inputs that references a Static
+// ResourceSetInputProvider, whose defaultValues become a single input
+// set the template iterates over with `<<- range $app := inputs.apps >>`.
+func TestRender_InputsFrom_StaticProvider(t *testing.T) {
+	rsip := &manifest.ResourceSetInputProvider{
+		Name: "apps", Namespace: "kube-system",
+		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+			Type: fluxopv1.InputProviderStatic,
+			DefaultValues: fluxopv1.ResourceSetInput{
+				"defaults": jsonTmpl(t, `{"capacity": "1Gi"}`),
+				"apps":     jsonTmpl(t, `[{"app": "alpha"}, {"app": "bravo", "capacity": "5Gi"}]`),
+			},
+		},
+	}
+	rs := &manifest.ResourceSet{
+		Name: "volsync", Namespace: "kube-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputsFrom: []fluxopv1.InputProviderReference{
+				{Name: "apps"},
+			},
+			ResourcesTemplate: `<<- range $app := inputs.apps >>
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << $app.app >>
+  namespace: default
+data:
+  capacity: << get $app "capacity" | default inputs.defaults.capacity >>
+<<- end >>
+`,
+		},
+	}
+	resolver := func(ref fluxopv1.InputProviderReference, ns string) ([]*manifest.ResourceSetInputProvider, error) {
+		if ref.Name == "apps" && ns == "kube-system" {
+			return []*manifest.ResourceSetInputProvider{rsip}, nil
+		}
+		return nil, nil
+	}
+	docs, err := resourceset.Render(rs, resolver)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 ConfigMaps, got %d", len(docs))
+	}
+	caps := map[string]string{}
+	for _, doc := range docs {
+		md := doc["metadata"].(map[string]any)
+		data := doc["data"].(map[string]any)
+		caps[md["name"].(string)] = data["capacity"].(string)
+	}
+	// alpha falls back to inputs.defaults.capacity (1Gi); bravo
+	// overrides via its own per-app capacity (5Gi).
+	if caps["alpha"] != "1Gi" || caps["bravo"] != "5Gi" {
+		t.Errorf("expected alpha=1Gi, bravo=5Gi; got %v", caps)
+	}
+}
+
+// TestRender_InputsFrom_DynamicProviderEmptySkip verifies that a
+// non-Static provider (which flate can't query offline) contributes
+// zero input sets rather than erroring — the ResourceSet still renders
+// with whatever inline inputs it has.
+func TestRender_InputsFrom_DynamicProviderEmptySkip(t *testing.T) {
+	rsip := &manifest.ResourceSetInputProvider{
+		Name: "branches", Namespace: "flux-system",
+		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+			Type: fluxopv1.InputProviderGitHubBranch,
+			URL:  "https://github.com/foo/bar",
+		},
+	}
+	rs := &manifest.ResourceSet{
+		Name: "matrix", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			Inputs: []fluxopv1.ResourceSetInput{
+				{"tenant": jsonTmpl(t, `"inline-only"`)},
+			},
+			InputsFrom: []fluxopv1.InputProviderReference{
+				{Name: "branches"},
+			},
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << inputs.tenant >>
+  namespace: flux-system
+`,
+		},
+	}
+	resolver := func(ref fluxopv1.InputProviderReference, ns string) ([]*manifest.ResourceSetInputProvider, error) {
+		return []*manifest.ResourceSetInputProvider{rsip}, nil
+	}
+	docs, err := resourceset.Render(rs, resolver)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc from inline input (dynamic provider contributes nothing), got %d", len(docs))
+	}
+	md := docs[0]["metadata"].(map[string]any)
+	if md["name"] != "inline-only" {
+		t.Errorf("expected name=inline-only; got %v", md["name"])
 	}
 }
 
@@ -397,7 +502,7 @@ metadata:
 			ResourcesTemplate: tmpl,
 		},
 	}
-	docs, err := resourceset.Render(rs)
+	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
 		t.Fatalf("Render: %v", err)
 	}


### PR DESCRIPTION
## Summary
- A ResourceSet referencing a Static ResourceSetInputProvider used to fail rendering — flate had no RSIP type and `resourceset.Render` only flattened the inline `spec.inputs` matrix
- Repos that share a single \`defaultValues\` block across multiple ResourceSets (e.g. billimek/k8s-gitops: \`volsync-apps\` RSIP shared by \`volsync-pvcs\` + \`volsync-backups\`, with templates iterating \`<<- range \$app := inputs.apps >>\`) couldn't render at all
- Now: orchestrator resolves \`spec.inputsFrom\` references by name or label selector against the in-memory store; \`Render(rs, resolve)\` flattens inline inputs + each resolved provider's exported inputs

## What's in
- \`KindResourceSetInputProvider\` constant + \`ParseResourceSetInputProvider\` wired into \`parse.go\`
- \`ResourceSetInputProvider.ExportedInputs()\`: Static returns one input set from \`defaultValues\` (with a synthetic stable \`id\`); dynamic types (GitHubBranch, OCIArtifactTag, ExternalService, …) return nil with a warn — flate can't query remote APIs offline
- \`resourceset.Render(rs, resolve ProviderResolver)\` flattens inline + provider-exported inputs in upstream's Combine ordering
- Orchestrator-backed \`ProviderResolver\`: O(1) name lookup against the store, selector walks RSIPs by namespace

## Verified
- \`flate test ks --path /tmp/billimek-k8s-gitops\`: **2/2 PASSED** (was: \`error: ResourceSet kube-system/volsync-pvcs: spec.resourcesTemplate: ... map has no entry for key \"apps\"\`)
- \`flate test hr\`: 74/75 PASSED (1 unrelated emqx 404)
- \`flate diff ks\`: a defaultValues edit (\`capacity: 5Gi → 7Gi\`) propagates through to all consumer ResourceSets
- Existing 7-scope matrix (bjw-s-labs, buroa, m00nwtchr, drag0n141, jory main/test/utility): all \`failed=0\` — no regressions
- New tests: \`TestRender_InputsFrom_StaticProvider\`, \`TestRender_InputsFrom_DynamicProviderEmptySkip\`

## Test plan
- [x] \`go test ./...\` — all 28 packages pass
- [x] billimek/k8s-gitops renders cleanly end-to-end
- [x] Pre-existing repos unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)