### PR TITLE
test: cover containsSubstitution, ListObjects byName, HR FilterDependsOn, Clone

### DIFF
--- a/pkg/controllers/kustomization/substitute_test.go
+++ b/pkg/controllers/kustomization/substitute_test.go
@@ -1,0 +1,84 @@
+package kustomization
+
+import "testing"
+
+// containsSubstitution gates whether substituteDoc pays for a full
+// YAML marshal/unmarshal round-trip. Walks the decoded tree looking
+// for any string leaf containing `${`. Test the obvious shapes.
+func TestContainsSubstitution(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty map", map[string]any{}, false},
+		{"plain scalars only", map[string]any{
+			"a": "literal", "b": 3, "c": true,
+		}, false},
+		{"top-level scalar with ${", map[string]any{
+			"a": "${VAR}",
+		}, true},
+		{"nested in list", map[string]any{
+			"data": []any{"first", "${VAR}", "third"},
+		}, true},
+		{"deeply nested", map[string]any{
+			"spec": map[string]any{
+				"containers": []any{
+					map[string]any{"image": "ghcr.io/x:${TAG}"},
+				},
+			},
+		}, true},
+		{"string with dollar but no brace", map[string]any{"a": "price$5"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := containsSubstitution(tc.in); got != tc.want {
+				t.Errorf("containsSubstitution = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// substituteDoc skips the marshal/unmarshal round-trip when no `${` is
+// present anywhere — pure pass-through with no allocations from yaml.
+func TestSubstituteDoc_NoSubstitutionShortCircuits(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "cm"},
+		"data":       map[string]any{"key": "literal"},
+	}
+	out, err := substituteDoc(doc, map[string]string{"VAR": "x"})
+	if err != nil {
+		t.Fatalf("substituteDoc: %v", err)
+	}
+	// Same pointer identity: short-circuit returned the input untouched.
+	if &out == &doc {
+		// Note: maps are reference types; &doc compares header addresses
+		// which are stack-local. The real assertion is that the returned
+		// map is the SAME map, which we verify via mutation visibility.
+	}
+	out["data"].(map[string]any)["new"] = "marker"
+	if doc["data"].(map[string]any)["new"] != "marker" {
+		t.Errorf("expected short-circuit to return the input map; got a copy")
+	}
+}
+
+// substituteDoc round-trips through YAML for type-coercion when `${`
+// is present — `replicas: ${N}` ends up as int after substitution.
+func TestSubstituteDoc_PreservesYAMLTypeCoercion(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+		"spec":       map[string]any{"replicas": "${REPLICAS}"},
+	}
+	out, err := substituteDoc(doc, map[string]string{"REPLICAS": "3"})
+	if err != nil {
+		t.Fatalf("substituteDoc: %v", err)
+	}
+	spec := out["spec"].(map[string]any)
+	if rep, _ := spec["replicas"].(int); rep != 3 {
+		t.Errorf("replicas = %v (%T), want int 3 (yaml round-trip should coerce)", spec["replicas"], spec["replicas"])
+	}
+}

--- a/pkg/manifest/deepcopy_test.go
+++ b/pkg/manifest/deepcopy_test.go
@@ -1,0 +1,96 @@
+package manifest
+
+import "testing"
+
+// DeepCopyMap must produce an independent tree — mutating the copy
+// can't bleed into the original or vice versa. Used by Kustomization.
+// Clone and HelmRelease.Clone to isolate reconcile-time mutations.
+func TestDeepCopyMap_Isolation(t *testing.T) {
+	src := map[string]any{
+		"top": "scalar",
+		"nested": map[string]any{
+			"k": "v",
+			"list": []any{
+				map[string]any{"x": "y"},
+				"z",
+			},
+		},
+	}
+	dst := DeepCopyMap(src)
+
+	// Mutate the copy at every nesting level. Source should be intact.
+	dst["top"] = "MUTATED"
+	dst["nested"].(map[string]any)["k"] = "MUTATED"
+	dst["nested"].(map[string]any)["list"].([]any)[0].(map[string]any)["x"] = "MUTATED"
+	dst["nested"].(map[string]any)["list"].([]any)[1] = "MUTATED"
+
+	if src["top"] != "scalar" {
+		t.Errorf("source top leaked: %v", src["top"])
+	}
+	if src["nested"].(map[string]any)["k"] != "v" {
+		t.Errorf("source nested leaked: %v", src["nested"])
+	}
+	if src["nested"].(map[string]any)["list"].([]any)[0].(map[string]any)["x"] != "y" {
+		t.Errorf("source deep nested leaked")
+	}
+	if src["nested"].(map[string]any)["list"].([]any)[1] != "z" {
+		t.Errorf("source list leaked")
+	}
+}
+
+func TestDeepCopyMap_Nil(t *testing.T) {
+	if DeepCopyMap(nil) != nil {
+		t.Errorf("nil source should produce nil")
+	}
+}
+
+// HelmRelease.Clone must produce a HR whose mutable fields don't alias
+// the source — critical for the store-immutability contract.
+func TestHelmRelease_Clone_Isolation(t *testing.T) {
+	src := &HelmRelease{
+		Name: "plex", Namespace: "media",
+		Values:           map[string]any{"replicas": 1, "nested": map[string]any{"k": "v"}},
+		ChartValuesFiles: []string{"values.yaml"},
+	}
+	dst := src.Clone()
+	dst.Values["replicas"] = 99
+	dst.Values["nested"].(map[string]any)["k"] = "MUTATED"
+	dst.ChartValuesFiles[0] = "MUTATED"
+
+	if src.Values["replicas"] != 1 {
+		t.Errorf("source Values aliased: %v", src.Values["replicas"])
+	}
+	if src.Values["nested"].(map[string]any)["k"] != "v" {
+		t.Errorf("source nested Values aliased: %v", src.Values["nested"])
+	}
+	if src.ChartValuesFiles[0] != "values.yaml" {
+		t.Errorf("source ChartValuesFiles aliased: %v", src.ChartValuesFiles)
+	}
+}
+
+// Kustomization.Clone must deep-copy Contents — the nested map that
+// UpdatePostBuildSubstitutions walks and writes into.
+func TestKustomization_Clone_Isolation(t *testing.T) {
+	src := &Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		PostBuildSubstitute: map[string]any{"K": "v"},
+		Contents: map[string]any{
+			"spec": map[string]any{
+				"postBuild": map[string]any{
+					"substitute": map[string]any{"X": "y"},
+				},
+			},
+		},
+	}
+	dst := src.Clone()
+	dst.PostBuildSubstitute["K"] = "MUTATED"
+	dst.Contents["spec"].(map[string]any)["postBuild"].(map[string]any)["substitute"].(map[string]any)["X"] = "MUTATED"
+
+	if src.PostBuildSubstitute["K"] != "v" {
+		t.Errorf("source PostBuildSubstitute aliased")
+	}
+	srcSub := src.Contents["spec"].(map[string]any)["postBuild"].(map[string]any)["substitute"].(map[string]any)
+	if srcSub["X"] != "y" {
+		t.Errorf("source Contents aliased: %v", srcSub)
+	}
+}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -799,6 +799,35 @@ spec:
 	}
 }
 
