### PR TITLE
fix(depwait): honor spec.timeout on Kustomization + HelmRelease

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -132,7 +132,11 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
-			w := &depwait.Waiter{Store: c.Store, Parent: id}
+			w := &depwait.Waiter{
+				Store:   c.Store,
+				Parent:  id,
+				Timeout: depwait.TimeoutFromSpec(hr.Timeout),
+			}
 			sum = depwait.WaitAll(w.Watch(ctx, deps))
 		})
 		if sum.AnyFailed() {
@@ -164,7 +168,11 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	}
 	var sum depwait.Summary
 	c.Tasks.YieldSlot(func() {
-		w := &depwait.Waiter{Store: c.Store, Parent: id}
+		w := &depwait.Waiter{
+			Store:   c.Store,
+			Parent:  id,
+			Timeout: depwait.TimeoutFromSpec(hr.Timeout),
+		}
 		sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
 	})
 	if sum.AnyFailed() {

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -105,7 +105,11 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// slots while waiting for children that need a slot to run.
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
-			w := &depwait.Waiter{Store: c.Store, Parent: id}
+			w := &depwait.Waiter{
+				Store:   c.Store,
+				Parent:  id,
+				Timeout: depwait.TimeoutFromSpec(ks.Timeout),
+			}
 			sum = depwait.WaitAll(w.Watch(ctx, deps))
 		})
 		if sum.AnyFailed() {

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -27,6 +29,18 @@ const DefaultTimeout = 30 * time.Second
 // failing — it covers the legitimate case where a KS render produces
 // the dep slightly later in the same run.
 const MissingGrace = 2 * time.Second
+
+// TimeoutFromSpec resolves a Flux spec.timeout (`*metav1.Duration` —
+// the shape used by both Kustomization and HelmRelease) into the
+// effective per-dep wait. Honors a user-supplied value when set; falls
+// back to flate's offline-tuned DefaultTimeout otherwise. Matches the
+// principle that a real Flux reconcile would respect spec.timeout.
+func TimeoutFromSpec(d *metav1.Duration) time.Duration {
+	if d == nil || d.Duration <= 0 {
+		return DefaultTimeout
+	}
+	return d.Duration
+}
 
 // DepStatus enumerates the per-dependency resolution result.
 type DepStatus int

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -116,5 +118,21 @@ func TestWaiter_PanicReportedAsFailed(t *testing.T) {
 	}
 	if msg := sum.Messages[dep]; !strings.Contains(msg, "depwait panic:") {
 		t.Errorf("expected 'depwait panic:' prefix, got %q", msg)
+	}
+}
+
+// TimeoutFromSpec mirrors Flux KS/HR's `*metav1.Duration` shape: nil
+// and zero fall back to DefaultTimeout; user-supplied values win.
+func TestTimeoutFromSpec(t *testing.T) {
+	if got := TimeoutFromSpec(nil); got != DefaultTimeout {
+		t.Errorf("nil → %v, want DefaultTimeout (%v)", got, DefaultTimeout)
+	}
+	zero := &metav1.Duration{Duration: 0}
+	if got := TimeoutFromSpec(zero); got != DefaultTimeout {
+		t.Errorf("zero → %v, want DefaultTimeout", got)
+	}
+	custom := &metav1.Duration{Duration: 5 * time.Minute}
+	if got := TimeoutFromSpec(custom); got != 5*time.Minute {
+		t.Errorf("5m → %v", got)
 	}
 }


### PR DESCRIPTION
## Summary
Real Flux's KS and HR specs carry \`spec.timeout\`. flate ignored it — so a KS with \`spec.timeout: 5m\` (legitimately waiting for a slow chart fetch) would fail at flate's 30s default.

**Fix**: \`depwait.TimeoutFromSpec(*metav1.Duration)\` returns the user value when set, falls back to \`DefaultTimeout\` otherwise. Both controllers thread the spec timeout into the Waiter (KS dependsOn + HR dependsOn + HR chart-source).

The 30 s default still applies when no spec.timeout is set — flate is offline-tuned and typos should surface fast rather than stall at upstream's minutes-long default.

## Test plan
- [x] \`TestTimeoutFromSpec\` covers nil/zero/custom
- [x] \`go test -race ./...\` clean
- [x] \`mise run lint\` clean
- [x] 7-repo matrix unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)