### PR TITLE
fix(bucket): SECURITY — reject path-traversal escapes from S3 keys

### DIFF
--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -220,7 +220,10 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 		if rel == "" {
 			rel = filepath.Base(e.key)
 		}
-		dst := filepath.Join(slot, filepath.FromSlash(rel))
+		dst, err := safeJoinUnderSlot(slot, rel)
+		if err != nil {
+			return nil, "", fmt.Errorf("bucket key %q: %w", e.key, err)
+		}
 		if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 			return nil, "", err
 		}
@@ -241,6 +244,27 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 		keys = append(keys, e.key)
 	}
 	return keys, "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// safeJoinUnderSlot resolves rel against slot and rejects any result
+// that would escape slot via path traversal (`..` segments) or absolute
+// paths. S3 keys are arbitrary strings; a bucket owner — accidentally
+// or deliberately — can produce a key whose filepath.FromSlash form
+// contains ../ enough times to climb past slot, and filepath.Join
+// happily cleans the climb-out without complaint. Without this guard,
+// such a key writes arbitrary files on the host. Mirrors the
+// extractTarGz protection in pkg/source/oci/layer.go.
+func safeJoinUnderSlot(slot, rel string) (string, error) {
+	joined := filepath.Join(slot, filepath.FromSlash(rel))
+	cleanSlot := filepath.Clean(slot)
+	relInside, err := filepath.Rel(cleanSlot, joined)
+	if err != nil {
+		return "", fmt.Errorf("path resolution: %w", err)
+	}
+	if relInside == ".." || strings.HasPrefix(relInside, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path traversal: %q escapes cache slot", rel)
+	}
+	return joined, nil
 }
 
 func downloadObject(ctx context.Context, client *minio.Client, bucket, key, dst string) error {

--- a/pkg/source/bucket/traversal_test.go
+++ b/pkg/source/bucket/traversal_test.go
@@ -1,0 +1,77 @@
+package bucket
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSafeJoinUnderSlot locks the bucket fetcher's defense against
+// malicious / mis-curated S3 keys whose name would climb out of the
+// cache slot via ../ segments or absolute paths. Without this guard,
+// `filepath.Join` cleans the climb-out and writeFile() lands on
+// arbitrary host paths.
+func TestSafeJoinUnderSlot(t *testing.T) {
+	slot := filepath.Join(t.TempDir(), "slot")
+	cases := []struct {
+		name    string
+		rel     string
+		wantErr string
+	}{
+		{
+			name: "normal nested key",
+			rel:  "dir/sub/file.yaml",
+		},
+		{
+			name: "plain filename",
+			rel:  "file.yaml",
+		},
+		{
+			name:    "single dotdot escape",
+			rel:     "../etc/passwd",
+			wantErr: "path traversal",
+		},
+		{
+			name:    "deep dotdot escape",
+			rel:     "../../../../../../etc/passwd",
+			wantErr: "path traversal",
+		},
+		{
+			name:    "interior dotdot reaches outside",
+			rel:     "a/../../etc/passwd",
+			wantErr: "path traversal",
+		},
+		{
+			name: "interior dotdot stays inside",
+			rel:  "a/../b/file.yaml",
+		},
+		{
+			// An absolute key (a bucket owner naming an object "/etc/passwd")
+			// is contained safely by filepath.Join, which treats the leading
+			// slash as a component boundary rather than re-rooting at /. The
+			// joined path stays under slot — not a traversal vector.
+			name: "absolute-looking key stays under slot",
+			rel:  "/etc/passwd",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := safeJoinUnderSlot(slot, tc.rel)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("rel=%q: err = %v, want substring %q", tc.rel, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("rel=%q: unexpected err: %v", tc.rel, err)
+			}
+			// Path must be inside slot.
+			cleanSlot := filepath.Clean(slot) + string(filepath.Separator)
+			if !strings.HasPrefix(filepath.Clean(got)+string(filepath.Separator), cleanSlot) &&
+				filepath.Clean(got) != filepath.Clean(slot) {
+				t.Errorf("rel=%q: got %q which is not under %q", tc.rel, got, slot)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
**Security**: \`walkBucket\` joined every minio object key into the cache slot via \`filepath.Join\` without verifying the result stayed inside slot. A malicious or mis-curated bucket producing a key like \`../../../../etc/passwd\` caused flate to write the downloaded body to an arbitrary host path — \`filepath.Join\` silently cleaned the climb-out and \`os.Create\` followed it.

Same severity class as the tar-extraction vulnerability source-controller fixed in its OCI path years ago. flate's OCI fetcher already had the equivalent guard in \`extractTarGz\`; the bucket fetcher did not.

**Fix**: factor a \`safeJoinUnderSlot\` helper that uses \`filepath.Rel\` against the cleaned slot and rejects any joined path starting with \`..\`. \`walkBucket\` routes every key through it. New \`TestSafeJoinUnderSlot\` table covers: normal nesting, single-dotdot, deep-dotdot, interior dotdot escape, interior dotdot that stays inside.

(Absolute-looking keys like literal \`/etc/passwd\` are safe — \`filepath.Join\` treats the leading slash as a component boundary, not an absolute root, so the joined path lands at \`<slot>/etc/passwd\`. Documented in the test.)

## Test plan
- [x] \`go test ./pkg/source/bucket/...\` — new table passes; existing tests unchanged
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)