### PR TITLE
feat(api): Orchestrator.Render + typed Store.On* listeners

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,6 +92,29 @@ type Orchestrator struct {
 	// loadManifests + namespace inheritance. Configured onto the
 	// kustomization controller at Run-time, never mutated thereafter.
 	parentOf map[manifest.NamedResource]manifest.NamedResource
+
+	// orphans records resources Run demoted from Failed → Ready because
+	// they aren't referenced by any parent KS. Populated during Run,
+	// surfaced via Render() so embedders can distinguish orphan-skips
+	// from genuine successes. Keyed by id, value is the original
+	// failure message.
+	orphans map[manifest.NamedResource]string
+}
+
+// Result is the structured output of Orchestrator.Render: the rendered
+// manifests keyed by the originating Kustomization / HelmRelease, the
+// set of resources that failed reconcile, and the orphans flate
+// detected (sources sitting under a parent KS's spec.path but never
+// emitted by that parent's render — real Flux would not reconcile
+// them either).
+//
+// Manifests is empty for an HR that had nothing to render or a KS
+// whose render produced zero docs; Failed/Orphans are empty when
+// everything reconciled cleanly.
+type Result struct {
+	Manifests map[manifest.NamedResource][]map[string]any
+	Failed    map[manifest.NamedResource]store.StatusInfo
+	Orphans   map[manifest.NamedResource]string
 }
 
 // New constructs an Orchestrator. It allocates the Store and TaskService
@@ -383,8 +407,10 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	// scans the whole tree. Surface as warnings instead of failures so
 	// the test isn't gated on stale on-disk files the user has not
 	// wired into their kustomize tree.
+	o.orphans = map[manifest.NamedResource]string{}
 	for id := range o.detectOrphans(failed) {
 		info := failed[id]
+		o.orphans[id] = info.Message
 		o.store.UpdateStatus(id, store.StatusReady, "orphaned (not referenced by any parent kustomization.yaml)")
 		slog.Warn("resource orphaned", "id", id.String(),
 			"file", o.sourceFiles[id],
@@ -424,6 +450,43 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",
 		len(msgs), strings.Join(msgs, "\n  "))
+}
+
+// Render is the structured embed-friendly entry point: Bootstrap +
+// Run + collect everything an external caller needs to consume the
+// reconcile result. CLI / Run() ergonomics remain unchanged; callers
+// who want a single function that returns a typed Result use this.
+//
+// The returned Result is non-nil even when err is non-nil — failures
+// during reconcile populate Result.Failed without aborting collection,
+// so the caller sees both the partial output and the failure list.
+// An error from Bootstrap (the load phase) is fatal and returns
+// (nil, err); errors from Run yield (result, err).
+func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
+	if err := o.Bootstrap(ctx); err != nil {
+		return nil, err
+	}
+	runErr := o.Run(ctx)
+	res := &Result{
+		Manifests: map[manifest.NamedResource][]map[string]any{},
+		Failed:    map[manifest.NamedResource]store.StatusInfo{},
+		Orphans:   map[manifest.NamedResource]string{},
+	}
+	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+		for _, obj := range o.store.ListObjects(kind) {
+			id := obj.Named()
+			if art, ok := o.store.GetArtifact(id).(store.RenderedArtifact); ok {
+				if mans := art.RenderedManifests(); len(mans) > 0 {
+					res.Manifests[id] = mans
+				}
+			}
+		}
+	}
+	for id, info := range o.store.FailedResources() {
+		res.Failed[id] = info
+	}
+	maps.Copy(res.Orphans, o.orphans)
+	return res, runErr
 }
 
 // Stop shuts the controllers down in reverse-construction order and

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -145,3 +145,85 @@ data: {k: v}
 		t.Errorf("expected at least 1 ConfigMap after reconcile, got %d", got)
 	}
 }
