### PR TITLE
refactor(manifest): move trimFluxPrefix → manifest.TrimSentinelPrefix

### DIFF
--- a/pkg/manifest/errors.go
+++ b/pkg/manifest/errors.go
@@ -6,6 +6,40 @@ import (
 	"strings"
 )
 
+// TrimSentinelPrefix removes the noisy `flux error: <subcategory>: `
+// chain produced by sentinel-wrapped errors (ErrFlux → ErrInput /
+// ErrObjectNotFound / …) so user-facing messages lead with the
+// actual cause. Idempotent — strings that don't start with the
+// prefix, or whose subcategory isn't one of the known sentinels,
+// pass through unchanged.
+//
+// Lives next to the sentinels themselves so the whitelist stays
+// in sync: adding a new ErrFoo here means updating one list, not
+// hunting through orchestrator code.
+func TrimSentinelPrefix(msg string) string {
+	const prefix = "flux error: "
+	if !strings.HasPrefix(msg, prefix) {
+		return msg
+	}
+	rest := msg[len(prefix):]
+	// One more level: `<subcategory>: <body>`. Strip subcategory only
+	// when it matches a known sentinel wrap so colon-containing
+	// non-sentinel messages aren't mangled.
+	i := strings.Index(rest, ": ")
+	if i <= 0 {
+		return rest
+	}
+	switch rest[:i] {
+	case "input error",
+		"object not found",
+		"invalid values reference",
+		"invalid substitute reference",
+		"command error":
+		return rest[i+2:]
+	}
+	return rest
+}
+
 // Sentinel errors. Callers branch on these with errors.Is. Every error
 // produced by this module wraps ErrFlux, so a generic
 // errors.Is(err, manifest.ErrFlux) classifies any flux-related failure.

--- a/pkg/manifest/errors_test.go
+++ b/pkg/manifest/errors_test.go
@@ -6,6 +6,39 @@ import (
 	"testing"
 )
 
