### PR TITLE
refactor(helm): route source-CR lookups through SourceResolver

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -69,32 +69,25 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 }
 
 // Start registers the listeners. The controller runs until Close.
+// The HR controller only listens for HelmRelease and HelmChartSource
+// (the chart-ref index) — source-kind events (HelmRepository,
+// OCIRepository, GitRepository, Bucket, ExternalArtifact) are now
+// consumed lazily by helm.Client through its SourceResolver against
+// the canonical Store. One fewer push-registry to keep in sync.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("helmrelease")
 	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
-	c.AddListener(store.EventArtifactUpdated, c.onArtifactUpdated)
 }
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	return func(id manifest.NamedResource, payload any) {
-		// Source-kind listeners re-read from the Store rather than
-		// trusting payload, because s.fire dispatches AFTER s.mu is
-		// released — two concurrent AddObject calls for the same id
-		// could deliver listener payloads in reverse of write order.
-		// The store always reflects the latest write under its own
-		// lock, so a fresh GetObject is authoritative.
 		switch id.Kind {
-		case manifest.KindHelmRepository:
-			_ = payload
-			if r, ok := c.Store.GetObject(id).(*manifest.HelmRepository); ok {
-				c.Helm.AddRepo(r)
-			}
-		case manifest.KindOCIRepository:
-			_ = payload
-			if r, ok := c.Store.GetObject(id).(*manifest.OCIRepository); ok {
-				c.Helm.AddOCIRepo(r)
-			}
 		case manifest.KindHelmChart:
+			// HelmChartSource is a flate-internal projection of a Flux
+			// HelmChart CR. Maintain an index so HR.ResolveChartRef can
+			// look up the producing source for a chartRef reference.
+			// Re-read from the Store to win the listener-ordering race
+			// (s.fire dispatches after s.mu releases).
 			_ = payload
 			if s, ok := c.Store.GetObject(id).(*manifest.HelmChartSource); ok {
 				c.chartSourcesMu.Lock()
@@ -114,26 +107,6 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 			})
 		}
 	}
