### PR TITLE
fix(manifest): reject Kustomization with empty sourceRef.name at parse time

### DIFF
--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -165,6 +165,15 @@ func ParseKustomization(doc map[string]any) (*Kustomization, error) {
 	if cr.Name == "" {
 		return nil, inputf("Kustomization missing metadata.name")
 	}
+	// sourceRef validation catches the truncated-YAML case where
+	// `name:` (no value, e.g. file ends mid-mapping) decodes silently
+	// as empty string. Without this, the failure surfaces as a
+	// misleading "kustomization path does not exist" 30 lines later
+	// in the reconcile flow.
+	if cr.Spec.SourceRef.Kind != "" && cr.Spec.SourceRef.Name == "" {
+		return nil, inputf("Kustomization %s/%s: spec.sourceRef.kind=%q but spec.sourceRef.name is empty (check for truncated YAML)",
+			cr.Namespace, cr.Name, cr.Spec.SourceRef.Kind)
+	}
 	// namespace is optional — a parent Kustomization's
 	// spec.targetNamespace may fill it in at apply time.
 	ns := cr.Namespace

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -355,6 +355,32 @@ spec:
 	}
 }
 
+// TestParseKustomization_SourceRefMissingNameRejected locks the
+// truncated-YAML guard: a Kustomization with sourceRef.kind set but
+// sourceRef.name empty (common shape for files that end mid-mapping)
+// must fail at parse time with a clear "check for truncated YAML"
+// hint, not 30 lines later as a misleading "path does not exist".
+func TestParseKustomization_SourceRefMissingNameRejected(t *testing.T) {
+	doc := mustYAML(t, `
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: ks, namespace: ns}
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: ""
+  interval: 5m
+`)
+	_, err := ParseKustomization(doc)
+	if err == nil {
+		t.Fatal("expected parse error for empty sourceRef.name with kind set")
+	}
+	if !strings.Contains(err.Error(), "sourceRef.name is empty") {
+		t.Errorf("error should mention sourceRef.name being empty; got %v", err)
+	}
+}
+
 func TestParseKustomization_Suspend(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: kustomize.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Summary
Iter-15 robustness audit caught: a YAML file ending mid-mapping — \`name:\` with no value, often the symptom of a truncated write or copy-paste mishap — decoded silently as the empty string. The parsed Kustomization carried \`sourceRef.kind=GitRepository\` but \`sourceRef.name=""\`, and the failure surfaced 30+ lines later as a misleading

\`\`\`
Kustomization X failed: kustomization path does not exist: /abs/...
\`\`\`

The path would exist if sourceRef resolved; the source-artifact lookup failed silently because the name was empty.

**Fix**: validate at parse time when \`sourceRef.kind\` is set but \`sourceRef.name\` is empty. Error message includes the KS's identity and a "check for truncated YAML" hint pointing the user straight at the malformed file.

\`TestParseKustomization_SourceRefMissingNameRejected\` locks the guard.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)