### PR TITLE
fix(orchestrator): strip flux:input: prefix; include source file in failure messages

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -431,7 +432,15 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 
 	for id, info := range failed {
-		slog.Warn("resource failed", "id", id.String(), "reason", info.Message)
+		// Include the originating source file when known so the user can
+		// jump straight to the offending YAML — `flux error: input error:`
+		// chains alone don't reveal which spec.path declared a missing
+		// directory.
+		args := []any{"id", id.String(), "reason", trimFluxPrefix(info.Message)}
+		if f := o.sourceFiles[id]; f != "" {
+			args = append(args, "file", f)
+		}
+		slog.Warn("resource failed", args...)
 	}
 
 	if len(failed) == 0 {
@@ -446,10 +455,51 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 	msgs := make([]string, 0, len(failed))
 	for id, info := range failed {
-		msgs = append(msgs, fmt.Sprintf("%s: %s", id.String(), info.Message))
+		// Strip the `flux error: …: ` chain from user-facing messages —
+		// it's three layers of noise before the actual cause. The
+		// sentinels are still wired up for errors.Is callers (e.g.
+		// embedders branching on ErrObjectNotFound), this only affects
+		// the formatted text the CLI ultimately prints.
+		msg := trimFluxPrefix(info.Message)
+		if f := o.sourceFiles[id]; f != "" {
+			msgs = append(msgs, fmt.Sprintf("%s (%s): %s", id.String(), f, msg))
+		} else {
+			msgs = append(msgs, fmt.Sprintf("%s: %s", id.String(), msg))
+		}
 	}
+	slices.Sort(msgs) // deterministic ordering across runs
 	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",
 		len(msgs), strings.Join(msgs, "\n  "))
+}
+
+// trimFluxPrefix removes the noisy `flux error: <subcategory>: ` chain
+// from a user-facing message so the actual cause leads. Idempotent —
+// callers that don't start with `flux error:` pass through unchanged.
+//
+// The sentinel chains (ErrFlux → ErrInput / ErrObjectNotFound / …)
+// remain intact for programmatic errors.Is branching; this only
+// reshapes the rendered string.
+func trimFluxPrefix(msg string) string {
+	const prefix = "flux error: "
+	if !strings.HasPrefix(msg, prefix) {
+		return msg
+	}
+	rest := msg[len(prefix):]
+	// One more level: `<subcategory>: <body>`. Strip subcategory too.
+	if i := strings.Index(rest, ": "); i > 0 {
+		// Only strip when the subcategory looks like a wrapped sentinel
+		// ("input error", "object not found", "invalid values reference",
+		// "invalid substitute reference", "command error") — otherwise
+		// leave it alone, the colon may be part of the actual message.
+		sub := rest[:i]
+		switch sub {
+		case "input error", "object not found",
+			"invalid values reference", "invalid substitute reference",
+			"command error":
+			return rest[i+2:]
+		}
+	}
+	return rest
 }
 
 // Render is the structured embed-friendly entry point: Bootstrap +

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -207,6 +207,38 @@ func keysOf[V any](m map[manifest.NamedResource]V) []manifest.NamedResource {
 	return out
 }
 
+// TestTrimFluxPrefix verifies the user-facing error format strips
+// the two-layer `flux error: <subcategory>:` chain so the actual
+// cause leads. Sentinel-wrapped errors used for errors.Is branching
+// keep working; only the rendered string is reshaped.
+func TestTrimFluxPrefix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			in:   "flux error: input error: kustomization path does not exist: /a/b",
+			want: "kustomization path does not exist: /a/b",
+		},
+		{
+			in:   "flux error: object not found: source flux-system/foo artifact not found",
+			want: "source flux-system/foo artifact not found",
+		},
+		{
+			in:   "chart not found at /tmp/x: stat /tmp/x/Chart.yaml: no such file",
+			want: "chart not found at /tmp/x: stat /tmp/x/Chart.yaml: no such file",
+		},
+		{
+			in:   "flux error: unknown subcategory: keep me intact",
+			want: "unknown subcategory: keep me intact",
+		},
+	}
+	for _, tc := range cases {
+		if got := trimFluxPrefix(tc.in); got != tc.want {
+			t.Errorf("trimFluxPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestOrchestrator_TypedListener verifies Store.OnStatus delivers a
 // typed StatusInfo payload (no `any` type-switching needed by the
 // embedder).


### PR DESCRIPTION
## Summary
Iter-13 CLI/UX audit caught two related noise sources in per-resource failure messages:

1. \`flux error: input error: <real cause>\` — every error wrapping a sentinel produced a triple-prefixed message. Sentinels exist for programmatic \`errors.Is\` branching; their text rendering gave the user two layers of bureaucracy before the actual cause.
2. **No source-file location.** Users saw "kustomization path does not exist" without any hint which YAML declared the broken \`spec.path\`. \`o.sourceFiles\` tracked file-of-origin but only used it for orphan logging.

**Before:**
\`\`\`
Kustomization/flux-system/apps: flux error: input error: kustomization path does not exist: /abs/apps
\`\`\`

**After:**
\`\`\`
Kustomization/flux-system/apps (testdata/simple/cluster/flux-system.yaml): kustomization path does not exist: /abs/apps
\`\`\`

New \`trimFluxPrefix\` helper strips the prefix only when the subcategory matches a known sentinel. The sentinels themselves remain — \`errors.Is\` callers see the same chain. Aggregated error messages now sort deterministically so CI logs match across runs.

## Test plan
- [x] new \`TestTrimFluxPrefix\` table covers happy/passthrough/non-sentinel cases
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] Manual: \`flate build all --path testdata/simple\` now shows file paths and skips the flux/input prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)