### PR TITLE
fix(helm): skip schema validation when values contain wipe placeholders

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -65,7 +65,15 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	inst.EnableDNS = opts.EnableDNS
 	inst.Replace = true
 	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
-	inst.SkipSchemaValidation = hr.DisableSchemaValidation
+	// When flate's wipe-secrets has replaced a substituteFrom / valuesFrom
+	// value with the ..PLACEHOLDER_KEY.. token, chart schemas with DNS /
+	// URL / regex patterns reject it (the placeholder isn't a valid
+	// hostname). Disable schema validation when any placeholder reaches
+	// rendering so the user sees the rendered output rather than a
+	// validation error against a value flate fabricated. Real Flux
+	// resolves the secret to the actual value and validates normally —
+	// flate can't, so this short-circuits the failure mode.
+	inst.SkipSchemaValidation = hr.DisableSchemaValidation || containsWipePlaceholder(hrValues)
 	// spec.postRenderers — pipe rendered output through one or more
 	// kustomize patch+image transforms. helm-controller does this via
 	// the same postrenderer.PostRenderer hook.
@@ -277,4 +285,28 @@ func filterShowOnly(content string, paths []string) string {
 
 func isTestHook(h *release.Hook) bool {
 	return slices.Contains(h.Events, release.HookTest)
+}
+
+// containsWipePlaceholder reports whether any string leaf in v matches
+// the secret-wipe marker `..PLACEHOLDER_<key>..`. Used to short-circuit
+// chart schema validation when flate has fabricated values that real
+// Flux would have resolved from a SOPS-encrypted secret.
+func containsWipePlaceholder(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return strings.Contains(t, "..PLACEHOLDER_")
+	case map[string]any:
+		for _, vv := range t {
+			if containsWipePlaceholder(vv) {
+				return true
+			}
+		}
+	case []any:
+		for _, vv := range t {
+			if containsWipePlaceholder(vv) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
flate's wipe-secrets pre-pass replaces SOPS-encrypted secret values with \`..PLACEHOLDER_KEY..\`. Helm charts that schema-validate values (DNS / URL / regex patterns) reject this token wherever it lands. Real Flux resolves the secret to the actual value before render — flate can't, so the user-fabricated placeholder fails any strict schema.

**Fix**: when materialized values contain the wipe marker, set \`SkipSchemaValidation = true\` for that one render. HRs without wiped values still get full schema validation.

## Verified
- m00nwtchr/homelab-cluster: \`HelmRelease/fediverse/apoci\` now renders (was failing on \`URLRewrite\` filter's hostname regex against PLACEHOLDER)
- \`flate test hr\` on m00n: **129 passed, 0 failed** (was 1+ failed)
- Other 6 repos (buroa/onedr0p/bjw-s-labs/jory-main/drag0n141/billimek): all unchanged at 0 failures

## Test plan
- [x] \`go test ./...\` clean
- [x] 7-repo \`test ks\` matrix unchanged (m00n keeps its 3 Category A stunner failures)
- [x] m00n \`test hr\` drops to 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)