### PR TITLE
docs: surface kustomize.Prepare alongside helm.Prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Other entry points worth knowing:
 
 - `Orchestrator.WithFetcher(kind, f)` — swap any source fetcher (in-memory fakes for tests, custom kinds).
 - `Store.OnObject` / `OnStatus` / `OnArtifact` — typed listeners; payloads are pre-cast.
-- `helm.Prepare(hr, charts, provider)` then `helmClient.TemplateDocs(...)` — render one HelmRelease without the orchestrator.
+- `helm.Prepare(hr, charts, provider)` then `helmClient.TemplateDocs(...)` — render one HelmRelease without the orchestrator. `kustomize.Prepare(ks, provider)` is the symmetric helper for Kustomizations.
 - `discovery.Run(ctx, Config{Path, Store, WipeSecrets})` — load phase as a standalone unit.
 - `Store.Mutate[T]` — clone-then-AddObject helper encoding the immutability contract. See [`pkg/manifest/doc.go`](pkg/manifest/doc.go) for the full rule.
 

--- a/pkg/kustomize/doc.go
+++ b/pkg/kustomize/doc.go
@@ -1,10 +1,15 @@
 // Package kustomize wraps sigs.k8s.io/kustomize/api so the rest of
 // flate never invokes the `kustomize` CLI. It provides:
 //
-//   - Build: renders a kustomization directory to YAML documents.
-//   - Filtering helpers (FilterKinds) that mirror flux-local's
-//     chainable Kustomize wrapper.
-//   - Variable substitution (envsubst-style "${VAR}" and "${VAR:=default}")
+//   - Build / RenderFlux: render a kustomization directory to YAML
+//     documents. Build is the plain krusty surface; RenderFlux adds
+//     the Flux generator that handles spec.components and embedded
+//     inline Contents.
+//   - Prepare: the standard pre-render dance (Clone + expand
+//     postBuild.substituteFrom) for embedders rendering a single
+//     Kustomization. Mirrors helm.Prepare for HelmReleases.
+//   - FilterKinds: chainable kind filter that mirrors flux-local.
+//   - Substitute: envsubst-style "${VAR}" / "${VAR:=default}" used
 //     for Flux post-build substitutions.
 //
 // Concurrent builds against the same path are serialized via an


### PR DESCRIPTION
## Summary
Iter-14 #167 added \`kustomize.Prepare\` symmetric to \`helm.Prepare\`. Update the package doc.go and the README "Library use" bullet so both helpers appear together — embedders no longer have to guess that the pattern carries from HR to KS.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)