### PR TITLE
refactor(cli): consume Orchestrator.Render() instead of reaching into Store

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -12,7 +12,6 @@ import (
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
-	"github.com/home-operations/flate/pkg/store"
 )
 
 // buildFlags holds flags shared across `build ks`, `build hr`, and
@@ -61,14 +60,14 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 			if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
 				return err
 			}
-			o, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
+			o, res, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}
 			w := cmd.OutOrStdout()
 			name := firstArg(argv)
 			for _, kind := range kinds {
-				if err := writeRendered(w, o, kind, name, c, b); err != nil {
+				if err := writeRendered(w, o, res, kind, name, c, b); err != nil {
 					return err
 				}
 			}
@@ -90,12 +89,16 @@ func applyBuildFlags(c *commonFlags, b *buildFlags) {
 	}
 }
 
-func writeRendered(w io.Writer, o *orchestrator.Orchestrator, kind, name string, c *commonFlags, b *buildFlags) error {
-	// Sort by (namespace, name) so `build` output is deterministic
-	// across runs — `Store.ListObjects` iterates the byName map and
-	// would otherwise produce a different ordering each invocation,
-	// breaking shell-piped diffs and CI consumers.
+func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags, b *buildFlags) error {
+	// Walk every loaded object of this kind so an explicit name positional
+	// that didn't render (failed reconcile, suspended, no docs) still
+	// counts as a match — without this the typo-detection error below
+	// would also fire for failed-but-existing resources.
 	objs := o.Store().ListObjects(kind)
+	// Sort by (namespace, name) so output is deterministic across runs
+	// — Store.ListObjects iterates the byName map and would otherwise
+	// produce a different ordering each invocation, breaking shell-piped
+	// diffs and CI consumers.
 	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
 		ai, bi := a.Named(), b.Named()
 		return cmp.Or(cmp.Compare(ai.Namespace, bi.Namespace), cmp.Compare(ai.Name, bi.Name))
@@ -110,22 +113,21 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, kind, name string,
 			continue
 		}
 		matched++
-		a, ok := o.Store().GetArtifact(id).(store.RenderedArtifact)
-		if !ok {
+		// res.Manifests is the structured render output keyed by
+		// NamedResource — no more Store.GetArtifact + type-assertion
+		// dance. A missing entry means the resource didn't render
+		// (failed, suspended, or produced zero docs).
+		mans, ok := res.Manifests[id]
+		if !ok || len(mans) == 0 {
 			continue
 		}
-		// Stream per-artifact rather than accumulating every doc into a
-		// single slice — keeps the working set small on big repos and
-		// lets onlyCRDs filter run incrementally instead of building a
-		// throw-away intermediate.
-		//
 		// Clone-and-sort per-artifact so output is byte-stable across
 		// runs even when a Helm chart uses `range $name, $svc := .Values`
 		// (Go map iteration is randomized — the chart still emits the
 		// same set but in arbitrary order). Sort by (kind, ns, name).
 		// SSA-applied output doesn't care about order; CI / diff
 		// consumers do.
-		docs := slices.Clone(a.RenderedManifests())
+		docs := slices.Clone(mans)
 		slices.SortStableFunc(docs, compareDocs)
 		if b.onlyCRDs {
 			docs = filterCRDsOnly(docs)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -144,12 +144,12 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	}
 }
 
-func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, error) {
+func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, *orchestrator.Result, error) {
 	if c.path == "" {
-		return nil, errors.New("path is required")
+		return nil, nil, errors.New("path is required")
 	}
 	if _, err := format.ParseOutput(c.output); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return runOrchestratorCfg(ctx, buildOrchCfg(c, h))
 }
@@ -188,25 +188,26 @@ func (c *commonFlags) requireOutput(allowed ...format.Output) error {
 		c.output, strings.Join(names, ", "))
 }
 
-// runOrchestratorCfg returns a non-nil orchestrator whenever Bootstrap
-// succeeds, even if Run had per-resource failures — the partial Store
-// still backs `build`/`get`/`diff` output. The returned error carries
-// any Run failure so the CLI can flip its exit code while still
-// emitting whatever partial output rendered. A nil orchestrator
-// indicates a fatal init/bootstrap problem (callers should bail).
+// runOrchestratorCfg routes the CLI through the embed-friendly
+// Orchestrator.Render entry point. Returns the populated orchestrator
+// (for Store lookups the CLI legitimately needs — object listings,
+// status queries, filter scope) AND the structured render Result.
+// Both stay non-nil when Bootstrap succeeded, even if Run had per-
+// resource failures: the partial output is still usable. A nil
+// orchestrator indicates a fatal init/bootstrap error and callers
+// should bail.
 //
