### PR TITLE
docs: document the library/embed API; refresh post-iter-12 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,9 +328,11 @@ Apply to `get ks` / `get hr`:
 
 ```
               ┌──────────────────────┐
-              │   ResourceLoader     │
-              │  walk + namespace    │
-              │   inheritance        │
+              │  pkg/discovery       │
+              │  walk + spec.path    │
+              │  expand + ResourceSet│
+              │  render + ns inherit │
+              │  + parent index      │
               └─────────┬────────────┘
                         ▼
               ┌──────────────────────┐
@@ -344,12 +346,48 @@ Apply to `get ks` / `get hr`:
        │ SourceCtrl  │ │ KSController │ │ HRController     │
        │ Fetchers:   │ │ krusty +     │ │ helm v4          │
        │  git/oci/   │ │ Flux gen     │ │ (ClientOnly)     │
-       │  bucket/    │ │              │ │                  │
+       │  bucket/    │ │              │ │ + SourceResolver │
        │  external   │ │              │ │                  │
        └─────────────┘ └──────────────┘ └──────────────────┘
 ```
 
-Orchestrator pipeline: load → iterative `spec.path` discovery → namespace inheritance → `dependsOn` validation → existence-only-ready → change-filter resolution → controllers → diff / build / get.
+Orchestrator pipeline: discovery (load → spec.path expansion → ResourceSet rendering → namespace inheritance → parent index) → `dependsOn` validation → change-filter resolution → controllers fire → reconcile waits for parent KS Ready → render → orphan demotion → diff / build / get.
+
+## Library use
+
+flate ships as a Go library too — `pkg/orchestrator` is the embed entry point and `pkg/helm.Prepare` is the helper for rendering one `HelmRelease` in isolation.
+
+```go
+import (
+    "context"
+    "fmt"
+    "github.com/home-operations/flate/pkg/orchestrator"
+)
+
+o, err := orchestrator.New(orchestrator.Config{
+    Path:        "/path/to/cluster",
+    EnableOCI:   true,
+    WipeSecrets: true,
+})
+if err != nil { panic(err) }
+
+res, err := o.Render(context.Background())
+// res is non-nil even when err != nil: partial output is still usable.
+for id, docs := range res.Manifests {
+    fmt.Printf("%s rendered %d docs\n", id, len(docs))
+}
+for id, info := range res.Failed {
+    fmt.Printf("%s FAILED: %s\n", id, info.Message)
+}
+```
+
+Other embed surfaces worth knowing:
+
+- `Orchestrator.WithFetcher(kind, fetcher)` — replace any source fetcher (e.g. swap `git.Fetcher` for an in-memory fake during tests).
+- `Orchestrator.Store().OnStatus(fn, replay)` / `OnObject` / `OnArtifact` — typed listeners; payloads are pre-cast so consumers don't type-switch on `any`.
+- `helm.Prepare(hr, charts, provider)` then `helmClient.TemplateDocs(...)` — render a single HelmRelease without standing up the full orchestrator.
+- `pkg/discovery.Run(ctx, Config{Path, Store, WipeSecrets})` — load phase as a standalone unit (returns `{RepoRoot, SourceFiles, ParentOf}`).
+- `Store.Mutate[T]` — clone-then-AddObject helper that encodes the immutability contract; mutating a stored manifest in place is a bug (see `pkg/manifest/doc.go`).
 
 ## Development
 

--- a/pkg/helm/doc.go
+++ b/pkg/helm/doc.go
@@ -1,16 +1,28 @@
 // Package helm wraps helm.sh/helm/v4 to render HelmReleases without
 // shelling out to the `helm` binary.
 //
-// The exported surface mirrors the operations flux-local performs:
+// The exported surface:
 //
-//   - Client.Template renders a HelmRelease to YAML documents (the
-//     equivalent of `helm template --dry-run --client-only`).
-//   - Client.AddRepo registers a HelmRepository / OCIRepository /
-//     LocalGitRepository so subsequent Template calls can resolve their
-//     charts.
+//   - Client.Template / Client.TemplateDocs render a HelmRelease to
+//     YAML documents (the equivalent of
+//     `helm template --dry-run --client-only`).
+//   - Client.SetSourceResolver wires the canonical source-CR lookup
+//     surface — production callers pass NewStoreSourceResolver(store)
+//     so HelmRepository / OCIRepository / GitRepository / Bucket /
+//     ExternalArtifact lookups read straight from the canonical
+//     object store. Embedders rendering a single HR without an
+//     orchestrator can implement SourceResolver directly.
+//   - Prepare(hr, charts, provider) performs the pre-render dance
+//     (Clone → ResolveChartRef → ExpandValueReferences) — call this
+//     before TemplateDocs when rendering a HelmRelease in isolation.
 //   - Options exposes the helm CLI flags flate understands
 //     (--kube-version, --api-versions, --no-hooks, etc.).
 //
-// The client is safe for concurrent use; chart downloads are cached on
-// disk keyed by chart name + version.
+// Legacy push API: Client.AddRepo / AddOCIRepo / AddLocalSource
+// remain for tests and standalone embedders that don't want to plug
+// in a resolver, but they're not used in production flate any more.
+//
+// The client is safe for concurrent use; chart downloads are cached
+// on disk keyed by chart name + version, and parallel first-loads
+// of the same chart coalesce through a per-path keylock.
 package helm

--- a/pkg/loader/doc.go
+++ b/pkg/loader/doc.go
@@ -1,6 +1,6 @@
-// Package loader implements ResourceLoader — the entry point that
-// scans a local filesystem path, decodes every YAML document found,
-// and adds the recognized Flux objects to a Store.
+// Package loader implements Loader — the entry point that scans a
+// local filesystem path, decodes every YAML document found, and adds
+// the recognized Flux objects to a Store.
 //
 // Loader honors a `.krmignore`-style ignore file at the scan root.
 // Unrecognized objects (Pods, Deployments, etc.) are silently skipped

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -16,7 +16,7 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// Options tunes the ResourceLoader.
+// Options tunes the Loader.
 type Options struct {
 	// WipeSecrets controls Secret cleartext replacement. Default true.
 	WipeSecrets bool


### PR DESCRIPTION
## Summary
Iter-13 documentation audit caught three gaps from the iter-10/11/12 refactoring spree:

1. **README is 100% CLI-focused.** \`pkg/orchestrator.Render\`, \`WithFetcher\`, typed \`Store.On*\` listeners, \`helm.Prepare\`, \`pkg/discovery.Run\` — the entire embed surface — was discoverable only by reading source. Add a "Library use" section with a working example.
2. **\`pkg/helm/doc.go\` led with \`AddRepo\`.** That's the legacy push API; production now wires \`SetSourceResolver(NewStoreSourceResolver(store))\`. Rewrite to lead with the canonical surface and demote the push API.
3. **README "Architecture" diagram was stale.** Labeled the load box \`ResourceLoader\` (renamed to \`Loader\` in iter-11), missing \`pkg/discovery\` (extracted in #149), pipeline summary didn't mention parent-KS enforcement or orphan demotion. Refreshed.

Also fixed the lingering \`ResourceLoader\` references in \`pkg/loader/{doc.go,loader.go}\`.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] README "Library use" example matches the actual \`Orchestrator.Render\` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)