-}
-
-// onArtifactUpdated registers fetched-artifact sources (GitRepository,
-// Bucket, ExternalArtifact) with the helm client so charts referenced
-// via the corresponding sourceRef.kind can be loaded from disk.
-func (c *Controller) onArtifactUpdated(id manifest.NamedResource, payload any) {
-	switch id.Kind {
-	case manifest.KindGitRepository, manifest.KindBucket, manifest.KindExternalArtifact:
-	default:
-		return
-	}
-	art, ok := payload.(*store.SourceArtifact)
-	if !ok || art.LocalPath == "" {
-		return
-	}
-	c.Helm.AddLocalSource(helm.LocalSource{
-		Name:      id.Name,
-		Namespace: id.Namespace,
-		Artifact:  art,
-	})
 }
 
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -49,7 +49,16 @@ type Client struct {
 	tmpDir   string
 	cacheDir string
 
-	mu           sync.RWMutex
+	mu sync.RWMutex
+	// resolver is the canonical source-lookup surface. When non-nil it
+	// wins over the legacy Add*-driven maps. The orchestrator wires
+	// NewStoreSourceResolver(store) at construction; embedders driving
+	// helm.Client directly can either set their own resolver or stay on
+	// the Add* API for back-compat.
+	resolver SourceResolver
+	// repos/ociRepos/localSources are the legacy push-registries. Kept
+	// for tests / standalone embedders that haven't migrated to the
+	// resolver. When the resolver is set, these maps are not consulted.
 	repos        map[string]*manifest.HelmRepository
 	ociRepos     map[string]*manifest.OCIRepository
 	localSources map[string]LocalSource
@@ -106,6 +115,62 @@ func (c *Client) SetSecretGetter(g SecretGetter) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.secrets = g
+}
+
+// SetSourceResolver installs the canonical lookup surface for
+// HelmRepository / OCIRepository / local-artifact sources. When set,
+// helm.Client reads through the resolver instead of consulting its
+// own Add*-populated maps — eliminating the duplicate-state hazard
+// where a source CR's spec change after registration could leave the
+// helm.Client looking at stale credentials. Safe to call before any
+// Add* / template call; typically once at orchestrator construction.
+// Pass nil to revert to the legacy push-API behavior.
+func (c *Client) SetSourceResolver(r SourceResolver) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.resolver = r
+}
+
+// resolveHelmRepo returns the HelmRepository at <namespace>-<name>,
+// reading from the resolver when present and falling back to the
+// legacy Add*-populated map otherwise.
+func (c *Client) resolveHelmRepo(hr *manifest.HelmRelease) *manifest.HelmRepository {
+	c.mu.RLock()
+	resolver := c.resolver
+	c.mu.RUnlock()
+	if resolver != nil {
+		return resolver.HelmRepository(hr.Chart.RepoNamespace, hr.Chart.RepoName)
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.repos[hr.Chart.RepoFullName()]
+}
+
+func (c *Client) resolveOCIRepo(hr *manifest.HelmRelease) *manifest.OCIRepository {
+	c.mu.RLock()
+	resolver := c.resolver
+	c.mu.RUnlock()
+	if resolver != nil {
+		return resolver.OCIRepository(hr.Chart.RepoNamespace, hr.Chart.RepoName)
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.ociRepos[hr.Chart.RepoFullName()]
+}
+
+func (c *Client) resolveLocalSource(hr *manifest.HelmRelease) *store.SourceArtifact {
+	c.mu.RLock()
+	resolver := c.resolver
+	c.mu.RUnlock()
+	if resolver != nil {
+		return resolver.LocalSourceArtifact(hr.Chart.RepoKind, hr.Chart.RepoNamespace, hr.Chart.RepoName)
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if ls, ok := c.localSources[hr.Chart.RepoFullName()]; ok {
+		return ls.Artifact
+	}
+	return nil
 }
 
 // AddRepo registers a HelmRepository so chart lookups can resolve it.

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -52,14 +52,12 @@ type ChartLoadResult struct {
 // artifact — GitRepository, Bucket, or ExternalArtifact. The chart
 // lives at <artifact.LocalPath>/<chart.Name> in every case.
 func (c *Client) locateLocalChart(hr *manifest.HelmRelease) (string, error) {
-	c.mu.RLock()
-	s, ok := c.localSources[hr.Chart.RepoFullName()]
-	c.mu.RUnlock()
-	if !ok || s.Artifact == nil {
+	art := c.resolveLocalSource(hr)
+	if art == nil {
 		return "", fmt.Errorf("%w: %s %s not available for HelmRelease %s",
 			manifest.ErrObjectNotFound, hr.Chart.RepoKind, hr.Chart.RepoFullName(), hr.NamespacedName())
 	}
-	path := filepath.Join(s.Artifact.LocalPath, hr.Chart.Name)
+	path := filepath.Join(art.LocalPath, hr.Chart.Name)
 	if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err != nil {
 		return "", fmt.Errorf("chart not found at %s: %w", path, err)
 	}
@@ -71,10 +69,8 @@ func (c *Client) locateLocalChart(hr *manifest.HelmRelease) (string, error) {
 // path. Otherwise we download the chart tarball via getter, applying
 // any SecretRef credentials.
 func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
-	c.mu.RLock()
-	r, ok := c.repos[hr.Chart.RepoFullName()]
-	c.mu.RUnlock()
-	if !ok {
+	r := c.resolveHelmRepo(hr)
+	if r == nil {
 		return "", fmt.Errorf("%w: HelmRepository %s not registered for HelmRelease %s",
 			manifest.ErrObjectNotFound, hr.Chart.RepoFullName(), hr.NamespacedName())
 	}
@@ -287,10 +283,8 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 // "chart-as-OCI-artifact" model) so we use it verbatim — the chart's
 // short name from the HelmRelease is metadata, not part of the URL.
 func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
-	c.mu.RLock()
-	r, ok := c.ociRepos[hr.Chart.RepoFullName()]
-	c.mu.RUnlock()
-	if !ok {
+	r := c.resolveOCIRepo(hr)
+	if r == nil {
 		return "", fmt.Errorf("%w: OCIRepository %s not registered", manifest.ErrObjectNotFound, hr.Chart.RepoFullName())
 	}
 	ver, err := r.Version()

--- a/pkg/helm/resolver.go
+++ b/pkg/helm/resolver.go
@@ -1,0 +1,60 @@
+package helm
+
+import (
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// SourceResolver is the lookup surface helm.Client needs to resolve a
+// HelmRelease's sourceRef against the canonical object store.
+//
+// The interface exists so helm.Client doesn't have to maintain its own
+// parallel registries of source CRs that the Store already owns — see
+// NewStoreSourceResolver for the production-side adapter. Embedders
+// rendering a single HelmRelease without an Orchestrator can implement
+// this directly.
+//
+// A nil return from any method means "not found" — callers translate
+// that into a typed manifest.ErrObjectNotFound error.
+type SourceResolver interface {
+	// HelmRepository returns the HelmRepository at the given (ns, name)
+	// or nil. Used for index.yaml fetch + SecretRef/CertSecretRef.
+	HelmRepository(namespace, name string) *manifest.HelmRepository
+	// OCIRepository returns the OCIRepository at the given (ns, name)
+	// or nil. The .url field is the chart-artifact root.
+	OCIRepository(namespace, name string) *manifest.OCIRepository
+	// LocalSourceArtifact returns the fetched on-disk artifact for a
+	// GitRepository / Bucket / ExternalArtifact source, or nil. Charts
+	// live at <artifact.LocalPath>/<hr.Chart.Name> for any of those
+	// three sourceRef.kind values.
+	LocalSourceArtifact(kind, namespace, name string) *store.SourceArtifact
+}
+
+// NewStoreSourceResolver returns a SourceResolver backed by the
+// canonical object store. The orchestrator wires this into helm.Client
+// so chart-source lookups read straight from the Store rather than
+// through helm.Client's now-deprecated AddRepo/AddOCIRepo/AddLocalSource
+// push API.
+func NewStoreSourceResolver(s *store.Store) SourceResolver {
+	return &storeResolver{store: s}
+}
+
+type storeResolver struct {
+	store *store.Store
+}
+
+func (r *storeResolver) HelmRepository(namespace, name string) *manifest.HelmRepository {
+	obj, _ := r.store.GetByName(manifest.KindHelmRepository, namespace, name).(*manifest.HelmRepository)
+	return obj
+}
+
+func (r *storeResolver) OCIRepository(namespace, name string) *manifest.OCIRepository {
+	obj, _ := r.store.GetByName(manifest.KindOCIRepository, namespace, name).(*manifest.OCIRepository)
+	return obj
+}
+
+func (r *storeResolver) LocalSourceArtifact(kind, namespace, name string) *store.SourceArtifact {
+	id := manifest.NamedResource{Kind: kind, Namespace: namespace, Name: name}
+	art, _ := r.store.GetArtifact(id).(*store.SourceArtifact)
+	return art
+}

--- a/pkg/helm/resolver_test.go
+++ b/pkg/helm/resolver_test.go
@@ -1,0 +1,76 @@
+package helm_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestSourceResolver_NoAddCallsNeeded verifies helm.Client renders a HR
+// whose chart lives in a GitRepository on disk, without any AddRepo /
+// AddLocalSource push-calls — only the SourceResolver wired in at
+// construction. This locks the iter-12 contract: the helm.Client reads
+// source CRs through the canonical Store, eliminating the duplicate
+// push-registries.
+func TestSourceResolver_NoAddCallsNeeded(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml", `apiVersion: v2
+name: mychart
+version: 0.1.0
+description: test
+`)
+	testutil.WriteFile(t, dir, "mychart/values.yaml", "greeting: hi\n")
+	testutil.WriteFile(t, dir, "mychart/templates/configmap.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+data:
+  greeting: {{ .Values.greeting }}
+`)
+
+	// Build a Store containing the GitRepository + its on-disk artifact.
+	st := store.New()
+	gr := &manifest.GitRepository{
+		Name: "chart-repo", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + dir},
+	}
+	st.AddObject(gr)
+	st.SetArtifact(gr.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir,
+	})
+
+	cli, err := helm.NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	// Resolver wired — NO AddRepo / AddLocalSource calls below.
+	cli.SetSourceResolver(helm.NewStoreSourceResolver(st))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "mychart",
+			RepoName:      "chart-repo",
+			RepoNamespace: "flux-system",
+			RepoKind:      manifest.KindGitRepository,
+		},
+	}
+
+	out, err := cli.Template(context.Background(), hr, map[string]any{"greeting": "hello"}, helm.Options{})
+	if err != nil {
+		t.Fatalf("Template via resolver: %v", err)
+	}
+	if !strings.Contains(out, "name: demo-cm") {
+		t.Errorf("expected rendered ConfigMap; got: %s", out)
+	}
+	if !strings.Contains(out, "greeting: hello") {
+		t.Errorf("expected values applied; got: %s", out)
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -125,6 +125,10 @@ func New(cfg Config) (*Orchestrator, error) {
 		return s
 	}
 	helmClient.SetSecretGetter(secretGet)
+	// Route helm.Client's source-CR lookups straight through the canonical
+	// Store rather than maintaining a duplicate registry the HR controller
+	// would otherwise have to keep in sync via Add* push-API calls.
+	helmClient.SetSourceResolver(helm.NewStoreSourceResolver(st))
 	srcCtrl := sourcectrl.New(st, ts)
 	srcCtrl.Fetchers[manifest.KindGitRepository] = &git.Fetcher{Cache: cache, Secrets: secretGet}
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = &external.Fetcher{}


### PR DESCRIPTION
## Summary
Iter-12 architectural review (Agent 1's headline) caught a duplicate-state hazard: \`helm.Client\` kept three push-registries (\`repos\`, \`ociRepos\`, \`localSources\`) that mirrored objects already owned by the canonical \`Store\`. The HR controller's listeners existed purely to keep those maps in sync — every source kind needed a switch arm in the controller AND an Add* method on the Client. A source CR spec change after registration could leave the Client looking at stale credentials.

Introduce a small \`SourceResolver\` interface (3 methods). \`helm.NewStoreSourceResolver\` adapts a \`*store.Store\`. The Client's \`locate*\` paths read through the resolver when set; the legacy \`Add*\`-populated maps remain as a fallback for tests and standalone embedders. The orchestrator wires the store-backed resolver at construction.

**Outcomes:**
- HR controller listener drops to **two cases** (HelmChart index + HelmRelease dispatch). The \`onArtifactUpdated\` listener is gone entirely. Five source-kind switch arms removed.
- \`helm.Client\` never holds stale credentials — every lookup re-reads the live Store.
- Embedders rendering a single HR set one resolver instead of three different Add* methods.

New \`TestSourceResolver_NoAddCallsNeeded\` fires a real Template call through helm.Client with only the resolver wired (no Add* calls), proving the store-backed lookup path resolves a GitRepository chart end-to-end.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 29 packages pass (incl. existing helm + helmrelease + orchestrator + e2e suites)
- [x] \`go test -race ./pkg/helm/... ./pkg/controllers/helmrelease/... ./pkg/orchestrator/... ./test/e2e/...\` clean
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)