### PR TITLE
fix(source): base64-decode Secret.Data values in StringFromSecret

### DIFF
--- a/pkg/source/secret.go
+++ b/pkg/source/secret.go
@@ -1,19 +1,24 @@
 package source
 
 import (
+	"encoding/base64"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
 // StringFromSecret reads a key from a Secret, preferring StringData
-// over Data. PLACEHOLDER_-wiped values (the result of flate's default
-// --wipe-secrets pre-processing) are reported as empty so callers
-// surface a clear "missing keys" error rather than authenticating
-// with the literal placeholder.
+// over Data. Data values are base64-decoded (per k8s Secret semantics)
+// before being returned, so the same string surface holds regardless
+// of whether the source manifest used `data:` or `stringData:`.
+// PLACEHOLDER_-wiped values (the result of flate's secret wiping
+// pre-processing) are reported as empty so callers surface a clear
+// "missing keys" error rather than authenticating with the literal
+// placeholder.
 //
-// Used by per-kind Fetchers (git, oci, bucket) to resolve auth from
-// the Secret a SecretRef points at.
+// Used by per-kind Fetchers (git, oci, bucket) and cosign verification
+// to resolve auth + trust material from the Secret a SecretRef points
+// at.
 func StringFromSecret(sec *manifest.Secret, key string) string {
 	if v, ok := sec.StringData[key].(string); ok {
 		if strings.HasPrefix(v, "..PLACEHOLDER_") {
@@ -22,10 +27,19 @@ func StringFromSecret(sec *manifest.Secret, key string) string {
 		return v
 	}
 	if v, ok := sec.Data[key].(string); ok {
-		if strings.HasPrefix(v, "..PLACEHOLDER_") {
+		// `data:` is base64-encoded YAML-side; decode so the returned
+		// value is the actual material (PEM block, dockerconfigjson,
+		// password, …) rather than its base64 envelope. Real k8s
+		// Secrets that ship a `cosign.pub` or `tls.crt` use this form.
+		decoded, err := base64.StdEncoding.DecodeString(v)
+		if err != nil {
 			return ""
 		}
-		return v
+		s := string(decoded)
+		if strings.HasPrefix(s, "..PLACEHOLDER_") {
+			return ""
+		}
+		return s
 	}
 	return ""
 }

--- a/pkg/source/secret_test.go
+++ b/pkg/source/secret_test.go
@@ -1,0 +1,66 @@
+package source
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// StringFromSecret prefers StringData over Data and base64-decodes
+// Data values (per k8s Secret semantics). Both the wipe-placeholder
+// and a non-base64 Data value surface as the empty string.
+func TestStringFromSecret(t *testing.T) {
+	pem := "-----BEGIN PUBLIC KEY-----\nblob\n-----END PUBLIC KEY-----\n"
+	b64 := base64.StdEncoding.EncodeToString([]byte(pem))
+
+	cases := []struct {
+		name string
+		sec  *manifest.Secret
+		key  string
+		want string
+	}{
+		{
+			name: "StringData wins over Data",
+			sec: &manifest.Secret{
+				StringData: map[string]any{"k": "plain"},
+				Data:       map[string]any{"k": base64.StdEncoding.EncodeToString([]byte("from-data"))},
+			},
+			key: "k", want: "plain",
+		},
+		{
+			name: "Data is base64-decoded",
+			sec:  &manifest.Secret{Data: map[string]any{"cosign.pub": b64}},
+			key:  "cosign.pub", want: pem,
+		},
+		{
+			name: "wiped StringData → empty",
+			sec:  &manifest.Secret{StringData: map[string]any{"k": "..PLACEHOLDER_k.."}},
+			key:  "k", want: "",
+		},
+		{
+			name: "wiped Data → empty (placeholder lands inside the base64 envelope)",
+			sec: &manifest.Secret{Data: map[string]any{
+				"k": base64.StdEncoding.EncodeToString([]byte("..PLACEHOLDER_k..")),
+			}},
+			key: "k", want: "",
+		},
+		{
+			name: "Data that isn't valid base64 → empty",
+			sec:  &manifest.Secret{Data: map[string]any{"k": "not-base64!@#$"}},
+			key:  "k", want: "",
+		},
+		{
+			name: "missing key → empty",
+			sec:  &manifest.Secret{},
+			key:  "absent", want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StringFromSecret(tc.sec, tc.key); got != tc.want {
+				t.Errorf("StringFromSecret = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Two independent third-pass review agents both flagged: \`StringFromSecret\` returned the raw base64 envelope for keys read from \`Secret.Data\`, breaking the Data fallback PR #129 added to cosign verification — and silently affecting **every** secret-based consumer (TLS, git, proxy, OCI dockerconfigjson).

**Fix**: base64-decode in the Data branch; apply PLACEHOLDER\_-wipe check against the decoded payload.

## Test plan
- [x] New \`pkg/source/secret_test.go\` covers StringData precedence, base64-decoded Data, wiped StringData, wiped Data (placeholder inside envelope), non-base64 Data → empty, missing key → empty
- [x] \`go test ./...\` clean
- [x] 6-scope \`test ks\` matrix all clean (m00nwtchr's pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)