### PR TITLE
feat(get): add `flate get images`; drop --enable-images / --only-images on `get all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ flate diff images  --path ./kubernetes --path-orig ../baseline/kubernetes -o jso
 |---|---|---|
 | `flate get ks` | `kustomization`, `kustomizations` | List Kustomizations |
 | `flate get hr` | `helmrelease`, `helmreleases` | List HelmReleases |
-| `flate get all` | | Cluster summary (`--enable-images`, `--only-images`) |
+| `flate get images` | | List container images across the cluster |
+| `flate get all` | | Kustomization + HelmRelease cluster summary |
 | `flate build ks` | | Render Kustomizations to YAML |
 | `flate build hr` | | Render HelmReleases to YAML |
 | `flate build all` | | Render every Kustomization and HelmRelease |
@@ -95,10 +96,10 @@ Every command takes `--path <dir>` (default `.`). Add `--path-orig <dir>` to swi
 ```bash
 flate get ks --path ./kubernetes -o json
 flate get hr --path ./kubernetes -l app.kubernetes.io/part-of=media
-flate get all --path ./kubernetes --only-images
+flate get images --path ./kubernetes
 ```
 
-`get all --enable-images` groups images per HelmRelease; `--only-images` emits a flat, deduplicated list across both HelmReleases and Kustomization-managed workloads (Deployments, StatefulSets, Pods, Jobs).
+`get images` emits a flat, deduplicated list across both HelmReleases and Kustomization-managed workloads (Deployments, StatefulSets, Pods, Jobs). The same shape as [`diff images`](#flate-diff-images) — that one filters down to images that actually changed.
 
 ### `flate build`
 
@@ -142,7 +143,7 @@ The header always shows the **parent** (HelmRelease or Kustomization) and the re
 
 #### `flate diff images`
 
-A diff-aware companion to `get all --only-images`. Emits images whose string actually changed between `--path` and `--path-orig` — touching an env var doesn't produce noise.
+A diff-aware companion to `get images`. Emits images whose string actually changed between `--path` and `--path-orig` — touching an env var doesn't produce noise.
 
 | Flag | Effect |
 |---|---|
@@ -307,15 +308,6 @@ Apply to `diff ks` / `diff hr`:
 | Flag | Default | Description |
 |---|---|---|
 | `--include-removed` | `false` | Emit images dropped from `--path-orig` alongside newly added ones. |
-
-### Get flags
-
-Apply to `get all`:
-
-| Flag | Default | Description |
-|---|---|---|
-| `--enable-images` | `false` | Group container images per HelmRelease in the summary. |
-| `--only-images` | `false` | Emit only the deduplicated image list (no counts or HelmRelease grouping). |
 
 ## Defaults
 

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"cmp"
 	"io"
 	"maps"
 	"slices"
@@ -9,16 +8,17 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/home-operations/flate/internal/format"
-	"github.com/home-operations/flate/pkg/image"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/selector"
-	"github.com/home-operations/flate/pkg/store"
 )
 
 func newGetCmd() *cobra.Command {
-	cmd := &cobra.Command{Use: "get", Short: "List Flux objects"}
-	cmd.AddCommand(newGetKSCmd(), newGetHRCmd(), newGetAllCmd())
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "List Kustomizations, HelmReleases, container images, or a cluster summary",
+	}
+	cmd.AddCommand(newGetKSCmd(), newGetHRCmd(), newGetImagesCmd(), newGetAllCmd())
 	return cmd
 }
 
@@ -82,7 +82,6 @@ func newGetHRCmd() *cobra.Command {
 func newGetAllCmd() *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
-	var enableImages, onlyImages bool
 	cmd := &cobra.Command{
 		Use:   "all",
 		Short: "Summarize every Kustomization and HelmRelease",
@@ -91,17 +90,35 @@ func newGetAllCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			w := cmd.OutOrStdout()
-			if enableImages || onlyImages {
-				return printClusterImages(w, o, c, onlyImages)
-			}
-			return printCluster(w, o, c.output)
+			return printCluster(cmd.OutOrStdout(), o, c.output)
 		},
 	}
 	bindCommon(cmd.Flags(), c)
 	bindHelmFlags(cmd.Flags(), h)
-	cmd.Flags().BoolVar(&enableImages, "enable-images", false, "include container images in the output")
-	cmd.Flags().BoolVar(&onlyImages, "only-images", false, "emit only the deduplicated list of images")
+	return cmd
+}
+
+// newGetImagesCmd emits a deduplicated list of container images
+// extracted from every rendered Kustomization and HelmRelease — the
+// symmetric counterpart of `flate diff images`, which emits the same
+// shape filtered to images that actually changed between paths.
+func newGetImagesCmd() *cobra.Command {
+	c := &commonFlags{}
+	h := &helmFlags{}
+	cmd := &cobra.Command{
+		Use:   "images",
+		Short: "List container images across the cluster",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			o, err := runOrchestrator(cmdContext(cmd), *c, *h)
+			if err != nil {
+				return err
+			}
+			imgs := slices.Sorted(maps.Keys(collectImages(o, c)))
+			return emitImageList(cmd.OutOrStdout(), imgs, c.output)
+		},
+	}
+	bindCommon(cmd.Flags(), c)
+	bindHelmFlags(cmd.Flags(), h)
 	return cmd
 }
 
@@ -199,45 +216,3 @@ func printCluster(w io.Writer, o *orchestrator.Orchestrator, out string) error {
 	return format.YAML(w, summary)
 }
 
-type imageEntry struct {
-	HelmRelease string   `json:"helmRelease" yaml:"helmRelease"`
-	Images      []string `json:"images"      yaml:"images"`
-}
-
-func printClusterImages(w io.Writer, o *orchestrator.Orchestrator, c *commonFlags, onlyImages bool) error {
-	if onlyImages {
-		return emitImageList(w, slices.Sorted(maps.Keys(collectImages(o, c))), c.output)
-	}
-
-	var releases []imageEntry
-	for _, obj := range o.Store().ListObjects(manifest.KindHelmRelease) {
-		hr := obj.(*manifest.HelmRelease)
-		if !c.includeNamespace(o.Filter(), hr.Namespace) {
-			continue
-		}
-		art, ok := o.Store().GetArtifact(hr.Named()).(*store.HelmReleaseArtifact)
-		if !ok {
-			continue
-		}
-		set := map[string]struct{}{}
-		for _, doc := range art.Manifests {
-			imgs, _ := image.Extract(doc)
-			for _, img := range imgs {
-				set[img] = struct{}{}
-			}
-		}
-		if len(set) == 0 {
-			continue
-		}
-		releases = append(releases, imageEntry{
-			HelmRelease: hr.NamespacedName(),
-			Images:      slices.Sorted(maps.Keys(set)),
-		})
-	}
-	slices.SortFunc(releases, func(a, b imageEntry) int { return cmp.Compare(a.HelmRelease, b.HelmRelease) })
-
-	if format.Output(c.output) == format.OutputJSON {
-		return format.JSON(w, releases)
-	}
-	return format.YAML(w, releases)
-}


### PR DESCRIPTION
## Summary
- \`flate get all\` carried two flags (\`--enable-images\` grouped per-HR, \`--only-images\` flat) that paralleled \`flate diff images\` with the wrong shape — two flags to do one job, and only the flat form matched the diff command's output
- This collapses both into a top-level \`flate get images\` that emits the same flat deduplicated list \`flate diff images\` does
- "Every image I'd render" and "every image that changed" now share a shape — no flag combos required

## Changes
- \`flate get images\` walks every rendered Kustomization + HelmRelease artifact and emits sorted unique image strings
- \`flate get all\` is now just the cluster summary (KS + HR counts)
- \`get\` short description: \"List Kustomizations, HelmReleases, container images, or a cluster summary\"
- README cleaned up — get-flags table dropped, examples and cross-link to \`diff images\` updated

## Test plan
- [x] \`go test ./...\` clean
- [x] \`flate get images --path ./kubernetes\` prints 84 sorted unique images for buroa/k8s-gitops
- [x] \`flate get all --help\` no longer surfaces removed flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)