### PR TITLE
fix: postBuild precedence + bootstrap aliases + git slot lock + dead code

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -227,38 +227,11 @@ func applyStrip(docs []Doc, attrs []string) []Doc {
 	}
 	out := make([]Doc, len(docs))
 	for i, d := range docs {
-		copyDoc := deepCopy(d.Manifest)
+		copyDoc := manifest.DeepCopyMap(d.Manifest)
 		manifest.StripResourceAttributes(copyDoc, attrs)
 		out[i] = Doc{Manifest: copyDoc, Parent: d.Parent}
 	}
 	return out
-}
-
-// deepCopy clones a parsed YAML document. The shapes we see are
-// JSON-equivalent (map[string]any / []any / scalars) so a structural
-// walk is enough and avoids the marshal/unmarshal round-trip cost on
-// the hot path.
-func deepCopy(in map[string]any) map[string]any {
-	out := make(map[string]any, len(in))
-	for k, v := range in {
-		out[k] = deepCopyValue(v)
-	}
-	return out
-}
-
-func deepCopyValue(v any) any {
-	switch t := v.(type) {
-	case map[string]any:
-		return deepCopy(t)
-	case []any:
-		out := make([]any, len(t))
-		for i, e := range t {
-			out[i] = deepCopyValue(e)
-		}
-		return out
-	default:
-		return v
-	}
 }
 
 // marshalSide serializes one side of a paired manifest. A nil manifest

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -178,9 +178,59 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	if err := o.loadManifests(ctx, repoRoot); err != nil {
 		return err
 	}
+	o.aliasBootstrapSources(repoRoot)
 	o.validateDependsOn()
 	o.warnSilentlySkippedVerification()
 	return o.buildChangeFilter(repoRoot)
+}
+
+// aliasBootstrapSources seeds a working-tree SourceArtifact for every
+// `flux-system/<name>` GitRepository referenced by a loaded Kustomization
+// whose definition isn't in the repo itself. This is the chkpwd-ops /
+// flux-bootstrap pattern: the user's entry-point KSes reference a
+// custom-named GitRepository (e.g. `chkpwd-ops`, `home-ops`) installed
+// by `flux bootstrap` into the cluster but never committed to the repo.
+// Without aliasing, every downstream KS fails with "source artifact not
+// found". Aliasing makes them all resolve to the working tree.
+func (o *Orchestrator) aliasBootstrapSources(repoRoot string) {
+	known := make(map[manifest.NamedResource]struct{})
+	for _, obj := range o.store.ListObjects(manifest.KindGitRepository) {
+		known[obj.Named()] = struct{}{}
+	}
+	seen := make(map[manifest.NamedResource]struct{})
+	for _, obj := range o.store.ListObjects(manifest.KindKustomization) {
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok || ks.SourceKind != manifest.KindGitRepository {
+			continue
+		}
+		// Only alias flux-system-namespaced GRs — that's the convention
+		// for the bootstrap source. A KS pointing at a GR in another
+		// namespace is a legitimate cross-tree reference and should fail
+		// if missing rather than silently aliasing to the working tree.
+		if ks.SourceNamespace != manifest.DefaultNamespace {
+			continue
+		}
+		id := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: ks.SourceNamespace, Name: ks.SourceName}
+		if _, ok := known[id]; ok {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		alias := &manifest.GitRepository{
+			Name: id.Name, Namespace: id.Namespace,
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + repoRoot},
+		}
+		o.store.AddObject(alias)
+		o.store.SetArtifact(id, &store.SourceArtifact{
+			Kind: manifest.KindGitRepository,
+			URL:  alias.URL, LocalPath: repoRoot,
+		})
+		o.store.UpdateStatus(id, store.StatusReady, "bootstrap alias")
+		slog.Debug("orchestrator: aliased bootstrap GitRepository",
+			"id", id.String(), "localPath", repoRoot)
+	}
 }
 
 // warnSilentlySkippedVerification surfaces cases where a user-configured

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -83,35 +83,7 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		client.InstallProtocol("https", githttp.NewClient(httpsClient))
 		defer client.InstallProtocol("https", githttp.DefaultClient)
 	}
-	art, err := fetch(ctx, f.Cache, repo, auth, proxy)
-	if err != nil {
-		return nil, err
-	}
-	if repo.Verification != nil {
-		cloned, oerr := git.PlainOpen(art.LocalPath)
-		if oerr != nil {
-			return nil, fmt.Errorf("verify: reopen %s: %w", art.LocalPath, oerr)
-		}
-		head, herr := cloned.Head()
-		if herr != nil {
-			return nil, fmt.Errorf("verify: resolve HEAD: %w", herr)
-		}
-		if err := verifySignatures(f.Secrets, repo, cloned, head.Hash()); err != nil {
-			_ = f.Cache.Reset(art.LocalPath)
-			return nil, err
-		}
-	}
-	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
-	}
-	// Write the revision marker AFTER ApplyIgnore so it survives any
-	// user-supplied "exclude all" patterns (common — `/*` + reincludes).
-	// Next run's cache-hit check (readCachedRevision) avoids the
-	// expensive re-clone for big repos whose .git/ was wiped by ignore.
-	if art.Revision != "" {
-		_ = writeCachedRevision(art.LocalPath, art.Revision)
-	}
-	return art, nil
+	return f.fetch(ctx, repo, auth, proxy)
 }
 
 // resolveTLS builds a *tls.Config from spec.secretRef for HTTPS GitRepositories
@@ -228,14 +200,18 @@ func sshUserFromURL(url string) string {
 	return "git"
 }
 
