### PR TITLE
perf+fix: O(K²)→O(K·depth) BuildParentIndex; change-filter keepByName symmetric

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -67,10 +67,12 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	if _, ok := f.keep[id]; ok {
 		return true
 	}
-	if id.Namespace != "" {
-		if _, ok := f.keepByName[nameKey{id.Kind, id.Name}]; ok {
-			return true
-		}
+	// Fall back to a (Kind, Name)-only lookup when EITHER side has an
+	// empty namespace — parent-KS targetNamespace inheritance is lazy,
+	// so a keep-set entry from disk-load (namespace=="") and a lookup
+	// after inheritance (namespace set) refer to the same resource.
+	if _, ok := f.keepByName[nameKey{id.Kind, id.Name}]; ok {
+		return true
 	}
 	return false
 }
@@ -157,11 +159,13 @@ func (f *Filter) resolve(objs ObjectLister) {
 	}
 	f.keep = keep
 
+	// Index every keep-set entry by (kind, name) so the namespace-tolerant
+	// lookup path (ShouldReconcile when either side's namespace is empty)
+	// finds it. The full id is still required for the primary keep map —
+	// this is purely the namespace-degenerate fallback.
 	f.keepByName = make(map[nameKey]struct{}, len(keep))
 	for id := range keep {
-		if id.Namespace == "" {
-			f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
-		}
+		f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
 	}
 }
 

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -36,6 +37,13 @@ func BuildParentIndex(s *store.Store, sourceFiles map[manifest.NamedResource]str
 		}
 		owners = append(owners, owner{prefix: normalizePrefix(ks.Path), id: ks.Named()})
 	}
+	// Sort by prefix length descending so the longest-prefix parent
+	// (the most specific structural owner) is the first match in the
+	// inner loop; we can short-circuit on first hit. Drops the worst
+	// case from O(K²) to O(K · depth) and the typical case to O(K).
+	sort.Slice(owners, func(i, j int) bool {
+		return len(owners[i].prefix) > len(owners[j].prefix)
+	})
 	out := map[manifest.NamedResource]manifest.NamedResource{}
 	for _, obj := range s.ListObjects(manifest.KindKustomization) {
 		ks, ok := obj.(*manifest.Kustomization)
@@ -48,20 +56,14 @@ func BuildParentIndex(s *store.Store, sourceFiles map[manifest.NamedResource]str
 			continue
 		}
 		slashFile := filepath.ToSlash(file)
-		var best owner
 		for _, o := range owners {
 			if o.id == id {
 				continue
 			}
-			if !strings.HasPrefix(slashFile, o.prefix) {
-				continue
+			if strings.HasPrefix(slashFile, o.prefix) {
+				out[id] = o.id
+				break
 			}
-			if len(o.prefix) > len(best.prefix) {
-				best = o
-			}
-		}
-		if best.prefix != "" {
-			out[id] = best.id
 		}
 	}
 	return out


### PR DESCRIPTION
## Summary
Two second-pass review findings.

1. **\`pkg/loader/parent.go\`**: \`BuildParentIndex\` walked all owners for every KS doing a full scan to find the longest-prefix match — O(K²). Sort owners by prefix length descending once, short-circuit the inner loop on first match. Worst case becomes O(K · depth); typical case O(K).

2. **\`pkg/change/filter.go\`**: \`keepByName\` only indexed entries with empty namespace, and only consulted when the lookup had a namespace — asymmetric despite the "either side" comment. Index every keep-set entry; consult \`keepByName\` whenever the id-keyed lookup misses.

## Test plan
- [x] \`go test ./...\` clean
- [x] 5-repo \`test ks\` matrix still passes (m00nwtchr's failures are pre-existing repo issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)