### PR TITLE
chore: purge dead code from review pass

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -199,11 +199,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		c.Store.AddRendered(obj)
 	}
 
-	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{
-		ChartName: hr.Chart.ChartName(),
-		Manifests: docs,
-		Values:    hr.Values,
-	})
+	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs})
 	return nil
 }
 

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -47,14 +47,6 @@ type Event struct {
 	Reason string
 }
 
-// Success reports whether the dependency reached DepReady.
-func (e Event) Success() bool { return e.Status == DepReady }
-
-// Failure reports whether the dependency reached a terminal non-success state.
-func (e Event) Failure() bool {
-	return e.Status == DepFailed || e.Status == DepTimeout || e.Status == DepCancelled
-}
-
 // Summary tallies the final state of a Waiter run.
 type Summary struct {
 	Ready    []manifest.NamedResource

--- a/pkg/kustomize/doc.go
+++ b/pkg/kustomize/doc.go
@@ -2,8 +2,8 @@
 // flate never invokes the `kustomize` CLI. It provides:
 //
 //   - Build: renders a kustomization directory to YAML documents.
-//   - Filtering helpers (FilterKinds / ExcludeKinds) that mirror
-//     flux-local's chainable Kustomize wrapper.
+//   - Filtering helpers (FilterKinds) that mirror flux-local's
+//     chainable Kustomize wrapper.
 //   - Variable substitution (envsubst-style "${VAR}" and "${VAR:=default}")
 //     for Flux post-build substitutions.
 //

--- a/pkg/kustomize/filter.go
+++ b/pkg/kustomize/filter.go
@@ -17,16 +17,6 @@ func FilterKinds(docs []map[string]any, keep []string) []map[string]any {
 	})
 }
 
-// ExcludeKinds returns a new slice with documents whose `kind` is NOT
-// in skip.
-func ExcludeKinds(docs []map[string]any, skip []string) []map[string]any {
-	if len(skip) == 0 {
-		return docs
-	}
-	return filter(docs, func(doc map[string]any) bool {
-		return !slices.Contains(skip, manifest.DocKind(doc))
-	})
-}
 
 // filter returns the elements of docs for which pred is true, without
 // mutating the input slice.

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -46,10 +46,6 @@ func TestFilterKinds(t *testing.T) {
 	if len(out) != 1 || out[0]["kind"] != "ConfigMap" {
 		t.Errorf("FilterKinds: %+v", out)
 	}
-	out = ExcludeKinds(docs, []string{"Secret", "Service"})
-	if len(out) != 1 || out[0]["kind"] != "ConfigMap" {
-		t.Errorf("ExcludeKinds: %+v", out)
-	}
 }
 
 func TestSubstitute(t *testing.T) {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -40,7 +40,7 @@ func TestNamedResource(t *testing.T) {
 
 	a := NamedResource{Kind: "A", Namespace: "ns", Name: "1"}
 	b := NamedResource{Kind: "A", Namespace: "ns", Name: "2"}
-	if !a.Less(b) || a.Compare(b) >= 0 {
+	if a.Compare(b) >= 0 {
 		t.Errorf("expected a < b for %v / %v", a, b)
 	}
 }

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -56,9 +56,6 @@ func (n NamedResource) Compare(other NamedResource) int {
 	return cmp.Compare(n.Name, other.Name)
 }
 
-// Less is the sort.Interface-style predicate.
-func (n NamedResource) Less(other NamedResource) bool { return n.Compare(other) < 0 }
-
 // BaseManifest is the marker interface every domain object implements.
 // Concrete handling is done via type assertions in each controller.
 type BaseManifest interface {

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -29,9 +29,6 @@ func NewCache(dir string) *Cache {
 	return &Cache{root: cmp.Or(dir, filepath.Join(os.TempDir(), "flate-cache"))}
 }
 
-// Root returns the cache root directory.
-func (c *Cache) Root() string { return c.root }
-
 // Slot returns the path under which (url, ref) should be cached. The
 // returned directory is created if it does not already exist. The
 // returned exists flag is true when the directory was already populated.

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -42,22 +42,17 @@ func (*SourceArtifact) artifact() {}
 type KustomizationArtifact struct {
 	Path      string
 	Manifests []map[string]any
-	Revision  string
 }
 
 func (*KustomizationArtifact) artifact() {}
 
-// RenderedManifests returns the manifests rendered by the Kustomization.
 func (a *KustomizationArtifact) RenderedManifests() []map[string]any { return a.Manifests }
 
 // HelmReleaseArtifact is the rendered output of a HelmRelease template.
 type HelmReleaseArtifact struct {
-	ChartName string
 	Manifests []map[string]any
-	Values    map[string]any
 }
 
 func (*HelmReleaseArtifact) artifact() {}
 
-// RenderedManifests returns the manifests rendered by the HelmRelease.
 func (a *HelmReleaseArtifact) RenderedManifests() []map[string]any { return a.Manifests }

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -35,9 +35,8 @@ type Condition = metav1.Condition
 // conventions so a future watch-mode could publish to a real cluster
 // without translating.
 const (
-	ConditionReady       = "Ready"
-	ConditionReconciling = "Reconciling"
-	ConditionHealthy     = "Healthy"
+	ConditionReady   = "Ready"
+	ConditionHealthy = "Healthy"
 )
 
 // Condition reasons attached to the Ready condition.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -300,18 +300,6 @@ func (s *Store) GetArtifact(id manifest.NamedResource) Artifact {
 	return s.artifacts[id]
 }
 
-// HasFailedResources reports whether any tracked Ready condition is False.
-func (s *Store) HasFailedResources() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, conds := range s.conditions {
-		if info, ok := statusInfoFromConditions(conds); ok && info.Status == StatusFailed {
-			return true
-		}
-	}
-	return false
-}
-
 // FailedResources returns every (id, info) currently in Failed state.
 func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 	s.mu.RLock()

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -160,18 +160,15 @@ func TestStore_SetCondition_IdenticalIsNoOp(t *testing.T) {
 	}
 }
 
