### PR TITLE
fix(source): walk all files instead of SkipDir on excluded parents

### DIFF
--- a/pkg/source/ignore.go
+++ b/pkg/source/ignore.go
@@ -39,12 +39,27 @@ func ApplyIgnore(root string, ignore *string) error {
 }
 
 func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) error {
+	// Decide per-file: walk every file, ask the matcher whether it
+	// belongs in the artifact. Don't SkipDir on excluded directories —
+	// that would prevent a deeper `!` re-include pattern from being
+	// observed. With patterns like
+	//
+	//   /*
+	//   !/charts/tekton-operator/
+	//
+	// the matcher correctly excludes `charts/` (match=true) but
+	// re-includes `charts/tekton-operator/Chart.yaml` (match=false);
+	// a SkipDir on `charts/` would wipe the latter alongside.
+	//
+	// Empty directories left after file removal are pruned in a
+	// second bottom-up sweep so the artifact mirrors source-
+	// controller's tarball shape.
 	var toRemove []string
 	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if p == root {
+		if p == root || d.IsDir() {
 			return nil
 		}
 		rel, err := filepath.Rel(root, p)
@@ -52,20 +67,43 @@ func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) erro
 			return err
 		}
 		segments := append(append([]string{}, domain...), strings.Split(rel, string(filepath.Separator))...)
-		if matcher.Match(segments, d.IsDir()) {
+		if matcher.Match(segments, false) {
 			toRemove = append(toRemove, p)
-			if d.IsDir() {
-				return fs.SkipDir
-			}
 		}
 		return nil
 	}); err != nil {
 		return fmt.Errorf("sourceignore walk: %w", err)
 	}
 	for _, p := range toRemove {
-		if err := os.RemoveAll(p); err != nil {
+		if err := os.Remove(p); err != nil {
 			return fmt.Errorf("sourceignore remove %s: %w", p, err)
 		}
+	}
+	return pruneEmptyDirs(root)
+}
+
+// pruneEmptyDirs removes directories that became empty after file
+// deletion, bottom-up. Stops at root.
+func pruneEmptyDirs(root string) error {
+	var dirs []string
+	if err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() && p != root {
+			dirs = append(dirs, p)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("sourceignore prune walk: %w", err)
+	}
+	// Bottom-up by path length: deepest first.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		entries, err := os.ReadDir(dirs[i])
+		if err != nil || len(entries) > 0 {
+			continue
+		}
+		_ = os.Remove(dirs[i])
 	}
 	return nil
 }

--- a/pkg/source/ignore_test.go
+++ b/pkg/source/ignore_test.go
@@ -143,6 +143,45 @@ func TestApplyIgnore_DoubleStarMatchesAtAnyDepth(t *testing.T) {
 	}
 }
 
+// Regression: m00nwtchr's tekton-operator / garage GitRepositories use
+//
+//	/*
+//	!/charts/tekton-operator/
+//
+// to extract a single chart subdir from a larger repo. The matcher
+// returns match=true for `charts/` but match=false for files under
+// `charts/tekton-operator/`. The previous walk SkipDir'd on `charts/`
+// and never gave the descendants a chance to be re-included, wiping
+// the chart subpath entirely.
+func TestApplyIgnore_ReIncludeUnderExcludedParent(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "README.md")
+	writeFile(t, root, "docs/index.md")
+	writeFile(t, root, "charts/tekton-operator/Chart.yaml")
+	writeFile(t, root, "charts/tekton-operator/values.yaml")
+	writeFile(t, root, "charts/tekton-other/Chart.yaml")
+
+	patterns := "/*\n!/charts/tekton-operator/\n"
+	if err := source.ApplyIgnore(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnore: %v", err)
+	}
+	if !exists(t, filepath.Join(root, "charts/tekton-operator/Chart.yaml")) {
+		t.Errorf("re-included file must survive")
+	}
+	if !exists(t, filepath.Join(root, "charts/tekton-operator/values.yaml")) {
+		t.Errorf("re-included sibling file must survive")
+	}
+	if exists(t, filepath.Join(root, "README.md")) {
+		t.Errorf("root-level file should be removed")
+	}
+	if exists(t, filepath.Join(root, "docs/index.md")) {
+		t.Errorf("non-re-included subtree should be removed")
+	}
+	if exists(t, filepath.Join(root, "charts/tekton-other/Chart.yaml")) {
+		t.Errorf("sibling subdir of re-included path should be removed")
+	}
+}
+
 func TestApplyIgnore_LeadingSlashAnchorsToRoot(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "config.yaml")


### PR DESCRIPTION
## Summary
GitRepositories using the "exclude all, re-include a subdir" pattern (very common — e.g. extracting a single chart from a huge upstream repo) were returning empty artifacts:

\`\`\`yaml
ignore: |-
  /*
  !/charts/tekton-operator/
\`\`\`

The gitignore matcher correctly classifies \`charts/\` as excluded and files under \`charts/tekton-operator/\` as re-included. But \`walkAndDelete\` returned \`fs.SkipDir\` on the excluded \`charts/\` and never visited the descendants — wiping the chart subpath entirely. The HelmRelease pointing at \`<cached>/charts/tekton-operator\` then failed with "Chart.yaml not found."

**Fix**: walk every file (not directories), decide per-file via the matcher, then sweep empty directories bottom-up to mirror source-controller's tarball shape.

## Verified
- m00nwtchr/homelab-cluster: \`tekton-operator\`, \`garage\`, and \`fediverse/apoci\` now find their charts; total failure count 11 → 8.
- Added regression test \`TestApplyIgnore_ReIncludeUnderExcludedParent\`.

## Test plan
- [x] All existing ignore tests pass
- [x] New regression test passes
- [x] \`go test ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)