### PR TITLE
fix: align with upstream Flux on CEL, helm strvals, slug, bucket, release-name

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -23,17 +23,19 @@ var (
 )
 
 // celEnv is the singleton CEL environment used by all ReadyExpr
-// evaluations. The single declared variable `object` mirrors what
-// Flux's kustomize/helm controllers expose — a generic JSON-shaped
-// view of the dep's resource. We use map[string]any (DynType) rather
-// than the typed Kubernetes proto descriptors so user expressions
-// remain stable across Kind changes and avoid pulling in
+// evaluations. The declared variables `self` and `dep` mirror what
+// Flux's kustomize/helm controllers expose (cel.WithStructVariables
+// in upstream evalReadyExpr): the consumer (self) and the dependency
+// (dep), each as a generic JSON-shaped view. We use map[string]any
+// (DynType) rather than typed Kubernetes proto descriptors so user
+// expressions remain stable across Kind changes and avoid pulling in
 // k8s.io/api OpenAPI schemas.
 var celEnv = mustCELEnv()
 
 func mustCELEnv() *cel.Env {
 	env, err := cel.NewEnv(
-		cel.Variable("object", cel.DynType),
+		cel.Variable("self", cel.DynType),
+		cel.Variable("dep", cel.DynType),
 	)
 	if err != nil {
 		panic("depwait: build CEL env: " + err.Error())
@@ -42,15 +44,18 @@ func mustCELEnv() *cel.Env {
 }
 
 // evaluateReadyExpr compiles (memoized) and evaluates expr against the
-// projected view of id. Returns true iff the program produces a bool
-// true. Any compile, eval, or type-shape error is returned verbatim.
-func evaluateReadyExpr(expr string, s *store.Store, id manifest.NamedResource) (bool, error) {
+// projected views of self (consumer) and dep (dependency). Returns true
+// iff the program produces a bool true. Any compile, eval, or type-
+// shape error is returned verbatim.
+func evaluateReadyExpr(expr string, s *store.Store, self, dep manifest.NamedResource) (bool, error) {
 	prog, err := compileReadyExpr(expr)
 	if err != nil {
 		return false, err
 	}
-	object := projectObject(s, id)
-	val, _, err := prog.Eval(map[string]any{"object": object})
+	val, _, err := prog.Eval(map[string]any{
+		"self": projectObject(s, self),
+		"dep":  projectObject(s, dep),
+	})
 	if err != nil {
 		return false, fmt.Errorf("eval: %w", err)
 	}

--- a/pkg/depwait/cel_test.go
+++ b/pkg/depwait/cel_test.go
@@ -26,7 +26,7 @@ func TestReadyExpr_ProjectsObservedGeneration(t *testing.T) {
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
 		// Common Flux readiness idiom.
-		ReadyExpr: `object.status.observedGeneration == object.metadata.generation`,
+		ReadyExpr: `dep.status.observedGeneration == dep.metadata.generation`,
 	}}))
 	if !sum.AllReady() {
 		t.Errorf("observedGeneration projection should match metadata.generation: %+v", sum)
@@ -46,7 +46,7 @@ func TestReadyExpr_NonAdditive_PassesOnTrue(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: time.Second}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
 	if !sum.AllReady() {
 		t.Errorf("non-additive ReadyExpr should override Failed Ready: %+v", sum)
@@ -73,7 +73,7 @@ func TestReadyExpr_NonAdditive_FlipsOnStatusUpdate(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: 2 * time.Second}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
 	if !sum.AllReady() {
 		t.Errorf("expected to satisfy after status update: %+v", sum)
@@ -91,7 +91,7 @@ func TestReadyExpr_NonAdditive_TimesOutOnFalse(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: 100 * time.Millisecond}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
 	if sum.AllReady() {
 		t.Fatalf("expected timeout: %+v", sum)
@@ -114,7 +114,7 @@ func TestReadyExpr_Additive_BothMustPass(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: time.Second, AdditiveReadyExpr: true}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
+		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
 	if !sum.AllReady() {
 		t.Errorf("expected AllReady when both checks pass: %+v", sum)
@@ -133,7 +133,7 @@ func TestReadyExpr_Additive_FalseFails(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: time.Second, AdditiveReadyExpr: true}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.status.conditions.exists(c, c.type == "Healthy")`,
+		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy")`,
 	}}))
 	if !sum.AnyFailed() {
 		t.Fatalf("expected failure: %+v", sum)
@@ -173,13 +173,37 @@ func TestReadyExpr_NonBoolResult(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: 100 * time.Millisecond}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
 		NamedResource: dep,
-		ReadyExpr:     `object.metadata.name`, // string, not bool
+		ReadyExpr:     `dep.metadata.name`, // string, not bool
 	}}))
 	if !sum.AnyFailed() {
 		t.Fatalf("expected failure for non-bool result: %+v", sum)
 	}
 	if !strings.Contains(sum.Messages[dep], "must return bool") {
 		t.Errorf("expected non-bool error; got %q", sum.Messages[dep])
+	}
+}
+
+// TestReadyExpr_BindsSelfAndDep locks the upstream Flux contract:
+// readyExpr sees both `self` (the consumer / Waiter.Parent) and `dep`
+// (the current dependency). The kustomize/helm controller idiom
+// `dep.status.lastAppliedRevision == self.spec.sourceRef.revision`
+// must compile and have access to both names.
+func TestReadyExpr_BindsSelfAndDep(t *testing.T) {
+	s := store.New()
+	self := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "parent"}
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "child"}
+	s.UpdateStatus(self, store.StatusReady, "")
+	s.UpdateStatus(dep, store.StatusReady, "")
+
+	w := &Waiter{Store: s, Parent: self, Timeout: time.Second}
+	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
+		NamedResource: dep,
+		// Reads both self and dep — would fail to compile under the old
+		// `object`-only binding.
+		ReadyExpr: `self.metadata.namespace == dep.metadata.namespace`,
+	}}))
+	if !sum.AllReady() {
+		t.Errorf("expected self/dep CEL to evaluate true: %+v", sum)
 	}
 }
 

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -195,7 +195,7 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 	// Additive mode: built-in Ready check passed AND the CEL must also
 	// agree. Flux's AdditiveCELDependencyCheck=true behavior.
 	if dep.ReadyExpr != "" {
-		ok, evalErr := evaluateReadyExpr(dep.ReadyExpr, w.Store, id)
+		ok, evalErr := evaluateReadyExpr(dep.ReadyExpr, w.Store, w.Parent, id)
 		if evalErr != nil {
 			return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + evalErr.Error()}
 		}
