### PR TITLE
refactor: ExistenceFetcher in source controller; canonical BootstrapSourceID

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -351,15 +351,6 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 	return deps
 }
 
-// bootstrapSourceID is the synthetic GitRepository the orchestrator
-// seeds for the user's working tree. Children that inherit sourceRef
-// only from a parent's render patches (a common onedr0p-style pattern)
-// look empty until the parent reconciles, so resolveSourceRoot uses
-// this as the fallback rather than mis-joining ks.Path against itself.
-var bootstrapSourceID = manifest.NamedResource{
-	Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "flux-system",
-}
-
 // resolveSourceRoot returns the on-disk root the kustomization should
 // be built from — i.e. the source artifact's local path. The Flux
 // renderer then joins ks.Path onto this root.
@@ -375,7 +366,7 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 			return "", fmt.Errorf("%w: kustomization %s has no path and no source",
 				manifest.ErrInput, ks.NamespacedName())
 		}
-		srcID = bootstrapSourceID
+		srcID = manifest.BootstrapSourceID
 	}
 	art := c.Store.GetArtifact(srcID)
 	if art == nil {

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -113,6 +113,13 @@ func (c *Controller) runFetch(ctx context.Context, id manifest.NamedResource, ob
 		c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
 		return
 	}
-	c.Store.SetArtifact(id, artifact)
+	// An ExistenceFetcher returns (nil, nil) — the kind doesn't produce
+	// an on-disk artifact (HelmRepository; OCIRepository when fetching
+	// is disabled). Mark Ready without writing an artifact so dependsOn
+	// watchers unblock and chart resolution falls through to whichever
+	// mechanism actually serves the chart.
+	if artifact != nil {
+		c.Store.SetArtifact(id, artifact)
+	}
 	c.Store.UpdateStatus(id, store.StatusReady, "")
 }

--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -33,6 +33,16 @@ const (
 // in `flux-system` when no namespace is declared.
 const DefaultNamespace = "flux-system"
 
+// BootstrapSourceID is the synthetic GitRepository the orchestrator
+// seeds for the user's local working tree. Child Kustomizations whose
+// sourceRef is patched in by a parent's render fall back to this id
+// when their own SourceRef is still empty (#105 — see resolveSourceRoot).
+// Exported so orchestrator and kustomization controller share one
+// declaration.
+var BootstrapSourceID = NamedResource{
+	Kind: KindGitRepository, Namespace: DefaultNamespace, Name: DefaultNamespace,
+}
+
 // HelmRepository types as understood by Flux.
 const (
 	RepoTypeDefault = "default"

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -128,11 +128,20 @@ func New(cfg Config) (*Orchestrator, error) {
 		manifest.KindGitRepository:    &git.Fetcher{Cache: cache, Secrets: secretGet},
 		manifest.KindExternalArtifact: &external.Fetcher{},
 		manifest.KindBucket:           &bucket.Fetcher{Cache: cache, Secrets: secretGet},
+		// HelmRepository: existence-only — flate resolves charts via the
+		// Helm client's registry/repo machinery directly, the controller
+		// just needs the resource to land in Ready so HelmRelease deps
+		// unblock.
+		manifest.KindHelmRepository: source.ExistenceFetcher{},
 	}
 	if cfg.EnableOCI {
 		fetchers[manifest.KindOCIRepository] = &oci.Fetcher{
 			Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet,
 		}
+	} else {
+		// --enable-oci=false: skip the real fetch but still mark each
+		// OCIRepository Ready so HRs that dependsOn one don't time out.
+		fetchers[manifest.KindOCIRepository] = source.ExistenceFetcher{}
 	}
 	o := &Orchestrator{
 		cfg:   cfg,
@@ -170,7 +179,6 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 		return err
 	}
 	o.validateDependsOn()
-	o.markExistenceOnlyReady()
 	return o.buildChangeFilter(repoRoot)
 }
 
@@ -184,7 +192,7 @@ func (o *Orchestrator) seedBootstrapSource() (string, error) {
 	root := findRepoRoot(abs)
 
 	repo := &manifest.GitRepository{
-		Name: "flux-system", Namespace: "flux-system",
+		Name: manifest.BootstrapSourceID.Name, Namespace: manifest.BootstrapSourceID.Namespace,
 		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
 	}
 	id := repo.Named()
@@ -498,21 +506,6 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 		}
 	}
 	return out
-}
-
-// markExistenceOnlyReady marks HelmRepository (always) and
-// OCIRepository (when source-controller is disabled) as Ready so
-// HelmRelease waits can resolve without a real fetch.
-func (o *Orchestrator) markExistenceOnlyReady() {
-	for _, obj := range o.store.ListObjects(manifest.KindHelmRepository) {
-		o.store.UpdateStatus(obj.Named(), store.StatusReady, "")
-	}
-	if o.cfg.EnableOCI {
-		return
-	}
-	for _, obj := range o.store.ListObjects(manifest.KindOCIRepository) {
-		o.store.UpdateStatus(obj.Named(), store.StatusReady, "")
-	}
 }
 
 // buildChangeFilter computes the file-level change set (if changed-only

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -38,6 +38,20 @@ type Suspendable interface {
 	Suspended() bool
 }
 
+// ExistenceFetcher is the no-op Fetcher registered for kinds whose
+// existence alone is enough to satisfy downstream waits — used today
+// for HelmRepository (always) and OCIRepository when EnableOCI is
+// false. Returning nil artifact + nil error lands the resource in
+// Ready without recording a SourceArtifact, so a HelmRelease that
+// dependsOn a HelmRepository unblocks instantly without flate having
+// to mirror the controllers' "did fetch succeed?" logic from outside
+// the controller package.
+type ExistenceFetcher struct{}
+
+func (ExistenceFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*store.SourceArtifact, error) {
+	return nil, nil
+}
+
 // SecretGetter resolves a Secret CR by namespace + name. Fetchers that
 // read authentication credentials (Bucket; future GitRepository
 // SecretRef; future OCIRepository SecretRef) accept one of these so


### PR DESCRIPTION
## Summary
Two second-pass review architectural tidies.

1. **\`pkg/source.ExistenceFetcher\`**: no-op Fetcher returning \`(nil, nil)\` — the source controller now treats nil-artifact-nil-error as "existence-only Ready." Registered for HelmRepository (always) and OCIRepository (when \`--enable-oci=false\`). The \`orchestrator.markExistenceOnlyReady\` out-of-band loop is gone; existence-only logic lives in the source controller's Fetchers map.

2. **\`manifest.BootstrapSourceID\`**: canonical \`NamedResource\` for the synthetic working-tree GitRepository, declared once in \`constants.go\`. Was duplicated between orchestrator bootstrap and the kustomization controller's source fallback — would have drifted silently.

## Test plan
- [x] \`go test ./...\` clean
- [x] 7-scope \`test ks\` matrix: buroa/onedr0p/bjw-s-labs/jory-main/drag0n141/billimek all pass cleanly; m00nwtchr has 5 pre-existing repo-level failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)