### PR TITLE
perf(helm): coalesce concurrent first-load of the same chart

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -13,6 +13,7 @@ import (
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
 	"helm.sh/helm/v4/pkg/registry"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
@@ -61,8 +62,14 @@ type Client struct {
 	// app-template referenced by 30+ HRs), the same chart was being
 	// re-parsed once per HR. Cache by path; the upstream cache key is
 	// already content-addressed (name-version-digest in the filename).
-	chartMu    sync.Mutex
-	chartCache map[string]*chart.Chart
+	//
+	// chartLoadLocks serializes first-time loads per-path so N parallel
+	// reconciles of the same chart issue exactly one loader.Load
+	// (thundering-herd coalesce); the rest hit the populated cache.
+	// Distinct paths still parse in parallel.
+	chartMu        sync.Mutex
+	chartCache     map[string]*chart.Chart
+	chartLoadLocks *keylock.KeyMap[string]
 }
 
 // NewClient constructs a Client. tmpDir and cacheDir are used for
@@ -81,12 +88,14 @@ func NewClient(tmpDir, cacheDir string) (*Client, error) {
 		return nil, fmt.Errorf("helm registry: %w", err)
 	}
 	return &Client{
-		tmpDir:       tmpDir,
-		cacheDir:     cacheDir,
-		repos:        map[string]*manifest.HelmRepository{},
-		ociRepos:     map[string]*manifest.OCIRepository{},
-		localSources: map[string]LocalSource{},
-		registry:     reg,
+		tmpDir:         tmpDir,
+		cacheDir:       cacheDir,
+		repos:          map[string]*manifest.HelmRepository{},
+		ociRepos:       map[string]*manifest.OCIRepository{},
+		localSources:   map[string]LocalSource{},
+		registry:       reg,
+		chartCache:     map[string]*chart.Chart{},
+		chartLoadLocks: keylock.New[string](),
 	}, nil
 }
 
@@ -161,16 +170,34 @@ func (c *Client) LoadChart(ctx context.Context, hr *manifest.HelmRelease) (Chart
 	if err != nil {
 		return ChartLoadResult{}, err
 	}
+	// Fast path: already parsed.
 	c.chartMu.Lock()
-	if c.chartCache == nil {
-		c.chartCache = make(map[string]*chart.Chart)
-	}
-	ch, ok := c.chartCache[path]
-	c.chartMu.Unlock()
-	if ok {
+	if ch, ok := c.chartCache[path]; ok {
+		c.chartMu.Unlock()
 		return ChartLoadResult{Path: path, Chart: ch}, nil
 	}
-	ch, err = loader.Load(path)
+	c.chartMu.Unlock()
+
+	// Coalesce parallel first-loads of the same chart so N concurrent
+	// reconciles of the same base chart (bjw-s app-template referenced
+	// by 30+ HRs, podinfo across multiple test envs) issue exactly one
+	// loader.Load instead of N. Distinct paths still parse in parallel.
+	release, err := c.chartLoadLocks.Acquire(ctx, path)
+	if err != nil {
+		return ChartLoadResult{}, err
+	}
+	defer release()
+
+	// Re-check under the per-path lock — another goroutine may have
+	// populated the cache while we waited.
+	c.chartMu.Lock()
+	if ch, ok := c.chartCache[path]; ok {
+		c.chartMu.Unlock()
+		return ChartLoadResult{Path: path, Chart: ch}, nil
+	}
+	c.chartMu.Unlock()
+
+	ch, err := loader.Load(path)
 	if err != nil {
 		// A truncated/corrupt chart tgz left on disk (process killed
 		// mid-download, fs fault, manual delete-then-recreate) would

--- a/pkg/helm/loadchart_test.go
+++ b/pkg/helm/loadchart_test.go
@@ -1,0 +1,98 @@
+package helm
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestLoadChart_CoalescesConcurrentFirstLoad verifies that N parallel
+// LoadChart calls for the same chart issue exactly one loader.Load.
+// Without the per-path keylock, every concurrent first-loader saw an
+// empty cache and parsed the tgz independently — wasted CPU and (more
+// importantly) divergent *chart.Chart pointers between callers.
+//
+// We can't directly intercept loader.Load, but we can verify the
+// post-condition: every caller ends up with the SAME *chart.Chart
+// pointer (cache wins) rather than independently-parsed copies.
+func TestLoadChart_CoalescesConcurrentFirstLoad(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml", `apiVersion: v2
+name: mychart
+version: 0.1.0
+description: test
+`)
+	testutil.WriteFile(t, dir, "mychart/values.yaml", "k: v\n")
+	testutil.WriteFile(t, dir, "mychart/templates/_helpers.tpl", "")
+
+	cli, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	cli.AddLocalSource(LocalSource{
+		Name:      "chart-repo",
+		Namespace: "flux-system",
+		Artifact:  &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
+	})
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "mychart",
+			RepoName:      "chart-repo",
+			RepoNamespace: "flux-system",
+			RepoKind:      manifest.KindGitRepository,
+		},
+	}
+
+	const goroutines = 16
+	var (
+		wg        sync.WaitGroup
+		pointers  = make(chan *chart.Chart, goroutines)
+		startGate sync.WaitGroup
+		errs      atomic.Int32
+	)
+	startGate.Add(1)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			startGate.Wait()
+			res, err := cli.LoadChart(context.Background(), hr)
+			if err != nil {
+				errs.Add(1)
+				t.Errorf("LoadChart: %v", err)
+				return
+			}
+			pointers <- res.Chart
+		}()
+	}
+	startGate.Done()
+	wg.Wait()
+	close(pointers)
+
+	if errs.Load() > 0 {
+		t.Fatalf("%d goroutines errored", errs.Load())
+	}
+
+	var canonical *chart.Chart
+	count := 0
+	for p := range pointers {
+		if canonical == nil {
+			canonical = p
+		} else if p != canonical {
+			t.Errorf("got divergent *chart.Chart pointers across goroutines — first-load coalesce broken")
+		}
+		count++
+	}
+	if count != goroutines {
+		t.Errorf("collected %d pointers, want %d", count, goroutines)
+	}
+}


### PR DESCRIPTION
## Summary
Iter-11 concurrency audit caught a thundering-herd in \`LoadChart\`: N parallel reconciles of the same base chart all observed an empty cache simultaneously, all called helm's \`loader.Load\` on the same path, and the last writer won. The (N-1) wasted parses also produced divergent \`*chart.Chart\` pointers across goroutines until the cache stabilized.

Add a per-path keylock (the same \`internal/keylock\` pattern \`repo.go\` already uses for cache-fetch serialization) so first-loaders of the same path serialize through one \`loader.Load\` while distinct paths still parse in parallel. Re-check the cache under the per-path lock so a load that wins the race doesn't trigger a duplicate parse from a contender that beat it to the keylock.

\`TestLoadChart_CoalescesConcurrentFirstLoad\` fires 16 parallel \`LoadChart\` calls and asserts every one returns the SAME \`*chart.Chart\` pointer — without the fix, parallel first-loaders see distinct freshly-parsed copies.

## Test plan
- [x] \`go test -race ./pkg/helm/... ./pkg/controllers/helmrelease/... ./pkg/orchestrator/...\` — clean under -race
- [x] new \`TestLoadChart_CoalescesConcurrentFirstLoad\` passes
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)