### PR TITLE
fix: store-immutability violations + 4 resource-leak / cleanup bugs

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -144,6 +144,11 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		}
 	}
 
+	// Clone before mutating: ResolveChartRef rewrites hr.Chart in place
+	// and ExpandValueReferences writes hr.Values. The store-owned HR
+	// stays canonical so concurrent readers (e.g. dependsOn watchers
+	// reading hr.Chart for a sibling reconcile) never see torn state.
+	hr = hr.Clone()
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
 
 	helmCharts := c.gatherHelmChartSources()

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -132,6 +132,12 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		return err
 	}
 
+	// Clone before mutating: ExpandPostBuildSubstituteReference writes
+	// into ks.PostBuildSubstitute and the nested ks.Contents tree.
+	// The store-owned object stays canonical so concurrent readers
+	// (e.g. an HR controller resolving a chartRef while this KS is
+	// rendering) never observe torn state.
+	ks = ks.Clone()
 	c.Store.UpdateStatus(id, store.StatusPending, "expanding substitutions")
 	provider := values.NewStoreProvider(c.Store)
 	if err := values.ExpandPostBuildSubstituteReference(ks, provider); err != nil {

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -266,6 +266,7 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 		return nil, err
 	}
 	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
 	if _, err := tmp.Write(buf.Bytes()); err != nil {
 		_ = tmp.Close()
 		return nil, err
@@ -273,7 +274,6 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 	if err := tmp.Close(); err != nil {
 		return nil, err
 	}
-	defer func() { _ = os.Remove(tmpPath) }()
 	idx, err := repo.LoadIndexFile(tmpPath)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", indexURL, err)

--- a/pkg/manifest/deepcopy.go
+++ b/pkg/manifest/deepcopy.go
@@ -1,0 +1,31 @@
+package manifest
+
+// DeepCopyMap returns a deep copy of m suitable for in-place mutation
+// without aliasing the source. Walks nested maps and slices; scalars
+// are copied by value. Used by Kustomization.Clone / HelmRelease.Clone
+// to isolate render-time mutations from the canonical store-owned
+// state.
+func DeepCopyMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+func deepCopyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return DeepCopyMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, vv := range t {
+			out[i] = deepCopyValue(vv)
+		}
+		return out
+	}
+	return v
+}

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -216,6 +217,18 @@ type HelmRelease struct {
 // Named identifies the release.
 func (h *HelmRelease) Named() NamedResource {
 	return NamedResource{Kind: KindHelmRelease, Namespace: h.Namespace, Name: h.Name}
+}
+
+// Clone returns a copy of h safe for in-place mutation during a single
+// reconcile pass. Deep-copies the maps and slices reconcile writes to
+// (Values, ChartValuesFiles, DependsOn) so the canonical store-owned
+// object is never observed mid-mutation by other goroutines.
+func (h *HelmRelease) Clone() *HelmRelease {
+	out := *h
+	out.Values = DeepCopyMap(h.Values)
+	out.ChartValuesFiles = slices.Clone(h.ChartValuesFiles)
+	out.DependsOn = slices.Clone(h.DependsOn)
+	return &out
 }
 
 // ReleaseName returns the resolved Helm release name — spec.releaseName

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -71,6 +71,17 @@ func (k *Kustomization) Named() NamedResource {
 	return NamedResource{Kind: KindKustomization, Namespace: k.Namespace, Name: k.Name}
 }
 
+// Clone returns a copy of k safe for in-place mutation during a single
+// reconcile pass. Deep-copies the maps reconcile writes to (Contents,
+// PostBuildSubstitute) so the canonical store-owned object is never
+// observed mid-mutation by other goroutines.
+func (k *Kustomization) Clone() *Kustomization {
+	out := *k
+	out.Contents = DeepCopyMap(k.Contents)
+	out.PostBuildSubstitute = maps.Clone(k.PostBuildSubstitute)
+	return &out
+}
+
 // NamespacedName is "<namespace>/<name>".
 func (k *Kustomization) NamespacedName() string { return k.Namespace + "/" + k.Name }
 

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -292,10 +292,12 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 		ref = *repo.Reference
 	}
 	if err := checkoutRef(cloned, ref, repo.SparseCheckout); err != nil {
+		_ = cache.Reset(slot)
 		return nil, fmt.Errorf("checkout %s: %w", refStr, err)
 	}
 	if repo.RecurseSubmodules {
 		if err := updateSubmodules(cloned, auth); err != nil {
+			_ = cache.Reset(slot)
 			return nil, fmt.Errorf("submodules: %w", err)
 		}
 	}

