### PR TITLE
fix(helm,values): honor spec.install.replace; valuesFrom ignores ConfigMap.binaryData

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -68,7 +68,15 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	inst.DisableHooks = disableHooks
 	inst.IsUpgrade = opts.IsUpgrade
 	inst.EnableDNS = opts.EnableDNS
-	inst.Replace = true
+	// Honor spec.install.replace per helm-controller's
+	// internal/action/install.go: install.Replace = obj.GetInstall().Replace.
+	// Default false (the chart fields' zero value); set true only when
+	// the HR explicitly asks. Mostly a no-op under DryRunClient but
+	// keeps flate's render path matching upstream so any future
+	// validation behavior change in helm.action lands consistently.
+	if hr.Install != nil {
+		inst.Replace = hr.Install.Replace
+	}
 	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
 	// When flate's wipe-secrets has replaced a substituteFrom / valuesFrom
 	// value with the ..PLACEHOLDER_KEY.. token, chart schemas with DNS /

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -148,7 +148,14 @@ func lookupValueRef(ref manifest.ValuesReference, namespace string, p Provider) 
 	case manifest.KindConfigMap:
 		c := p.ConfigMap(namespace, ref.Name)
 		if c != nil {
-			data, err = decodeBag(c.Data, c.BinaryData)
+			// valuesFrom reads only ConfigMap.data; upstream
+			// fluxcd/pkg/chartutil/values.go ChartValuesFromReferences
+			// pulls from typedRes.Data[ref.GetValuesKey()] and never
+			// touches BinaryData. Pass nil so a ConfigMap carrying
+			// binaryData doesn't quietly leak base64-decoded entries
+			// into hr.Values — flate would render with keys real Flux
+			// never sees.
+			data, err = decodeBag(c.Data, nil)
 		}
 	default:
 		return "", fmt.Errorf("%w: unsupported valuesFrom kind %s", manifest.ErrInvalidValuesReference, ref.Kind)

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -59,6 +59,36 @@ func TestExpandValueReferences_ConfigMap(t *testing.T) {
 	}
 }
 
+// TestExpandValueReferences_IgnoresConfigMapBinaryData locks the
+// upstream contract: valuesFrom on a ConfigMap reads only .data,
+// never .binaryData. fluxcd/pkg/chartutil/values.go's
+// ChartValuesFromReferences pulls from typedRes.Data exclusively.
+// A ConfigMap carrying binaryData must not leak those entries into
+// hr.Values — that would render keys real Flux never sees.
+func TestExpandValueReferences_IgnoresConfigMapBinaryData(t *testing.T) {
+	cm := &manifest.ConfigMap{
+		Name: "mixed", Namespace: "default",
+		Data:       map[string]any{"values.yaml": "fromData: \"yes\"\n"},
+		BinaryData: map[string]any{"hidden.yaml": "fromBinary: \"leaked\"\n"},
+	}
+	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "mixed"}},
+		},
+	}
+	if err := ExpandValueReferences(hr, provider); err != nil {
+		t.Fatalf("ExpandValueReferences: %v", err)
+	}
+	if hr.Values["fromData"] != "yes" {
+		t.Errorf("data key should have merged; got %v", hr.Values["fromData"])
+	}
+	if _, leaked := hr.Values["fromBinary"]; leaked {
+		t.Errorf("binaryData key leaked into hr.Values: %+v", hr.Values)
+	}
+}
+
 func TestExpandValueReferences_TargetPath(t *testing.T) {
 	cm := &manifest.ConfigMap{
 		Name: "k", Namespace: "default",


### PR DESCRIPTION
## Summary
Two small upstream-fidelity items from iter-15 Agent 3 secondaries.

1. **\`helm install.Replace\` was hard-coded \`true\`**. helm-controller uses \`install.Replace = obj.GetInstall().Replace\`. Mostly a no-op under DryRunClient today but matching upstream future-proofs the render path. Default is now zero-value; set true only when the HR asks.

2. **\`valuesFrom\` on a ConfigMap merged both \`Data\` and \`BinaryData\`**. Upstream \`fluxcd/pkg/chartutil/values.go\` reads only \`Data\`. A ConfigMap carrying binaryData would silently leak base64-decoded entries into \`hr.Values\` that real Flux never sees. Pass nil for binaryData; substituteFrom already did the right thing.

\`TestExpandValueReferences_IgnoresConfigMapBinaryData\` locks the ConfigMap behavior with a mixed fixture.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)