@@ -212,7 +212,7 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 // Surfaces the parent ctx's timeout/cancel.
 func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, expr string) Event {
 	// Initial evaluation against current state.
-	if ok, err := evaluateReadyExpr(expr, w.Store, id); err != nil {
+	if ok, err := evaluateReadyExpr(expr, w.Store, w.Parent, id); err != nil {
 		return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}
 	} else if ok {
 		return Event{Dep: id, Status: DepReady, Reason: "readyExpr satisfied"}
@@ -230,7 +230,7 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 		}
 	}, false)
 	defer unsub()
-	if ok, err := evaluateReadyExpr(expr, w.Store, id); err != nil {
+	if ok, err := evaluateReadyExpr(expr, w.Store, w.Parent, id); err != nil {
 		return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}
 	} else if ok {
 		return Event{Dep: id, Status: DepReady, Reason: "readyExpr satisfied"}
@@ -239,7 +239,7 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 	for {
 		select {
 		case <-ch:
-			ok, err := evaluateReadyExpr(expr, w.Store, id)
+			ok, err := evaluateReadyExpr(expr, w.Store, w.Parent, id)
 			if err != nil {
 				return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}
 			}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -42,6 +42,11 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	inst.DryRunStrategy = action.DryRunClient
 	inst.ReleaseName = hr.ReleaseName()
 	inst.Namespace = hr.ReleaseNamespace()
+	// Match helm-controller: Devel=true so chart references pinned to a
+	// prerelease semver (e.g. `1.0.0-beta`) resolve. Without this, the
+	// HR renders cleanly in flate (which doesn't consult Devel for local
+	// chart resolution) but fails in cluster, or vice versa.
+	inst.Devel = true
 	inst.IncludeCRDs = !opts.SkipCRDs
 	// HR-scoped policy wins: spec.install.crds / spec.upgrade.crds set
 	// to "Skip" suppresses CRDs even when the CLI requests them.

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -232,13 +233,32 @@ func (h *HelmRelease) Clone() *HelmRelease {
 }
 
 // ReleaseName returns the resolved Helm release name — spec.releaseName
-// when set, otherwise metadata.name. Mirrors helm-controller's behavior
-// at template time. Always non-empty.
+// when set, otherwise metadata.name — passed through release.ShortenName
+// so HRs whose effective name is >53 characters get the same hash-
+// suffixed shortened form a real cluster sees. Mirrors helm-controller's
+// internal/release.ShortenName (a 40-char prefix + "-" + 12 hex chars of
+// sha256(name)). Without shortening, charts referencing `.Release.Name`
+// rendered different resource names/labels in flate vs cluster.
+// Always non-empty.
 func (h *HelmRelease) ReleaseName() string {
-	if h.HelmReleaseSpec.ReleaseName != "" {
-		return h.HelmReleaseSpec.ReleaseName
+	name := h.HelmReleaseSpec.ReleaseName
+	if name == "" {
+		name = h.Name
 	}
-	return h.Name
+	return shortenReleaseName(name)
+}
+
+// shortenReleaseName mirrors helm-controller/internal/release.ShortenName.
+// Inlined to keep pkg/manifest free of a helm-controller import (the
+// canonical impl lives in an internal/ tree we cannot reference).
+func shortenReleaseName(name string) string {
+	if len(name) <= 53 {
+		return name
+	}
+	const maxLength = 53
+	const shortHashLength = 12
+	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
+	return name[:maxLength-(shortHashLength+1)] + "-" + sum[:shortHashLength]
 }
 
 // ReleaseNamespace returns TargetNamespace when set, otherwise Namespace.

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -659,6 +659,35 @@ spec:
 	}
 }
 
+// TestReleaseName_Shortens locks the helm-controller release.ShortenName
+// contract: names ≤53 chars pass through; longer names become a 40-char
+// prefix + "-" + 12 hex chars of sha256(name). Without this flate's
+// `.Release.Name` diverges from a real cluster's for long HR names.
+func TestReleaseName_Shortens(t *testing.T) {
+	short := &HelmRelease{Name: "short-name"}
+	if got := short.ReleaseName(); got != "short-name" {
+		t.Errorf("short name should pass through: got %q", got)
+	}
+
+	// 60-char name exceeds the 53 threshold.
+	longName := "this-is-a-very-long-helmrelease-name-that-exceeds-53-chars"
+	if len(longName) <= 53 {
+		t.Fatalf("test setup: longName should be >53 chars, got %d", len(longName))
+	}
+	hr := &HelmRelease{Name: longName}
+	got := hr.ReleaseName()
+	if len(got) != 53 {
+		t.Errorf("shortened name should be exactly 53 chars; got %d (%q)", len(got), got)
+	}
+	if got == longName {
+		t.Errorf("expected shortening; got %q", got)
+	}
+	// Deterministic: same input → same hash suffix.
+	if got2 := hr.ReleaseName(); got2 != got {
+		t.Errorf("non-deterministic shortening: %q vs %q", got, got2)
+	}
+}
+
 func TestParseHelmRelease_ChartRef(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -319,6 +319,17 @@ func renderSingle(tmplStr string, inputSet map[string]any) (map[string]any, erro
 	return doc, nil
 }
 
+// init mirrors upstream flux-operator's slugify configuration
+// (internal/builder/resourceset.go init): 63-char max with smart-
+// truncate, matching Kubernetes label-value limits. Without this,
+// slugify on inputs ≥64 chars renders the full slug in flate but a
+// truncated 63-char prefix in cluster — different downstream resource
+// names for the same ResourceSet input.
+func init() {
+	slug.MaxLength = 63
+	slug.EnableSmartTruncate = true
+}
+
 func execute(tmplStr string, inputSet map[string]any) ([]byte, error) {
 	tmpl, err := template.New("resourceset").
 		Delims("<<", ">>").

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -229,10 +229,15 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 		}
 	}
 
+	// Format matches source-controller's internal/index/digest.go:
+	// `"%s %s\n"` (single space delimiter). Using a tab made flate's
+	// revision diverge silently from what a cluster Bucket reports
+	// for identical contents — change detection across runs and any
+	// readyExpr keyed off status.artifact.revision would never align.
 	h := sha256.New()
 	keys := make([]string, 0, len(entries))
 	for _, e := range entries {
-		_, _ = fmt.Fprintf(h, "%s\t%s\n", e.key, e.etag)
+		_, _ = fmt.Fprintf(h, "%s %s\n", e.key, e.etag)
 		keys = append(keys, e.key)
 	}
 	return keys, "sha256:" + hex.EncodeToString(h.Sum(nil)), nil

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"strings"
 
+	"helm.sh/helm/v4/pkg/strvals"
 	"sigs.k8s.io/yaml"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -194,23 +195,18 @@ func decodeBag(stringData, binaryData map[string]any) (map[string]string, error)
 
 // updateHelmReleaseValues writes found into values using ref.TargetPath
 // when set; otherwise the found YAML is parsed and deep-merged.
+//
+// When targetPath is set, write through Helm's strvals parser
+// (path=value form). This matches upstream Flux's
+// chartutil.ChartValuesFromReferences (which calls strvals.ParseInto)
+// and gives the correct type coercion: "3" → int 3, "true" → bool,
+// "null" → nil. Single/double-quoted values force string-coercion
+// (strvals.ParseIntoString). A naive `inner[k] = found` left every
+// targetPath value as a literal string, which broke chart-schema
+// validation against `replicaCount: integer` and similar.
 func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values map[string]any) (map[string]any, error) {
 	if ref.TargetPath != "" {
-		parts := splitDottedPath(ref.TargetPath)
-		inner := values
-		for _, p := range parts[:len(parts)-1] {
-			next, ok := inner[p].(map[string]any)
-			if !ok {
-				if _, alreadyHas := inner[p]; alreadyHas {
-					return nil, fmt.Errorf("expected '%s' at %q to be a map", ref.Name, ref.TargetPath)
-				}
-				next = map[string]any{}
-				inner[p] = next
-			}
-			inner = next
-		}
-		inner[parts[len(parts)-1]] = found
-		return values, nil
+		return replaceValueAtPath(values, ref.TargetPath, found)
 	}
 
 	// Wiped Secret values surface here as the literal placeholder
@@ -231,28 +227,29 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 	return DeepMerge(values, parsed), nil
 }
 