--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -208,13 +208,22 @@ func (f *Fetcher) loadCosignPublicKeys(repo *manifest.OCIRepository) ([]crypto.P
 			repo.Namespace, repo.Name, repo.Namespace, repo.Verify.SecretRef.Name)
 	}
 	var keys []crypto.PublicKey
-	for k, v := range sec.StringData {
-		s, ok := v.(string)
-		if !ok || s == "" {
-			continue
-		}
-		// Treat the --wipe-secrets placeholder as missing.
-		if s = source.StringFromSecret(sec, k); s == "" {
+	// Iterate the union of StringData + Data keys so PEM blocks stored
+	// under either field are discovered. k8s Secrets typically put
+	// `cosign.pub` under `data:` (base64-encoded); StringData is the
+	// at-apply-time convenience field.
+	seen := make(map[string]struct{}, len(sec.StringData)+len(sec.Data))
+	for k := range sec.StringData {
+		seen[k] = struct{}{}
+	}
+	for k := range sec.Data {
+		seen[k] = struct{}{}
+	}
+	for k := range seen {
+		// StringFromSecret prefers StringData over Data and strips the
+		// PLACEHOLDER_-wipe marker, so callers see "" for wiped values.
+		s := source.StringFromSecret(sec, k)
+		if s == "" {
 			continue
 		}
 		parsed := parsePEMPublicKeys([]byte(s))

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -257,23 +257,23 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 
 	desc, err := oras.Copy(ctx, repoClient, tag, dest, tag, oras.DefaultCopyOptions)
 	if err != nil {
-		_ = os.RemoveAll(slot)
+		_ = cache.Reset(slot)
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
 	digest := desc.Digest.String()
 	if repo.Verify != nil {
 		if err := f.verifyCosignSignature(ctx, repoClient, repo, digest); err != nil {
-			_ = os.RemoveAll(slot)
+			_ = cache.Reset(slot)
 			return nil, err
 		}
 	}
 	if err := applyLayerSelector(ctx, repoClient, slot, desc.Digest.String(), repo.LayerSelector); err != nil {
-		_ = os.RemoveAll(slot)
+		_ = cache.Reset(slot)
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
 	if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
-		_ = os.RemoveAll(slot)
+		_ = cache.Reset(slot)
 		return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
 	}
 	// Persist the resolved digest so a subsequent cache hit can


### PR DESCRIPTION
## Summary
Five HIGH-severity correctness bugs from a second multi-agent review pass:

1. **Store-immutability violations** in kustomization + helmrelease controllers — \`ExpandPostBuildSubstituteReference\`, \`ResolveChartRef\`, \`ExpandValueReferences\` mutated the store-owned object in place. Added \`Kustomization.Clone()\` and \`HelmRelease.Clone()\` (deep-copying the maps reconcile writes); render operates on the local clone.
2. **Git slot stale-cache on checkout failure** — \`checkoutRef\` / \`updateSubmodules\` errors left a half-populated slot that future fetches would PlainOpen as a corrupt artifact. Added \`cache.Reset(slot)\` on those paths.
3. **\`fetchIndex\` temp leak** — \`defer os.Remove\` registered after Write + Close succeeded, leaking on either failure. Moved defer immediately after CreateTemp.
4. **OCI fetch bypassing cache.Reset** — error paths used \`os.RemoveAll(slot)\` directly, racing the cache mutex. Switched to \`cache.Reset\`.
5. **Cosign keys hidden in \`Secret.Data\`** — only \`StringData\` was iterated, missing keys stored under \`data:\` (base64). Walk the union.

## Test plan
- [x] \`go test ./...\` clean
- [x] 5-repo diff matrix all \`failed=0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)