### PR TITLE
refactor(api): dedupe SecretGetter, simplify discovery.Config, document shadow-fields rule

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -45,11 +45,10 @@ type Result struct {
 	ParentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
-// Config is the input contract for Run. Store and Loader are mandatory.
+// Config is the input contract for Run. Store is mandatory.
 type Config struct {
 	Path        string
 	Store       *store.Store
-	Loader      *loader.Loader
 	WipeSecrets bool
 }
 
@@ -57,10 +56,16 @@ type Config struct {
 // into cfg.Store. Returns the structural metadata the orchestrator
 // needs for change-filter construction and controller wiring.
 func Run(ctx context.Context, cfg Config) (*Result, error) {
-	if cfg.Store == nil || cfg.Loader == nil {
-		return nil, errors.New("discovery: Store and Loader are required")
+	if cfg.Store == nil {
+		return nil, errors.New("discovery: Store is required")
 	}
-	d := &discoverer{cfg: cfg, sourceFiles: map[manifest.NamedResource]string{}}
+	l := loader.New(cfg.Store)
+	l.Options.WipeSecrets = cfg.WipeSecrets
+	d := &discoverer{
+		cfg:         cfg,
+		loader:      l,
+		sourceFiles: map[manifest.NamedResource]string{},
+	}
 	repoRoot, err := d.seedBootstrapSource()
 	if err != nil {
 		return nil, err
@@ -80,6 +85,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 
 type discoverer struct {
 	cfg         Config
+	loader      *loader.Loader
 	sourceFiles map[manifest.NamedResource]string
 }
 
@@ -113,7 +119,7 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 // KS may emit a ResourceSet which itself emits child Kustomizations
 // referencing new spec.paths the file walker hasn't visited yet.
 func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
-	l := d.cfg.Loader
+	l := d.loader
 	l.SourceRoot = repoRoot
 	l.SourceFiles = d.sourceFiles
 

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/home-operations/flate/pkg/discovery"
-	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -52,9 +51,8 @@ spec:
 `)
 
 	st := store.New()
-	l := loader.New(st)
 	res, err := discovery.Run(context.Background(), discovery.Config{
-		Path: dir, Store: st, Loader: l, WipeSecrets: true,
+		Path: dir, Store: st, WipeSecrets: true,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -14,6 +14,7 @@ import (
 	"helm.sh/helm/v4/pkg/registry"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -37,11 +38,10 @@ func (l LocalSource) RepoFullName() string {
 	return l.Namespace + "-" + l.Name
 }
 
-// SecretGetter resolves a Secret CR by namespace + name. The helm
-// Client uses this to look up HelmRepository.SecretRef credentials at
-// pull time. Orchestrator wires it to Store.GetByName; nil is OK when
-// no HelmRepositories use SecretRef.
-type SecretGetter func(namespace, name string) *manifest.Secret
+// SecretGetter is the same shape as source.SecretGetter; aliased so
+// the helm Client and the source Fetchers consume one canonical type.
+// The orchestrator wires the same closure into both.
+type SecretGetter = source.SecretGetter
 
 // Client renders HelmReleases. Construct with NewClient.
 type Client struct {

--- a/pkg/kustomize/substitute.go
+++ b/pkg/kustomize/substitute.go
@@ -2,7 +2,6 @@ package kustomize
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 
 	"github.com/fluxcd/pkg/envsubst"
@@ -35,12 +34,6 @@ func Substitute(data []byte, vars map[string]string) ([]byte, error) {
 	}
 	return []byte(out), nil
 }
-
-// ErrSubstitution wraps any non-missing-var failure from the
-// underlying envsubst engine (e.g. parse errors). Kept exported so
-// callers can errors.Is against it if they need to distinguish
-// envsubst failures from store / source errors in the future.
-var ErrSubstitution = errors.New("substitution failed")
 
 // HasSubstitutions returns whether data contains any ${...} placeholder.
 // Useful when callers want to short-circuit costly substitution work.

--- a/pkg/manifest/doc.go
+++ b/pkg/manifest/doc.go
@@ -12,4 +12,25 @@
 // data/stringData fields are rewritten with placeholder tokens of the form
 // "..PLACEHOLDER_<key>..". This matches flux-local's behavior — flate never
 // needs the cleartext values to verify cluster shape.
+//
+// # Shadow fields
+//
+// HelmRelease and Kustomization embed the upstream Flux Spec struct and
+// also expose projected top-level fields (Values, DependsOn, Chart,
+// Path, SourceKind, ...) that mirror commonly-read pieces of that
+// nested spec. Reads should use the projected fields; the embedded
+// Spec is retained for round-tripping unknown fields back out via
+// pkg/manifest's encoders. Writing to the embedded Spec.* after parse
+// is a bug — the projections are populated once during ParseDoc and
+// later reads will diverge.
+//
+// # Mutation contract
+//
+// Every concrete manifest type in this package is treated as
+// immutable once stored. Controllers and embedders that need to amend
+// a resource must Clone() it, mutate the clone, and AddObject the
+// result; the store helper pkg/store.Mutate[T] encodes that contract.
+// Mutating a *HelmRelease / *Kustomization / etc. in place after it
+// has been added to the store corrupts the canonical state that
+// other concurrent readers depend on.
 package manifest

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -16,7 +16,6 @@ import (
 	"github.com/home-operations/flate/pkg/discovery"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/kustomize"
-	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/bucket"
@@ -125,7 +124,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		s, _ := obj.(*manifest.Secret)
 		return s
 	}
-	helmClient.SetSecretGetter(helm.SecretGetter(secretGet))
+	helmClient.SetSecretGetter(secretGet)
 	srcCtrl := sourcectrl.New(st, ts)
 	srcCtrl.Fetchers[manifest.KindGitRepository] = &git.Fetcher{Cache: cache, Secrets: secretGet}
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = &external.Fetcher{}
@@ -185,11 +184,8 @@ func (o *Orchestrator) Filter() *change.Filter { return o.filter }
 // Delegates the load / expand / alias phase to pkg/discovery; the
 // remainder is dependency validation + change-filter construction.
 func (o *Orchestrator) Bootstrap(ctx context.Context) error {
-	l := loader.New(o.store)
-	l.Options.WipeSecrets = o.cfg.WipeSecrets
-
 	res, err := discovery.Run(ctx, discovery.Config{
-		Path: o.cfg.Path, Store: o.store, Loader: l, WipeSecrets: o.cfg.WipeSecrets,
+		Path: o.cfg.Path, Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
Iter-11 API-surface audit findings, none alone urgent — together they remove three sources of embedder confusion.

- **\`helm.SecretGetter\`** was an identical-signature shadow of \`source.SecretGetter\`; the orchestrator did a no-op \`helm.SecretGetter(secretGet)\` cast at the boundary. Replace with a type alias — one canonical signature, one fewer cast.
- **\`discovery.Config\`** required callers to construct + pass a \`*loader.Loader\`, but Loader only needed \`cfg.Store\` + \`cfg.WipeSecrets\` — both already on Config. Drop the redundant field; construct the Loader internally.
- **\`pkg/manifest/doc.go\`** now states the shadow-fields rule (Values/DependsOn/Chart/Path/... shadow the embedded Spec.*) and the mutation contract (every manifest is immutable once stored; clone-then-AddObject via \`store.Mutate[T]\`). Both invariants every embedder previously had to discover by reading source.
- Remove dead exported \`ErrSubstitution\` (declared but never returned wrapped). Drops unused \`errors\` import.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)