### PR TITLE
chore: clean up 5 revive lint warnings

### DIFF
--- a/pkg/controllers/kustomization/substitute_test.go
+++ b/pkg/controllers/kustomization/substitute_test.go
@@ -53,12 +53,10 @@ func TestSubstituteDoc_NoSubstitutionShortCircuits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("substituteDoc: %v", err)
 	}
-	// Same pointer identity: short-circuit returned the input untouched.
-	if &out == &doc {
-		// Note: maps are reference types; &doc compares header addresses
-		// which are stack-local. The real assertion is that the returned
-		// map is the SAME map, which we verify via mutation visibility.
-	}
+	// Short-circuit returned the input map untouched. Maps are
+	// reference types so we can't compare pointer identity via &out;
+	// the real assertion is mutation visibility: writing to out must
+	// be visible on doc.
 	out["data"].(map[string]any)["new"] = "marker"
 	if doc["data"].(map[string]any)["new"] != "marker" {
 		t.Errorf("expected short-circuit to return the input map; got a copy")

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -461,7 +461,7 @@ metadata:
 `,
 		},
 	}
-	resolver := func(ref fluxopv1.InputProviderReference, ns string) ([]*manifest.ResourceSetInputProvider, error) {
+	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
 		return []*manifest.ResourceSetInputProvider{rsip}, nil
 	}
 	docs, err := resourceset.Render(rs, resolver)

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -48,6 +48,7 @@ type Suspendable interface {
 // the controller package.
 type ExistenceFetcher struct{}
 
+// Fetch implements source.Fetcher as a no-op — see ExistenceFetcher.
 func (ExistenceFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*store.SourceArtifact, error) {
 	return nil, nil
 }

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -46,6 +46,7 @@ type KustomizationArtifact struct {
 
 func (*KustomizationArtifact) artifact() {}
 
+// RenderedManifests implements RenderedArtifact.
 func (a *KustomizationArtifact) RenderedManifests() []map[string]any { return a.Manifests }
 
 // HelmReleaseArtifact is the rendered output of a HelmRelease template.
@@ -55,4 +56,5 @@ type HelmReleaseArtifact struct {
 
 func (*HelmReleaseArtifact) artifact() {}
 
+// RenderedManifests implements RenderedArtifact.
 func (a *HelmReleaseArtifact) RenderedManifests() []map[string]any { return a.Manifests }


### PR DESCRIPTION
## Summary
Five \`revive\` warnings from \`mise run lint\`:

- \`pkg/controllers/kustomization/substitute_test.go\`: empty identity-compare block removed
- \`pkg/resourceset/render_test.go\`: unused resolver params renamed to \`_\`
- \`pkg/source/source.go\`: doc comment on \`ExistenceFetcher.Fetch\`
- \`pkg/store/artifact.go\`: doc comments on the two \`RenderedManifests\`

## Test plan
- [x] \`mise run lint\` → 0 issues
- [x] \`go test ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)