-// splitDottedPath splits a target_path on unescaped dots. Backslash
-// escapes a literal dot in a key name.
-func splitDottedPath(s string) []string {
-	var out []string
-	var cur strings.Builder
-	for i := 0; i < len(s); i++ {
-		switch s[i] {
-		case '\\':
-			if i+1 < len(s) {
-				cur.WriteByte(s[i+1])
-				i++
-				continue
-			}
-		case '.':
-			out = append(out, cur.String())
-			cur.Reset()
-		default:
-			cur.WriteByte(s[i])
-		}
+// replaceValueAtPath writes value into values at path using Helm's
+// strvals parser. Matches upstream Flux's chartutil.ReplacePathValue:
+// single/double-quoted values use ParseIntoString (forced string);
+// bare values use ParseInto (type-coerced: "3" → int, "true" → bool,
+// "null" → nil). Strvals also handles list indices (foo.bar[0]) and
+// escaped dot keys (foo\\.bar).
+func replaceValueAtPath(values map[string]any, path, value string) (map[string]any, error) {
+	const (
+		singleQuote = "'"
+		doubleQuote = `"`
+	)
+	var err error
+	if (strings.HasPrefix(value, singleQuote) && strings.HasSuffix(value, singleQuote)) ||
+		(strings.HasPrefix(value, doubleQuote) && strings.HasSuffix(value, doubleQuote)) {
+		stripped := value[1 : len(value)-1]
+		err = strvals.ParseIntoString(path+"="+stripped, values)
+	} else {
+		err = strvals.ParseInto(path+"="+value, values)
 	}
-	out = append(out, cur.String())
-	return out
+	if err != nil {
+		return nil, fmt.Errorf("targetPath %q: %w", path, err)
+	}
+	return values, nil
 }
 
 // ExpandPostBuildSubstituteReference resolves substituteFrom references

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -1,7 +1,7 @@
 package values
 
 import (
-	"slices"
+	"strings"
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -121,20 +121,80 @@ func TestExpandPostBuildSubstituteReference(t *testing.T) {
 	}
 }
 
-func TestSplitDottedPath(t *testing.T) {
+// TestReplaceValueAtPath_TypeCoercion locks the upstream Flux contract
+// (chartutil.ReplacePathValue → strvals.ParseInto): a value flowing
+// in through ValuesReference.TargetPath is parsed as a Helm CLI
+// `--set foo=value` would be, with full type coercion. Without this,
+// `replicaCount` came back as the string "3" and chart schemas with
+// `replicaCount: integer` rejected the HR.
+func TestReplaceValueAtPath_TypeCoercion(t *testing.T) {
 	cases := []struct {
-		in   string
-		want []string
+		name string
+		path string
+		val  string
+		want any
 	}{
-		{"a.b.c", []string{"a", "b", "c"}},
-		{`a\.b.c`, []string{"a.b", "c"}},
-		{"single", []string{"single"}},
+		{"int", "replicaCount", "3", float64(3)},
+		{"bool", "enabled", "true", true},
+		{"null", "extra", "null", nil},
+		{"nested map", "image.repository", "nginx", "nginx"},
+		{"quoted string forces string", "tag", `"123"`, "123"},
+		{"list index", "ports[0]", "8080", float64(8080)},
 	}
 	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			if got := splitDottedPath(tc.in); !slices.Equal(got, tc.want) {
-				t.Errorf("got %v, want %v", got, tc.want)
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := replaceValueAtPath(map[string]any{}, tc.path, tc.val)
+			if err != nil {
+				t.Fatalf("replaceValueAtPath: %v", err)
+			}
+			// Walk got along path to extract the leaf.
+			leaf := walkPath(t, got, tc.path)
+			if !equalish(leaf, tc.want) {
+				t.Errorf("path %q: got %v (%T), want %v (%T)", tc.path, leaf, leaf, tc.want, tc.want)
 			}
 		})
 	}
+}
+
+func walkPath(t *testing.T, m map[string]any, path string) any {
+	t.Helper()
+	cur := any(m)
+	parts := strings.Split(path, ".")
+	for _, p := range parts {
+		if idx := strings.IndexByte(p, '['); idx >= 0 {
+			key := p[:idx]
+			if cm, ok := cur.(map[string]any); ok {
+				cur = cm[key]
+			}
+			// Strip "[0]" → 0 and index.
+			cur = cur.([]any)[0]
+			continue
+		}
+		if cm, ok := cur.(map[string]any); ok {
+			cur = cm[p]
+		}
+	}
+	return cur
+}
+
+func equalish(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	// strvals.ParseInto returns int64 for integers; allow comparison
+	// against float64 literals in test cases.
+	switch av := a.(type) {
+	case int64:
+		if bv, ok := b.(float64); ok {
+			return float64(av) == bv
+		}
+	case int:
+		if bv, ok := b.(float64); ok {
+			return float64(av) == bv
+		}
+	}
+	return a == b
 }


### PR DESCRIPTION
## Summary
Iter-12 fresh-eyes correctness audit caught six places where flate's rendered output **silently diverged** from real Flux / flux-operator. Each fix matches the cited upstream behavior 1:1. None of these are refactors — they're bug-class fixes.

| Finding | Upstream source | Fix |
|---|---|---|
| CEL readyExpr binds \`object\` instead of \`self\`/\`dep\` | kustomize-controller \`internal/controller/kustomization_controller.go:633-641\` | Bind both \`self\` (consumer / Waiter.Parent) and \`dep\` (current dep) |
| valuesFrom \`targetPath\` writes raw string instead of strvals-parsed | \`fluxcd/pkg/chartutil/values.go:233-243\` (\`strvals.ParseInto\`) | Use \`helm.sh/helm/v4/pkg/strvals\` with quoted-string handling |
| ResourceSet \`slugify\` uses defaults | flux-operator \`internal/builder/resourceset.go:174-180\` | \`slug.MaxLength = 63\`, \`slug.EnableSmartTruncate = true\` in init() |
| Bucket revision uses \`\\t\` delimiter | source-controller \`internal/index/digest.go:219\` | Use space delimiter |
| Helm install missing \`Devel = true\` | helm-controller | Set \`inst.Devel = true\` |
| \`ReleaseName()\` doesn't shorten long names | helm-controller \`internal/release/name.go\` ShortenName | Inline shorten (40-char prefix + sha256-12 hex chars) when \`len > 53\` |

Two new tests lock the headline behaviors: \`TestReadyExpr_BindsSelfAndDep\` for the CEL fix, \`TestReleaseName_Shortens\` for the helm-controller name contract. \`TestReplaceValueAtPath_TypeCoercion\` (6 rows) verifies strvals coerces int/bool/null/list-index/quoted-string correctly.

Migration: all existing \`object.*\` references in depwait/cel_test.go switch to \`dep.*\` (no API surface change for embedders since the CEL env is internal).

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)