### PR TITLE
fix(bucket): skip VCS/extension default excludes — match source-controller

### DIFF
--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -88,7 +88,12 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		_ = f.Cache.Reset(slot)
 		return nil, fmt.Errorf("bucket %s/%s walk: %w", b.Namespace, b.Name, err)
 	}
-	if err := source.ApplyIgnore(slot, b.Ignore); err != nil {
+	// Bucket uses the no-defaults ignore variant — matches upstream
+	// source-controller's bucket_controller.go, which constructs an
+	// ignore Matcher without VCS / extension defaults. Buckets are
+	// object stores with no VCS semantics; .jpg / .flux.yaml / etc.
+	// are legitimate content and must reach the artifact.
+	if err := source.ApplyIgnoreNoDefaults(slot, b.Ignore); err != nil {
 		_ = f.Cache.Reset(slot)
 		return nil, fmt.Errorf("bucket %s/%s: %w", b.Namespace, b.Name, err)
 	}

--- a/pkg/source/ignore.go
+++ b/pkg/source/ignore.go
@@ -15,19 +15,40 @@ import (
 // controller ignore matcher: VCS + Default excludes (.git/, .github/,
 // *.jpg/png/zip, .sops.yaml, .flux.yaml, ...) PLUS any in-tree
 // .sourceignore files PLUS the user-supplied spec.ignore patterns when
-// non-nil. Mirrors source-controller's artifact-build behavior.
+// non-nil. Mirrors source-controller's GitRepository / OCIRepository
+// artifact-build behavior.
 //
 // nil spec.ignore is NOT a no-op — the VCS + Default patterns still
-// apply, matching what real Flux ships in an artifact tarball.
+// apply, matching what real Flux ships in a Git/OCI artifact tarball.
+//
+// Bucket sources use ApplyIgnoreNoDefaults instead — see that function
+// for the rationale.
 func ApplyIgnore(root string, ignore *string) error {
+	return applyIgnore(root, ignore, true)
+}
+
+// ApplyIgnoreNoDefaults is the Bucket-flavored variant: it skips the
+// VCS + Default exclude patterns and applies ONLY the in-tree
+// .sourceignore plus the user-supplied spec.ignore. Mirrors
+// fluxcd/source-controller/internal/controller/bucket_controller.go
+// which uses sourceignore.NewMatcher (no defaults) rather than the
+// NewDefaultMatcher that GitRepository / OCIRepository use.
+//
+// The rationale: Bucket has no VCS semantics. An object store can
+// legitimately carry .git/-named keys, .jpg/.png images, .flux.yaml,
+// etc., and source-controller delivers them as-is. Stripping them
+// would diverge from what a cluster Bucket reconcile produces.
+func ApplyIgnoreNoDefaults(root string, ignore *string) error {
+	return applyIgnore(root, ignore, false)
+}
+
+func applyIgnore(root string, ignore *string, withDefaults bool) error {
 	abs, err := filepath.Abs(root)
 	if err != nil {
 		return fmt.Errorf("sourceignore abs: %w", err)
 	}
 	domain := strings.Split(abs, string(filepath.Separator))
 
-	// Default to VCS + extension excludes + any .sourceignore files
-	// reachable from root, then layer user patterns on top.
 	patterns, err := sourceignore.LoadIgnorePatterns(abs, domain)
 	if err != nil {
 		return fmt.Errorf("sourceignore load: %w", err)
@@ -35,7 +56,13 @@ func ApplyIgnore(root string, ignore *string) error {
 	if ignore != nil && strings.TrimSpace(*ignore) != "" {
 		patterns = append(patterns, sourceignore.ReadPatterns(strings.NewReader(*ignore), domain)...)
 	}
-	return walkAndDelete(abs, domain, sourceignore.NewDefaultMatcher(patterns, domain))
+	var matcher gitignore.Matcher
+	if withDefaults {
+		matcher = sourceignore.NewDefaultMatcher(patterns, domain)
+	} else {
+		matcher = sourceignore.NewMatcher(patterns)
+	}
+	return walkAndDelete(abs, domain, matcher)
 }
 
 func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) error {

--- a/pkg/source/ignore_test.go
+++ b/pkg/source/ignore_test.go
@@ -31,6 +31,50 @@ func exists(t *testing.T, p string) bool {
 	return false
 }
 
+// TestApplyIgnoreNoDefaults_PreservesVCSAndExtensions locks the
+// Bucket-flavored ignore variant: when ApplyIgnoreNoDefaults runs
+// with a nil spec.ignore, files that the default-matcher would
+// exclude (VCS-named, image extensions, .flux.yaml) are left in
+// place. Mirrors upstream source-controller's bucket_controller.go
+// using sourceignore.NewMatcher instead of NewDefaultMatcher —
+// buckets can legitimately carry these as regular objects.
+func TestApplyIgnoreNoDefaults_PreservesVCSAndExtensions(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "image.jpg")
+	writeFile(t, root, "kept/.flux.yaml")
+	writeFile(t, root, "kept/keep.txt")
+	writeFile(t, root, ".sops.yaml")
+
+	if err := source.ApplyIgnoreNoDefaults(root, nil); err != nil {
+		t.Fatalf("ApplyIgnoreNoDefaults: %v", err)
+	}
+
+	for _, rel := range []string{"image.jpg", "kept/.flux.yaml", "kept/keep.txt", ".sops.yaml"} {
+		if !exists(t, filepath.Join(root, rel)) {
+			t.Errorf("ApplyIgnoreNoDefaults stripped %q which Bucket should preserve", rel)
+		}
+	}
+}
+
+// TestApplyIgnoreNoDefaults_HonorsUserSpecIgnore confirms that the
+// no-defaults variant still applies user-supplied spec.ignore.
+func TestApplyIgnoreNoDefaults_HonorsUserSpecIgnore(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "image.jpg")
+	writeFile(t, root, "kept.txt")
+	patterns := "*.jpg"
+
+	if err := source.ApplyIgnoreNoDefaults(root, &patterns); err != nil {
+		t.Fatalf("ApplyIgnoreNoDefaults: %v", err)
+	}
+	if exists(t, filepath.Join(root, "image.jpg")) {
+		t.Error("user-supplied *.jpg pattern was not honored")
+	}
+	if !exists(t, filepath.Join(root, "kept.txt")) {
+		t.Error("kept.txt was stripped despite not matching user pattern")
+	}
+}
+
 // TestApplyIgnore_AppliesDefaultsWhenIgnoreNil asserts the source-
 // controller default exclusions (VCS + ExcludeExt + ExcludeCI +
 // ExcludeExtra) fire even when spec.ignore is nil, matching real


### PR DESCRIPTION
## Summary
Iter-15 Flux-fidelity audit caught a divergence: flate's bucket fetcher used \`source.ApplyIgnore\` → \`sourceignore.NewDefaultMatcher\`, which prepends VCS + ExcludeExt + ExcludeCI + ExcludeExtra defaults to any user \`spec.ignore\`. That matches GitRepository / OCIRepository artifact-build, but is **wrong for Bucket** — an object store has no VCS semantics, and upstream \`bucket_controller.go\` uses \`sourceignore.NewMatcher\` (no defaults). \`.jpg\` / \`.flux.yaml\` / \`.git\`-prefixed keys / \`.sops.yaml\` are legitimate bucket content that real Flux delivers as-is.

**Repro pre-fix**: a Bucket containing \`image.jpg\` had it stripped before downstream Kustomizations could reference it.

**Fix**: factor \`source.ApplyIgnoreNoDefaults\` parallel to \`ApplyIgnore\`. Both share the walk / \`.sourceignore\` / user-pattern plumbing via a private \`applyIgnore(root, ignore, withDefaults bool)\`. \`bucket.go\` switches to the no-defaults variant; git/oci stay on \`ApplyIgnore\`.

Two new tests:
- \`TestApplyIgnoreNoDefaults_PreservesVCSAndExtensions\` — nil ignore keeps \`.jpg\`, \`.flux.yaml\`, \`.sops.yaml\`.
- \`TestApplyIgnoreNoDefaults_HonorsUserSpecIgnore\` — user spec.ignore still applies normally.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)