+
+// TestOrchestrator_Render exercises the embed-friendly Render() entry:
+// one call drives Bootstrap + Run + result collection, and returns a
+// structured Result keyed by NamedResource. Embedders previously had
+// to scrape o.Store().GetArtifact(id) per-kind after Run.
+func TestOrchestrator_Render(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello
+data: {k: v}
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Render returned nil Result")
+	}
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	mans, ok := res.Manifests[ksID]
+	if !ok {
+		t.Fatalf("Result.Manifests missing %s; keys=%v", ksID, keysOf(res.Manifests))
+	}
+	if len(mans) == 0 {
+		t.Errorf("expected rendered docs for %s; got empty", ksID)
+	}
+	if len(res.Failed) != 0 {
+		t.Errorf("expected no failures; got %v", res.Failed)
+	}
+	if len(res.Orphans) != 0 {
+		t.Errorf("expected no orphans; got %v", res.Orphans)
+	}
+}
+
+func keysOf[V any](m map[manifest.NamedResource]V) []manifest.NamedResource {
+	out := make([]manifest.NamedResource, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestOrchestrator_TypedListener verifies Store.OnStatus delivers a
+// typed StatusInfo payload (no `any` type-switching needed by the
+// embedder).
+func TestOrchestrator_TypedListener(t *testing.T) {
+	s := store.New()
+	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "k"}
+
+	var seen store.StatusInfo
+	unsub := s.OnStatus(func(other manifest.NamedResource, info store.StatusInfo) {
+		if other == id {
+			seen = info
+		}
+	}, false)
+	defer unsub()
+
+	s.UpdateStatus(id, store.StatusFailed, "boom")
+	if seen.Status != store.StatusFailed || seen.Message != "boom" {
+		t.Errorf("typed listener did not receive payload: %+v", seen)
+	}
+}

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -27,3 +27,32 @@ type Listener func(id manifest.NamedResource, payload any)
 // Unsubscribe removes a listener. It is safe to call from inside the
 // listener.
 type Unsubscribe func()
+
+// OnObject registers fn for every EventObjectAdded with a typed
+// payload. When replay is true, fn fires synchronously for every
+// object already in the store before returning — useful when wiring
+// a UI mid-render. Listeners MUST NOT block the dispatching goroutine.
+func (s *Store) OnObject(fn func(manifest.NamedResource, manifest.BaseManifest), replay bool) Unsubscribe {
+	return s.AddListener(EventObjectAdded, func(id manifest.NamedResource, p any) {
+		obj, _ := p.(manifest.BaseManifest)
+		fn(id, obj)
+	}, replay)
+}
+
+// OnStatus registers fn for every EventStatusUpdated with the typed
+// StatusInfo payload. Same blocking / replay semantics as OnObject.
+func (s *Store) OnStatus(fn func(manifest.NamedResource, StatusInfo), replay bool) Unsubscribe {
+	return s.AddListener(EventStatusUpdated, func(id manifest.NamedResource, p any) {
+		info, _ := p.(StatusInfo)
+		fn(id, info)
+	}, replay)
+}
+
+// OnArtifact registers fn for every EventArtifactUpdated with the
+// typed Artifact payload.
+func (s *Store) OnArtifact(fn func(manifest.NamedResource, Artifact), replay bool) Unsubscribe {
+	return s.AddListener(EventArtifactUpdated, func(id manifest.NamedResource, p any) {
+		art, _ := p.(Artifact)
+		fn(id, art)
+	}, replay)
+}


### PR DESCRIPTION
## Summary
Iter-12 embed-as-library audit found two friction points that made flate awkward to use as a Go SDK:

1. **No structured render output.** Run returns \`error\`; embedders had to scrape \`o.Store().GetArtifact(id).(store.RenderedArtifact).RenderedManifests()\` per id per kind post-hoc, parse the error string for failure detail, and discover orphans only via log lines.
2. **Listeners are untyped.** \`store.AddListener\` takes \`func(NamedResource, any)\`; every embedder type-switched on the payload to recover the typed value.

**Add:**
- \`Orchestrator.Render(ctx) (*Result, error)\` — one call drives Bootstrap + Run and returns \`Result{Manifests, Failed, Orphans}\`, each keyed by \`NamedResource\`. \`Result\` is non-nil even on err so partial output stays usable. Orphans are now a first-class \`Orchestrator\` field instead of message-sniffed.
- \`Store.OnObject(fn, replay)\`, \`Store.OnStatus\`, \`Store.OnArtifact\` — three thin wrappers around \`AddListener\` that supply the type assertion. Embedders write typed callbacks directly.

New \`TestOrchestrator_Render\` runs an end-to-end small repo through the new API; \`TestOrchestrator_TypedListener\` proves \`OnStatus\` delivers a typed \`StatusInfo\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)