### PR TITLE
test(source): cover oci semver/ref helpers and bucket endpoint

### DIFF
--- a/pkg/source/bucket/endpoint_test.go
+++ b/pkg/source/bucket/endpoint_test.go
@@ -1,0 +1,92 @@
+package bucket
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeEndpoint(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		endpoint   string
+		insecure   bool
+		wantHost   string
+		wantSecure bool
+		wantErr    string
+	}{
+		{
+			name:       "https scheme stripped, tls forced on",
+			endpoint:   "https://s3.example.com",
+			wantHost:   "s3.example.com",
+			wantSecure: true,
+		},
+		{
+			name:       "http scheme stripped, tls forced off (ignores insecure flag)",
+			endpoint:   "http://s3.example.com",
+			insecure:   false,
+			wantHost:   "s3.example.com",
+			wantSecure: false,
+		},
+		{
+			name:       "no scheme defaults to secure",
+			endpoint:   "s3.example.com",
+			wantHost:   "s3.example.com",
+			wantSecure: true,
+		},
+		{
+			name:       "no scheme with insecure flag",
+			endpoint:   "minio.local:9000",
+			insecure:   true,
+			wantHost:   "minio.local:9000",
+			wantSecure: false,
+		},
+		{
+			name:       "trailing slash trimmed",
+			endpoint:   "https://s3.example.com/",
+			wantHost:   "s3.example.com",
+			wantSecure: true,
+		},
+		{
+			name:     "empty endpoint errors",
+			endpoint: "",
+			wantErr:  "empty",
+		},
+		{
+			name:     "scheme-only endpoint errors after trim",
+			endpoint: "https://",
+			wantErr:  "empty",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			host, secure, err := normalizeEndpoint(tc.endpoint, tc.insecure)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if host != tc.wantHost {
+				t.Errorf("host = %q, want %q", host, tc.wantHost)
+			}
+			if secure != tc.wantSecure {
+				t.Errorf("secure = %v, want %v", secure, tc.wantSecure)
+			}
+		})
+	}
+}
+
+func TestSchemeFor(t *testing.T) {
+	t.Parallel()
+	if got := schemeFor(true); got != "https" {
+		t.Errorf("schemeFor(true) = %q, want https", got)
+	}
+	if got := schemeFor(false); got != "http" {
+		t.Errorf("schemeFor(false) = %q, want http", got)
+	}
+}

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -359,6 +359,20 @@ func versionedURL(base string, ref manifest.OCIRepositoryRef) string {
 // filter, then returns the highest tag matching the semver constraint.
 // Mirrors source-controller's `getTagBySemver` (ocirepository_controller.go).
 func resolveOCISemver(ctx context.Context, repoClient *remote.Repository, expr, filterPattern string) (string, error) {
+	var collected []string
+	if err := repoClient.Tags(ctx, "", func(tags []string) error {
+		collected = append(collected, tags...)
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("list tags: %w", err)
+	}
+	return pickSemverTag(collected, expr, filterPattern)
+}
+
+// pickSemverTag picks the highest semver-matching tag from a list,
+// applying an optional regex filter. Pure function so it's testable
+// without a real registry.
+func pickSemverTag(tags []string, expr, filterPattern string) (string, error) {
 	constraint, err := semver.NewConstraint(expr)
 	if err != nil {
 		return "", fmt.Errorf("semver %q: %w", expr, err)
@@ -373,29 +387,23 @@ func resolveOCISemver(ctx context.Context, repoClient *remote.Repository, expr, 
 
 	var matching semver.Collection
 	var matchingTags []string
-	err = repoClient.Tags(ctx, "", func(tags []string) error {
-		for _, tag := range tags {
-			if pattern != nil && !pattern.MatchString(tag) {
-				continue
-			}
-			v, perr := semver.NewVersion(tag)
-			if perr != nil {
-				continue
-			}
-			if constraint.Check(v) {
-				matching = append(matching, v)
-				matchingTags = append(matchingTags, tag)
-			}
+	for _, tag := range tags {
+		if pattern != nil && !pattern.MatchString(tag) {
+			continue
 		}
-		return nil
-	})
-	if err != nil {
-		return "", fmt.Errorf("list tags: %w", err)
+		v, perr := semver.NewVersion(tag)
+		if perr != nil {
+			continue
+		}
+		if constraint.Check(v) {
+			matching = append(matching, v)
+			matchingTags = append(matchingTags, tag)
+		}
 	}
 	if len(matching) == 0 {
 		return "", fmt.Errorf("no tag matched semver %q (filter %q)", expr, filterPattern)
 	}
-	// Highest match wins — find the max-index via slices.MaxFunc so the
+	// Highest match wins — find the max-index by walking once so the
 	// parallel matching[]/matchingTags[] stay aligned.
 	hi := 0
 	for i := 1; i < len(matching); i++ {

--- a/pkg/source/oci/oci_test.go
+++ b/pkg/source/oci/oci_test.go
@@ -1,0 +1,207 @@
+package oci
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestPickSemverTag(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		tags    []string
+		expr    string
+		filter  string
+		want    string
+		wantErr string
+	}{
+		{
+			name: "highest in range",
+			tags: []string{"1.2.3", "1.3.0", "1.4.0-rc1", "2.0.0", "garbage"},
+			expr: ">=1.0.0 <2.0.0",
+			want: "1.3.0",
+		},
+		{
+			name: "regex filter narrows candidate set",
+			// Without filter the highest 1.x semver wins. With filter only
+			// rc-prereleased entries qualify; semver treats prereleases as
+			// less than non-prereleases of the same version, so within the
+			// filtered set the highest prerelease wins.
+			tags:   []string{"1.2.0-rc1", "1.4.0-rc1", "2.0.0", "1.5.0"},
+			expr:   ">=1.0.0-0 <2.0.0",
+			filter: "-rc",
+			want:   "1.4.0-rc1",
+		},
+		{
+			name: "non-semver tags ignored",
+			tags: []string{"latest", "main", "1.0.0", "foo-bar"},
+			expr: ">=0.0.1",
+			want: "1.0.0",
+		},
+		{
+			name:    "no match returns error",
+			tags:    []string{"1.0.0", "1.1.0"},
+			expr:    ">=2.0.0",
+			wantErr: "no tag matched",
+		},
+		{
+			name:    "invalid constraint returns error",
+			tags:    []string{"1.0.0"},
+			expr:    "not-a-constraint",
+			wantErr: "semver",
+		},
+		{
+			name:    "invalid filter regex returns error",
+			tags:    []string{"1.0.0"},
+			expr:    ">=0.0.1",
+			filter:  "[invalid",
+			wantErr: "semverFilter",
+		},
+		{
+			name: "empty tag list returns error",
+			tags: nil,
+			expr: ">=0.0.1",
+			// Constraint is valid but matches nothing.
+			wantErr: "no tag matched",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := pickSemverTag(tc.tags, tc.expr, tc.filter)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseOCIRef(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"strips oci scheme", "oci://ghcr.io/owner/chart", "ghcr.io/owner/chart"},
+		{"strips tag", "oci://ghcr.io/owner/chart:v1.2.3", "ghcr.io/owner/chart"},
+		{"strips digest", "oci://ghcr.io/owner/chart@sha256:abc123", "ghcr.io/owner/chart"},
+		{"preserves port without tag", "oci://registry:5000/x", "registry:5000/x"},
+		{"preserves port with tag", "oci://registry:5000/x:v1", "registry:5000/x"},
+		{"preserves port with digest", "oci://registry:5000/x@sha256:abc", "registry:5000/x"},
+		{"no scheme passes through", "ghcr.io/owner/chart:v1", "ghcr.io/owner/chart"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseOCIRef(tc.in)
+			if err != nil {
+				t.Fatalf("parseOCIRef(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("parseOCIRef(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOCIRevision(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		ref    manifest.OCIRepositoryRef
+		digest string
+		want   string
+	}{
+		{
+			name:   "tag and digest joined with @",
+			ref:    manifest.OCIRepositoryRef{Tag: "v1.2.3"},
+			digest: "sha256:abc",
+			want:   "v1.2.3@sha256:abc",
+		},
+		{
+			name:   "tag only when no digest",
+			ref:    manifest.OCIRepositoryRef{Tag: "v1.2.3"},
+			digest: "",
+			want:   "v1.2.3",
+		},
+		{
+			name:   "digest only when no tag",
+			ref:    manifest.OCIRepositoryRef{Digest: "sha256:abc"},
+			digest: "sha256:abc",
+			want:   "sha256:abc",
+		},
+		{
+			name:   "empty ref falls back to latest tag",
+			ref:    manifest.OCIRepositoryRef{},
+			digest: "sha256:abc",
+			want:   "latest@sha256:abc",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ociRevision(tc.ref, tc.digest)
+			if got != tc.want {
+				t.Errorf("ociRevision(%+v, %q) = %q, want %q", tc.ref, tc.digest, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionedURL(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		base string
+		ref  manifest.OCIRepositoryRef
+		want string
+	}{
+		{"digest wins over tag", "ghcr.io/x", manifest.OCIRepositoryRef{Tag: "v1", Digest: "sha256:abc"}, "ghcr.io/x@sha256:abc"},
+		{"tag when no digest", "ghcr.io/x", manifest.OCIRepositoryRef{Tag: "v1"}, "ghcr.io/x:v1"},
+		{"bare base when empty ref", "ghcr.io/x", manifest.OCIRepositoryRef{}, "ghcr.io/x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := versionedURL(tc.base, tc.ref)
+			if got != tc.want {
+				t.Errorf("versionedURL(%q, %+v) = %q, want %q", tc.base, tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionTag(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		ref  manifest.OCIRepositoryRef
+		want string
+	}{
+		{"digest wins", manifest.OCIRepositoryRef{Digest: "sha256:abc", Tag: "v1"}, "sha256:abc"},
+		{"tag when no digest", manifest.OCIRepositoryRef{Tag: "v1"}, "v1"},
+		{"semver when no tag/digest", manifest.OCIRepositoryRef{SemVer: ">=1.0"}, ">=1.0"},
+		{"empty returns empty", manifest.OCIRepositoryRef{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := versionTag(tc.ref)
+			if got != tc.want {
+				t.Errorf("versionTag(%+v) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Iter-11 test-coverage audit flagged the silent-corruption helpers in \`pkg/source/{oci,bucket}\` as the highest-impact uncovered code. A regression in OCI tag selection ships the wrong chart version; a regression in endpoint normalization talks to the wrong host. Both fail without clear errors.

- **OCI**: Extract \`pickSemverTag\` from \`resolveOCISemver\` so the constraint/regex-filter/max-pick logic is testable without a real registry. Table tests for \`pickSemverTag\`, \`parseOCIRef\` (port-vs-tag, digest+port, no-scheme), \`ociRevision\`, \`versionedURL\`, \`versionTag\`.
- **Bucket**: Table tests for \`normalizeEndpoint\` (scheme stripping, trailing slash, empty/scheme-only failure modes, insecure flag) and \`schemeFor\`.

Coverage: \`pkg/source/oci\` 37.0% → 48.8% (+11.8 pts), \`pkg/source/bucket\` 25.9% → 39.3% (+13.4 pts).

## Test plan
- [x] \`go test ./pkg/source/...\` clean
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)