-func TestStore_HasFailedResources(t *testing.T) {
+func TestStore_FailedResources(t *testing.T) {
 	s := New()
-	if s.HasFailedResources() {
+	if len(s.FailedResources()) != 0 {
 		t.Errorf("empty store should not have failures")
 	}
 	id := manifest.NamedResource{Kind: "Kustomization", Name: "x"}
 	s.UpdateStatus(id, StatusFailed, "boom")
-	if !s.HasFailedResources() {
-		t.Errorf("expected failures after Failed status")
-	}
-	if len(s.FailedResources()) != 1 {
-		t.Errorf("FailedResources count: %d", len(s.FailedResources()))
+	if got := len(s.FailedResources()); got != 1 {
+		t.Errorf("FailedResources count: %d, want 1", got)
 	}
 }
 

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -142,10 +141,3 @@ func (s *Store) WatchExists(ctx context.Context, id manifest.NamedResource) (man
 	}
 }
 
-// String formatter is occasionally useful for tests.
-func (s *Store) String() string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return fmt.Sprintf("Store{objects:%d, conditions:%d, artifacts:%d}",
-		len(s.objects), len(s.conditions), len(s.artifacts))
-}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -103,9 +103,6 @@ func (s *Service) YieldSlot(fn func()) {
 	fn()
 }
 
-// ActiveCount returns the number of currently active tasks.
-func (s *Service) ActiveCount() int64 { return s.active.Load() }
-
 // Failures returns the number of panicked tasks observed.
 func (s *Service) Failures() int64 { return s.failures.Load() }
 

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -69,9 +69,6 @@ func TestService_BlockTillDone(t *testing.T) {
 	if n.Load() != 50 {
 		t.Errorf("expected 50, got %d", n.Load())
 	}
-	if s.ActiveCount() != 0 {
-		t.Errorf("ActiveCount: %d", s.ActiveCount())
-	}
 }
 
 func TestService_PanicCountedAndRecovered(t *testing.T) {


### PR DESCRIPTION
## Summary
Ten dead exports / fields / constants from the multi-agent review, each independently grep-verified before deletion:

- \`HelmReleaseArtifact.{ChartName,Values}\` and \`KustomizationArtifact.Revision\` — set by controllers, never read
- \`Store.String()\` — debug-only, no callers
- \`Store.HasFailedResources\` — only its own test; \`FailedResources()\` is the surviving primitive
- \`NamedResource.Less\` — \`Compare\` covers real callers
- \`Cache.Root()\` — zero callers
- \`ExcludeKinds\` — only its own test; \`FilterKinds\` survives
- \`ConditionReconciling\` constant — unused
- \`Service.ActiveCount\` — only its own test
- \`Event.{Success,Failure}\` — consumers branch on \`.Status\` directly

## Test plan
- [x] \`go test ./...\` clean
- [x] Surface shrinks ~80 LOC across 9 files; nothing in production paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)