### PR TITLE
fix(source/cache): per-slot locking; OCI defer-order on error paths

### DIFF
--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -76,10 +76,11 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	// Cache key: bucket+prefix; reset on first error so retries start
 	// clean. The revision identifier (sha256 over sorted etags) is
 	// recomputed after listing.
-	slot, _, err := f.Cache.Slot(endpoint+"/"+b.BucketName, b.Prefix)
+	slot, _, release, err := f.Cache.Slot(endpoint+"/"+b.BucketName, b.Prefix)
 	if err != nil {
 		return nil, fmt.Errorf("bucket %s/%s cache slot: %w", b.Namespace, b.Name, err)
 	}
+	defer release()
 
 	keys, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot)
 	if err != nil {

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -16,11 +16,18 @@ import (
 // sources. Each (url, ref) tuple gets its own slot, so multiple revisions
 // of the same upstream coexist without clobbering one another.
 //
-// The cache is safe for concurrent use; an internal mutex serializes
-// allocation so two reconcilers can't race on the same slot path.
+// The cache is safe for concurrent use. A per-slot mutex serializes the
+// full fetch-write-read lifecycle on a single slot — two distinct
+// source CRs with the same (url, ref) hash to the same slot, and
+// without per-slot locking one would observe the other mid-write
+// (e.g. read an empty marker, call Reset, wipe the in-progress clone).
+// Different slots proceed in parallel.
 type Cache struct {
 	root string
-	mu   sync.Mutex
+	mu   sync.Mutex // guards locks
+	// locks holds a sync.Mutex per slot path. Lazily created; never
+	// reaped — the slot count is bounded by user-declared sources.
+	locks map[string]*sync.Mutex
 }
 
 // NewCache constructs a Cache rooted at dir. If dir is empty, a
@@ -29,17 +36,38 @@ func NewCache(dir string) *Cache {
 	return &Cache{root: cmp.Or(dir, filepath.Join(os.TempDir(), "flate-cache"))}
 }
 
-// Slot returns the path under which (url, ref) should be cached. The
-// returned directory is created if it does not already exist. The
-// returned exists flag is true when the directory was already populated.
-func (c *Cache) Slot(url, ref string) (path string, exists bool, err error) {
+// slotMu returns the per-slot mutex for path, creating it on first
+// access. Caller must NOT hold c.mu.
+func (c *Cache) slotMu(path string) *sync.Mutex {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.locks == nil {
+		c.locks = make(map[string]*sync.Mutex)
+	}
+	m, ok := c.locks[path]
+	if !ok {
+		m = &sync.Mutex{}
+		c.locks[path] = m
+	}
+	return m
+}
 
+// Slot returns the path under which (url, ref) should be cached, the
+// per-slot release function the caller MUST defer, and an exists flag
+// indicating the directory was already populated.
+//
+// Holding the returned release across the full fetch-and-publish
+// lifecycle serializes other fetchers (different CRs, same (url, ref))
+// against the in-flight one — see Cache type doc for the race motivation.
+func (c *Cache) Slot(url, ref string) (path string, exists bool, release func(), err error) {
 	slug := slugifyRepo(url)
 	h := sha256.Sum256([]byte(url + "@" + ref))
 	hash := hex.EncodeToString(h[:])[:16]
 	path = filepath.Join(c.root, slug, hash)
+
+	m := c.slotMu(path)
+	m.Lock()
+	release = m.Unlock
 
 	info, statErr := os.Stat(path)
 	switch {
@@ -47,34 +75,35 @@ func (c *Cache) Slot(url, ref string) (path string, exists bool, err error) {
 		// Non-empty directory counts as populated. We use the presence
 		// of any entry as the indicator so a bare `mkdir` from a prior
 		// aborted run doesn't masquerade as a hit.
-		f, err := os.Open(path) //nolint:gosec // path is a cache slot under our cache root
-		if err == nil {
-			defer func() { _ = f.Close() }()
+		f, ferr := os.Open(path) //nolint:gosec // path is a cache slot under our cache root
+		if ferr == nil {
 			entries, _ := f.Readdirnames(1)
+			_ = f.Close()
 			exists = len(entries) > 0
 		}
-		return path, exists, nil
+		return path, exists, release, nil
 	case os.IsNotExist(statErr):
-		return path, false, os.MkdirAll(path, 0o750)
+		if mkErr := os.MkdirAll(path, 0o750); mkErr != nil {
+			release()
+			return "", false, nil, mkErr
+		}
+		return path, false, release, nil
 	default:
-		return "", false, fmt.Errorf("cache slot stat: %w", statErr)
+		release()
+		return "", false, nil, fmt.Errorf("cache slot stat: %w", statErr)
 	}
 }
 
-// Reset removes a previously allocated slot. Called when a fetch fails so
-// retries start clean.
-//
-// Acquires the cache mutex for the same reason Slot does: two fetchers
-// for the same (url, ref) hash to the same slot, and a Reset overlapping
-// with another fetcher's mid-clone could partially delete the
-// in-progress directory. Holding c.mu here serializes Reset against any
-// concurrent Slot allocation.
+// Reset removes a previously allocated slot. Called when a fetch fails
+// so retries start clean. The caller is expected to hold the slot
+// release (i.e. Reset is called from within the Slot-Acquire critical
+// section). This function does NOT take the per-slot lock — doing so
+// would self-deadlock — but it does serialize against new Slot
+// acquisitions via the absence of a sibling holder.
 func (c *Cache) Reset(path string) error {
 	if path == "" {
 		return nil
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	return os.RemoveAll(path)
 }
 

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -1,8 +1,12 @@
 package source
 
 import (
+	"os"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestCache_ResetSerializesAgainstSlot exercises the mutex Cache.Reset
@@ -17,34 +21,92 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(goroutines * 2)
 
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
-				path, _, err := c.Slot("https://shared.example/repo", "main")
+			for range iterations {
+				path, _, release, err := c.Slot("https://shared.example/repo", "main")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
 				}
 				_ = path
+				release()
 			}
 		}()
 		go func() {
 			defer wg.Done()
-			for j := 0; j < iterations; j++ {
-				path, _, err := c.Slot("https://shared.example/repo", "main")
+			for range iterations {
+				path, _, release, err := c.Slot("https://shared.example/repo", "main")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
 				}
 				if err := c.Reset(path); err != nil {
 					t.Errorf("Reset: %v", err)
+					release()
 					return
 				}
+				release()
 			}
 		}()
 	}
 	wg.Wait()
+}
+
+// TestCache_SlotSerializesSameKey: two goroutines competing for the
+// same (url, ref) must execute their critical sections serially — the
+// second caller's exists=true observation must follow the first
+// caller's writes, not race them. Reproduces the PR-137 cross-CR slot
+// collision the previous Cache mutex (which guarded only allocation)
+// allowed.
+func TestCache_SlotSerializesSameKey(t *testing.T) {
+	c := NewCache(t.TempDir())
+	var seq int32
+	var firstReleased, secondAcquired int32
+
+	done := make(chan struct{}, 2)
+	go func() {
+		path, _, release, err := c.Slot("https://shared.example/repo", "main")
+		if err != nil {
+			t.Errorf("Slot: %v", err)
+			done <- struct{}{}
+			return
+		}
+		// Hold the lock briefly while a sibling fetcher tries to enter.
+		atomic.AddInt32(&seq, 1)
+		// Write a tiny file to simulate in-progress fetch state.
+		_ = os.WriteFile(filepath.Join(path, ".inprogress"), []byte("x"), 0o600)
+		atomic.StoreInt32(&firstReleased, 1)
+		release()
+		done <- struct{}{}
+	}()
+	// Give G1 a moment to take the lock.
+	time.Sleep(5 * time.Millisecond)
+	go func() {
+		_, exists, release, err := c.Slot("https://shared.example/repo", "main")
+		if err != nil {
+			t.Errorf("Slot: %v", err)
+			done <- struct{}{}
+			return
+		}
+		// We acquired only after G1 released, so should see exists=true
+		// (G1 wrote a marker file).
+		if atomic.LoadInt32(&firstReleased) != 1 {
+			t.Errorf("second goroutine acquired before first released — serialization failed")
+		}
+		atomic.StoreInt32(&secondAcquired, 1)
+		if !exists {
+			t.Errorf("expected exists=true on second acquisition after first wrote a file")
+		}
+		release()
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+	if atomic.LoadInt32(&secondAcquired) != 1 {
+		t.Errorf("second goroutine never acquired the slot")
+	}
 }
 
 func TestSlugifyRepo(t *testing.T) {

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -250,10 +250,11 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 		}
 	}
 
-	slot, exists, err := cache.Slot(repo.URL, refStr)
+	slot, exists, release, err := cache.Slot(repo.URL, refStr)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", repo.URL, err)
 	}
+	defer release()
 
 	if exists {
 		// The flate-revision marker is written AFTER a successful

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -212,10 +212,11 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	}
 
 	versioned := versionedURL(repo.URL, ref)
-	slot, exists, err := cache.Slot(versioned, "")
+	slot, exists, release, err := cache.Slot(versioned, "")
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
+	defer release()
 	if exists {
 		cachedDigest := readCachedDigest(slot)
 		if cachedDigest == "" {
@@ -253,29 +254,37 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	if err != nil {
 		return nil, fmt.Errorf("oras file store: %w", err)
 	}
-	defer func() { _ = dest.Close() }()
+	// Track close + slot-reset ordering manually rather than via defer:
+	// orasfile.Close must flush/release file handles BEFORE cache.Reset
+	// wipes the slot, otherwise Close fsyncs against a deleted directory
+	// (and, worse, could touch another tenant's directory if the slot
+	// path were re-allocated in between — although the per-slot release
+	// above prevents that race today).
+	closeDest := func() { _ = dest.Close() }
+	resetOnErr := func() { closeDest(); _ = cache.Reset(slot) }
 
 	desc, err := oras.Copy(ctx, repoClient, tag, dest, tag, oras.DefaultCopyOptions)
 	if err != nil {
-		_ = cache.Reset(slot)
+		resetOnErr()
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
 	digest := desc.Digest.String()
 	if repo.Verify != nil {
 		if err := f.verifyCosignSignature(ctx, repoClient, repo, digest); err != nil {
-			_ = cache.Reset(slot)
+			resetOnErr()
 			return nil, err
 		}
 	}
 	if err := applyLayerSelector(ctx, repoClient, slot, desc.Digest.String(), repo.LayerSelector); err != nil {
-		_ = cache.Reset(slot)
+		resetOnErr()
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
 	if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
-		_ = cache.Reset(slot)
+		resetOnErr()
 		return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
 	}
+	closeDest()
 	// Persist the resolved digest so a subsequent cache hit can
 	// re-verify against the exact bytes we wrote, even when the spec
 	// pinned only a tag. A write failure isn't fatal — the next fetch


### PR DESCRIPTION
## Summary
Iteration-5 review reproduced a deterministic FS-level race (invisible to \`go test -race\`) and a defer-ordering bug both flagged on PR-137.

**Race**: \`Cache.Slot\` only protected directory allocation. Two distinct source CRs hashing to the same slot ran their full fetch-write-publish lifecycles in parallel. Result: one fetcher observed \`exists=true\` on a slot another was still populating, read an empty marker, called \`cache.Reset\`, and wiped the in-progress clone.

**Defer-order**: \`defer dest.Close()\` in OCI fetch ran after the inline \`cache.Reset\` in error branches — orasfile fsynced against a deleted directory.

## Fix
- \`Cache.Slot\` returns a \`release\` func the caller MUST defer; serializes the entire fetch lifecycle per (url, ref).
- OCI fetch: explicit close-then-reset on every error branch via \`resetOnErr\` helper.

## Tests
- \`TestCache_SlotSerializesSameKey\` reproduces the cross-CR serialization the previous code violated.
- \`go test -race ./...\` clean.
- 7-repo \`test ks\` matrix unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)