### PR TITLE
perf(build): stream per-artifact, sort for deterministic output

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -1,13 +1,14 @@
 package cli
 
 import (
+	"cmp"
 	"io"
+	"slices"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/home-operations/flate/internal/format"
-	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/store"
@@ -81,8 +82,16 @@ func applyBuildFlags(c *commonFlags, b *buildFlags) {
 }
 
 func writeRendered(w io.Writer, o *orchestrator.Orchestrator, kind, name string, c *commonFlags, b *buildFlags) error {
-	var all []map[string]any
-	for _, obj := range o.Store().ListObjects(kind) {
+	// Sort by (namespace, name) so `build` output is deterministic
+	// across runs — `Store.ListObjects` iterates the byName map and
+	// would otherwise produce a different ordering each invocation,
+	// breaking shell-piped diffs and CI consumers.
+	objs := o.Store().ListObjects(kind)
+	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
+		ai, bi := a.Named(), b.Named()
+		return cmp.Or(cmp.Compare(ai.Namespace, bi.Namespace), cmp.Compare(ai.Name, bi.Name))
+	})
+	for _, obj := range objs {
 		id := obj.Named()
 		if name != "" && id.Name != name {
 			continue
@@ -90,12 +99,58 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, kind, name string,
 		if !c.includeNamespace(o.Filter(), id.Namespace) {
 			continue
 		}
-		if a, ok := o.Store().GetArtifact(id).(store.RenderedArtifact); ok {
-			all = append(all, a.RenderedManifests()...)
+		a, ok := o.Store().GetArtifact(id).(store.RenderedArtifact)
+		if !ok {
+			continue
+		}
+		// Stream per-artifact rather than accumulating every doc into a
+		// single slice — keeps the working set small on big repos and
+		// lets onlyCRDs filter run incrementally instead of building a
+		// throw-away intermediate.
+		//
+		// Clone-and-sort per-artifact so output is byte-stable across
+		// runs even when a Helm chart uses `range $name, $svc := .Values`
+		// (Go map iteration is randomized — the chart still emits the
+		// same set but in arbitrary order). Sort by (kind, ns, name).
+		// SSA-applied output doesn't care about order; CI / diff
+		// consumers do.
+		docs := slices.Clone(a.RenderedManifests())
+		slices.SortStableFunc(docs, compareDocs)
+		if b.onlyCRDs {
+			docs = filterCRDsOnly(docs)
+			if len(docs) == 0 {
+				continue
+			}
+		}
+		if err := format.YAMLMulti(w, docs); err != nil {
+			return err
 		}
 	}
-	if b.onlyCRDs {
-		all = kustomize.FilterKinds(all, []string{manifest.KindCustomResourceDefinition})
+	return nil
+}
+
+// compareDocs orders rendered docs by (kind, namespace, name).
+func compareDocs(a, b map[string]any) int {
+	an, ans := manifest.DocMetadata(a)
+	bn, bns := manifest.DocMetadata(b)
+	return cmp.Or(
+		cmp.Compare(manifest.DocKind(a), manifest.DocKind(b)),
+		cmp.Compare(ans, bns),
+		cmp.Compare(an, bn),
+	)
+}
+
+// filterCRDsOnly returns the subset of docs whose `kind` is
+// CustomResourceDefinition. Inlined here (rather than via
+// kustomize.FilterKinds) to skip the slice-copy when nothing matches:
+// most rendered artifacts contain zero CRDs, so the common case is to
+// return a length-0 slice without allocation.
+func filterCRDsOnly(docs []map[string]any) []map[string]any {
+	var out []map[string]any
+	for _, doc := range docs {
+		if manifest.DocKind(doc) == manifest.KindCustomResourceDefinition {
+			out = append(out, doc)
+		}
 	}
-	return format.YAMLMulti(w, all)
+	return out
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -133,6 +133,19 @@ func TestE2E_BuildHR(t *testing.T) {
 	}
 }
 
+// build hr emits identical bytes on repeated runs against the same
+// tree. Pins the per-artifact sort that's needed because some Helm
+// charts use `range $name, $v := .Values.*` which iterates Go maps
+// randomly — without the sort, byte-stable diffs in CI would break.
+func TestE2E_BuildHR_Deterministic(t *testing.T) {
+	dir := copyTree(t, testdataPath(t, "simple"))
+	out1 := runCLIStdout(t, "build", "hr", "--path", dir)
+	out2 := runCLIStdout(t, "build", "hr", "--path", dir)
+	if out1 != out2 {
+		t.Errorf("build hr output differs between runs (length %d vs %d)", len(out1), len(out2))
+	}
+}
+
 func TestE2E_GetAll_JSON(t *testing.T) {
 	out := runCLI(t, "get", "all", "--path", testdataPath(t, "simple"), "-o", "json")
 	if !strings.Contains(out, `"kustomizations"`) {


### PR DESCRIPTION
## Summary
\`flate build {ks,hr,all}\` now produces byte-stable output across runs and emits incrementally instead of accumulating every rendered doc into a single slice.

### Determinism
- **Artifacts sorted by (namespace, name)** — \`Store.ListObjects\` returns map iteration order, which is randomized.
- **Docs sorted by (kind, namespace, name) WITHIN each artifact** — some Helm charts use \`range $name, $v := .Values.*\` which iterates Go maps randomly, so the same rendered SET lands in arbitrary doc order.
- Cloning the slice before sorting keeps the store's canonical ordering untouched.

### Streaming
- \`writeRendered\` now calls \`format.YAMLMulti(w, docs)\` once per artifact instead of building a union \`[]map[string]any\` first.
- \`onlyCRDs\` filter runs incrementally — \`kustomize.FilterKinds\` previously allocated a length-N slice even when nothing matched. New \`filterCRDsOnly\` returns nil for the empty case.

### Caveat
A small class of non-determinism remains (chart-internal \`checksum/secret-*\` annotations computed inside helm templates) — that's upstream of flate.

## Test plan
- [x] \`TestE2E_BuildHR_Deterministic\` pins byte stability
- [x] \`go test -race ./...\` clean
- [x] \`mise run lint\` clean
- [x] 8-repo \`test ks\` unchanged
- [x] Verified 3-run determinism on buroa/jory-main/billimek; remaining repos non-deterministic only on the chart-internal-checksum subclass

🤖 Generated with [Claude Code](https://claude.com/claude-code)