### PR TITLE
fix: iter-7 — CLI UX, store replay panic, helm listener payload, perf

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/orchestrator"
@@ -140,6 +141,9 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, error) {
 	if c.path == "" {
 		return nil, errors.New("path is required")
+	}
+	if _, err := format.ParseOutput(c.output); err != nil {
+		return nil, err
 	}
 	return runOrchestratorCfg(ctx, buildOrchCfg(c, h))
 }

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -23,6 +23,22 @@ const (
 	OutputName  Output = "name"
 )
 
+// ValidOutputs returns the supported -o values, suitable for help text
+// and CLI validation.
+func ValidOutputs() []string {
+	return []string{string(OutputTable), string(OutputYAML), string(OutputJSON), string(OutputName)}
+}
+
+// ParseOutput validates a user-supplied -o value. Returns an error
+// listing the supported values when unrecognized.
+func ParseOutput(s string) (Output, error) {
+	switch Output(s) {
+	case OutputTable, OutputYAML, OutputJSON, OutputName:
+		return Output(s), nil
+	}
+	return "", fmt.Errorf("invalid -o %q: want one of %s", s, strings.Join(ValidOutputs(), ", "))
+}
+
 // Column describes a single table column.
 type Column struct {
 	Header string

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -68,17 +68,26 @@ func (c *Controller) Close() {
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	return func(id manifest.NamedResource, payload any) {
+		// Source-kind listeners re-read from the Store rather than
+		// trusting payload, because s.fire dispatches AFTER s.mu is
+		// released — two concurrent AddObject calls for the same id
+		// could deliver listener payloads in reverse of write order.
+		// The store always reflects the latest write under its own
+		// lock, so a fresh GetObject is authoritative.
 		switch id.Kind {
 		case manifest.KindHelmRepository:
-			if r, ok := payload.(*manifest.HelmRepository); ok {
+			_ = payload
+			if r, ok := c.Store.GetObject(id).(*manifest.HelmRepository); ok {
 				c.Helm.AddRepo(r)
 			}
 		case manifest.KindOCIRepository:
-			if r, ok := payload.(*manifest.OCIRepository); ok {
+			_ = payload
+			if r, ok := c.Store.GetObject(id).(*manifest.OCIRepository); ok {
 				c.Helm.AddOCIRepo(r)
 			}
 		case manifest.KindHelmChart:
-			if s, ok := payload.(*manifest.HelmChartSource); ok {
+			_ = payload
+			if s, ok := c.Store.GetObject(id).(*manifest.HelmChartSource); ok {
 				c.chartSourcesMu.Lock()
 				c.chartSources[s.ResourceFullName()] = s
 				c.chartSourcesMu.Unlock()

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -236,7 +236,20 @@ func mergeStringMap(md map[string]any, key string, in map[string]string) {
 // returns a single YAML string. ShowOnly filters by template path,
 // mirroring `helm template --show-only`.
 func releaseManifest(rel *release.Release, opts Options, disableHooks, skipTests bool) string {
+	// Pre-size the builder: rendered manifest + every hook body. Saves
+	// the geometric bytes.Buffer.grow walk on big releases — measured
+	// at ~300 MB of allocations on a 200-HR drag0n141 run.
+	size := len(rel.Manifest)
+	if !disableHooks {
+		for _, h := range rel.Hooks {
+			if skipTests && isTestHook(h) {
+				continue
+			}
+			size += len("---\n# Source: \n") + len(h.Path) + len(h.Manifest) + 1
+		}
+	}
 	var b strings.Builder
+	b.Grow(size)
 	b.WriteString(rel.Manifest)
 	if !disableHooks {
 		for _, h := range rel.Hooks {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -3,7 +3,9 @@ package orchestrator
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -256,7 +258,7 @@ func (o *Orchestrator) warnSilentlySkippedVerification() {
 // seedBootstrapSource publishes a synthetic GitRepository pointing at
 // the working tree's repo root, the anchor for spec.path resolution.
 func (o *Orchestrator) seedBootstrapSource() (string, error) {
-	abs, err := filepath.Abs(o.cfg.Path)
+	abs, err := resolveScanPath(o.cfg.Path)
 	if err != nil {
 		return "", err
 	}
@@ -290,7 +292,7 @@ func (o *Orchestrator) loadManifests(ctx context.Context, repoRoot string) error
 
 	scanRoot := repoRoot
 	if o.cfg.Path != "" {
-		if abs, err := filepath.Abs(o.cfg.Path); err == nil {
+		if abs, err := resolveScanPath(o.cfg.Path); err == nil {
 			scanRoot = abs
 		}
 	}
@@ -585,13 +587,23 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	changes := o.cfg.ExternalChanges
 	if changes == nil && o.cfg.PathOrig != "" {
-		origAbs, err := filepath.Abs(o.cfg.PathOrig)
+		origAbs, err := resolveScanPath(o.cfg.PathOrig)
 		if err != nil {
 			return fmt.Errorf("--path-orig: %w", err)
 		}
-		currAbs, err := filepath.Abs(o.cfg.Path)
+		currAbs, err := resolveScanPath(o.cfg.Path)
 		if err != nil {
 			return fmt.Errorf("--path: %w", err)
+		}
+		// Both paths resolved to the same directory (e.g. a symlink and
+		// its target, or literally the same arg twice). Changed-only mode
+		// would diff a tree against itself producing an empty change set.
+		// Skip filter build so the user's `--path-orig` typo doesn't
+		// silently render zero output.
+		if origAbs == currAbs {
+			slog.Warn("--path and --path-orig resolve to the same directory; ignoring --path-orig",
+				"resolvedPath", currAbs)
+			return nil
 		}
 		// Diff the literal user-supplied paths so subdir-vs-subdir
 		// comparisons inside one repo work. Walking up to .git would
@@ -654,10 +666,18 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			"reason", info.Message)
 		delete(failed, id)
 	}
+	ksCount := len(o.store.ListObjects(manifest.KindKustomization))
+	hrCount := len(o.store.ListObjects(manifest.KindHelmRelease))
 	slog.Info("reconcile complete",
-		"kustomizations", len(o.store.ListObjects(manifest.KindKustomization)),
-		"helmReleases", len(o.store.ListObjects(manifest.KindHelmRelease)),
+		"kustomizations", ksCount,
+		"helmReleases", hrCount,
 		"failed", len(failed))
+	// Surface a clear warning when the scan turned up nothing — covers
+	// the "typo'd --path that happens to be an empty directory" case
+	// where flate would otherwise look like a silent success.
+	if ksCount == 0 && hrCount == 0 {
+		slog.Warn("no Flux Kustomization or HelmRelease objects found under --path; check the path is correct")
+	}
 
 	for id, info := range failed {
 		slog.Warn("resource failed", "id", id.String(), "reason", info.Message)
@@ -690,6 +710,29 @@ func (o *Orchestrator) Stop() {
 	if o.staging != nil {
 		_ = o.staging.Close()
 	}
+}
+
+// resolveScanPath normalizes a user-supplied --path / --path-orig:
+// absolute, with symlinks resolved. Without symlink resolution flate
+// would walk through the symlink itself (Go's filepath.WalkDir does
+// not follow root-level symlinks), producing an empty manifest set
+// without any error indication — a footgun.
+func resolveScanPath(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// Pass through the unresolved absolute path so the caller can
+		// produce a clearer "no such file or directory" error on Stat
+		// than the symlink-resolution failure.
+		if errors.Is(err, fs.ErrNotExist) {
+			return abs, nil
+		}
+		return "", fmt.Errorf("resolve --path %q: %w", p, err)
+	}
+	return resolved, nil
 }
 
 // findRepoRoot walks upward from p looking for a .git directory; falls

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -315,8 +315,11 @@ func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 
 // AddListener registers a callback for the given event kind. When
 // flush==true, the listener is immediately invoked with every matching
-// object already in the store before the call returns, in deterministic
-// order. The returned Unsubscribe removes the listener.
+// object already in the store before the call returns. Replay order is
+// unspecified (Go-map iteration); listeners that need a deterministic
+// order must sort what they receive. Listener panics during replay
+// are recovered, same as live dispatch. The returned Unsubscribe
+// removes the listener.
 func (s *Store) AddListener(event EventKind, fn Listener, flush bool) Unsubscribe {
 	set, ok := s.listeners[event]
 	if !ok {
@@ -331,7 +334,9 @@ func (s *Store) AddListener(event EventKind, fn Listener, flush bool) Unsubscrib
 }
 
 // replayInto delivers existing state to a fresh listener so it can catch
-// up. Called under no lock; takes its own RLock.
+// up. Called under no lock; takes its own RLock. Listener panics are
+// recovered via safeInvoke — replay must NOT crash the controller that
+// just attached the listener (parity with live `fire` dispatch).
 func (s *Store) replayInto(event EventKind, fn Listener) {
 	switch event {
 	case EventObjectAdded:
@@ -340,7 +345,7 @@ func (s *Store) replayInto(event EventKind, fn Listener) {
 		maps.Copy(snap, s.objects)
 		s.mu.RUnlock()
 		for id, obj := range snap {
-			fn(id, obj)
+			safeInvoke(fn, id, obj)
 		}
 	case EventStatusUpdated:
 		s.mu.RLock()
@@ -352,7 +357,7 @@ func (s *Store) replayInto(event EventKind, fn Listener) {
 		}
 		s.mu.RUnlock()
 		for id, info := range snap {
-			fn(id, info)
+			safeInvoke(fn, id, info)
 		}
 	case EventArtifactUpdated:
 		s.mu.RLock()
@@ -360,7 +365,7 @@ func (s *Store) replayInto(event EventKind, fn Listener) {
 		maps.Copy(snap, s.artifacts)
 		s.mu.RUnlock()
 		for id, art := range snap {
-			fn(id, art)
+			safeInvoke(fn, id, art)
 		}
 	}
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -422,6 +422,32 @@ func TestStore_ListenerPanicIsolated(t *testing.T) {
 	}
 }
 
+// AddListener with flush=true replays existing store contents into the
+// new listener. A panic in the listener during replay must not crash
+// the caller — controllers attach with flush=true in Start() and a
+// crash here would tear down the whole reconcile pipeline before the
+// orchestrator's Run loop ever ticked. Parity with the live `fire`
+// path in TestStore_ListenerPanicIsolated.
+func TestStore_ListenerPanicRecoveredDuringReplay(t *testing.T) {
+	s := New()
+	s.AddObject(newCM("a", "ns"))
+	s.AddObject(newCM("b", "ns"))
+	// The panicky listener attaches with flush=true → replay fires
+	// against every existing object. Without panic recovery the test
+	// would fail with a runtime panic.
+	s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) {
+		panic("boom during replay")
+	}, true)
+	// Confirm the Store is still healthy after the recovered panic.
+	other := 0
+	s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) {
+		other++
+	}, true)
+	if other != 2 {
+		t.Errorf("post-panic listener should replay 2 objects, got %d", other)
+	}
+}
+
 func TestStore_Concurrency(_ *testing.T) {
 	s := New()
 	const N = 200


### PR DESCRIPTION
## Summary
Six iter-7 multi-agent findings batched.

### CLI UX
- **Symlinked \`--path\`** silently returned 0 docs (\`filepath.Abs\` doesn't resolve symlinks). New \`resolveScanPath\` does Abs+EvalSymlinks for every --path handler.
- **Invalid \`-o\`** silently fell through to table. \`format.ParseOutput\` validates against the enum at \`runOrchestrator\` entry.
- **Empty/Flux-less \`--path\`** looked like success — WARN added when both KS and HR counts are 0.
- **\`--path == --path-orig\`** ran two orchestrators against the same tree. \`buildChangeFilter\` short-circuits with a WARN.

### Correctness
- **Store \`replayInto\` had no panic recovery** — a flush=true listener panic crashed the pipeline. Parity with \`fire\` via \`safeInvoke\`. Regression test added.
- **Helm controller listener trusted dispatched payload** — \`s.fire\` runs after Unlock, so concurrent AddObjects for the same id can deliver payloads in reverse of write order. Re-read from Store inside the listener.

### Perf
- **\`releaseManifest\` strings.Builder** triggered ~300 MB of \`bytes.Buffer.grow\` allocations on big runs. Pre-size with \`b.Grow(size)\`.

## Test plan
- [x] \`go test -race ./...\` clean
- [x] \`mise run lint\` clean
- [x] 8-repo matrix unchanged
- [x] Verified each CLI fix: symlink test ks → 73 passed; \`-o invalidformat\` → error; empty path → WARN; \`--path == --path-orig\` → WARN

🤖 Generated with [Claude Code](https://claude.com/claude-code)