### PR TITLE
fix(depwait): surface metadata.labels + metadata.annotations to readyExpr CEL

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -80,37 +80,80 @@ func compileReadyExpr(expr string) (cel.Program, error) {
 	return prog, nil
 }
 
-// projectObject builds the unstructured-shaped `object` value the CEL
-// expression sees. Includes metadata + status.conditions derived from
-// the Store. We deliberately do NOT include the full BaseManifest
-// payload — ReadyExpr should evaluate against the live status, not
-// the spec. Mirrors how Flux's CEL env exposes only the runtime view.
+// projectObject builds the unstructured-shaped value the CEL
+// expression sees for `self` / `dep`. Includes:
+//   - apiVersion + kind
+//   - metadata.{name,namespace,generation,labels,annotations}
+//   - status.{observedGeneration,conditions}
+//
+// Labels and annotations are surfaced from the typed manifest in the
+// store when available — common upstream Flux readiness idioms like
+// `dep.metadata.annotations['app.kubernetes.io/component'] == 'cache'`
+// rely on these being populated. The full spec is not yet projected;
+// CEL expressions touching spec.* read undefined (documented gap).
 func projectObject(s *store.Store, id manifest.NamedResource) map[string]any {
 	conds := s.GetConditions(id)
 	condsAny := make([]any, 0, len(conds))
 	for _, c := range conds {
 		condsAny = append(condsAny, conditionToMap(c))
 	}
+	meta := map[string]any{
+		"name":      id.Name,
+		"namespace": id.Namespace,
+		// flate has no apiserver, so there is no monotonically-
+		// increasing generation count to model. The single-snapshot
+		// render pins both metadata.generation and
+		// status.observedGeneration to the same value so CEL
+		// expressions like
+		//   dep.status.observedGeneration == dep.metadata.generation
+		// — a common Flux readiness idiom — never spuriously fail.
+		"generation": int64(1),
+	}
+	if labels, annotations := labelsAndAnnotations(s.GetObject(id)); labels != nil || annotations != nil {
+		if labels != nil {
+			meta["labels"] = labels
+		}
+		if annotations != nil {
+			meta["annotations"] = annotations
+		}
+	}
 	return map[string]any{
 		"kind":       id.Kind,
 		"apiVersion": apiVersionFor(id.Kind),
-		"metadata": map[string]any{
-			"name":      id.Name,
-			"namespace": id.Namespace,
-			// flate has no apiserver, so there is no monotonically-
-			// increasing generation count to model. The single-snapshot
-			// render pins both metadata.generation and
-			// status.observedGeneration to the same value so CEL
-			// expressions like
-			//   object.status.observedGeneration == object.metadata.generation
-			// — a common Flux readiness idiom — never spuriously fail.
-			"generation": int64(1),
-		},
+		"metadata":   meta,
 		"status": map[string]any{
 			"observedGeneration": int64(1),
 			"conditions":         condsAny,
 		},
 	}
+}
+
+// labelsAndAnnotations extracts metadata.labels / metadata.annotations
+// from the typed manifest when the type carries them. Returns nil maps
+// when missing (so CEL's `has(dep.metadata.labels)` evaluates false
+// rather than seeing an empty map). The conversion to map[string]any
+// is needed because the CEL DynType resolver doesn't deep-walk
+// map[string]string.
+func labelsAndAnnotations(obj manifest.BaseManifest) (labels, annotations map[string]any) {
+	type withMeta interface {
+		GetLabels() map[string]string
+		GetAnnotations() map[string]string
+	}
+	if m, ok := obj.(withMeta); ok {
+		return stringMapToAny(m.GetLabels()), stringMapToAny(m.GetAnnotations())
+	}
+	return nil, nil
+}
+
+func stringMapToAny(in map[string]string) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func conditionToMap(c metav1.Condition) map[string]any {

--- a/pkg/depwait/cel_test.go
+++ b/pkg/depwait/cel_test.go
@@ -183,6 +183,37 @@ func TestReadyExpr_NonBoolResult(t *testing.T) {
 	}
 }
 