+// TestTrimSentinelPrefix locks the user-facing error format: strip
+// the two-layer `flux error: <subcategory>:` chain produced by
+// sentinel-wrapped errors so the actual cause leads. Sentinel chains
+// used for errors.Is branching keep working; only the rendered
+// string is reshaped.
+func TestTrimSentinelPrefix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{
+			in:   "flux error: input error: kustomization path does not exist: /a/b",
+			want: "kustomization path does not exist: /a/b",
+		},
+		{
+			in:   "flux error: object not found: source flux-system/foo artifact not found",
+			want: "source flux-system/foo artifact not found",
+		},
+		{
+			in:   "chart not found at /tmp/x: stat /tmp/x/Chart.yaml: no such file",
+			want: "chart not found at /tmp/x: stat /tmp/x/Chart.yaml: no such file",
+		},
+		{
+			in:   "flux error: unknown subcategory: keep me intact",
+			want: "unknown subcategory: keep me intact",
+		},
+	}
+	for _, tc := range cases {
+		if got := TrimSentinelPrefix(tc.in); got != tc.want {
+			t.Errorf("TrimSentinelPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestDependencyFailedError_Format(t *testing.T) {
 	parent := NamedResource{Kind: KindKustomization, Namespace: "default", Name: "child"}
 	depA := NamedResource{Kind: KindKustomization, Namespace: "security", Name: "pocket-id-instance"}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -449,7 +449,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		// jump straight to the offending YAML — `flux error: input error:`
 		// chains alone don't reveal which spec.path declared a missing
 		// directory.
-		args := []any{"id", id.String(), "reason", trimFluxPrefix(info.Message)}
+		args := []any{"id", id.String(), "reason", manifest.TrimSentinelPrefix(info.Message)}
 		if f := o.sourceFiles[id]; f != "" {
 			args = append(args, "file", f)
 		}
@@ -473,7 +473,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		// sentinels are still wired up for errors.Is callers (e.g.
 		// embedders branching on ErrObjectNotFound), this only affects
 		// the formatted text the CLI ultimately prints.
-		msg := trimFluxPrefix(info.Message)
+		msg := manifest.TrimSentinelPrefix(info.Message)
 		if f := o.sourceFiles[id]; f != "" {
 			msgs = append(msgs, fmt.Sprintf("%s (%s): %s", id.String(), f, msg))
 		} else {
@@ -485,35 +485,6 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		len(msgs), strings.Join(msgs, "\n  "))
 }
 
-// trimFluxPrefix removes the noisy `flux error: <subcategory>: ` chain
-// from a user-facing message so the actual cause leads. Idempotent —
-// callers that don't start with `flux error:` pass through unchanged.
-//
-// The sentinel chains (ErrFlux → ErrInput / ErrObjectNotFound / …)
-// remain intact for programmatic errors.Is branching; this only
-// reshapes the rendered string.
-func trimFluxPrefix(msg string) string {
-	const prefix = "flux error: "
-	if !strings.HasPrefix(msg, prefix) {
-		return msg
-	}
-	rest := msg[len(prefix):]
-	// One more level: `<subcategory>: <body>`. Strip subcategory too.
-	if i := strings.Index(rest, ": "); i > 0 {
-		// Only strip when the subcategory looks like a wrapped sentinel
-		// ("input error", "object not found", "invalid values reference",
-		// "invalid substitute reference", "command error") — otherwise
-		// leave it alone, the colon may be part of the actual message.
-		sub := rest[:i]
-		switch sub {
-		case "input error", "object not found",
-			"invalid values reference", "invalid substitute reference",
-			"command error":
-			return rest[i+2:]
-		}
-	}
-	return rest
-}
 
 // Render is the structured embed-friendly entry point: Bootstrap +
 // Run + collect everything an external caller needs to consume the

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -208,38 +208,6 @@ func keysOf[V any](m map[manifest.NamedResource]V) []manifest.NamedResource {
 	return out
 }
 
-// TestTrimFluxPrefix verifies the user-facing error format strips
-// the two-layer `flux error: <subcategory>:` chain so the actual
-// cause leads. Sentinel-wrapped errors used for errors.Is branching
-// keep working; only the rendered string is reshaped.
-func TestTrimFluxPrefix(t *testing.T) {
-	cases := []struct {
-		in, want string
-	}{
-		{
-			in:   "flux error: input error: kustomization path does not exist: /a/b",
-			want: "kustomization path does not exist: /a/b",
-		},
-		{
-			in:   "flux error: object not found: source flux-system/foo artifact not found",
-			want: "source flux-system/foo artifact not found",
-		},
-		{
-			in:   "chart not found at /tmp/x: stat /tmp/x/Chart.yaml: no such file",
-			want: "chart not found at /tmp/x: stat /tmp/x/Chart.yaml: no such file",
-		},
-		{
-			in:   "flux error: unknown subcategory: keep me intact",
-			want: "unknown subcategory: keep me intact",
-		},
-	}
-	for _, tc := range cases {
-		if got := trimFluxPrefix(tc.in); got != tc.want {
-			t.Errorf("trimFluxPrefix(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
 // TestOrchestrator_TypedListener verifies Store.OnStatus delivers a
 // typed StatusInfo payload (no `any` type-switching needed by the
 // embedder).


### PR DESCRIPTION
## Summary
Iter-15 sr-eng audit secondary: \`trimFluxPrefix\` in \`pkg/orchestrator\` is error-string massaging based on a hardcoded whitelist of subcategory names (\`"input error"\`, \`"object not found"\`, etc.) — the exact names produced by the sentinel chain in \`pkg/manifest/errors.go\`. Two places to keep in sync when a new \`ErrFoo\` lands.

Move + rename to \`pkg/manifest.TrimSentinelPrefix\` so the whitelist stays in sync with the sentinel declarations in one file. The test moves with it. Orchestrator callers swap to the new name.

No behavior change.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)