### PR TITLE
feat+perf+ux: Configure refactor, more chart sources, --skip-schema, chartRef version

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ All output is written to stdout — redirect with `> file.yaml` to capture it. L
 | `--no-hooks` | `false` | Exclude hook-annotated templates. |
 | `-s`, `--show-only` | _(none)_ | Restrict render to specific template paths, repeatable. |
 | `--enable-dns` | `false` | Allow DNS lookups during `helm template`. |
+| `--skip-schema-validation` | `false` | Skip `values.schema.json` validation. Helm's jsonschema validator dominates allocation churn — flipping this on saves ~45% wall time on large repos. |
 
 ### Build flags
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -89,12 +89,13 @@ func (c *commonFlags) includeNamespace(filter *change.Filter, ns string) bool {
 // helmFlags collect the helm template options. Mirrors flux-local's
 // --kube-version/--api-versions/--no-hooks/etc.
 type helmFlags struct {
-	kubeVersion string
-	apiVersions string
-	isUpgrade   bool
-	noHooks     bool
-	showOnly    []string
-	enableDNS   bool
+	kubeVersion          string
+	apiVersions          string
+	isUpgrade            bool
+	noHooks              bool
+	showOnly             []string
+	enableDNS            bool
+	skipSchemaValidation bool
 }
 
 func bindHelmFlags(fs *pflag.FlagSet, h *helmFlags) {
@@ -109,20 +110,23 @@ func bindHelmFlags(fs *pflag.FlagSet, h *helmFlags) {
 	fs.BoolVar(&h.noHooks, "no-hooks", false, "exclude hook-annotated templates")
 	fs.StringSliceVarP(&h.showOnly, "show-only", "s", nil, "only show specific template paths (repeatable)")
 	fs.BoolVar(&h.enableDNS, "enable-dns", false, "enable DNS lookups during helm template")
+	fs.BoolVar(&h.skipSchemaValidation, "skip-schema-validation", false,
+		"skip helm values.schema.json validation (dominates allocation churn on big repos)")
 }
 
 func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 	return helm.Options{
-		SkipCRDs:    c.skipCRDs,
-		SkipSecrets: c.skipSecrets,
-		SkipKinds:   c.skipKinds,
-		KubeVersion: h.kubeVersion,
-		APIVersions: h.apiVersions,
-		IsUpgrade:   h.isUpgrade,
-		NoHooks:     h.noHooks,
-		ShowOnly:    h.showOnly,
-		EnableDNS:   h.enableDNS,
-		SkipTests:   true,
+		SkipCRDs:             c.skipCRDs,
+		SkipSecrets:          c.skipSecrets,
+		SkipKinds:            c.skipKinds,
+		KubeVersion:          h.kubeVersion,
+		APIVersions:          h.apiVersions,
+		IsUpgrade:            h.isUpgrade,
+		NoHooks:              h.noHooks,
+		ShowOnly:             h.showOnly,
+		EnableDNS:            h.enableDNS,
+		SkipSchemaValidation: h.skipSchemaValidation,
+		SkipTests:            true,
 	}
 }
 

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -25,7 +25,7 @@ func newGetCmd() *cobra.Command {
 func newGetKSCmd() *cobra.Command {
 	return resourceListCmd("ks", []string{"kustomization", "kustomizations"},
 		"List Kustomizations", manifest.KindKustomization, ksColumns,
-		func(o *manifest.Kustomization) (row map[string]string, doc map[string]any) {
+		func(_ *orchestrator.Orchestrator, o *manifest.Kustomization) (row map[string]string, doc map[string]any) {
 			doc = map[string]any{
 				"kind": manifest.KindKustomization, "namespace": o.Namespace,
 				"name": o.Name, "path": o.Path,
@@ -53,11 +53,19 @@ func newGetKSCmd() *cobra.Command {
 func newGetHRCmd() *cobra.Command {
 	return resourceListCmd("hr", []string{"helmrelease", "helmreleases"},
 		"List HelmReleases", manifest.KindHelmRelease, hrColumns,
-		func(o *manifest.HelmRelease) (row map[string]string, doc map[string]any) {
+		func(orch *orchestrator.Orchestrator, o *manifest.HelmRelease) (row map[string]string, doc map[string]any) {
+			version := o.Chart.Version
+			// chartRef HRs leave hr.Chart.Version empty — the version is
+			// pinned on the referenced OCIRepository (ref.tag) or
+			// HelmChart CRD (spec.version). Surface that for display
+			// instead of an empty column.
+			if version == "" {
+				version = resolveChartRefVersion(orch, o)
+			}
 			doc = map[string]any{
 				"kind": manifest.KindHelmRelease, "namespace": o.Namespace,
 				"name": o.Name, "chart": o.Chart.ChartName(),
-				"version": o.Chart.Version, "source": o.Chart.RepoName,
+				"version": version, "source": o.Chart.RepoName,
 				"sourceRef": map[string]string{
 					"kind":      o.Chart.RepoKind,
 					"name":      o.Chart.RepoName,
@@ -73,10 +81,38 @@ func newGetHRCmd() *cobra.Command {
 			}
 			return map[string]string{
 				"namespace": o.Namespace, "name": o.Name,
-				"chart": o.Chart.ChartName(), "version": o.Chart.Version,
+				"chart": o.Chart.ChartName(), "version": version,
 				"source": o.Chart.RepoName,
 			}, doc
 		})
+}
+
+// resolveChartRefVersion looks up the version pinned on the source CR
+// that hr.Chart references. For OCIRepository the source's
+// spec.ref.tag (or semver) is the version; for the HelmChart CRD the
+// version field is part of the CRD spec.
+func resolveChartRefVersion(orch *orchestrator.Orchestrator, hr *manifest.HelmRelease) string {
+	srcID := manifest.NamedResource{
+		Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
+	}
+	obj := orch.Store().GetObject(srcID)
+	switch s := obj.(type) {
+	case *manifest.OCIRepository:
+		if s.Reference != nil {
+			if s.Reference.Tag != "" {
+				return s.Reference.Tag
+			}
+			if s.Reference.SemVer != "" {
+				return s.Reference.SemVer
+			}
+			if s.Reference.Digest != "" {
+				return s.Reference.Digest
+			}
+		}
+	case *manifest.HelmChartSource:
+		return s.Version
+	}
+	return ""
 }
 
 func newGetAllCmd() *cobra.Command {
@@ -124,10 +160,11 @@ func newGetImagesCmd() *cobra.Command {
 
 // resourceListCmd builds a `get <kind>` subcommand. mapper converts each
 // stored object to (table row, structured doc); cols is the table
-// schema.
+// schema. The orchestrator is threaded into mapper so display logic
+// can resolve cross-references (e.g. HR chartRef → OCIRepository tag).
 func resourceListCmd[T manifest.BaseManifest](
 	use string, aliases []string, short, kind string,
-	cols []format.Column, mapper func(T) (map[string]string, map[string]any),
+	cols []format.Column, mapper func(*orchestrator.Orchestrator, T) (map[string]string, map[string]any),
 ) *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
@@ -157,7 +194,7 @@ func resourceListCmd[T manifest.BaseManifest](
 func printResources[T manifest.BaseManifest](
 	w io.Writer, o *orchestrator.Orchestrator, sel selector.Metadata, c *commonFlags,
 	out, kind string,
-	cols []format.Column, mapper func(T) (map[string]string, map[string]any),
+	cols []format.Column, mapper func(*orchestrator.Orchestrator, T) (map[string]string, map[string]any),
 ) error {
 	objs := o.Store().ListObjects(kind)
 	rows := make([]map[string]string, 0, len(objs))
@@ -174,7 +211,7 @@ func printResources[T manifest.BaseManifest](
 		if !ok {
 			continue
 		}
-		row, doc := mapper(t)
+		row, doc := mapper(o, t)
 		rows = append(rows, row)
 		docs = append(docs, doc)
 	}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"maps"
 	"sync"
+	"sync/atomic"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -24,15 +25,12 @@ import (
 	"github.com/home-operations/flate/pkg/values"
 )
 
-// Controller orchestrates HelmRelease reconciliation.
+// Controller orchestrates HelmRelease reconciliation. Reconcile-shaping
+// state (Filter) flows in via Configure exactly once before Start.
 type Controller struct {
 	Store *store.Store
 	Tasks *task.Service
 	Helm  *helm.Client
-	// Filter, when non-nil and enabled, narrows reconciliation to
-	// only the HelmReleases whose source files (or whose referenced
-	// sources/values) changed between two checkouts.
-	Filter *change.Filter
 
 	// Options applied to every template call.
 	Options helm.Options
@@ -41,15 +39,38 @@ type Controller struct {
 	// templates.
 	WipeSecrets bool
 
-	unsub []store.Unsubscribe
-	coal  *task.Coalescer[manifest.NamedResource]
+	// Set via Configure() — see Options.
+	filter *change.Filter
+
+	started atomic.Bool
+	unsub   []store.Unsubscribe
+	coal    *task.Coalescer[manifest.NamedResource]
 
 	chartSourcesMu sync.RWMutex
 	chartSources   map[string]*manifest.HelmChartSource
 }
 
+// ReconcileOptions carries the post-bootstrap state the orchestrator
+// wires onto the controller. Filter narrows reconciliation to changed
+// HelmReleases (and their referenced sources/values) in changed-only
+// mode.
+type ReconcileOptions struct {
+	Filter *change.Filter
+}
+
+// Configure installs the post-bootstrap state. Panics if called after
+// Start — encodes the invariant that reconcile-shaping config is
+// read-only once dispatch begins.
+func (c *Controller) Configure(opts ReconcileOptions) {
+	if c.started.Load() {
+		panic("helmrelease controller: Configure called after Start")
+	}
+	c.filter = opts.Filter
+}
+
 // Start registers the listeners. The controller runs until Close.
 func (c *Controller) Start(ctx context.Context) {
+	c.started.Store(true)
 	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
 	c.chartSources = map[string]*manifest.HelmChartSource{}
 	c.unsub = append(c.unsub,
@@ -101,7 +122,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 				return
 			}
-			if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {
+			if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
 				c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
 				return
 			}
@@ -112,22 +133,24 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	}
 }
 
-// onArtifactUpdated registers GitRepository artifacts with the helm
-// client so charts referenced via sourceRef.kind=GitRepository can be
-// loaded from disk.
+// onArtifactUpdated registers fetched-artifact sources (GitRepository,
+// Bucket, ExternalArtifact) with the helm client so charts referenced
+// via the corresponding sourceRef.kind can be loaded from disk.
 func (c *Controller) onArtifactUpdated(id manifest.NamedResource, payload any) {
-	if id.Kind != manifest.KindGitRepository {
+	switch id.Kind {
+	case manifest.KindGitRepository, manifest.KindBucket, manifest.KindExternalArtifact:
+	default:
 		return
 	}
-	gitArt, ok := payload.(*store.SourceArtifact)
-	if !ok || gitArt.Kind != manifest.KindGitRepository {
+	art, ok := payload.(*store.SourceArtifact)
+	if !ok || art.LocalPath == "" {
 		return
 	}
-	repo, _ := c.Store.GetObject(id).(*manifest.GitRepository)
-	if repo == nil {
-		return
-	}
-	c.Helm.AddLocalGit(helm.LocalGitRepository{Repo: repo, Artifact: gitArt})
+	c.Helm.AddLocalSource(helm.LocalSource{
+		Name:      id.Name,
+		Namespace: id.Namespace,
+		Artifact:  art,
+	})
 }
 
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -23,7 +23,8 @@ func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store
 	if err != nil {
 		t.Fatalf("helm.NewClient: %v", err)
 	}
-	c := &Controller{Store: st, Tasks: ts, Helm: hc, Filter: filter}
+	c := &Controller{Store: st, Tasks: ts, Helm: hc}
+	c.Configure(ReconcileOptions{Filter: filter})
 	c.Start(context.Background())
 	t.Cleanup(func() {
 		c.Close()

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	yaml "go.yaml.in/yaml/v4"
 
@@ -24,7 +25,11 @@ import (
 	"github.com/home-operations/flate/pkg/values"
 )
 
-// Controller orchestrates Kustomization reconciliation.
+// Controller orchestrates Kustomization reconciliation. Construction
+// args are immutable from the outside; reconcile-shaping state (Filter,
+// ParentOf) flows in via Configure exactly once before Start. The
+// invariant — "config is read-only after Start" — is encoded in the
+// type, not just in code review.
 type Controller struct {
 	Store *store.Store
 	Tasks *task.Service
@@ -32,30 +37,47 @@ type Controller struct {
 	// into writable copies so Flux's Generator can write the merged
 	// kustomization.yaml without touching the user's working tree.
 	Staging *kustomize.StagingCache
-	// Filter, when non-nil and enabled, narrows reconciliation to
-	// only the resources whose source files changed between two
-	// checkouts.
-	Filter *change.Filter
 
 	// WipeSecrets controls whether Secret cleartext is wiped when
 	// parsing rendered manifests.
 	WipeSecrets bool
 
-	// ParentOf maps each Flux Kustomization to its structural parent —
-	// the enclosing KS whose spec.path contains this one's source
-	// file. Reconcile waits for the parent's Ready before rendering so
-	// any parent-render-time spec mutations (e.g. `replacements:`
-	// injecting spec.targetNamespace) are observable when the child
-	// renders. Nil means "no parent enforcement," matching pre-#102
-	// behavior.
-	ParentOf map[manifest.NamedResource]manifest.NamedResource
+	// Set via Configure() — see Options.
+	filter   *change.Filter
+	parentOf map[manifest.NamedResource]manifest.NamedResource
 
-	unsub []store.Unsubscribe
-	coal  *task.Coalescer[manifest.NamedResource]
+	started atomic.Bool
+	unsub   []store.Unsubscribe
+	coal    *task.Coalescer[manifest.NamedResource]
+}
+
+// Options carries the post-bootstrap state the orchestrator wires onto
+// the controller before Start. Filter narrows reconciliation to
+// changed resources in changed-only mode. ParentOf maps each Flux
+// Kustomization to its structural parent so reconcile waits for the
+// parent's Ready before rendering (so any parent-render-time spec
+// mutations — e.g. `replacements:` injecting spec.targetNamespace —
+// are observable when the child renders). A nil ParentOf disables
+// parent-enforcement, matching pre-#102 behavior.
+type Options struct {
+	Filter   *change.Filter
+	ParentOf map[manifest.NamedResource]manifest.NamedResource
+}
+
+// Configure installs the post-bootstrap state. Panics if called after
+// Start — encodes the invariant that reconcile-shaping config is
+// read-only once the controller is dispatching.
+func (c *Controller) Configure(opts Options) {
+	if c.started.Load() {
+		panic("kustomization controller: Configure called after Start")
+	}
+	c.filter = opts.Filter
+	c.parentOf = opts.ParentOf
 }
 
 // Start registers the listener that drives reconciliation.
 func (c *Controller) Start(ctx context.Context) {
+	c.started.Store(true)
 	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
 	c.unsub = append(c.unsub,
 		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
@@ -83,7 +105,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
 			return
 		}
-		if c.Filter.Enabled() && !c.Filter.ShouldReconcile(id) {
+		if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
 			c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
 			return
 		}
@@ -325,7 +347,7 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 			},
 		})
 	}
-	if parent, ok := c.ParentOf[ks.Named()]; ok {
+	if parent, ok := c.parentOf[ks.Named()]; ok {
 		deps = append(deps, manifest.DependencyRef{NamedResource: parent})
 	}
 	return deps

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -16,9 +16,10 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 	}
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
 
-	c := &Controller{ParentOf: map[manifest.NamedResource]manifest.NamedResource{
+	c := &Controller{}
+	c.Configure(Options{ParentOf: map[manifest.NamedResource]manifest.NamedResource{
 		child.Named(): parent,
-	}}
+	}})
 	deps := c.collectDeps(child)
 	for _, d := range deps {
 		if d.NamedResource == parent {

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -12,6 +12,7 @@ package source
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -23,13 +24,11 @@ import (
 
 // Controller watches the Store for source-kind objects, fetches each
 // into an on-disk artifact via the matching Fetcher, and updates the
-// Store with the result.
+// Store with the result. Reconcile-shaping state (Filter) flows in
+// via Configure exactly once before Start.
 type Controller struct {
 	Store *store.Store
 	Tasks *task.Service
-	// Filter, when non-nil and enabled, narrows fetches to only
-	// sources referenced by changed resources.
-	Filter *change.Filter
 
 	// Fetchers maps source CR kind → Fetcher implementation. Source
 	// kinds with no entry are ignored, which is also how a flate caller
@@ -37,13 +36,34 @@ type Controller struct {
 	// from the map).
 	Fetchers map[string]src.Fetcher
 
+	// Set via Configure() — see FetchOptions.
+	filter *change.Filter
+
+	started       atomic.Bool
 	unsubscribers []store.Unsubscribe
 	coal          *task.Coalescer[manifest.NamedResource]
+}
+
+// FetchOptions carries the post-bootstrap state the orchestrator wires
+// onto the controller. Filter narrows fetches to sources referenced by
+// changed resources in changed-only mode.
+type FetchOptions struct {
+	Filter *change.Filter
+}
+
+// Configure installs the post-bootstrap state. Panics if called after
+// Start.
+func (c *Controller) Configure(opts FetchOptions) {
+	if c.started.Load() {
+		panic("source controller: Configure called after Start")
+	}
+	c.filter = opts.Filter
 }
 
 // Start registers listeners on the Store. The controller runs until
 // Close is called.
 func (c *Controller) Start(ctx context.Context) {
+	c.started.Store(true)
 	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
 	c.unsubscribers = append(c.unsubscribers,
 		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
@@ -88,10 +108,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 // skip applies the change filter and marks unaffected sources Ready
 // without fetching so dependsOn waits succeed instantly.
 func (c *Controller) skip(id manifest.NamedResource) bool {
-	if !c.Filter.Enabled() {
+	if !c.filter.Enabled() {
 		return false
 	}
-	if c.Filter.ShouldReconcile(id) {
+	if c.filter.ShouldReconcile(id) {
 		return false
 	}
 	c.Store.UpdateStatus(id, store.StatusReady, "unchanged")

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -152,7 +152,8 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 		"",
 		mapLister{},
 	)
-	c := &Controller{Store: st, Tasks: ts, Fetchers: map[string]src.Fetcher{manifest.KindGitRepository: f}, Filter: filter}
+	c := &Controller{Store: st, Tasks: ts, Fetchers: map[string]src.Fetcher{manifest.KindGitRepository: f}}
+	c.Configure(FetchOptions{Filter: filter})
 	c.Start(context.Background())
 	t.Cleanup(func() {
 		c.Close()

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -17,20 +17,24 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// LocalGitRepository couples a GitRepository CRD with the cached working
-// tree produced by SourceController. The helm Client uses these to
-// resolve charts whose sourceRef.kind is GitRepository.
-type LocalGitRepository struct {
-	Repo     *manifest.GitRepository
-	Artifact *store.SourceArtifact
+// LocalSource couples a source CR (GitRepository / Bucket /
+// ExternalArtifact — any fetched artifact that lives as a directory on
+// disk) with the fetcher-produced SourceArtifact. The helm Client uses
+// these to resolve charts whose sourceRef.kind points at one of those
+// three kinds; the chart sits at `<Artifact.LocalPath>/<hr.Chart.Name>`
+// in every case. Name+Namespace mirror the source CR so RepoFullName
+// matches what hr.Chart.RepoFullName() produces.
+type LocalSource struct {
+	Name      string
+	Namespace string
+	Artifact  *store.SourceArtifact
 }
 
-// RepoName mirrors HelmRepository.RepoName for convenience in lookups.
-func (l LocalGitRepository) RepoName() string {
-	if l.Repo == nil {
-		return ""
-	}
-	return l.Repo.RepoName()
+// RepoFullName is the `<namespace>-<name>` lookup key. Matches
+// manifest.HelmChart.RepoFullName so listing the helm client's
+// local sources resolves cleanly against the HR's chartRef.
+func (l LocalSource) RepoFullName() string {
+	return l.Namespace + "-" + l.Name
 }
 
 // SecretGetter resolves a Secret CR by namespace + name. The helm
@@ -44,12 +48,12 @@ type Client struct {
 	tmpDir   string
 	cacheDir string
 
-	mu       sync.RWMutex
-	repos    map[string]*manifest.HelmRepository
-	ociRepos map[string]*manifest.OCIRepository
-	gitRepos map[string]LocalGitRepository
-	registry *registry.Client
-	secrets  SecretGetter
+	mu           sync.RWMutex
+	repos        map[string]*manifest.HelmRepository
+	ociRepos     map[string]*manifest.OCIRepository
+	localSources map[string]LocalSource
+	registry     *registry.Client
+	secrets      SecretGetter
 
 	// chartCache memoizes parsed *chart.Chart by on-disk path. Helm's
 	// loader.Load reparses the entire tgz on every call — for repos
@@ -77,12 +81,12 @@ func NewClient(tmpDir, cacheDir string) (*Client, error) {
 		return nil, fmt.Errorf("helm registry: %w", err)
 	}
 	return &Client{
-		tmpDir:   tmpDir,
-		cacheDir: cacheDir,
-		repos:    map[string]*manifest.HelmRepository{},
-		ociRepos: map[string]*manifest.OCIRepository{},
-		gitRepos: map[string]LocalGitRepository{},
-		registry: reg,
+		tmpDir:       tmpDir,
+		cacheDir:     cacheDir,
+		repos:        map[string]*manifest.HelmRepository{},
+		ociRepos:     map[string]*manifest.OCIRepository{},
+		localSources: map[string]LocalSource{},
+		registry:     reg,
 	}, nil
 }
 
@@ -115,15 +119,16 @@ func (c *Client) AddOCIRepo(repo *manifest.OCIRepository) {
 	c.ociRepos[repo.RepoName()] = repo
 }
 
-// AddLocalGit registers a GitRepository / artifact pair so charts
-// referenced via sourceRef.kind=GitRepository can be loaded.
-func (c *Client) AddLocalGit(g LocalGitRepository) {
-	if g.Repo == nil || g.Artifact == nil {
+// AddLocalSource registers a fetched-artifact source — GitRepository,
+// Bucket, or ExternalArtifact — so charts referenced via the
+// corresponding sourceRef.kind can be resolved on disk.
+func (c *Client) AddLocalSource(s LocalSource) {
+	if s.Name == "" || s.Artifact == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.gitRepos[g.RepoName()] = g
+	c.localSources[s.RepoFullName()] = s
 }
 
 // LocateChart returns a filesystem path to the chart referenced by hr.
@@ -134,8 +139,8 @@ func (c *Client) LocateChart(ctx context.Context, hr *manifest.HelmRelease) (str
 		return "", errors.New("nil HelmRelease")
 	}
 	switch hr.Chart.RepoKind {
-	case manifest.KindGitRepository:
-		return c.locateGitChart(hr)
+	case manifest.KindGitRepository, manifest.KindBucket, manifest.KindExternalArtifact:
+		return c.locateLocalChart(hr)
 	case manifest.KindOCIRepository:
 		return c.locateOCIChart(ctx, hr)
 	case manifest.KindHelmRepository, "":

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 
@@ -35,12 +34,10 @@ data:
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	cli.AddLocalGit(LocalGitRepository{
-		Repo: &manifest.GitRepository{
-			Name: "chart-repo", Namespace: "flux-system",
-			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + dir},
-		},
-		Artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
+	cli.AddLocalSource(LocalSource{
+		Name:      "chart-repo",
+		Namespace: "flux-system",
+		Artifact:  &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
 	})
 
 	hr := &manifest.HelmRelease{
@@ -83,12 +80,10 @@ func helmChartFixture(t *testing.T) *Client {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	cli.AddLocalGit(LocalGitRepository{
-		Repo: &manifest.GitRepository{
-			Name: "chart-repo", Namespace: "flux-system",
-			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + dir},
-		},
-		Artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
+	cli.AddLocalSource(LocalSource{
+		Name:      "chart-repo",
+		Namespace: "flux-system",
+		Artifact:  &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
 	})
 	return cli
 }

--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -33,6 +33,13 @@ type Options struct {
 	ShowOnly []string
 	// EnableDNS enables DNS lookups during templating.
 	EnableDNS bool
+	// SkipSchemaValidation opts out of `values.schema.json` validation
+	// for every HR — helm's jsonschema validator recompiles the schema
+	// per render and dominates allocation churn on big repos. The
+	// per-HR placeholder-detection path still kicks in on top of this:
+	// even with this flag false, schema validation is skipped when the
+	// HR values contain a wipe placeholder.
+	SkipSchemaValidation bool
 }
 
 // SkipResourceKinds returns the union of canonical and user-specified

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -48,17 +48,18 @@ type ChartLoadResult struct {
 	Chart *chart.Chart
 }
 
-// locateGitChart resolves a chart whose source is a GitRepository — the
-// chart lives at <artifact.LocalPath>/<chart.Name>.
-func (c *Client) locateGitChart(hr *manifest.HelmRelease) (string, error) {
+// locateLocalChart resolves a chart whose source is a fetched on-disk
+// artifact — GitRepository, Bucket, or ExternalArtifact. The chart
+// lives at <artifact.LocalPath>/<chart.Name> in every case.
+func (c *Client) locateLocalChart(hr *manifest.HelmRelease) (string, error) {
 	c.mu.RLock()
-	g, ok := c.gitRepos[hr.Chart.RepoFullName()]
+	s, ok := c.localSources[hr.Chart.RepoFullName()]
 	c.mu.RUnlock()
-	if !ok || g.Artifact == nil {
-		return "", fmt.Errorf("%w: GitRepository %s not available for HelmRelease %s",
-			manifest.ErrObjectNotFound, hr.Chart.RepoFullName(), hr.NamespacedName())
+	if !ok || s.Artifact == nil {
+		return "", fmt.Errorf("%w: %s %s not available for HelmRelease %s",
+			manifest.ErrObjectNotFound, hr.Chart.RepoKind, hr.Chart.RepoFullName(), hr.NamespacedName())
 	}
-	path := filepath.Join(g.Artifact.LocalPath, hr.Chart.Name)
+	path := filepath.Join(s.Artifact.LocalPath, hr.Chart.Name)
 	if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err != nil {
 		return "", fmt.Errorf("chart not found at %s: %w", path, err)
 	}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -73,7 +73,7 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	// validation error against a value flate fabricated. Real Flux
 	// resolves the secret to the actual value and validates normally —
 	// flate can't, so this short-circuits the failure mode.
-	inst.SkipSchemaValidation = hr.DisableSchemaValidation || manifest.ContainsValuePlaceholder(hrValues)
+	inst.SkipSchemaValidation = opts.SkipSchemaValidation || hr.DisableSchemaValidation || manifest.ContainsValuePlaceholder(hrValues)
 	// spec.postRenderers — pipe rendered output through one or more
 	// kustomize patch+image transforms. helm-controller does this via
 	// the same postrenderer.PostRenderer hook.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -92,6 +92,11 @@ type Orchestrator struct {
 	// is populated during loadManifests and consumed once by Bootstrap
 	// to construct the immutable change.Filter.
 	sourceFiles map[manifest.NamedResource]string
+
+	// parentOf is the structural-parent index Bootstrap computes after
+	// loadManifests + namespace inheritance. Configured onto the
+	// kustomization controller at Run-time, never mutated thereafter.
+	parentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
 // New constructs an Orchestrator. It allocates the Store and TaskService
@@ -352,7 +357,7 @@ func (o *Orchestrator) loadManifests(ctx context.Context, repoRoot string) error
 	// Build the parent index after namespace inheritance so the
 	// recorded child→parent ids reflect the canonical (post-rewrite)
 	// NamedResources the controller will see.
-	o.ksc.ParentOf = loader.BuildParentIndex(o.store, o.sourceFiles)
+	o.parentOf = loader.BuildParentIndex(o.store, o.sourceFiles)
 	return nil
 }
 
@@ -612,17 +617,18 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	return nil
 }
 
-// attachFilter wires the same filter into every controller.
+// attachFilter records the resolved Filter; controllers consume it
+// via Configure() at Run time.
 func (o *Orchestrator) attachFilter(f *change.Filter) {
 	o.filter = f
-	o.src.Filter = f
-	o.ksc.Filter = f
-	o.hrc.Filter = f
 }
 
 // Run starts every controller, blocks until the task service drains,
 // then aggregates and returns any failures.
 func (o *Orchestrator) Run(ctx context.Context) error {
+	o.src.Configure(sourcectrl.FetchOptions{Filter: o.filter})
+	o.ksc.Configure(kustomization.Options{Filter: o.filter, ParentOf: o.parentOf})
+	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
 	o.hrc.Start(ctx)


### PR DESCRIPTION
## Summary
Worked through the deferred items list. Four wins:

### PR-A — Controller \`Configure\` refactor (architecture)
- Three controllers (kustomization, helmrelease, source) used to expose \`Filter\` / \`ParentOf\` as exported fields the orchestrator mutated post-New(). Encode the "read-only after Start" invariant in the type.
- Each controller gets a typed \`Configure(opts)\` method + \`atomic.Bool started\` guard. Orchestrator calls \`Configure\` inside Run, just before \`Start\`.

### PR-B — Bucket / ExternalArtifact as chart sources (parity)
- Real Flux's chart \`sourceRef.kind\` enum includes \`Bucket\` and \`ExternalArtifact\`. flate only handled HelmRepository / OCIRepository / GitRepository.
- Rename \`LocalGitRepository\` → \`LocalSource\` (generic fetched-artifact source). All three kinds dispatch through the same locator. HR controller's \`onArtifactUpdated\` registers Bucket + ExternalArtifact too.

### PR-C — \`--skip-schema-validation\` flag (perf)
- Helm's jsonschema validator dominates allocation churn (~56% on drag0n141's 200-HR run per iter-7 memory profile).
- New CLI flag gates it globally; per-HR placeholder-detection path still applies on top.
- **Measured: drag0n141 warm-run 2.95s → 1.61s (~45% faster)**.

### PR-D — \`get hr\` VERSION fallback for chartRef (UX)
- chartRef HRs left the VERSION column empty. Thread orchestrator into the mapper; resolve through OCIRepository.spec.ref or HelmChart.spec.version.
- m00n's \`flux-instance\` now shows \`0.49.0\` instead of empty.

## Test plan
- [x] \`go test -race ./...\` clean
- [x] \`mise run lint\` clean
- [x] 8-repo matrix unchanged
- [x] Measured perf delta on drag0n141 (45% faster with --skip-schema-validation)
- [x] Verified VERSION column populated for chartRef HRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)