### PR TITLE
refactor(controllers): consolidate lifecycle into base.Controller; fix(oci): cache-poison

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -1,18 +1,122 @@
-// Package base provides the small shared harness that the
-// kustomization, helmrelease, and source controllers wrap around their
-// per-resource reconcile bodies. It centralizes panic attribution
-// (so a panicked reconcile marks the affected resource Failed instead
-// of silently disappearing) and the post-reconcile status transition.
+// Package base provides the shared lifecycle harness every flate
+// controller wraps around its per-resource reconcile body.
+//
+// Each concrete controller (source, kustomization, helmrelease)
+// embeds *base.Controller and contributes only the controller-specific
+// dependencies (Fetchers, Helm client, Staging cache, ...) plus the
+// reconcile function itself. Lifecycle wiring — the started gate, the
+// unsubscriber slice, the per-id coalescer, the change filter, the
+// Suspend/Filter pre-gate — lives here exactly once.
+//
+// The package also owns the panic-recovery + status-transition harness
+// (Recover, RunWithStatus) that surrounds individual reconcile bodies.
 package base
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 
+	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
 )
+
+// Controller is the embeddable lifecycle harness. Construct via New,
+// install reconcile-shaping config via SetFilter (panics if called
+// after Start), then Start to register listeners.
+//
+// All three concrete controllers carry the same lifecycle shape:
+//   - a started gate so Configure-after-Start is a hard error
+//   - a coalescer so duplicate AddObject events don't double-reconcile
+//   - a filter for changed-only mode
+//   - an unsubscriber list cleared by Close
+//
+// Encoding it once means new pre-reconcile concerns (rate-limit,
+// retries, debug-mode toggle) drop into one place and propagate.
+type Controller struct {
+	Store *store.Store
+	Tasks *task.Service
+
+	started atomic.Bool
+	unsub   []store.Unsubscribe
+	coal    *task.Coalescer[manifest.NamedResource]
+	filter  *change.Filter
+
+	// kindLabel prefixes coalescer keys ("source/", "kustomization/",
+	// "helmrelease/") and labels panic logs. Set by Start.
+	kindLabel string
+}
+
+// New constructs a base controller. Concrete controllers call this
+// from their own constructor and embed the result.
+func New(s *store.Store, t *task.Service) *Controller {
+	return &Controller{Store: s, Tasks: t}
+}
+
+// SetFilter installs the change filter that gates reconciliation in
+// changed-only mode. Panics if called after Start — the invariant is
+// that reconcile-shaping config is frozen once dispatch begins.
+func (c *Controller) SetFilter(f *change.Filter) {
+	if c.started.Load() {
+		panic("controller: SetFilter called after Start")
+	}
+	c.filter = f
+}
+
+// Filter returns the configured filter (may be nil-but-non-active).
+func (c *Controller) Filter() *change.Filter { return c.filter }
+
+// StartLifecycle flips the started gate and allocates the coalescer.
+// Concrete controllers call this from their Start(ctx) before
+// installing listeners via AddListener.
+func (c *Controller) StartLifecycle(kindLabel string) {
+	c.kindLabel = kindLabel
+	c.started.Store(true)
+	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
+}
+
+// AddListener registers a store listener and records it so Close can
+// unsubscribe. snapshot=true matches every concrete controller's needs
+// (deliver the current store state on subscribe).
+func (c *Controller) AddListener(event store.EventKind, l store.Listener) {
+	c.unsub = append(c.unsub, c.Store.AddListener(event, l, true))
+}
+
+// Close removes every registered listener. Idempotent.
+func (c *Controller) Close() {
+	for _, u := range c.unsub {
+		u()
+	}
+	c.unsub = nil
+}
+
+// Submit enqueues a reconcile body keyed by id. Duplicate submits with
+// the same id coalesce so a re-emit by a parent KS doesn't double the
+// work. Caller-supplied fn runs with panic-recover already installed.
+func (c *Controller) Submit(ctx context.Context, id manifest.NamedResource, fn func(context.Context)) {
+	c.coal.Submit(ctx, c.kindLabel+"/"+id.String(), id, fn)
+}
+
+// PreGate is the canonical Suspend/Filter pre-reconcile check.
+// Returns true when the resource is gated out — caller MUST bail.
+//
+//   - suspended → marks Ready "suspended", returns true
+//   - filter excludes the id → marks Ready "unchanged", returns true
+//   - otherwise → returns false, caller proceeds to Submit/reconcile
+func (c *Controller) PreGate(id manifest.NamedResource, suspended bool) bool {
+	if suspended {
+		c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+		return true
+	}
+	if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
+		c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
+		return true
+	}
+	return false
+}
 
 // Recover catches a panic from the current goroutine and marks id
 // StatusFailed with a "panic: <r>" message so the orchestrator

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -13,7 +13,6 @@ import (
 	"log/slog"
 	"maps"
 	"sync"
-	"sync/atomic"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -28,9 +27,9 @@ import (
 // Controller orchestrates HelmRelease reconciliation. Reconcile-shaping
 // state (Filter) flows in via Configure exactly once before Start.
 type Controller struct {
-	Store *store.Store
-	Tasks *task.Service
-	Helm  *helm.Client
+	*base.Controller
+
+	Helm *helm.Client
 
 	// Options applied to every template call.
 	Options helm.Options
@@ -38,13 +37,6 @@ type Controller struct {
 	// WipeSecrets controls whether secrets are wiped from rendered
 	// templates.
 	WipeSecrets bool
-
-	// Set via Configure() — see Options.
-	filter *change.Filter
-
-	started atomic.Bool
-	unsub   []store.Unsubscribe
-	coal    *task.Coalescer[manifest.NamedResource]
 
 	chartSourcesMu sync.RWMutex
 	chartSources   map[string]*manifest.HelmChartSource
@@ -58,33 +50,29 @@ type ReconcileOptions struct {
 	Filter *change.Filter
 }
 
+// New constructs a HelmRelease controller.
+func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wipeSecrets bool) *Controller {
+	return &Controller{
+		Controller:   base.New(s, t),
+		Helm:         h,
+		Options:      opts,
+		WipeSecrets:  wipeSecrets,
+		chartSources: map[string]*manifest.HelmChartSource{},
+	}
+}
+
 // Configure installs the post-bootstrap state. Panics if called after
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once dispatch begins.
 func (c *Controller) Configure(opts ReconcileOptions) {
-	if c.started.Load() {
-		panic("helmrelease controller: Configure called after Start")
-	}
-	c.filter = opts.Filter
+	c.SetFilter(opts.Filter)
 }
 
 // Start registers the listeners. The controller runs until Close.
 func (c *Controller) Start(ctx context.Context) {
-	c.started.Store(true)
-	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
-	c.chartSources = map[string]*manifest.HelmChartSource{}
-	c.unsub = append(c.unsub,
-		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
-		c.Store.AddListener(store.EventArtifactUpdated, c.onArtifactUpdated, true),
-	)
-}
-
-// Close removes listeners.
-func (c *Controller) Close() {
-	for _, u := range c.unsub {
-		u()
-	}
-	c.unsub = nil
+	c.StartLifecycle("helmrelease")
+	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
+	c.AddListener(store.EventArtifactUpdated, c.onArtifactUpdated)
 }
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
@@ -118,15 +106,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			if !ok {
 				return
 			}
-			if hr.Suspend {
-				c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+			if c.PreGate(id, hr.Suspend) {
 				return
 			}
-			if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
-				c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
-				return
-			}
-			c.coal.Submit(ctx, "helmrelease/"+id.String(), id, func(ctx context.Context) {
+			c.Submit(ctx, id, func(ctx context.Context) {
 				base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
 			})
 		}

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -23,7 +23,7 @@ func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store
 	if err != nil {
 		t.Fatalf("helm.NewClient: %v", err)
 	}
-	c := &Controller{Store: st, Tasks: ts, Helm: hc}
+	c := New(st, ts, hc, helm.Options{}, false)
 	c.Configure(ReconcileOptions{Filter: filter})
 	c.Start(context.Background())
 	t.Cleanup(func() {

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	"path/filepath"
 	"strings"
-	"sync/atomic"
 
 	yaml "go.yaml.in/yaml/v4"
 
@@ -25,14 +24,13 @@ import (
 	"github.com/home-operations/flate/pkg/values"
 )
 
-// Controller orchestrates Kustomization reconciliation. Construction
-// args are immutable from the outside; reconcile-shaping state (Filter,
-// ParentOf) flows in via Configure exactly once before Start. The
-// invariant — "config is read-only after Start" — is encoded in the
-// type, not just in code review.
+// Controller orchestrates Kustomization reconciliation. Reconcile-
+// shaping state (Filter, ParentOf) flows in via Configure exactly once
+// before Start. The invariant — "config is read-only after Start" — is
+// encoded in the embedded *base.Controller, not just in code review.
 type Controller struct {
-	Store *store.Store
-	Tasks *task.Service
+	*base.Controller
+
 	// Staging is a process-wide cache that materializes source roots
 	// into writable copies so Flux's Generator can write the merged
 	// kustomization.yaml without touching the user's working tree.
@@ -43,12 +41,7 @@ type Controller struct {
 	WipeSecrets bool
 
 	// Set via Configure() — see Options.
-	filter   *change.Filter
 	parentOf map[manifest.NamedResource]manifest.NamedResource
-
-	started atomic.Bool
-	unsub   []store.Unsubscribe
-	coal    *task.Coalescer[manifest.NamedResource]
 }
 
 // Options carries the post-bootstrap state the orchestrator wires onto
@@ -64,32 +57,27 @@ type Options struct {
 	ParentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
+// New constructs a Kustomization controller.
+func New(s *store.Store, t *task.Service, staging *kustomize.StagingCache, wipeSecrets bool) *Controller {
+	return &Controller{
+		Controller:  base.New(s, t),
+		Staging:     staging,
+		WipeSecrets: wipeSecrets,
+	}
+}
+
 // Configure installs the post-bootstrap state. Panics if called after
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once the controller is dispatching.
 func (c *Controller) Configure(opts Options) {
-	if c.started.Load() {
-		panic("kustomization controller: Configure called after Start")
-	}
-	c.filter = opts.Filter
+	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
 }
 
 // Start registers the listener that drives reconciliation.
 func (c *Controller) Start(ctx context.Context) {
-	c.started.Store(true)
-	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
-	c.unsub = append(c.unsub,
-		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
-	)
-}
-
-// Close removes listeners.
-func (c *Controller) Close() {
-	for _, u := range c.unsub {
-		u()
-	}
-	c.unsub = nil
+	c.StartLifecycle("kustomization")
+	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
 }
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
@@ -101,15 +89,10 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if !ok {
 			return
 		}
-		if ks.Suspend {
-			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+		if c.PreGate(id, ks.Suspend) {
 			return
 		}
-		if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
-			c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
-			return
-		}
-		c.coal.Submit(ctx, "kustomization/"+id.String(), id, func(ctx context.Context) {
+		c.Submit(ctx, id, func(ctx context.Context) {
 			base.RunWithStatus(ctx, c.Store, id, "kustomization", c.reconcile)
 		})
 	}

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // TestCollectDeps_AppendsStructuralParent locks the contract that
@@ -16,7 +17,7 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 	}
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
 
-	c := &Controller{}
+	c := New(store.New(), nil, nil, false)
 	c.Configure(Options{ParentOf: map[manifest.NamedResource]manifest.NamedResource{
 		child.Named(): parent,
 	}})
@@ -33,7 +34,7 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 // controllers (e.g. unit-test setups) panicking on a nil map.
 func TestCollectDeps_NoParentNoExtraDep(t *testing.T) {
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
-	c := &Controller{} // ParentOf nil
+	c := New(store.New(), nil, nil, false) // ParentOf nil
 	deps := c.collectDeps(child)
 	if len(deps) != 0 {
 		t.Errorf("expected no deps for KS without sourceRef/dependsOn/parent; got %+v", deps)

--- a/pkg/controllers/kustomization/source_root_test.go
+++ b/pkg/controllers/kustomization/source_root_test.go
@@ -30,7 +30,7 @@ func TestResolveSourceRoot_FallsBackToBootstrapWhenSourceRefEmpty(t *testing.T) 
 		Kind: manifest.KindGitRepository, URL: "file:///repo", LocalPath: "/repo",
 	})
 
-	c := &Controller{Store: s}
+	c := New(s, nil, nil, false)
 	ks := &manifest.Kustomization{
 		Name: "foo", Namespace: "flux-system",
 		KustomizationSpec: kustomizev1.KustomizationSpec{
@@ -71,7 +71,7 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 		Kind: manifest.KindGitRepository, URL: "file:///repo", LocalPath: "/repo",
 	})
 
-	c := &Controller{Store: s}
+	c := New(s, nil, nil, false)
 	ks := &manifest.Kustomization{
 		Name: "foo", Namespace: "flux-system",
 		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
@@ -92,7 +92,7 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 // net for setups that genuinely have neither — error rather than mis-
 // resolve.
 func TestResolveSourceRoot_NoBootstrapNoSourceRefErrors(t *testing.T) {
-	c := &Controller{Store: store.New()}
+	c := New(store.New(), nil, nil, false)
 	ks := &manifest.Kustomization{
 		Name: "foo", Namespace: "flux-system",
 		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -1,5 +1,5 @@
 // Package source reconciles Flux source CRs (GitRepository,
-// OCIRepository, future: Bucket, ExternalArtifact, …) into on-disk
+// OCIRepository, Bucket, ExternalArtifact, HelmRepository) into on-disk
 // artifacts via per-kind Fetcher implementations from pkg/source, then
 // publishes the result to the Store. Mirrors
 // pkg/controllers/{kustomization,helmrelease}.
@@ -12,7 +12,6 @@ package source
 import (
 	"context"
 	"log/slog"
-	"sync/atomic"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -24,24 +23,15 @@ import (
 
 // Controller watches the Store for source-kind objects, fetches each
 // into an on-disk artifact via the matching Fetcher, and updates the
-// Store with the result. Reconcile-shaping state (Filter) flows in
-// via Configure exactly once before Start.
+// Store with the result.
 type Controller struct {
-	Store *store.Store
-	Tasks *task.Service
+	*base.Controller
 
 	// Fetchers maps source CR kind → Fetcher implementation. Source
 	// kinds with no entry are ignored, which is also how a flate caller
 	// disables a kind (e.g. EnableOCI=false simply omits OCIRepository
-	// from the map).
+	// from the map). Exposed for Orchestrator.WithFetcher.
 	Fetchers map[string]src.Fetcher
-
-	// Set via Configure() — see FetchOptions.
-	filter *change.Filter
-
-	started       atomic.Bool
-	unsubscribers []store.Unsubscribe
-	coal          *task.Coalescer[manifest.NamedResource]
 }
 
 // FetchOptions carries the post-bootstrap state the orchestrator wires
@@ -51,31 +41,26 @@ type FetchOptions struct {
 	Filter *change.Filter
 }
 
+// New constructs a source controller. Register fetchers on the
+// returned struct's Fetchers map before Start.
+func New(s *store.Store, t *task.Service) *Controller {
+	return &Controller{
+		Controller: base.New(s, t),
+		Fetchers:   map[string]src.Fetcher{},
+	}
+}
+
 // Configure installs the post-bootstrap state. Panics if called after
 // Start.
 func (c *Controller) Configure(opts FetchOptions) {
-	if c.started.Load() {
-		panic("source controller: Configure called after Start")
-	}
-	c.filter = opts.Filter
+	c.SetFilter(opts.Filter)
 }
 
 // Start registers listeners on the Store. The controller runs until
 // Close is called.
 func (c *Controller) Start(ctx context.Context) {
-	c.started.Store(true)
-	c.coal = task.NewCoalescer[manifest.NamedResource](c.Tasks)
-	c.unsubscribers = append(c.unsubscribers,
-		c.Store.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx), true),
-	)
-}
-
-// Close removes all listeners.
-func (c *Controller) Close() {
-	for _, u := range c.unsubscribers {
-		u()
-	}
-	c.unsubscribers = nil
+	c.StartLifecycle("source")
+	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
 }
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
@@ -88,34 +73,18 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if !ok {
 			return
 		}
-		if sus, ok := obj.(src.Suspendable); ok && sus.Suspended() {
-			c.Store.UpdateStatus(id, store.StatusReady, "suspended")
-			return
-		}
-		if c.skip(id) {
+		sus, _ := obj.(src.Suspendable)
+		if c.PreGate(id, sus != nil && sus.Suspended()) {
 			return
 		}
 		// Coalesce per-id so a duplicate AddObject for the same source
 		// (e.g. a parent KS re-emits a child source on re-render)
 		// doesn't race two concurrent fetches into the same cache slot.
-		c.coal.Submit(ctx, "source/"+id.String(), id, func(ctx context.Context) {
+		c.Submit(ctx, id, func(ctx context.Context) {
 			defer base.Recover(c.Store, id, "source")
 			c.runFetch(ctx, id, obj, fetcher)
 		})
 	}
-}
-
-// skip applies the change filter and marks unaffected sources Ready
-// without fetching so dependsOn waits succeed instantly.
-func (c *Controller) skip(id manifest.NamedResource) bool {
-	if !c.filter.Enabled() {
-		return false
-	}
-	if c.filter.ShouldReconcile(id) {
-		return false
-	}
-	c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
-	return true
 }
 
 // runFetch invokes the registered Fetcher and translates the result

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -33,7 +33,10 @@ func newController(t *testing.T, fetchers map[string]src.Fetcher) (*Controller, 
 	t.Helper()
 	st := store.New()
 	ts := task.New()
-	c := &Controller{Store: st, Tasks: ts, Fetchers: fetchers}
+	c := New(st, ts)
+	for k, f := range fetchers {
+		c.Fetchers[k] = f
+	}
 	c.Start(context.Background())
 	t.Cleanup(func() {
 		c.Close()
@@ -152,7 +155,8 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 		"",
 		mapLister{},
 	)
-	c := &Controller{Store: st, Tasks: ts, Fetchers: map[string]src.Fetcher{manifest.KindGitRepository: f}}
+	c := New(st, ts)
+	c.Fetchers[manifest.KindGitRepository] = f
 	c.Configure(FetchOptions{Filter: filter})
 	c.Start(context.Background())
 	t.Cleanup(func() {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -126,36 +126,31 @@ func New(cfg Config) (*Orchestrator, error) {
 		return s
 	}
 	helmClient.SetSecretGetter(helm.SecretGetter(secretGet))
-	fetchers := map[string]source.Fetcher{
-		manifest.KindGitRepository:    &git.Fetcher{Cache: cache, Secrets: secretGet},
-		manifest.KindExternalArtifact: &external.Fetcher{},
-		manifest.KindBucket:           &bucket.Fetcher{Cache: cache, Secrets: secretGet},
-		// HelmRepository: existence-only — flate resolves charts via the
-		// Helm client's registry/repo machinery directly, the controller
-		// just needs the resource to land in Ready so HelmRelease deps
-		// unblock.
-		manifest.KindHelmRepository: source.ExistenceFetcher{},
-	}
+	srcCtrl := sourcectrl.New(st, ts)
+	srcCtrl.Fetchers[manifest.KindGitRepository] = &git.Fetcher{Cache: cache, Secrets: secretGet}
+	srcCtrl.Fetchers[manifest.KindExternalArtifact] = &external.Fetcher{}
+	srcCtrl.Fetchers[manifest.KindBucket] = &bucket.Fetcher{Cache: cache, Secrets: secretGet}
+	// HelmRepository: existence-only — flate resolves charts via the
+	// Helm client's registry/repo machinery directly, the controller
+	// just needs the resource to land in Ready so HelmRelease deps
+	// unblock.
+	srcCtrl.Fetchers[manifest.KindHelmRepository] = source.ExistenceFetcher{}
 	if cfg.EnableOCI {
-		fetchers[manifest.KindOCIRepository] = &oci.Fetcher{
+		srcCtrl.Fetchers[manifest.KindOCIRepository] = &oci.Fetcher{
 			Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet,
 		}
 	} else {
 		// --enable-oci=false: skip the real fetch but still mark each
 		// OCIRepository Ready so HRs that dependsOn one don't time out.
-		fetchers[manifest.KindOCIRepository] = source.ExistenceFetcher{}
+		srcCtrl.Fetchers[manifest.KindOCIRepository] = source.ExistenceFetcher{}
 	}
 	o := &Orchestrator{
-		cfg:   cfg,
-		store: st,
-		tasks: ts,
-		src: &sourcectrl.Controller{
-			Store:    st,
-			Tasks:    ts,
-			Fetchers: fetchers,
-		},
-		ksc:     &kustomization.Controller{Store: st, Tasks: ts, Staging: staging, WipeSecrets: cfg.WipeSecrets},
-		hrc:     &helmrelease.Controller{Store: st, Tasks: ts, Helm: helmClient, Options: cfg.HelmOptions, WipeSecrets: cfg.WipeSecrets},
+		cfg:     cfg,
+		store:   st,
+		tasks:   ts,
+		src:     srcCtrl,
+		ksc:     kustomization.New(st, ts, staging, cfg.WipeSecrets),
+		hrc:     helmrelease.New(st, ts, helmClient, cfg.HelmOptions, cfg.WipeSecrets),
 		helm:    helmClient,
 		staging: staging,
 	}

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -231,6 +231,11 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 				_ = cache.Reset(slot)
 				exists = false
 			} else if err := f.verifyCosignSignature(ctx, repoClient, repo, cachedDigest); err != nil {
+				// Cosign rejected the cached bytes. Without resetting, the
+				// next reconcile re-hits the same poisoned slot and fails
+				// verify identically — a hard-to-debug repeated failure.
+				// Reset so a fresh pull is attempted.
+				_ = cache.Reset(slot)
 				return nil, err
 			}
 		}


### PR DESCRIPTION
## Summary
Iter-11 fresh-eyes architectural pass — four parallel agents (sr eng, concurrency, API surface, tests). Two of them independently flagged the same headline issue from different angles:

- **Senior-eng:** "controller-base under-abstraction; lifecycle duplicated 3×"
- **API audit:** "controller structs expose mandatory wiring fields publicly with no constructor; embedders hand-build struct literals and discover \`Configure()\`-after-\`Start()\` is a runtime panic"

One fix, both payoffs. \`base.Controller\` now owns the shared lifecycle (Store, Tasks, started, unsub, coal, filter, kindLabel) plus the canonical \`SetFilter\` / \`StartLifecycle\` / \`AddListener\` / \`Close\` / \`Submit\` / \`PreGate\` methods. Each concrete controller embeds \`*base.Controller\` and contributes only its kind-specific deps + reconcile fn.

Six invariants moved from "documented in prose, enforced via copy-paste" to "encoded in the type, enforced by the compiler":
- single \`started\` gate
- single unsubscriber lifecycle
- single coalescer construction
- single Configure-after-Start panic point
- single Suspend / Filter pre-gate
- single Close implementation

API change: \`New(...)\` constructors per kind. Mandatory wiring (\`Store\`, \`Tasks\`) is now set via constructor only. \`Fetchers\` stays public on \`source.Controller\` since \`Orchestrator.WithFetcher\` is the documented embed entry point.

Per-controller LOC: source 145→114, kustomization 383→365, helmrelease 272→254. Base 53→157 absorbs the shared scaffolding + docs. Net wash on total lines, structural duplication eliminated.

Bundled second commit: **fix(oci) cache-poison.** Iter-11 concurrency audit caught a latent bug — \`verifyCosignSignature\` failure against cached bytes leaves the poisoned slot in place, looping the same error every reconcile. \`cache.Reset(slot)\` on the failure path lets transient mismatches self-heal.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`go test -race ./pkg/controllers/... ./pkg/orchestrator/... ./pkg/store/... ./test/e2e/...\` — clean under -race
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)