### PR TITLE
perf: list-objects by-kind index + skip envsubst round-trip on docs with no `${`

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	yaml "go.yaml.in/yaml/v4"
 
@@ -239,14 +240,18 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 // and unmarshals the result back. Per-doc substitution (rather than
 // substitute-the-whole-blob) lets us honor Flux's
 // "kustomize.toolkit.fluxcd.io/substitute: disabled" opt-out, which is
-// scoped to individual resources.
+// scoped to individual resources. The marshal/unmarshal round-trip is
+// load-bearing — it preserves Flux's YAML type-coercion semantics where
+// `replicas: ${REPLICAS}` (plain scalar) round-trips through envsubst
+// as int rather than string. Cheap pre-check on the decoded tree skips
+// the round-trip for the (common) case of docs with no `${` anywhere.
 func substituteDoc(doc map[string]any, vars map[string]string) (map[string]any, error) {
+	if !containsSubstitution(doc) {
+		return doc, nil
+	}
 	raw, err := yaml.Marshal(doc)
 	if err != nil {
 		return nil, fmt.Errorf("substitute: marshal doc: %w", err)
-	}
-	if !kustomize.HasSubstitutions(raw) {
-		return doc, nil
 	}
 	out, err := kustomize.Substitute(raw, vars)
 	if err != nil {
@@ -257,6 +262,30 @@ func substituteDoc(doc map[string]any, vars map[string]string) (map[string]any, 
 		return nil, fmt.Errorf("substitute: unmarshal doc: %w", err)
 	}
 	return next, nil
+}
+
+// containsSubstitution scans the decoded tree for any string leaf
+// containing `${`. Cheap walk over the parsed map avoids the
+// allocate-marshal-scan-discard pattern that dominated CPU on
+// kustomization reconciles when most docs had no substitutions at all.
+func containsSubstitution(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return strings.Contains(t, "${")
+	case map[string]any:
+		for _, vv := range t {
+			if containsSubstitution(vv) {
+				return true
+			}
+		}
+	case []any:
+		for _, vv := range t {
+			if containsSubstitution(vv) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // shouldDispatchAsObject reports whether a render-emitted Flux

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -176,15 +176,23 @@ func (s *Store) GetByName(kind, namespace, name string) manifest.BaseManifest {
 }
 
 // ListObjects returns every stored manifest, optionally filtered by kind.
-// An empty kind matches all objects.
+// An empty kind matches all objects. The byName index is hit directly
+// when kind is set — O(K) instead of O(N) — which matters on the
+// orchestrator's per-pass list calls when one kind dominates the
+// store (HelmReleases are typically the bulk).
 func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	out := make([]manifest.BaseManifest, 0, len(s.objects))
-	for id, obj := range s.objects {
-		if kind != "" && id.Kind != kind {
-			continue
+	if kind != "" {
+		inner := s.byName[kind]
+		out := make([]manifest.BaseManifest, 0, len(inner))
+		for _, obj := range inner {
+			out = append(out, obj)
 		}
+		return out
+	}
+	out := make([]manifest.BaseManifest, 0, len(s.objects))
+	for _, obj := range s.objects {
 		out = append(out, obj)
 	}
 	return out


### PR DESCRIPTION
## Summary
Two hot-path wins from the multi-agent review:

1. **\`Store.ListObjects(kind)\` uses the byName index when kind is set** — O(K) instead of O(N). The previous full-map walk + filter pattern got hit by every orchestrator pass and most controllers. With HelmReleases dominating large repos, callers asking for \`ListObjects(KindGitRepository)\` were doing N/K extra work.

2. **\`substituteDoc\` pre-checks the decoded tree for \`\${\` before marshaling** — most docs in a substitute-enabled Kustomization don't reference any var. We were paying for a yaml.Marshal + byte scan + discard per doc. The marshal/unmarshal round-trip stays for docs that DO have \`\${\` references — it's load-bearing for Flux's bit-for-bit type coercion (\`replicas: \${REPLICAS}\` → int after substitution).

## Test plan
- [x] \`go test ./...\` clean across 28 packages
- [x] 5-scope diff matrix (bjw-s-labs / buroa / m00nwtchr / drag0n141 / jory-main): all \`failed=0\`, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)