+// TestReadyExpr_ReadsLabelsAndAnnotations locks the upstream Flux
+// contract that readyExpr can read dep.metadata.{labels,annotations}.
+// The HR/KS manifest types now carry these maps and the CEL projection
+// surfaces them under metadata.labels / metadata.annotations.
+func TestReadyExpr_ReadsLabelsAndAnnotations(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "child"}
+	// AddObject the typed manifest so projectObject can read labels.
+	s.AddObject(&manifest.Kustomization{
+		Name: "child", Namespace: "ns",
+		Labels:      map[string]string{"tier": "data"},
+		Annotations: map[string]string{"app.kubernetes.io/version": "1.2.3"},
+	})
+	s.UpdateStatus(dep, store.StatusReady, "")
+
+	w := &Waiter{Store: s, Timeout: time.Second}
+	cases := []string{
+		`dep.metadata.labels["tier"] == "data"`,
+		`dep.metadata.annotations["app.kubernetes.io/version"] == "1.2.3"`,
+	}
+	for _, expr := range cases {
+		sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{
+			NamedResource: dep,
+			ReadyExpr:     expr,
+		}}))
+		if !sum.AllReady() {
+			t.Errorf("expr %q: not Ready: %+v", expr, sum)
+		}
+	}
+}
+
 // TestReadyExpr_BindsSelfAndDep locks the upstream Flux contract:
 // readyExpr sees both `self` (the consumer / Waiter.Parent) and `dep`
 // (the current dependency). The kustomize/helm controller idiom

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -196,7 +196,8 @@ type HelmRelease struct {
 	// ReadyExpr). Shadows the embedded Spec.DependsOn ([]DependencyReference).
 	DependsOn []DependencyRef `json:"-" yaml:"-"`
 
-	Labels map[string]string `json:"-" yaml:"-"`
+	Labels      map[string]string `json:"-" yaml:"-"`
+	Annotations map[string]string `json:"-" yaml:"-"`
 
 	// CRDsPolicy collapses spec.install.crds vs spec.upgrade.crds. One
 	// of "" (chart's helm default), "Skip", "Create", "CreateReplace".
@@ -231,6 +232,13 @@ func (h *HelmRelease) Clone() *HelmRelease {
 	out.DependsOn = slices.Clone(h.DependsOn)
 	return &out
 }
+
+// GetLabels returns the HelmRelease's metadata.labels. Implements the
+// shared accessor pkg/depwait projectObject uses for CEL exposure.
+func (h *HelmRelease) GetLabels() map[string]string { return h.Labels }
+
+// GetAnnotations returns the HelmRelease's metadata.annotations.
+func (h *HelmRelease) GetAnnotations() map[string]string { return h.Annotations }
 
 // ReleaseName returns the resolved Helm release name — spec.releaseName
 // when set, otherwise metadata.name — passed through release.ShortenName
@@ -375,6 +383,7 @@ func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		Values:                   values,
 		DependsOn:                dependsOn,
 		Labels:                   cr.Labels,
+		Annotations:              cr.Annotations,
 		DisableSchemaValidation:  disableSchema,
 		DisableOpenAPIValidation: disableOpenAPI,
 		ChartValuesFiles:         chartValuesFiles,

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -63,8 +63,16 @@ type Kustomization struct {
 	// ReadyExpr. Shadows the embedded Spec.DependsOn ([]DependencyReference).
 	DependsOn []DependencyRef `json:"-" yaml:"-"`
 
-	Labels map[string]string `json:"-" yaml:"-"`
+	Labels      map[string]string `json:"-" yaml:"-"`
+	Annotations map[string]string `json:"-" yaml:"-"`
 }
+
+// GetLabels returns the Kustomization's metadata.labels. Implements
+// the shared accessor pkg/depwait projectObject uses for CEL exposure.
+func (k *Kustomization) GetLabels() map[string]string { return k.Labels }
+
+// GetAnnotations returns the Kustomization's metadata.annotations.
+func (k *Kustomization) GetAnnotations() map[string]string { return k.Annotations }
 
 // Named identifies the Kustomization.
 func (k *Kustomization) Named() NamedResource {
@@ -205,5 +213,6 @@ func ParseKustomization(doc map[string]any) (*Kustomization, error) {
 		PostBuildSubstituteFrom: substituteFrom,
 		DependsOn:               dependsOn,
 		Labels:                  cr.Labels,
+		Annotations:             cr.Annotations,
 	}, nil
 }


### PR DESCRIPTION
## Summary
Iter-15 Flux-fidelity audit flagged that flate's depwait \`projectObject\` constructed a minimal CEL view (\`kind\`, \`apiVersion\`, \`metadata.{name,namespace,generation}\`, \`status.{observedGeneration,conditions}\`). Upstream kustomize-/helm-controller pass the full unstructured object via \`runtime.DefaultUnstructuredConverter.ToUnstructured(dep)\`.

The common Flux readiness idiom
\`\`\`yaml
readyExpr: dep.metadata.annotations["app.kubernetes.io/version"] == self.spec.version
\`\`\`
evaluated **undefined** in flate, blocking dependency gating that real Flux honors.

**Fix**:
- \`manifest.HelmRelease\` + \`manifest.Kustomization\` gain an \`Annotations\` field parallel to the existing \`Labels\` field.
- Parsers record \`cr.Annotations\` (mirroring \`cr.Labels\` capture).
- HR and KS get \`GetLabels\` / \`GetAnnotations\` accessors so depwait fetches them via interface assertion.
- \`projectObject\` surfaces \`metadata.labels\` + \`metadata.annotations\` when present; empty maps are elided so CEL's \`has(...)\` evaluates correctly.

Spec.\* exposure remains a documented gap (would need per-type unstructured conversion). Most common upstream idioms touch labels/annotations, so this lands the high-leverage fix first.

New \`TestReadyExpr_ReadsLabelsAndAnnotations\` table covers both idioms.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)