+// FilterDependsOn is the free function shared by KS and HR pruning;
+// verify it works on a synthetic HR-style dep list too.
+func TestFilterDependsOn_AcrossKinds(t *testing.T) {
+	deps := []DependencyRef{
+		{NamedResource: NamedResource{Kind: KindHelmRelease, Namespace: "media", Name: "plex"}},
+		{NamedResource: NamedResource{Kind: KindHelmRelease, Namespace: "media", Name: "gone"}},
+	}
+	known := map[string]struct{}{"media/plex": {}}
+	kept, dropped := FilterDependsOn(deps, known)
+	if len(kept) != 1 || kept[0].NamespacedName() != "media/plex" {
+		t.Errorf("kept = %v", kept)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+
+	// nil-known: every dep dropped.
+	_, dropped = FilterDependsOn(deps, nil)
+	if dropped != 2 {
+		t.Errorf("nil-known dropped = %d, want 2", dropped)
+	}
+
+	// empty deps: no work, no allocation.
+	out, dropped := FilterDependsOn(nil, known)
+	if out != nil || dropped != 0 {
+		t.Errorf("empty deps: out=%v dropped=%d", out, dropped)
+	}
+}
+
 func TestKustomization_UpdatePostBuildSubstitutions(t *testing.T) {
 	k := &Kustomization{Contents: map[string]any{"spec": map[string]any{}}}
 	k.UpdatePostBuildSubstitutions(map[string]any{"K": "v"})

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -172,6 +172,31 @@ func TestStore_FailedResources(t *testing.T) {
 	}
 }
 
+// PR125 switched ListObjects(kind) to a byName-index walk when kind is
+// non-empty. Verify it returns exactly the entries for that kind, that
+// the empty-kind path still walks everything, and that DeleteObject
+// keeps the secondary index consistent.
+func TestStore_ListObjects_ByKindIndex(t *testing.T) {
+	s := New()
+	s.AddObject(newCM("a", "ns1"))
+	s.AddObject(newCM("b", "ns2"))
+	s.AddObject(&manifest.Secret{Name: "s", Namespace: "ns1"})
+
+	if got := len(s.ListObjects(manifest.KindConfigMap)); got != 2 {
+		t.Errorf("ListObjects(KindConfigMap) = %d, want 2", got)
+	}
+	if got := len(s.ListObjects(manifest.KindSecret)); got != 1 {
+		t.Errorf("ListObjects(KindSecret) = %d, want 1", got)
+	}
+	if got := len(s.ListObjects("")); got != 3 {
+		t.Errorf("ListObjects(\"\") = %d, want 3", got)
+	}
+	s.DeleteObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns1", Name: "a"})
+	if got := len(s.ListObjects(manifest.KindConfigMap)); got != 1 {
+		t.Errorf("after Delete: ListObjects(KindConfigMap) = %d, want 1", got)
+	}
+}
+
 func TestStore_WatchReady_AlreadyReady(t *testing.T) {
 	s := New()
 	id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}


### PR DESCRIPTION
## Summary
Tests the second-pass review flagged as missing for recent PRs:

- **PR 125** (envsubst pre-check + ListObjects byName): \`containsSubstitution\` table tests (nil/empty/scalars/nested-in-list/deeply-nested/dollar-no-brace), \`substituteDoc\` short-circuit verification + YAML type-coercion preservation, \`TestStore_ListObjects_ByKindIndex\` + Delete consistency
- **PR 124** (HR FilterDependsOn pruning): \`TestFilterDependsOn_AcrossKinds\` exercises the free function with synthetic HR deps + nil-known + empty-deps edges
- **PR 129** (Clone deep-copy): \`TestDeepCopyMap_Isolation\` + \`TestHelmRelease_Clone_Isolation\` + \`TestKustomization_Clone_Isolation\` — mutate every nesting depth, source stays intact

## Test plan
- [x] All new tests pass
- [x] \`go test ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)