### PR TITLE
fix(orchestrator): detect dependsOn cycles up-front, strip cycle edges

### DIFF
--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -1,0 +1,205 @@
+package orchestrator
+
+import (
+	"cmp"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// detectDependsOnCycles runs a DFS over the dependsOn graph within
+// each reconcilable kind (Kustomization, HelmRelease) and returns
+// the cycle paths it finds. A cycle path is the closed loop, e.g.
+// [A, B, C, A]. Without this pre-check, depwait would burn the full
+// 30s per-dep timeout on every cycle member before failing.
+//
+// We don't reach across kinds — dependsOn on a Kustomization refers
+// to Kustomizations only, dependsOn on a HelmRelease refers to
+// HelmReleases only (Flux spec).
+func (o *Orchestrator) detectDependsOnCycles() [][]manifest.NamedResource {
+	var all [][]manifest.NamedResource
+	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+		all = append(all, findDependencyCycles(o.store, kind)...)
+	}
+	return all
+}
+
+// breakDependsOnCycles detects cycles and strips the dependsOn edges
+// between cycle members so depwait completes immediately. The cycle
+// path is logged for the user to see — flate's reconcile output may
+// then show whatever real failure (or success) the cycle members
+// have once they're no longer waiting on each other. Without this,
+// every cycle member burned its full per-dep budget waiting for a
+// peer that would never become Ready.
+//
+// Stripping is the pragmatic choice: the alternative (pre-marking
+// every member Failed with the cycle message) loses the message when
+// the controller's reconcile overwrites status. The warn log keeps
+// the cycle information visible regardless.
+func (o *Orchestrator) breakDependsOnCycles() {
+	cycles := o.detectDependsOnCycles()
+	if len(cycles) == 0 {
+		return
+	}
+	// Collect every id involved in any cycle, keyed by kind, so we can
+	// strip its dependsOn edges only against cycle peers of the same
+	// kind. A KS in a cycle with another KS still keeps any legitimate
+	// dependsOn entry on a non-cycle KS — only the cycle edge goes.
+	inCycle := map[string]map[manifest.NamedResource]struct{}{
+		manifest.KindKustomization: {},
+		manifest.KindHelmRelease:   {},
+	}
+	for _, path := range cycles {
+		slog.Warn("dependency cycle detected; stripping cycle edges to fail fast",
+			"cycle", formatCyclePath(path))
+		for _, id := range path {
+			if set, ok := inCycle[id.Kind]; ok {
+				set[id] = struct{}{}
+			}
+		}
+	}
+	for _, ks := range o.store.ListObjects(manifest.KindKustomization) {
+		k, ok := ks.(*manifest.Kustomization)
+		if !ok {
+			continue
+		}
+		if _, member := inCycle[manifest.KindKustomization][k.Named()]; !member {
+			continue
+		}
+		stripped := stripCycleDeps(k.DependsOn, inCycle[manifest.KindKustomization])
+		store.Mutate(o.store, k.Named(), func(x *manifest.Kustomization) { x.DependsOn = stripped })
+	}
+	for _, hr := range o.store.ListObjects(manifest.KindHelmRelease) {
+		h, ok := hr.(*manifest.HelmRelease)
+		if !ok {
+			continue
+		}
+		if _, member := inCycle[manifest.KindHelmRelease][h.Named()]; !member {
+			continue
+		}
+		stripped := stripCycleDeps(h.DependsOn, inCycle[manifest.KindHelmRelease])
+		store.Mutate(o.store, h.Named(), func(x *manifest.HelmRelease) { x.DependsOn = stripped })
+	}
+}
+
+// stripCycleDeps returns deps minus any entry whose target is in the
+// cycle set. The original slice is left untouched (the caller swaps
+// the returned value into a fresh Clone via store.Mutate).
+func stripCycleDeps(deps []manifest.DependencyRef, cycleMembers map[manifest.NamedResource]struct{}) []manifest.DependencyRef {
+	if len(deps) == 0 {
+		return deps
+	}
+	out := make([]manifest.DependencyRef, 0, len(deps))
+	for _, d := range deps {
+		if _, ok := cycleMembers[d.NamedResource]; ok {
+			continue
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+// findDependencyCycles walks the dependsOn graph of one kind using
+// the standard tri-color DFS (WHITE/GRAY/BLACK) and returns every
+// cycle as the closed loop. Visit order is sorted so cycle output is
+// deterministic across runs — CI/log diffs depend on it.
+func findDependencyCycles(s *store.Store, kind string) [][]manifest.NamedResource {
+	graph := buildDepGraph(s, kind)
+	if len(graph) == 0 {
+		return nil
+	}
+	const (
+		white = iota
+		gray
+		black
+	)
+	color := map[manifest.NamedResource]int{}
+	var stack []manifest.NamedResource
+	var cycles [][]manifest.NamedResource
+
+	nodes := make([]manifest.NamedResource, 0, len(graph))
+	for n := range graph {
+		nodes = append(nodes, n)
+	}
+	slices.SortFunc(nodes, func(a, b manifest.NamedResource) int {
+		return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
+	})
+
+	var visit func(n manifest.NamedResource)
+	visit = func(n manifest.NamedResource) {
+		color[n] = gray
+		stack = append(stack, n)
+		// Sort outgoing edges for determinism.
+		out := append([]manifest.NamedResource(nil), graph[n]...)
+		slices.SortFunc(out, func(a, b manifest.NamedResource) int {
+			return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
+		})
+		for _, m := range out {
+			switch color[m] {
+			case white:
+				visit(m)
+			case gray:
+				// Back-edge to a node currently on the stack → cycle.
+				start := 0
+				for i, sNode := range stack {
+					if sNode == m {
+						start = i
+						break
+					}
+				}
+				cycle := append([]manifest.NamedResource(nil), stack[start:]...)
+				cycle = append(cycle, m) // close the loop visually
+				cycles = append(cycles, cycle)
+			}
+		}
+		color[n] = black
+		stack = stack[:len(stack)-1]
+	}
+	for _, n := range nodes {
+		if color[n] == white {
+			visit(n)
+		}
+	}
+	return cycles
+}
+
+// buildDepGraph extracts the (id → []deps) adjacency map for one
+// kind. Cross-kind deps (a Kustomization depending on a HelmRelease,
+// for instance — not legal under Flux spec) are filtered out so the
+// graph stays kind-homogeneous and DFS stops at kind boundaries.
+func buildDepGraph(s *store.Store, kind string) map[manifest.NamedResource][]manifest.NamedResource {
+	graph := map[manifest.NamedResource][]manifest.NamedResource{}
+	for _, obj := range s.ListObjects(kind) {
+		var deps []manifest.DependencyRef
+		switch v := obj.(type) {
+		case *manifest.Kustomization:
+			deps = v.DependsOn
+		case *manifest.HelmRelease:
+			deps = v.DependsOn
+		default:
+			continue
+		}
+		id := obj.Named()
+		targets := make([]manifest.NamedResource, 0, len(deps))
+		for _, d := range deps {
+			if d.Kind != kind {
+				continue
+			}
+			targets = append(targets, d.NamedResource)
+		}
+		graph[id] = targets
+	}
+	return graph
+}
+
+// formatCyclePath returns the cycle as "A → B → C → A" for log output.
+func formatCyclePath(path []manifest.NamedResource) string {
+	parts := make([]string, len(path))
+	for i, id := range path {
+		parts[i] = id.String()
+	}
+	return strings.Join(parts, " → ")
+}

--- a/pkg/orchestrator/cycles_test.go
+++ b/pkg/orchestrator/cycles_test.go
@@ -1,0 +1,110 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func makeKS(name, ns string, deps ...manifest.NamedResource) *manifest.Kustomization {
+	refs := make([]manifest.DependencyRef, len(deps))
+	for i, d := range deps {
+		refs[i] = manifest.DependencyRef{NamedResource: d}
+	}
+	return &manifest.Kustomization{
+		Name: name, Namespace: ns,
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./" + name},
+		DependsOn:         refs,
+	}
+}
+
+// TestDetectDependsOnCycles_Simple locks the headline case: a two-
+// node KS cycle is reported as a closed loop, deterministic across
+// runs (sort + sort = same output every invocation).
+func TestDetectDependsOnCycles_Simple(t *testing.T) {
+	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+
+	o := &Orchestrator{store: store.New()}
+	o.store.AddObject(makeKS("a", "ns", idB))
+	o.store.AddObject(makeKS("b", "ns", idA))
+
+	cycles := o.detectDependsOnCycles()
+	if len(cycles) == 0 {
+		t.Fatal("expected at least one cycle; got none")
+	}
+	got := formatCyclePath(cycles[0])
+	if !strings.Contains(got, "a") || !strings.Contains(got, "b") {
+		t.Errorf("cycle path missing nodes: %q", got)
+	}
+	// Closed loop: first id repeats at the end.
+	if cycles[0][0] != cycles[0][len(cycles[0])-1] {
+		t.Errorf("cycle should close on itself; got %v", cycles[0])
+	}
+}
+
+// TestDetectDependsOnCycles_NoCycleNoOutput confirms acyclic graphs
+// produce no false positives.
+func TestDetectDependsOnCycles_NoCycleNoOutput(t *testing.T) {
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+	idC := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "c"}
+
+	o := &Orchestrator{store: store.New()}
+	o.store.AddObject(makeKS("a", "ns", idB, idC)) // a → {b, c}
+	o.store.AddObject(makeKS("b", "ns", idC))      // b → c
+	o.store.AddObject(makeKS("c", "ns"))           // c has no deps
+
+	if cycles := o.detectDependsOnCycles(); len(cycles) != 0 {
+		t.Errorf("expected no cycles on a DAG; got %v", cycles)
+	}
+}
+
+// TestBreakDependsOnCycles_StripsCycleEdges verifies the runtime
+// behavior the user cares about: after Bootstrap, KSes that were in
+// a cycle have their cycle-closing dependsOn entries dropped. Their
+// reconcile won't hang 30s waiting on a peer that can't become Ready.
+func TestBreakDependsOnCycles_StripsCycleEdges(t *testing.T) {
+	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+	// `extra` is an acyclic dep — it must SURVIVE the strip.
+	idExtra := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "extra"}
+
+	o := &Orchestrator{store: store.New()}
+	o.store.AddObject(makeKS("a", "ns", idB, idExtra))
+	o.store.AddObject(makeKS("b", "ns", idA))
+	o.store.AddObject(makeKS("extra", "ns"))
+
+	o.breakDependsOnCycles()
+
+	a, _ := o.store.GetObject(idA).(*manifest.Kustomization)
+	b, _ := o.store.GetObject(idB).(*manifest.Kustomization)
+	if a == nil || b == nil {
+		t.Fatal("post-Bootstrap objects went missing")
+	}
+	// a should no longer depend on b (cycle edge), but should still
+	// depend on extra (acyclic).
+	for _, d := range a.DependsOn {
+		if d.NamedResource == idB {
+			t.Errorf("a→b cycle edge not stripped from a.DependsOn: %+v", a.DependsOn)
+		}
+	}
+	hasExtra := false
+	for _, d := range a.DependsOn {
+		if d.NamedResource == idExtra {
+			hasExtra = true
+		}
+	}
+	if !hasExtra {
+		t.Errorf("a→extra acyclic dep was stripped along with the cycle edge: %+v", a.DependsOn)
+	}
+	// b should have lost its only edge.
+	for _, d := range b.DependsOn {
+		if d.NamedResource == idA {
+			t.Errorf("b→a cycle edge not stripped: %+v", b.DependsOn)
+		}
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -231,6 +231,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	o.parentOf = res.ParentOf
 
 	o.validateDependsOn()
+	o.breakDependsOnCycles()
 	return o.buildChangeFilter(res.RepoRoot)
 }
 


### PR DESCRIPTION
## Summary
Iter-15 robustness audit caught: a circular \`dependsOn\` — A→B→A — made every cycle member wait its full 30-second per-dep budget before failing. A real-repo cycle could waste minutes of CI time before the user saw any signal.

**Fix**: after \`validateDependsOn()\` in Bootstrap, run cycle detection over the per-kind dependsOn graph (standard tri-color DFS). For each cycle, log a clear warning showing the closed loop (\`A → B → A\`) and strip the cycle-closing edges so depwait completes immediately. Legitimate non-cycle deps survive — only the edges between cycle peers are removed.

Stripping is the pragmatic UX: the alternative (pre-marking each member \`StatusFailed\` with the cycle message) loses the message when the controller's reconcile overwrites status mid-flight. The warn log keeps cycle info visible regardless.

**Repro pre-fix**: \`time flate test all --path <cycle-repo>\` → ~30s.
**Post-fix**: ~0.9s, with \`cycle=Kustomization/flux-system/a → Kustomization/flux-system/b → Kustomization/flux-system/a\` in stderr.

Three new tests cover output format determinism, no-cycle false-positives, and the strip-but-keep-acyclic invariant.

## Test plan
- [x] new \`TestDetectDependsOnCycles_Simple\` / \`TestDetectDependsOnCycles_NoCycleNoOutput\` / \`TestBreakDependsOnCycles_StripsCycleEdges\` pass
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] Manual reproducer: a 2-node KS cycle now completes in <1s with clear stderr message (was 30s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)