### PR TITLE
refactor+fix: helm.Prepare helper; reject invalid substituteFrom var names

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -136,15 +136,13 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		}
 	}
 
-	// Clone before mutating: ResolveChartRef rewrites hr.Chart in place
-	// and ExpandValueReferences writes hr.Values. The store-owned HR
-	// stays canonical so concurrent readers (e.g. dependsOn watchers
-	// reading hr.Chart for a sibling reconcile) never see torn state.
-	hr = hr.Clone()
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
-
-	helmCharts := c.gatherHelmChartSources()
-	if err := hr.ResolveChartRef(helmCharts); err != nil {
+	// helm.Prepare clones hr, resolves chartRef, and expands values —
+	// the same pre-render dance an embedder calling TemplateDocs
+	// directly performs. Keeping one canonical implementation here
+	// means changes to the contract only land in one place.
+	hr, err := helm.Prepare(hr, c.gatherHelmChartSources(), values.NewStoreProvider(c.Store))
+	if err != nil {
 		return err
 	}
 
@@ -166,12 +164,6 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	if sum.AnyFailed() {
 		return fmt.Errorf("%w: chart source %s not ready: %s",
 			manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
-	}
-
-	c.Store.UpdateStatus(id, store.StatusPending, "resolving values")
-	provider := values.NewStoreProvider(c.Store)
-	if err := values.ExpandValueReferences(hr, provider); err != nil {
-		return err
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering chart")

--- a/pkg/helm/prepare.go
+++ b/pkg/helm/prepare.go
@@ -1,0 +1,33 @@
+package helm
+
+import (
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/values"
+)
+
+// Prepare runs the standard pre-render dance for a HelmRelease so it
+// is ready to feed into Client.Template / TemplateDocs:
+//
+//  1. Clone hr so subsequent mutations don't touch the store-canonical
+//     copy (the immutability contract every flate controller honors).
+//  2. Resolve hr.spec.chartRef against the supplied HelmChartSource
+//     index. A chartRef points at a Flux HelmChart CR — typically
+//     emitted by a parent Kustomization render — and is rewritten
+//     into the concrete hr.Chart projection.
+//  3. Expand values / valuesFrom against the supplied provider so
+//     hr.Values reflects the merged result a render would consume.
+//
+// Embedders rendering a single HelmRelease without standing up the
+// orchestrator's HR controller call Prepare then TemplateDocs. The
+// returned *HelmRelease is the cloned, resolved one — pass it to
+// Template / TemplateDocs and discard once rendered.
+func Prepare(hr *manifest.HelmRelease, charts map[string]*manifest.HelmChartSource, provider values.Provider) (*manifest.HelmRelease, error) {
+	hr = hr.Clone()
+	if err := hr.ResolveChartRef(charts); err != nil {
+		return nil, err
+	}
+	if err := values.ExpandValueReferences(hr, provider); err != nil {
+		return nil, err
+	}
+	return hr, nil
+}

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"regexp"
 	"strings"
 
 	"helm.sh/helm/v4/pkg/strvals"
@@ -12,6 +13,13 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
+
+// varsubRegex matches the upstream kustomize-controller var-name
+// validation from fluxcd/pkg/kustomize/kustomize_varsub.go: identifiers
+// composed of an alpha/underscore lead and alnum/underscore tail. A
+// ConfigMap key like `my-var` (dash) is invalid; upstream rejects the
+// whole postBuild rather than silently substituting nothing.
+var varsubRegex = regexp.MustCompile(`^[_a-zA-Z][_a-zA-Z0-9]*$`)
 
 // Provider exposes the ConfigMap/Secret lookups needed for value
 // reference expansion. The controllers implement it against the central
@@ -314,6 +322,18 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 	// Layer inline spec.postBuild.substitute on top — inline wins on
 	// key collision per upstream LoadVariables order.
 	maps.Copy(values, ks.PostBuildSubstitute)
+
+	// Reject invalid var names — matches upstream fluxcd/pkg/kustomize
+	// varSubstitution which fails the whole postBuild on any name that
+	// doesn't match `^[_[:alpha:]][_[:alpha:][:digit:]]*$`. Without this
+	// check flate would render with the invalid keys silently dropped
+	// while real Flux would fail the Kustomization — divergent output.
+	for name := range values {
+		if !varsubRegex.MatchString(name) {
+			return fmt.Errorf("%w: substituteFrom var name %q is invalid (must match %s)",
+				manifest.ErrInvalidSubstituteReference, name, varsubRegex.String())
+		}
+	}
 	ks.UpdatePostBuildSubstitutions(values)
 	return nil
 }

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -121,6 +121,30 @@ func TestExpandPostBuildSubstituteReference(t *testing.T) {
 	}
 }
 
+// TestExpandPostBuildSubstituteReference_RejectsInvalidVarName locks
+// the upstream contract (fluxcd/pkg/kustomize varSubstitution): any
+// var name failing `^[_[:alpha:]][_[:alpha:][:digit:]]*$` fails the
+// whole postBuild rather than being silently dropped. A ConfigMap key
+// with a dash makes upstream Flux fail the Kustomization; flate must
+// surface the same error.
+func TestExpandPostBuildSubstituteReference_RejectsInvalidVarName(t *testing.T) {
+	ks := &manifest.Kustomization{Name: "k", Namespace: "ns"}
+	ks.PostBuildSubstituteFrom = []manifest.SubstituteReference{{Kind: manifest.KindConfigMap, Name: "cm"}}
+	provider := &SliceProvider{
+		ConfigMaps: []*manifest.ConfigMap{{
+			Name: "cm", Namespace: "ns",
+			Data: map[string]any{"my-var": "v", "ok_name": "v"},
+		}},
+	}
+	err := ExpandPostBuildSubstituteReference(ks, provider)
+	if err == nil {
+		t.Fatal("expected error for dashed var name")
+	}
+	if !strings.Contains(err.Error(), "my-var") {
+		t.Errorf("error should name the invalid var; got %v", err)
+	}
+}
+
 // TestReplaceValueAtPath_TypeCoercion locks the upstream Flux contract
 // (chartutil.ReplacePathValue → strvals.ParseInto): a value flowing
 // in through ValuesReference.TargetPath is parsed as a Helm CLI


### PR DESCRIPTION
## Summary
Two iter-12 items bundled.

**\`fix(values)\` — reject invalid substituteFrom var names.** Upstream \`fluxcd/pkg/kustomize\` \`varSubstitution\` rejects the whole postBuild when any var name fails \`^[_[:alpha:]][_[:alpha:][:digit:]]*$\`. A ConfigMap with a \`my-var\` key (dash) would make real Flux fail the Kustomization; flate silently dropped the invalid keys and rendered. Add the same regex check after substituteFrom merge.

**\`refactor(helm)\` — extract \`Prepare\` helper.** The pre-render dance (\`Clone → ResolveChartRef → ExpandValueReferences\`) was locked inside the HR controller's reconcile body. Embedders rendering a single HelmRelease had to reproduce 10+ lines of controller-internal wiring or fork the controller package. Extract \`helm.Prepare(hr, charts, provider)\` as a public helper; the HR controller now uses it too, eliminating the duplication.

New \`TestExpandPostBuildSubstituteReference_RejectsInvalidVarName\` locks the var-name regex contract.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 29 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)