### PR TITLE
fix(helm): exclude CRDs from commonMetadata stamping

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -341,6 +341,35 @@ func TestApplyHRCommonMetadata_SkipsHooks(t *testing.T) {
 	}
 }
 
+// TestApplyHRCommonMetadata_SkipsCRDs locks the upstream behavior:
+// helm-controller's separate applyCRDs path uses setOriginVisitor for
+// origin labels but never CommonMetadata. flate must not stamp
+// commonMetadata onto CRDs — that produces labels real Flux doesn't
+// apply in cluster.
+func TestApplyHRCommonMetadata_SkipsCRDs(t *testing.T) {
+	docs := []map[string]any{
+		{
+			"kind":     "Deployment",
+			"metadata": map[string]any{"name": "real"},
+		},
+		{
+			"kind":     "CustomResourceDefinition",
+			"metadata": map[string]any{"name": "things.example.com"},
+		},
+	}
+	applyHRCommonMetadata(docs, &helmv2.CommonMetadata{
+		Labels: map[string]string{"team": "platform"},
+	})
+
+	if docs[0]["metadata"].(map[string]any)["labels"] == nil {
+		t.Error("workload doc lost its commonMetadata stamp")
+	}
+	crdMd := docs[1]["metadata"].(map[string]any)
+	if _, ok := crdMd["labels"]; ok {
+		t.Errorf("CRD should not receive commonMetadata stamp; got %v", crdMd["labels"])
+	}
+}
+
 // TestApplyHROriginLabels_SkipsHooks mirrors the commonMetadata
 // hook-exclusion above for the origin-labels pass.
 func TestApplyHROriginLabels_SkipsHooks(t *testing.T) {

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -213,21 +213,26 @@ func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
 }
 
 // applyHRCommonMetadata merges spec.commonMetadata.labels and .annotations
-// onto every non-hook rendered doc's metadata, mirroring helm-controller's
+// onto every workload rendered doc's metadata, mirroring helm-controller's
 // CommonRenderer pass fed through PostRenderStrategyNoHooks. commonMetadata
 // overwrites chart-template defaults but loses to origin labels on
 // collision — applyHROriginLabels runs AFTER this and reasserts the
 // helm.toolkit.fluxcd.io/{name,namespace} keys, matching helm-controller's
 // build.go:46 comment.
 //
-// Hooks are excluded for the same reason applyHROriginLabels excludes
-// them: upstream's post-render chain runs after hook separation.
+// Excluded from the stamping pass:
+//   - Hooks (helm.sh/hook annotation): upstream's post-render chain
+//     runs after hook separation via PostRenderStrategyNoHooks.
+//   - CRDs (CustomResourceDefinition kind): upstream's separate
+//     applyCRDs path attaches only origin labels via setOriginVisitor,
+//     never commonMetadata. Stamping CRDs in flate produced labels
+//     real Flux never applies in cluster.
 func applyHRCommonMetadata(docs []map[string]any, cm *helmv2.CommonMetadata) {
 	if cm == nil || (len(cm.Labels) == 0 && len(cm.Annotations) == 0) {
 		return
 	}
 	for _, doc := range docs {
-		if isHookDoc(doc) {
+		if isHookDoc(doc) || manifest.DocKind(doc) == manifest.KindCustomResourceDefinition {
 			continue
 		}
 		md, _ := doc["metadata"].(map[string]any)


### PR DESCRIPTION
## Summary
Follow-up to #173 (hooks-no-postrender). Iter-15 Flux-fidelity audit also flagged that helm-controller's separate \`applyCRDs\` path uses \`setOriginVisitor\` for origin labels but **never** attaches \`spec.commonMetadata\`. CRDs are applied through a distinct code path that doesn't traverse the CommonRenderer chain.

flate stamped commonMetadata onto CRDs because \`applyHRCommonMetadata\` walked every doc. A user diffing flate output against \`kubectl get crd <name>\` would see phantom labels/annotations real Flux never applies.

**Fix**: extend the existing \`isHookDoc\` skip in \`applyHRCommonMetadata\` to also skip \`CustomResourceDefinition\` docs. \`applyHROriginLabels\` keeps stamping CRDs — that matches upstream's \`setOriginVisitor\` pass.

New \`TestApplyHRCommonMetadata_SkipsCRDs\` locks the contract.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)