-// fetch clones the GitRepository referenced by repo into the supplied
-// cache and returns a populated *store.SourceArtifact. If a usable
-// cached copy already exists, it is reused. auth may be nil for
-// anonymous clones; proxy may be nil for direct connections.
+// fetch clones the GitRepository, then runs verification, ignore, and
+// the cache-marker write — ALL inside the per-slot critical section.
+// Holding the slot lock across post-clone work prevents another
+// fetcher with the same (url, ref) from observing torn state (an
+// in-progress clone, a missing marker, an unverified slot) or from
+// racing a sibling cache.Reset against an in-flight write.
 //
+// auth may be nil for anonymous clones; proxy may be nil for direct.
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
-func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
+func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
+	cache := f.Cache
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}
@@ -315,10 +291,49 @@ func fetch(ctx context.Context, cache *source.Cache, repo *manifest.GitRepositor
 	}
 
 	rev, _ := readResolvedRevision(slot)
-	return &store.SourceArtifact{
+	art := &store.SourceArtifact{
 		Kind: manifest.KindGitRepository,
 		URL:  repo.URL, LocalPath: slot, Revision: rev,
-	}, nil
+	}
+	// Post-clone work — verification, ignore, marker — runs under the
+	// slot lock so a sibling Fetcher of the same (url, ref) can't race
+	// our writes or our error-path cache.Reset.
+	if err := f.finalize(repo, art); err != nil {
+		_ = cache.Reset(slot)
+		return nil, err
+	}
+	return art, nil
+}
+
+// finalize runs PGP verification (when configured), applies the
+// source-controller-compatible ignore patterns, and writes the cache-
+// hit marker. Returns the first error encountered; the caller is
+// expected to Reset the slot on error while still holding the lock.
+func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifact) error {
+	if repo.Verification != nil {
+		cloned, oerr := git.PlainOpen(art.LocalPath)
+		if oerr != nil {
+			return fmt.Errorf("verify: reopen %s: %w", art.LocalPath, oerr)
+		}
+		head, herr := cloned.Head()
+		if herr != nil {
+			return fmt.Errorf("verify: resolve HEAD: %w", herr)
+		}
+		if err := verifySignatures(f.Secrets, repo, cloned, head.Hash()); err != nil {
+			return err
+		}
+	}
+	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
+		return fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+	}
+	// Write the revision marker AFTER ApplyIgnore so it survives any
+	// user-supplied "exclude all" patterns (common — `/*` + reincludes).
+	// Next run's cache-hit check (readCachedRevision) avoids the
+	// expensive re-clone for big repos whose .git/ was wiped by ignore.
+	if art.Revision != "" {
+		_ = writeCachedRevision(art.LocalPath, art.Revision)
+	}
+	return nil
 }
 
 // cachedRevisionFile holds the resolved commit SHA of a fetched slot.

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -267,10 +267,12 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 		return fmt.Errorf("%w: Kustomization with substituteFrom has no namespace", manifest.ErrInvalidSubstituteReference)
 	}
 
-	values := maps.Clone(ks.PostBuildSubstitute)
-	if values == nil {
-		values = map[string]any{}
-	}
+	// Upstream kustomize-controller's LoadVariables merges substituteFrom
+	// refs first, then OVERWRITES with inline spec.postBuild.substitute —
+	// inline values win on key collision. flate previously inverted this
+	// (seeded from inline, then substituteFrom overwrote). Match upstream:
+	// substituteFrom first into a fresh map, then layer inline on top.
+	values := map[string]any{}
 	for _, ref := range ks.PostBuildSubstituteFrom {
 		var data map[string]string
 		var err error
@@ -283,7 +285,10 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 		case manifest.KindConfigMap:
 			c := p.ConfigMap(ks.Namespace, ref.Name)
 			if c != nil {
-				data, err = decodeBag(c.Data, c.BinaryData)
+				// substituteFrom only reads cm.Data — upstream
+				// kustomize-controller does NOT expose binaryData as
+				// substitution vars. Pass nil to skip that branch.
+				data, err = decodeBag(c.Data, nil)
 			}
 		default:
 			slog.Debug("values: unsupported SubstituteReference kind",
@@ -309,6 +314,9 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 			values[k] = strings.ReplaceAll(v, "\n", "")
 		}
 	}
+	// Layer inline spec.postBuild.substitute on top — inline wins on
+	// key collision per upstream LoadVariables order.
+	maps.Copy(values, ks.PostBuildSubstitute)
 	ks.UpdatePostBuildSubstitutions(values)
 	return nil
 }


### PR DESCRIPTION
## Summary
Iteration-6 multi-agent review surfaced multiple real-Flux divergences and a slot-lock regression. Batched into one PR.

1. **postBuild substitute precedence inverted** (real Flux divergence): upstream merges \`substituteFrom\` then OVERWRITES with inline \`substitute\` — inline wins. flate had it backwards.
2. **binaryData no longer exposed as substituteFrom var**: upstream only reads \`cm.Data\`. Pass nil for binaryData on the substituteFrom call.
3. **Bootstrap aliasing**: \`flux-system/<custom-name>\` GitRepositories installed via \`flux bootstrap\` (chkpwd-iac's \`chkpwd-ops\`, etc.) now alias to the repo root. **chkpwd-iac: 71/3 → 74/0**.
4. **Git slot Reset outside lock**: verify path ran after slot release. Moved verify/ignore/marker inside the slot's critical section via a \`finalize\` helper.
5. **Dead deepCopy in pkg/diff**: byte-identical to \`manifest.DeepCopyMap\`. Dropped.

## Test plan
- [x] \`go test -race ./...\` clean
- [x] \`mise run lint\` clean
- [x] 8-repo matrix: 7 prior repos unchanged, chkpwd-iac unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)