### PR TITLE
fix: correctness pass — git race, depwait drop, HR dependsOn pruning

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -113,11 +113,12 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 			// Recover from panics in watchOne (e.g. malformed CEL expression
 			// evaluating against an unexpected payload type) so the whole
 			// run isn't killed. The dep is reported failed instead.
-			ev := safeWatchOne(ctx, w, dep, timeout)
-			select {
-			case out <- ev:
-			case <-ctx.Done():
-			}
+			//
+			// Send unconditionally — `out` is buffered to len(deps) so
+			// the send never blocks. The previous select-on-ctx silently
+			// dropped events on cancellation, leaving the consumer with
+			// a Pending dep that would time out at the full budget.
+			out <- safeWatchOne(ctx, w, dep, timeout)
 		}(dep)
 	}
 

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -261,7 +261,7 @@ func validatePath(p string) error {
 		if errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("%w: kustomization path does not exist: %s", manifest.ErrInput, p)
 		}
-		return fmt.Errorf("%w: stat kustomization path %s: %v", manifest.ErrInput, p, err)
+		return fmt.Errorf("%w: stat kustomization path %s: %w", manifest.ErrInput, p, err)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("%w: kustomization path is not a directory: %s", manifest.ErrInput, p)

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -74,32 +74,29 @@ func (k *Kustomization) Named() NamedResource {
 // NamespacedName is "<namespace>/<name>".
 func (k *Kustomization) NamespacedName() string { return k.Namespace + "/" + k.Name }
 
-// FilterDependsOn returns a copy of k.DependsOn with any entries
-// whose target is not present in allKS removed. allKS is a set of
-// "namespace/name" identifiers. The second return value is the count
-// of entries that were dropped.
-//
-// Pure function — does not mutate k. Callers wanting to update a
-// stored Kustomization should follow the Store's immutability
-// contract: shallow-copy k, set the new DependsOn on the copy, then
+// FilterDependsOn returns a copy of deps with any entries whose target
+// is not present in known removed. known is a set of "namespace/name"
+// identifiers. The second return value is the count of dropped
+// entries. Pure function — does not mutate deps. Callers updating a
+// stored object should follow the Store's immutability contract:
+// shallow-copy the object, set the new DependsOn on the copy, then
 // re-AddObject the copy.
-func (k *Kustomization) FilterDependsOn(allKS map[string]struct{}) ([]DependencyRef, int) {
-	if len(k.DependsOn) == 0 {
-		return k.DependsOn, 0
+func FilterDependsOn(deps []DependencyRef, known map[string]struct{}) ([]DependencyRef, int) {
+	if len(deps) == 0 {
+		return deps, 0
 	}
-	kept := slices.DeleteFunc(slices.Clone(k.DependsOn), func(dep DependencyRef) bool {
-		_, ok := allKS[dep.NamespacedName()]
+	kept := slices.DeleteFunc(slices.Clone(deps), func(dep DependencyRef) bool {
+		_, ok := known[dep.NamespacedName()]
 		return !ok
 	})
-	dropped := len(k.DependsOn) - len(kept)
+	dropped := len(deps) - len(kept)
 	if dropped > 0 {
 		// Demoted to Debug: dependsOn references often dangle in a
 		// statically-loaded view because parent-Kustomization
 		// targetNamespace inheritance happens lazily. Real Flux resolves
 		// them at apply time, and dropping them here only affects the
 		// wait order during flate's reconcile.
-		slog.Debug("kustomization dependsOn entries dropped",
-			"kustomization", k.NamespacedName(),
+		slog.Debug("dependsOn entries dropped",
 			"dropped", dropped, "kept", len(kept))
 	}
 	return kept, dropped

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -790,7 +790,7 @@ spec:
 		t.Errorf("substitute = %+v", k.PostBuildSubstitute)
 	}
 
-	kept, dropped := k.FilterDependsOn(map[string]struct{}{"flux-system/infra": {}})
+	kept, dropped := FilterDependsOn(k.DependsOn, map[string]struct{}{"flux-system/infra": {}})
 	if len(kept) != 1 || kept[0].NamespacedName() != "flux-system/infra" {
 		t.Errorf("FilterDependsOn kept = %v", kept)
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -391,31 +391,54 @@ func (o *Orchestrator) resolveInputProvider(ref fluxopv1.InputProviderReference,
 	return out, nil
 }
 
-// validateDependsOn drops dangling dependsOn references so the
-// dependency-wait phase never blocks on a resource that will never
-// appear.
+// validateDependsOn drops dangling dependsOn references on both
+// Kustomizations and HelmReleases so the dependency-wait phase fails
+// fast on typos instead of stalling out the full per-dep budget.
+// Pre-2026-05-23 only Kustomizations were pruned, so a dangling
+// HR→HR dependsOn would hit the 30-second timeout.
 func (o *Orchestrator) validateDependsOn() {
-	known := make(map[string]struct{})
+	known := map[string]map[string]struct{}{
+		manifest.KindKustomization: {},
+		manifest.KindHelmRelease:   {},
+	}
 	ksList := o.store.ListObjects(manifest.KindKustomization)
 	for _, obj := range ksList {
 		if ks, ok := obj.(*manifest.Kustomization); ok {
-			known[ks.NamespacedName()] = struct{}{}
+			known[manifest.KindKustomization][ks.NamespacedName()] = struct{}{}
 		}
 	}
+	hrList := o.store.ListObjects(manifest.KindHelmRelease)
+	for _, obj := range hrList {
+		if hr, ok := obj.(*manifest.HelmRelease); ok {
+			known[manifest.KindHelmRelease][hr.NamespacedName()] = struct{}{}
+		}
+	}
+	// Store immutability contract: clone the struct, set the new slice
+	// on the clone, re-AddObject so listeners see the transition cleanly
+	// and any in-flight reader's pointer stays valid.
 	for _, obj := range ksList {
 		ks, ok := obj.(*manifest.Kustomization)
 		if !ok {
 			continue
 		}
-		kept, dropped := ks.FilterDependsOn(known)
+		kept, dropped := manifest.FilterDependsOn(ks.DependsOn, known[manifest.KindKustomization])
 		if dropped == 0 {
 			continue
 		}
-		// Store immutability contract: clone the struct, set the new
-		// slice on the clone, then re-AddObject so listeners see the
-		// transition cleanly and the existing pointer stays valid for
-		// any in-flight readers.
 		clone := *ks
+		clone.DependsOn = kept
+		o.store.AddObject(&clone)
+	}
+	for _, obj := range hrList {
+		hr, ok := obj.(*manifest.HelmRelease)
+		if !ok {
+			continue
+		}
+		kept, dropped := manifest.FilterDependsOn(hr.DependsOn, known[manifest.KindHelmRelease])
+		if dropped == 0 {
+			continue
+		}
+		clone := *hr
 		clone.DependsOn = kept
 		o.store.AddObject(&clone)
 	}

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -31,12 +31,17 @@ import (
 type Fetcher struct {
 	Cache   *source.Cache
 	Secrets source.SecretGetter
-	// httpsMu serializes the brief window where a per-CR HTTPS client
-	// is installed as go-git's global transport. go-git v5 does not
-	// expose per-CloneOptions TLS config, so custom-CA fetches must
-	// take this lock for the duration of the clone.
-	httpsMu sync.Mutex
 }
+
+// httpsTransportMu serializes the brief window where a per-CR HTTPS
+// client is installed as go-git's process-global transport. go-git v5
+// has no per-CloneOptions TLS hook, so custom-CA fetches must hold
+// this lock across InstallProtocol → clone → restore. The lock is
+// package-global because `client.InstallProtocol` is itself
+// process-global: a per-Fetcher mutex (as flate had pre-2026-05-23)
+// raced when `flate diff` ran two Fetchers concurrently and clobbered
+// each other's transport.
+var httpsTransportMu sync.Mutex
 
 // Fetch implements source.Fetcher for *manifest.GitRepository.
 func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
@@ -64,8 +69,8 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		return nil, err
 	}
 	if tlsCfg != nil {
-		f.httpsMu.Lock()
-		defer f.httpsMu.Unlock()
+		httpsTransportMu.Lock()
+		defer httpsTransportMu.Unlock()
 		tr := &http.Transport{TLSClientConfig: tlsCfg}
 		if proxy != nil {
 			pfn, perr := proxy.HTTPProxyFunc()

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -277,8 +278,14 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	}
 	// Persist the resolved digest so a subsequent cache hit can
 	// re-verify against the exact bytes we wrote, even when the spec
-	// pinned only a tag.
-	_ = writeCachedDigest(slot, digest)
+	// pinned only a tag. A write failure isn't fatal — the next fetch
+	// just falls through to a fresh pull — but it does silently weaken
+	// spec.verify on cache hits, so log it.
+	if err := writeCachedDigest(slot, digest); err != nil {
+		slog.Warn("oci: failed to persist cached digest",
+			"ociRepository", repo.Namespace+"/"+repo.Name,
+			"err", err)
+	}
 	return &store.SourceArtifact{
 		Kind: manifest.KindOCIRepository,
 		URL:  repo.URL, LocalPath: slot,


### PR DESCRIPTION
## Summary
Five tightly-scoped fixes from a multi-agent code review pass.

1. **\`pkg/source/git/git.go\`**: hoist InstallProtocol mutex from per-Fetcher to package-global. \`client.InstallProtocol\` mutates a process-global registry; the per-Fetcher lock raced in \`flate diff\` when two Fetchers ran concurrently.
2. **\`pkg/depwait/depwait.go\`**: drop the ctx-arm of the result-send select. Channel is buffered to \`len(deps)\` so sends never block; the ctx arm silently dropped events on cancellation, stalling consumers until the per-dep timeout fired.
3. **\`pkg/orchestrator/orchestrator.go\`** + **\`pkg/manifest/kustomization.go\`**: prune dangling \`dependsOn\` on HelmReleases too, not only Kustomizations. Extracted \`manifest.FilterDependsOn\` as a free function shared by both kinds.
4. **\`pkg/kustomize/flux.go\`**: \`%v\` → \`%w\` on the stat-error wrap so \`errors.Is\` works through the chain.
5. **\`pkg/source/oci/oci.go\`**: log a warn when the cached-digest write fails — silent skip was weakening \`spec.verify\` on cache hits.

## Test plan
- [x] \`go test ./...\` — all 28 packages pass
- [x] Existing 7-scope matrix unchanged
- [ ] Verify against billimek + onedr0p (next pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)