### PR TITLE
fix(helm): exclude Helm hooks from commonMetadata + origin-label stamps

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -299,6 +299,77 @@ func TestApplyHRCommonMetadata_CreatesMetadataWhenMissing(t *testing.T) {
 	}
 }
 
+// TestApplyHRCommonMetadata_SkipsHooks locks the upstream contract:
+// commonMetadata + origin labels apply only to "real" workload
+// resources. Helm hooks (helm.sh/hook annotation) are skipped because
+// helm-controller's PostRenderStrategy is NoHooks — the chain is fed
+// only non-hook templates. Without this, flate stamped labels on
+// hooks that cluster-side Flux never adds.
+func TestApplyHRCommonMetadata_SkipsHooks(t *testing.T) {
+	docs := []map[string]any{
+		{
+			"kind": "Deployment",
+			"metadata": map[string]any{
+				"name": "real-workload",
+			},
+		},
+		{
+			"kind": "ConfigMap",
+			"metadata": map[string]any{
+				"name": "hook-cm",
+				"annotations": map[string]any{
+					"helm.sh/hook": "pre-install",
+				},
+			},
+		},
+	}
+	applyHRCommonMetadata(docs, &helmv2.CommonMetadata{
+		Labels: map[string]string{"team": "platform"},
+	})
+
+	workloadLabels := docs[0]["metadata"].(map[string]any)["labels"]
+	if workloadLabels == nil {
+		t.Fatal("workload doc lost its labels stamp")
+	}
+	if workloadLabels.(map[string]any)["team"] != "platform" {
+		t.Errorf("workload doc labels: %v", workloadLabels)
+	}
+
+	hookMd := docs[1]["metadata"].(map[string]any)
+	if _, ok := hookMd["labels"]; ok {
+		t.Errorf("hook doc should not receive commonMetadata stamp; got labels %v", hookMd["labels"])
+	}
+}
+
+// TestApplyHROriginLabels_SkipsHooks mirrors the commonMetadata
+// hook-exclusion above for the origin-labels pass.
+func TestApplyHROriginLabels_SkipsHooks(t *testing.T) {
+	docs := []map[string]any{
+		{
+			"kind":     "Deployment",
+			"metadata": map[string]any{"name": "real"},
+		},
+		{
+			"kind": "Job",
+			"metadata": map[string]any{
+				"name": "hook-job",
+				"annotations": map[string]any{
+					"helm.sh/hook": "pre-install",
+				},
+			},
+		},
+	}
+	applyHROriginLabels(docs, &manifest.HelmRelease{Name: "demo", Namespace: "apps"})
+
+	if _, ok := docs[0]["metadata"].(map[string]any)["labels"]; !ok {
+		t.Error("workload doc lost its origin labels")
+	}
+	hookMd := docs[1]["metadata"].(map[string]any)
+	if _, ok := hookMd["labels"]; ok {
+		t.Errorf("hook doc should not receive origin labels; got %v", hookMd["labels"])
+	}
+}
+
 func TestMergeChartValuesFiles(t *testing.T) {
 	chartWith := func(files map[string]string) *chart.Chart {
 		c := &chart.Chart{}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -180,12 +180,19 @@ func (c *Client) TemplateDocs(ctx context.Context, hr *manifest.HelmRelease, val
 }
 
 // applyHROriginLabels stamps the helm.toolkit.fluxcd.io/{name,namespace}
-// ownership labels onto every rendered doc, mirroring helm-controller's
-// OriginLabels post-renderer. Real Flux uses these to track which HR
+// ownership labels onto every non-hook rendered doc, mirroring
+// helm-controller's OriginLabels post-renderer fed through
+// PostRenderStrategyNoHooks. Real Flux uses these to track which HR
 // owns each in-cluster resource for pruning + selection
 // (`kubectl get -l helm.toolkit.fluxcd.io/name=...`), and they take
 // precedence over CommonMetadata when keys collide — so we apply this
 // pass AFTER applyHRCommonMetadata, matching the upstream order.
+//
+// Helm hooks (Job / ConfigMap with helm.sh/hook annotation) are
+// intentionally NOT stamped — upstream's BuildPostRenderers chain is
+// fed only the non-hook stream via PostRenderStrategyNoHooks. Stamping
+// hooks in flate would produce labels real Flux never applies in
+// cluster.
 func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
 	group := helmv2.GroupVersion.Group
 	origin := map[string]string{
@@ -193,6 +200,9 @@ func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
 		group + "/namespace": hr.Namespace,
 	}
 	for _, doc := range docs {
+		if isHookDoc(doc) {
+			continue
+		}
 		md, _ := doc["metadata"].(map[string]any)
 		if md == nil {
 			md = map[string]any{}
@@ -203,16 +213,23 @@ func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
 }
 
 // applyHRCommonMetadata merges spec.commonMetadata.labels and .annotations
-// onto every rendered doc's metadata, mirroring helm-controller's
-// CommonRenderer pass. commonMetadata overwrites chart-template defaults
-// but loses to origin labels on collision — applyHROriginLabels runs
-// AFTER this and reasserts the helm.toolkit.fluxcd.io/{name,namespace}
-// keys, matching helm-controller's build.go:46 comment.
+// onto every non-hook rendered doc's metadata, mirroring helm-controller's
+// CommonRenderer pass fed through PostRenderStrategyNoHooks. commonMetadata
+// overwrites chart-template defaults but loses to origin labels on
+// collision — applyHROriginLabels runs AFTER this and reasserts the
+// helm.toolkit.fluxcd.io/{name,namespace} keys, matching helm-controller's
+// build.go:46 comment.
+//
+// Hooks are excluded for the same reason applyHROriginLabels excludes
+// them: upstream's post-render chain runs after hook separation.
 func applyHRCommonMetadata(docs []map[string]any, cm *helmv2.CommonMetadata) {
 	if cm == nil || (len(cm.Labels) == 0 && len(cm.Annotations) == 0) {
 		return
 	}
 	for _, doc := range docs {
+		if isHookDoc(doc) {
+			continue
+		}
 		md, _ := doc["metadata"].(map[string]any)
 		if md == nil {
 			md = map[string]any{}
@@ -221,6 +238,24 @@ func applyHRCommonMetadata(docs []map[string]any, cm *helmv2.CommonMetadata) {
 		mergeStringMap(md, "labels", cm.Labels)
 		mergeStringMap(md, "annotations", cm.Annotations)
 	}
+}
+
+// isHookDoc reports whether a rendered manifest is a Helm hook
+// (carrying the helm.sh/hook annotation). Used to gate the
+// commonMetadata + origin-label post-render passes so they only apply
+// to "real" workload resources — matching upstream helm-controller's
+// PostRenderStrategyNoHooks contract.
+func isHookDoc(doc map[string]any) bool {
+	md, _ := doc["metadata"].(map[string]any)
+	if md == nil {
+		return false
+	}
+	anns, _ := md["annotations"].(map[string]any)
+	if anns == nil {
+		return false
+	}
+	_, has := anns["helm.sh/hook"]
+	return has
 }
 
 func mergeStringMap(md map[string]any, key string, in map[string]string) {


### PR DESCRIPTION
## Summary
Iter-15 Flux-fidelity audit caught a divergence: helm-controller sets \`install.PostRenderStrategy = action.PostRenderStrategyNoHooks\`, so the CommonRenderer + OriginLabels post-renderer chain is fed ONLY non-hook templates. Hooks reach cluster without \`spec.commonMetadata\` labels/annotations and without the \`helm.toolkit.fluxcd.io/{name,namespace}\` origin labels.

flate's \`TemplateDocs\` did the opposite: \`SplitDocs\` sees \`rel.Manifest\` + \`rel.Hooks\` joined into one stream, \`applyHRCommonMetadata\` and \`applyHROriginLabels\` walked every doc and stamped both. The rendered output contained labels real Flux would never apply in cluster — a user diffing flate output against \`kubectl get -l ...\` on a hook Job would see phantom labels.

**Fix**: gate both stamping passes on a new \`isHookDoc\` check. A doc is a hook when \`metadata.annotations\` carries \`helm.sh/hook\` (any value).

Two new tests lock the contract:
- \`TestApplyHRCommonMetadata_SkipsHooks\`
- \`TestApplyHROriginLabels_SkipsHooks\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)