-// Discarding the Run error here is what previously let `flate build`
-// exit 0 against a repo where every Kustomization failed — CI would
-// pipe the partial YAML to kubectl apply and notice nothing wrong.
-func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config) (*orchestrator.Orchestrator, error) {
+// Dogfooding Render here closes a drift hazard the iter-13 review
+// flagged: the embed API and the CLI used to read rendered artifacts
+// through different code paths (CLI reached straight into the Store
+// with a type assertion). Now there's one path.
+func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config) (*orchestrator.Orchestrator, *orchestrator.Result, error) {
 	o, err := orchestrator.New(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if err := o.Bootstrap(ctx); err != nil {
-		return nil, err
-	}
-	return o, o.Run(ctx)
+	res, err := o.Render(ctx)
+	return o, res, err
 }
 
 func cmdContext(cmd *cobra.Command) context.Context {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -87,10 +87,10 @@ func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemo
 		return err
 	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
-	if orig == nil || current == nil {
+	if orig.O == nil || current.O == nil {
 		return runErr
 	}
-	imgs := imageSetDiff(collectImages(orig, c), collectImages(current, c), includeRemoved)
+	imgs := imageSetDiff(collectImages(orig.O, orig.Res, c), collectImages(current.O, current.Res, c), includeRemoved)
 	if err := emitImageList(cmd.OutOrStdout(), imgs, c.output); err != nil {
 		return err
 	}
@@ -125,11 +125,11 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 		return err
 	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
-	if orig == nil || current == nil {
+	if orig.O == nil || current.O == nil {
 		return runErr
 	}
-	origDocs := gatherArtifacts(orig, kind, name, c)
-	currentDocs := gatherArtifacts(current, kind, name, c)
+	origDocs := gatherArtifacts(orig.O, orig.Res, kind, name, c)
+	currentDocs := gatherArtifacts(current.O, current.Res, kind, name, c)
 
 	outFormat := c.output
 	if outFormat == "table" {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -122,7 +122,7 @@ func newGetAllCmd() *cobra.Command {
 		Use:   "all",
 		Short: "Summarize every Kustomization and HelmRelease",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			o, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
+			o, _, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}
@@ -148,11 +148,11 @@ func newGetImagesCmd() *cobra.Command {
 		Use:   "images",
 		Short: "List container images across the cluster",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			o, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
+			o, res, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}
-			imgs := slices.Sorted(maps.Keys(collectImages(o, c)))
+			imgs := slices.Sorted(maps.Keys(collectImages(o, res, c)))
 			if err := emitImageList(cmd.OutOrStdout(), imgs, c.output); err != nil {
 				return err
 			}
@@ -180,7 +180,7 @@ func resourceListCmd[T manifest.BaseManifest](
 		Short:   short,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			o, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
+			o, _, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -19,7 +19,6 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/source"
-	"github.com/home-operations/flate/pkg/store"
 )
 
 // firstArg returns the first positional arg, or "" when none was given.
@@ -42,25 +41,22 @@ func sortRows(rows []map[string]string) {
 }
 
 // collectImages returns the union of images extracted from every
-// rendered Kustomization and HelmRelease artifact. Namespace scope on
-// c is honored.
-func collectImages(o *orchestrator.Orchestrator, c *commonFlags) map[string]struct{} {
+// rendered Kustomization and HelmRelease document. Namespace scope on
+// c is honored. Walks Result.Manifests directly (no Store
+// GetArtifact + type-assertion dance).
+func collectImages(o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags) map[string]struct{} {
 	set := map[string]struct{}{}
-	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
-		for _, obj := range o.Store().ListObjects(kind) {
-			id := obj.Named()
-			if !c.includeNamespace(o.Filter(), id.Namespace) {
-				continue
-			}
-			art, ok := o.Store().GetArtifact(id).(store.RenderedArtifact)
-			if !ok {
-				continue
-			}
-			for _, doc := range art.RenderedManifests() {
-				imgs, _ := image.Extract(doc)
-				for _, img := range imgs {
-					set[img] = struct{}{}
-				}
+	for id, docs := range res.Manifests {
+		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
+			continue
+		}
+		if !c.includeNamespace(o.Filter(), id.Namespace) {
+			continue
+		}
+		for _, doc := range docs {
+			imgs, _ := image.Extract(doc)
+			for _, img := range imgs {
+				set[img] = struct{}{}
 			}
 		}
 	}
@@ -90,9 +86,17 @@ func emitImageList(w io.Writer, imgs []string, out string) error {
 // sides are independent (separate task service, helm client, staging
 // cache, store), so they run concurrently — wall time roughly halves on
 // changed-only diffs.
-func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (*orchestrator.Orchestrator, *orchestrator.Orchestrator, error) {
+// diffSide pairs an Orchestrator with its render Result. Diff
+// commands need both — orchestrator for filter/object lookup, Result
+// for the rendered docs feeding the diff.
+type diffSide struct {
+	O   *orchestrator.Orchestrator
+	Res *orchestrator.Result
+}
+
+func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (diffSide, diffSide, error) {
 	if c.pathOrig == "" {
-		return nil, nil, errors.New("diff requires --path-orig")
+		return diffSide{}, diffSide{}, errors.New("diff requires --path-orig")
 	}
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg
@@ -112,13 +116,13 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (*o
 	origCfg.SourceCache = shared
 
 	var (
-		orig, current     *orchestrator.Orchestrator
-		origErr, currErr  error
+		orig, current    diffSide
+		origErr, currErr error
 	)
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		o, err := runOrchestratorCfg(gctx, currentCfg)
-		current = o
+		o, res, err := runOrchestratorCfg(gctx, currentCfg)
+		current = diffSide{O: o, Res: res}
 		currErr = err
 		// Fatal Bootstrap errors return nil orchestrator — propagate
 		// those so the errgroup cancels its sibling. Per-resource Run
@@ -130,8 +134,8 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (*o
 		return nil
 	})
 	g.Go(func() error {
-		o, err := runOrchestratorCfg(gctx, origCfg)
-		orig = o
+		o, res, err := runOrchestratorCfg(gctx, origCfg)
+		orig = diffSide{O: o, Res: res}
 		origErr = err
 		if o == nil {
 			return err
@@ -139,7 +143,7 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (*o
 		return nil
 	})
 	if err := g.Wait(); err != nil {
-		return nil, nil, err
+		return diffSide{}, diffSide{}, err
 	}
 	// Either side may have reconcile failures — return the combined
 	// run-error alongside the orchestrators so the diff caller can
@@ -162,14 +166,20 @@ func joinRunErrors(orig, curr error) error {
 }
 
 // gatherArtifacts collects every rendered manifest produced by the
-// stored Kustomization or HelmRelease artifacts of the given kind,
-// tagged with the parent that produced them. name optionally filters
-// to a single resource. When c is non-nil the namespace scope from
-// commonFlags + the orchestrator's change filter is honored.
-func gatherArtifacts(o *orchestrator.Orchestrator, kind, name string, c *commonFlags) []diff.Doc {
+// Kustomizations or HelmReleases of the given kind, tagged with the
+// parent that produced them. name optionally filters to a single
+// resource. When c is non-nil the namespace scope from commonFlags +
+// the orchestrator's change filter is honored.
+//
+// Reads res.Manifests for the rendered docs; falls back to the Store
+// only to recover the producing object's spec.path (the diff header
+// shows it for KS parents).
+func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
 	var out []diff.Doc
-	for _, obj := range o.Store().ListObjects(kind) {
-		id := obj.Named()
+	for id, docs := range res.Manifests {
+		if id.Kind != kind {
+			continue
+		}
 		if name != "" && id.Name != name {
 			continue
 		}
@@ -177,13 +187,11 @@ func gatherArtifacts(o *orchestrator.Orchestrator, kind, name string, c *commonF
 			continue
 		}
 		parent := diff.Parent{Kind: id.Kind, Namespace: id.Namespace, Name: id.Name}
-		if ks, ok := obj.(*manifest.Kustomization); ok {
+		if ks, ok := o.Store().GetObject(id).(*manifest.Kustomization); ok {
 			parent.Path = strings.TrimPrefix(ks.Path, "./")
 		}
-		if a, ok := o.Store().GetArtifact(id).(store.RenderedArtifact); ok {
-			for _, m := range a.RenderedManifests() {
-				out = append(out, diff.Doc{Manifest: m, Parent: parent})
-			}
+		for _, m := range docs {
+			out = append(out, diff.Doc{Manifest: m, Parent: parent})
 		}
 	}
 	return out

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -37,7 +37,7 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 		Short:   short,
 		Args:    args,
 		RunE: func(cmd *cobra.Command, argv []string) error {
-			o, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
+			o, _, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}


### PR DESCRIPTION
## Summary
Iter-13 sr-eng review flagged a drift hazard: \`Orchestrator.Render()\` (shipped iter-12 #156) had **zero internal callers**. The CLI reached straight into \`o.Store().GetArtifact(id).(store.RenderedArtifact)\`, coupling itself to a type assertion that should be a method call. Two paths into the same data; future Result shape changes wouldn't catch CLI drift.

**Fix**: have \`runOrchestratorCfg\` call \`o.Render(ctx)\` internally and surface the structured \`*Result\` alongside the orchestrator. Bootstrap + Run sequencing unchanged.

**Migrated:**
- \`build.writeRendered\` — \`res.Manifests[id]\` replaces the Store + type-assertion dance. Object iteration via Store kept so typo'd \`--name\` still fires "no resource named X".
- \`helpers.gatherArtifacts\` (diff path) — iterates \`res.Manifests\` directly.
- \`helpers.collectImages\` — walks \`res.Manifests\`; no more lookup + assertion.
- \`runDiffOrchestrators\` returns a \`diffSide\` struct pairing \`Orchestrator + Result\` per side.

\`get\` keeps using Store iteration — it's *listing the objects flate knows about*, the Store's legitimate purpose, not an artifact bypass.

Net: one canonical path from rendered artifacts to output. Future Result shape changes are now caught by the compiler at every consumer.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass (incl. 12 e2e tests covering diff propagation, ResourceSet expansion, SOPS wipe, orphan handling)
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)