### PR TITLE
fix(resourceset): reject inputStrategy=Permute instead of silent fall-through

### DIFF
--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -120,10 +120,20 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 // order = rset's inline inputs first, then providers in sorted
 // (kind, namespace, name) order.
 //
-// Permute strategy is not yet implemented (#109). inputs.id is left to
-// the provider when it's a Static RSIP; inline-only inputs see no
-// synthetic id under Flatten.
+// inputs.id is left to the provider when it's a Static RSIP; inline-
+// only inputs see no synthetic id under Flatten.
+//
+// Permute (Cartesian product) is rejected with a clear error rather
+// than silently falling through to Flatten — Flatten produces wrong
+// cardinality for a ResourceSet that requested Permute. Real Flux's
+// flux-operator/internal/inputs/combine.go dispatches on
+// spec.inputStrategy.name and would emit the Cartesian product;
+// any flate render that doesn't would silently disagree with cluster.
 func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]any, error) {
+	if rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
+		return nil, fmt.Errorf("%w: ResourceSet %s/%s requests spec.inputStrategy.name=Permute, which flate does not yet implement (#109)",
+			manifest.ErrInput, rs.Namespace, rs.Name)
+	}
 	var out []map[string]any
 	for _, in := range rs.Inputs {
 		decoded := decodeInputSet(in)

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -1,6 +1,7 @@
 package resourceset_test
 
 import (
+	"strings"
 	"testing"
 
 	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
@@ -9,6 +10,37 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
 )
+
+// TestRender_PermuteIsRejected locks the upstream-fidelity guard: a
+// ResourceSet requesting spec.inputStrategy.name=Permute fails loud
+// rather than silently falling through to Flatten. Flatten produces
+// wrong cardinality for a Permute consumer — flate would render
+// differently from what flux-operator emits in cluster.
+func TestRender_PermuteIsRejected(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "apps", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputStrategy: &fluxopv1.InputStrategySpec{
+				Name: fluxopv1.InputStrategyPermute,
+			},
+			Inputs: []fluxopv1.ResourceSetInput{
+				{"x": jsonTmpl(t, `"a"`)},
+				{"x": jsonTmpl(t, `"b"`)},
+			},
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << .input.x >>`,
+		},
+	}
+	_, err := resourceset.Render(rs, nil)
+	if err == nil {
+		t.Fatal("expected Permute to be rejected; got nil error")
+	}
+	if !strings.Contains(err.Error(), "Permute") {
+		t.Errorf("error should mention Permute; got %v", err)
+	}
+}
 
 func jsonTmpl(t *testing.T, raw string) *apix.JSON {
 	t.Helper()


### PR DESCRIPTION
## Summary
Iter-15 Flux-fidelity audit caught: when a ResourceSet declares \`spec.inputStrategy.name=Permute\` (Cartesian product of provider inputs), flate silently used the Flatten strategy. The resulting input matrix has wrong cardinality — Flatten concatenates inputs (M+N sets); Permute combines them (M*N sets). flate's render would silently disagree with what flux-operator emits in cluster.

\`flux-operator/internal/inputs/combine.go\` dispatches on \`spec.inputStrategy.name\`. flate's \`buildInputSets\` ignored the field. The docstring already noted Permute as "not yet implemented" but runtime behavior was to silently emit wrong output instead of failing.

**Fix**: detect \`rs.InputStrategy.Name == Permute\` in \`buildInputSets\` and return a clear \`ErrInput\`-wrapped error naming the ResourceSet. The full Permute implementation remains deferred; the loud failure prevents users from shipping wrong manifests believing they matched cluster output.

\`TestRender_PermuteIsRejected\` locks the guard.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)