### PR TITLE
refactor(helm): delete legacy Add* push API; SourceResolver is the only path

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -19,26 +19,6 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// LocalSource couples a source CR (GitRepository / Bucket /
-// ExternalArtifact — any fetched artifact that lives as a directory on
-// disk) with the fetcher-produced SourceArtifact. The helm Client uses
-// these to resolve charts whose sourceRef.kind points at one of those
-// three kinds; the chart sits at `<Artifact.LocalPath>/<hr.Chart.Name>`
-// in every case. Name+Namespace mirror the source CR so RepoFullName
-// matches what hr.Chart.RepoFullName() produces.
-type LocalSource struct {
-	Name      string
-	Namespace string
-	Artifact  *store.SourceArtifact
-}
-
-// RepoFullName is the `<namespace>-<name>` lookup key. Matches
-// manifest.HelmChart.RepoFullName so listing the helm client's
-// local sources resolves cleanly against the HR's chartRef.
-func (l LocalSource) RepoFullName() string {
-	return l.Namespace + "-" + l.Name
-}
-
 // SecretGetter is the same shape as source.SecretGetter; aliased so
 // the helm Client and the source Fetchers consume one canonical type.
 // The orchestrator wires the same closure into both.
@@ -50,20 +30,13 @@ type Client struct {
 	cacheDir string
 
 	mu sync.RWMutex
-	// resolver is the canonical source-lookup surface. When non-nil it
-	// wins over the legacy Add*-driven maps. The orchestrator wires
-	// NewStoreSourceResolver(store) at construction; embedders driving
-	// helm.Client directly can either set their own resolver or stay on
-	// the Add* API for back-compat.
+	// resolver is the canonical (and only) source-lookup surface.
+	// Embedders MUST call SetSourceResolver before any Template call;
+	// the orchestrator wires NewStoreSourceResolver(store) at
+	// construction.
 	resolver SourceResolver
-	// repos/ociRepos/localSources are the legacy push-registries. Kept
-	// for tests / standalone embedders that haven't migrated to the
-	// resolver. When the resolver is set, these maps are not consulted.
-	repos        map[string]*manifest.HelmRepository
-	ociRepos     map[string]*manifest.OCIRepository
-	localSources map[string]LocalSource
-	registry     *registry.Client
-	secrets      SecretGetter
+	registry *registry.Client
+	secrets  SecretGetter
 
 	// chartCache memoizes parsed *chart.Chart by on-disk path. Helm's
 	// loader.Load reparses the entire tgz on every call — for repos
@@ -99,9 +72,6 @@ func NewClient(tmpDir, cacheDir string) (*Client, error) {
 	return &Client{
 		tmpDir:         tmpDir,
 		cacheDir:       cacheDir,
-		repos:          map[string]*manifest.HelmRepository{},
-		ociRepos:       map[string]*manifest.OCIRepository{},
-		localSources:   map[string]LocalSource{},
 		registry:       reg,
 		chartCache:     map[string]*chart.Chart{},
 		chartLoadLocks: keylock.New[string](),
@@ -118,91 +88,44 @@ func (c *Client) SetSecretGetter(g SecretGetter) {
 }
 
 // SetSourceResolver installs the canonical lookup surface for
-// HelmRepository / OCIRepository / local-artifact sources. When set,
-// helm.Client reads through the resolver instead of consulting its
-// own Add*-populated maps — eliminating the duplicate-state hazard
-// where a source CR's spec change after registration could leave the
-// helm.Client looking at stale credentials. Safe to call before any
-// Add* / template call; typically once at orchestrator construction.
-// Pass nil to revert to the legacy push-API behavior.
+// HelmRepository / OCIRepository / local-artifact sources. helm.Client
+// reads through the resolver on every Template call — there's no
+// alternate path. Safe to call before any template call; typically
+// once at orchestrator construction.
 func (c *Client) SetSourceResolver(r SourceResolver) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.resolver = r
 }
 
-// resolveHelmRepo returns the HelmRepository at <namespace>-<name>,
-// reading from the resolver when present and falling back to the
-// legacy Add*-populated map otherwise.
 func (c *Client) resolveHelmRepo(hr *manifest.HelmRelease) *manifest.HelmRepository {
 	c.mu.RLock()
 	resolver := c.resolver
 	c.mu.RUnlock()
-	if resolver != nil {
-		return resolver.HelmRepository(hr.Chart.RepoNamespace, hr.Chart.RepoName)
+	if resolver == nil {
+		return nil
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.repos[hr.Chart.RepoFullName()]
+	return resolver.HelmRepository(hr.Chart.RepoNamespace, hr.Chart.RepoName)
 }
 
 func (c *Client) resolveOCIRepo(hr *manifest.HelmRelease) *manifest.OCIRepository {
 	c.mu.RLock()
 	resolver := c.resolver
 	c.mu.RUnlock()
-	if resolver != nil {
-		return resolver.OCIRepository(hr.Chart.RepoNamespace, hr.Chart.RepoName)
+	if resolver == nil {
+		return nil
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.ociRepos[hr.Chart.RepoFullName()]
+	return resolver.OCIRepository(hr.Chart.RepoNamespace, hr.Chart.RepoName)
 }
 
 func (c *Client) resolveLocalSource(hr *manifest.HelmRelease) *store.SourceArtifact {
 	c.mu.RLock()
 	resolver := c.resolver
 	c.mu.RUnlock()
-	if resolver != nil {
-		return resolver.LocalSourceArtifact(hr.Chart.RepoKind, hr.Chart.RepoNamespace, hr.Chart.RepoName)
+	if resolver == nil {
+		return nil
 	}
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	if ls, ok := c.localSources[hr.Chart.RepoFullName()]; ok {
-		return ls.Artifact
-	}
-	return nil
-}
-
-// AddRepo registers a HelmRepository so chart lookups can resolve it.
-func (c *Client) AddRepo(repo *manifest.HelmRepository) {
-	if repo == nil {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.repos[repo.RepoName()] = repo
-}
-
-// AddOCIRepo registers an OCIRepository.
-func (c *Client) AddOCIRepo(repo *manifest.OCIRepository) {
-	if repo == nil {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.ociRepos[repo.RepoName()] = repo
-}
-
-// AddLocalSource registers a fetched-artifact source — GitRepository,
-// Bucket, or ExternalArtifact — so charts referenced via the
-// corresponding sourceRef.kind can be resolved on disk.
-func (c *Client) AddLocalSource(s LocalSource) {
-	if s.Name == "" || s.Artifact == nil {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.localSources[s.RepoFullName()] = s
+	return resolver.LocalSourceArtifact(hr.Chart.RepoKind, hr.Chart.RepoNamespace, hr.Chart.RepoName)
 }
 
 // LocateChart returns a filesystem path to the chart referenced by hr.

--- a/pkg/helm/doc.go
+++ b/pkg/helm/doc.go
@@ -18,10 +18,6 @@
 //   - Options exposes the helm CLI flags flate understands
 //     (--kube-version, --api-versions, --no-hooks, etc.).
 //
-// Legacy push API: Client.AddRepo / AddOCIRepo / AddLocalSource
-// remain for tests and standalone embedders that don't want to plug
-// in a resolver, but they're not used in production flate any more.
-//
 // The client is safe for concurrent use; chart downloads are cached
 // on disk keyed by chart name + version, and parallel first-loads
 // of the same chart coalesce through a per-path keylock.

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -34,11 +34,7 @@ data:
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	cli.AddLocalSource(LocalSource{
-		Name:      "chart-repo",
-		Namespace: "flux-system",
-		Artifact:  &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
-	})
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
 
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
@@ -80,12 +76,24 @@ func helmChartFixture(t *testing.T) *Client {
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	cli.AddLocalSource(LocalSource{
-		Name:      "chart-repo",
-		Namespace: "flux-system",
-		Artifact:  &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
-	})
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
 	return cli
+}
+
+// localChartResolver wires a *store.Store containing a single
+// GitRepository with its on-disk artifact, then returns a
+// StoreSourceResolver backed by it. The helper keeps the existing
+// test fixtures using the canonical resolver path instead of the
+// legacy Add*-driven push API.
+func localChartResolver(t *testing.T, name, namespace, dir string) SourceResolver {
+	t.Helper()
+	st := store.New()
+	gr := &manifest.GitRepository{Name: name, Namespace: namespace}
+	st.AddObject(gr)
+	st.SetArtifact(gr.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir,
+	})
+	return NewStoreSourceResolver(st)
 }
 
 func newHR() *manifest.HelmRelease {

--- a/pkg/helm/loadchart_test.go
+++ b/pkg/helm/loadchart_test.go
@@ -36,11 +36,13 @@ description: test
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
-	cli.AddLocalSource(LocalSource{
-		Name:      "chart-repo",
-		Namespace: "flux-system",
-		Artifact:  &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir},
+	st := store.New()
+	gr := &manifest.GitRepository{Name: "chart-repo", Namespace: "flux-system"}
+	st.AddObject(gr)
+	st.SetArtifact(gr.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir,
 	})
+	cli.SetSourceResolver(NewStoreSourceResolver(st))
 
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",

--- a/pkg/helm/resolver.go
+++ b/pkg/helm/resolver.go
@@ -8,11 +8,11 @@ import (
 // SourceResolver is the lookup surface helm.Client needs to resolve a
 // HelmRelease's sourceRef against the canonical object store.
 //
-// The interface exists so helm.Client doesn't have to maintain its own
-// parallel registries of source CRs that the Store already owns — see
-// NewStoreSourceResolver for the production-side adapter. Embedders
-// rendering a single HelmRelease without an Orchestrator can implement
-// this directly.
+// The interface exists so helm.Client reads source CRs from the
+// canonical store on every lookup rather than maintaining a parallel
+// registry — see NewStoreSourceResolver for the production-side
+// adapter. Embedders rendering a single HelmRelease without an
+// Orchestrator can implement this directly.
 //
 // A nil return from any method means "not found" — callers translate
 // that into a typed manifest.ErrObjectNotFound error.
@@ -32,9 +32,7 @@ type SourceResolver interface {
 
 // NewStoreSourceResolver returns a SourceResolver backed by the
 // canonical object store. The orchestrator wires this into helm.Client
-// so chart-source lookups read straight from the Store rather than
-// through helm.Client's now-deprecated AddRepo/AddOCIRepo/AddLocalSource
-// push API.
+// so chart-source lookups read straight from the Store.
 func NewStoreSourceResolver(s *store.Store) SourceResolver {
 	return &storeResolver{store: s}
 }


### PR DESCRIPTION
## Summary
Iter-12 introduced \`helm.SourceResolver\` and wired it as the production lookup surface, but kept the legacy \`Add*\` / map-based push API for back-compat with tests and standalone embedders. Iter-13's senior-eng review flagged the dual-path as the last clearly-wrong shape in the helm package: ~100 LOC of dead state plus three \`resolveXXX\` helpers that branched between resolver and maps.

With the resolver being the production path through iter-12, the only remaining callers were three test fixtures. Migrate them to \`NewStoreSourceResolver(store)\` (a few extra lines per fixture) and delete:

- \`Client.repos / .ociRepos / .localSources\` maps + their mutex use
- \`Client.AddRepo / .AddOCIRepo / .AddLocalSource\` methods
- The \`LocalSource\` struct (only the Add* path needed it)
- The dual-path \`resolveHelmRepo / resolveOCIRepo / resolveLocalSource\` branches — each simplifies to "delegate to the resolver"

Net: **~120 LOC delete**, one canonical lookup path, no risk of stale push-state diverging from the live Store.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass (incl. helm + e2e suites)
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)