### PR TITLE
refactor(kustomize): add Prepare helper symmetric to helm.Prepare

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -141,15 +141,13 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		return err
 	}
 
-	// Clone before mutating: ExpandPostBuildSubstituteReference writes
-	// into ks.PostBuildSubstitute and the nested ks.Contents tree.
-	// The store-owned object stays canonical so concurrent readers
-	// (e.g. an HR controller resolving a chartRef while this KS is
-	// rendering) never observe torn state.
-	ks = ks.Clone()
 	c.Store.UpdateStatus(id, store.StatusPending, "expanding substitutions")
-	provider := values.NewStoreProvider(c.Store)
-	if err := values.ExpandPostBuildSubstituteReference(ks, provider); err != nil {
+	// kustomize.Prepare clones ks and expands postBuild.substituteFrom —
+	// the same pre-render dance an embedder calling RenderFlux directly
+	// would perform. Keeping one canonical implementation here means
+	// changes to the contract only land in one place. Mirrors helm.Prepare.
+	ks, err = kustomize.Prepare(ks, values.NewStoreProvider(c.Store))
+	if err != nil {
 		return err
 	}
 

--- a/pkg/kustomize/prepare.go
+++ b/pkg/kustomize/prepare.go
@@ -1,0 +1,27 @@
+package kustomize
+
+import (
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/values"
+)
+
+// Prepare runs the standard pre-render dance for a Kustomization so it
+// is ready to feed into RenderFlux:
+//
+//  1. Clone ks so subsequent mutations don't touch the store-canonical
+//     copy (the immutability contract every flate controller honors —
+//     see pkg/manifest/doc.go).
+//  2. Expand spec.postBuild.substituteFrom references against the
+//     supplied values provider so ks.PostBuildSubstitute reflects the
+//     merged result a render would consume.
+//
+// Embedders rendering a single Kustomization without standing up the
+// orchestrator's KS controller call Prepare then RenderFlux. Mirrors
+// the symmetric helm.Prepare for HelmReleases.
+func Prepare(ks *manifest.Kustomization, provider values.Provider) (*manifest.Kustomization, error) {
+	ks = ks.Clone()
+	if err := values.ExpandPostBuildSubstituteReference(ks, provider); err != nil {
+		return nil, err
+	}
+	return ks, nil
+}


### PR DESCRIPTION
## Summary
Iter-13 sr-eng review flagged the asymmetry: \`helm.Prepare\` (iter-12 #157) extracted the HR controller's clone-then-expand pattern as a public embed-friendly helper, but the KS controller still open-coded the same shape inline.

\`kustomize.Prepare(ks, provider)\` clones the KS and expands \`postBuild.substituteFrom\` — exactly mirroring \`helm.Prepare\`. The KS controller now calls Prepare the same way the HR controller calls helm.Prepare. Embedders rendering a single Kustomization without the orchestrator have a public helper instead of having to know the pre-render contract.

No behavior change.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)