### PR TITLE
fix(cli): gate --output per subcommand; honor -o json for build

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -56,6 +56,11 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 		Args:    args,
 		RunE: func(cmd *cobra.Command, argv []string) error {
 			applyBuildFlags(c, b)
+			// build only emits manifest streams; reject -o values that
+			// don't make sense (e.g. name, which is a get-only concept).
+			if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+				return err
+			}
 			o, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
@@ -128,7 +133,7 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, kind, name string,
 				continue
 			}
 		}
-		if err := format.YAMLMulti(w, docs); err != nil {
+		if err := emitDocs(w, docs, c.outputOrDefault(format.OutputYAML)); err != nil {
 			return err
 		}
 	}
@@ -139,6 +144,19 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, kind, name string,
 		return fmt.Errorf("no %s named %q in --path", kind, name)
 	}
 	return nil
+}
+
+// emitDocs writes a sequence of rendered docs as either multi-doc YAML
+// (the default for `flate build`) or a single JSON array — the two
+// formats the agent quorum agreed make sense for build output. Other
+// -o values are rejected earlier by requireOutput.
+func emitDocs(w io.Writer, docs []map[string]any, out format.Output) error {
+	switch out {
+	case format.OutputJSON:
+		return format.JSON(w, docs)
+	default:
+		return format.YAMLMulti(w, docs)
+	}
 }
 
 // compareDocs orders rendered docs by (kind, namespace, name).

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -150,6 +152,40 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 		return nil, err
 	}
 	return runOrchestratorCfg(ctx, buildOrchCfg(c, h))
+}
+
+// outputOrDefault returns the user's -o choice, or fallback when -o
+// is at its CLI default ("table"). Subcommands like build/diff have
+// no table representation, so "table" effectively means "the
+// subcommand-natural default" (yaml for build, diff for diff).
+func (c *commonFlags) outputOrDefault(fallback format.Output) format.Output {
+	if c.output == string(format.OutputTable) {
+		return fallback
+	}
+	return format.Output(c.output)
+}
+
+// requireOutput rejects an -o value that's outside the subcommand's
+// supported set. Use for subcommands that don't honor every global -o
+// value (e.g. build has no concept of "name"; diff has no concept of
+// "name"). Treats "table" as accepted so the global default doesn't
+// trigger this check — callers downstream coerce "table" to their
+// own natural default via outputOrDefault.
+func (c *commonFlags) requireOutput(allowed ...format.Output) error {
+	if c.output == string(format.OutputTable) {
+		return nil
+	}
+	for _, a := range allowed {
+		if format.Output(c.output) == a {
+			return nil
+		}
+	}
+	names := make([]string, len(allowed))
+	for i, a := range allowed {
+		names[i] = string(a)
+	}
+	return fmt.Errorf("--output %q not supported by this subcommand (want one of: table, %s)",
+		c.output, strings.Join(names, ", "))
 }
 
 // runOrchestratorCfg returns a non-nil orchestrator whenever Bootstrap

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/diff"
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -81,6 +82,10 @@ func newDiffImagesCmd() *cobra.Command {
 }
 
 func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemoved bool) error {
+	// diff images emits a flat list — only json/yaml are honored.
+	if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+		return err
+	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
 	if orig == nil || current == nil {
 		return runErr
@@ -113,6 +118,12 @@ func imageSetDiff(orig, current map[string]struct{}, includeRemoved bool) []stri
 }
 
 func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kind, name string) error {
+	// diff has no `name` output mode; only diff/yaml/json/object are
+	// meaningful. Reject early so the user sees a clear error instead
+	// of "unknown diff format" from pkg/diff.
+	if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+		return err
+	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
 	if orig == nil || current == nil {
 		return runErr


### PR DESCRIPTION
## Summary
Iter-13 CLI/UX audit caught two papercuts:

1. **\`flate build\` silently ignored \`-o\`**. The global flag advertises \`table, yaml, json, name\` but \`writeRendered\` always emitted multi-doc YAML. \`flate build -o name\` was undocumented undefined behavior.
2. **\`flate diff -o name\` bombed** with "unknown diff format" from \`pkg/diff\` — an internal type leaking through.

**Fix:**
- \`commonFlags.requireOutput(allowed...)\` rejects \`-o\` values outside the subcommand's set. \`table\` (the global default) is treated as accepted so fresh CLIs still work.
- \`commonFlags.outputOrDefault(fallback)\` coerces \`table\` to the subcommand's natural fallback (yaml for build, diff for diff).
- \`build\` now honors \`-o json\` via a new \`emitDocs\` dispatcher; \`-o name\` fails fast with the supported set.
- \`diff\` rejects \`-o name\` before reaching \`pkg/diff\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] Manual: \`flate build all -o json\` emits JSON array; \`-o name\` exits 1 with clear error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)