### PR TITLE
fix(cli): apply --skip-secrets/--skip-crds/--skip-kinds to KS-sourced output

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/home-operations/flate/internal/format"
+	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 )
@@ -131,6 +132,17 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 		slices.SortStableFunc(docs, compareDocs)
 		if b.onlyCRDs {
 			docs = filterCRDsOnly(docs)
+			if len(docs) == 0 {
+				continue
+			}
+		} else {
+			// --skip-secrets / --skip-crds / --skip-kinds apply across
+			// every source. HelmRelease output was pre-filtered by
+			// helm.TemplateDocs (no-op here), but KS-rendered docs
+			// reach the store unfiltered (downstream KS / HR resolve
+			// valuesFrom / substituteFrom against them). This emit-time
+			// drop ensures the user sees consistent filtering. See #169.
+			docs = kustomize.DropKinds(docs, c.skipResourceKinds())
 			if len(docs) == 0 {
 				continue
 			}

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -46,6 +46,27 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 		"max parallel reconcile bodies (0 = unbounded)")
 }
 
+// skipResourceKinds returns the union of canonical kinds (CRDs +
+// Secrets when their corresponding boolean flags are set) and any
+// user-supplied `--skip-kinds` entries. Build / diff write paths
+// apply this against rendered docs from BOTH HelmRelease and
+// Kustomization sources — helm.TemplateDocs pre-filters HR output
+// inside the controller, but KS-rendered docs go through unfiltered
+// (the docs must reach the Store unfiltered so downstream HRs can
+// resolve valuesFrom / substituteFrom against them). The CLI applies
+// this union at emit time so the user sees consistent filtering
+// regardless of which controller produced the resource.
+func (c *commonFlags) skipResourceKinds() []string {
+	out := append([]string{}, c.skipKinds...)
+	if c.skipCRDs {
+		out = append(out, "CustomResourceDefinition")
+	}
+	if c.skipSecrets {
+		out = append(out, "Secret")
+	}
+	return out
+}
+
 // bindSelector wires the `-l/--selector` flag. Scoped to commands that
 // actually filter by labels — today, only `get`. Binding it on
 // commands that ignore it (build/diff/test) would silently accept

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/diff"
 	"github.com/home-operations/flate/pkg/image"
+	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/source"
@@ -176,6 +177,13 @@ func joinRunErrors(orig, curr error) error {
 // shows it for KS parents).
 func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
 	var out []diff.Doc
+	// Drop kinds the user opted out of (--skip-secrets / --skip-crds /
+	// --skip-kinds). KS-rendered docs reach Result.Manifests unfiltered;
+	// see comment in writeRendered. See #169.
+	var skip []string
+	if c != nil {
+		skip = c.skipResourceKinds()
+	}
 	for id, docs := range res.Manifests {
 		if id.Kind != kind {
 			continue
@@ -190,7 +198,7 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 		if ks, ok := o.Store().GetObject(id).(*manifest.Kustomization); ok {
 			parent.Path = strings.TrimPrefix(ks.Path, "./")
 		}
-		for _, m := range docs {
+		for _, m := range kustomize.DropKinds(docs, skip) {
 			out = append(out, diff.Doc{Manifest: m, Parent: parent})
 		}
 	}

--- a/pkg/kustomize/filter.go
+++ b/pkg/kustomize/filter.go
@@ -17,6 +17,23 @@ func FilterKinds(docs []map[string]any, keep []string) []map[string]any {
 	})
 }
 
+// DropKinds returns docs with every entry whose `kind` appears in drop
+// removed. drop=nil is a no-op (returns docs unchanged). The symmetric
+// counterpart of FilterKinds.
+//
+// Used by the CLI's build/diff paths to honor --skip-secrets /
+// --skip-crds / --skip-kinds against Kustomization-rendered output.
+// (HelmRelease output is already filtered inside helm.TemplateDocs
+// before reaching the store — see pkg/helm/template.go.)
+func DropKinds(docs []map[string]any, drop []string) []map[string]any {
+	if len(drop) == 0 {
+		return docs
+	}
+	return filter(docs, func(doc map[string]any) bool {
+		return !slices.Contains(drop, manifest.DocKind(doc))
+	})
+}
+
 
 // filter returns the elements of docs for which pred is true, without
 // mutating the input slice.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -323,6 +323,57 @@ func TestE2E_ParentPatchesPropagateToChildren(t *testing.T) {
 	}
 }
 
+// TestE2E_SkipKindsAppliesToKustomizationOutput is the regression
+// test for issue #169 — `--skip-secrets`, `--skip-crds`, and
+// `--skip-kinds` were silently ignored for Kustomization-rendered
+// docs. helm.TemplateDocs pre-filtered HR output but KS docs reached
+// stdout unfiltered.
+//
+// The fixture contains one Kustomization that emits a ConfigMap, a
+// Secret, and a CRD straight from kustomize (no HelmRelease). With
+// default flags (--skip-secrets=true, --skip-crds=true) only the
+// ConfigMap should reach stdout. Lifting the flags brings everything
+// back.
+func TestE2E_SkipKindsAppliesToKustomizationOutput(t *testing.T) {
+	src := testdataPath(t, "skip-kinds")
+	root := copyTree(t, src)
+
+	t.Run("DefaultsDropSecretsAndCRDs", func(t *testing.T) {
+		out := runCLIStdout(t, "build", "all", "--path", root, "-o", "yaml")
+		if !strings.Contains(out, "name: kept-cm") {
+			t.Errorf("ConfigMap should reach output: %s", out)
+		}
+		if strings.Contains(out, "name: dropped-secret") {
+			t.Errorf("--skip-secrets (default true) failed to drop KS-rendered Secret:\n%s", out)
+		}
+		if strings.Contains(out, "kind: CustomResourceDefinition") {
+			t.Errorf("--skip-crds (default true) failed to drop KS-rendered CRD:\n%s", out)
+		}
+	})
+
+	t.Run("ExplicitFlagsAllowEverything", func(t *testing.T) {
+		out := runCLIStdout(t, "build", "all", "--path", root, "-o", "yaml",
+			"--skip-secrets=false", "--skip-crds=false")
+		for _, want := range []string{"name: kept-cm", "name: dropped-secret", "kind: CustomResourceDefinition"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q with --skip-* disabled:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("SkipKindsListDropsArbitraryKinds", func(t *testing.T) {
+		out := runCLIStdout(t, "build", "all", "--path", root, "-o", "yaml",
+			"--skip-secrets=false", "--skip-crds=false",
+			"--skip-kinds=ConfigMap")
+		if strings.Contains(out, "name: kept-cm") {
+			t.Errorf("--skip-kinds=ConfigMap failed to drop KS-rendered ConfigMap:\n%s", out)
+		}
+		if !strings.Contains(out, "name: dropped-secret") {
+			t.Errorf("Secret should remain when only ConfigMap was skipped:\n%s", out)
+		}
+	})
+}
+
 // TestE2E_SOPSValueWipedToPlaceholder verifies the rendered output
 // actually contains the PLACEHOLDER token where a SOPS-encrypted value
 // would have lived. Without the wipe-to-placeholder behavior, this

--- a/testdata/skip-kinds/apps/configmap.yaml
+++ b/testdata/skip-kinds/apps/configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kept-cm
+  namespace: default
+data:
+  greeting: hello

--- a/testdata/skip-kinds/apps/crd.yaml
+++ b/testdata/skip-kinds/apps/crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.flate.test
+spec:
+  group: flate.test
+  names:
+    kind: Example
+    listKind: ExampleList
+    plural: examples
+    singular: example
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object

--- a/testdata/skip-kinds/apps/kustomization.yaml
+++ b/testdata/skip-kinds/apps/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - configmap.yaml
+  - secret.yaml
+  - crd.yaml

--- a/testdata/skip-kinds/apps/secret.yaml
+++ b/testdata/skip-kinds/apps/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dropped-secret
+  namespace: default
+type: Opaque
+stringData:
+  password: hunter2

--- a/testdata/skip-kinds/cluster/flux-system.yaml
+++ b/testdata/skip-kinds/cluster/flux-system.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system


### PR DESCRIPTION
## Summary
Fixes #169.

\`helm.TemplateDocs\` filtered HR output via \`opts.SkipResourceKinds()\` before returning, so HelmRelease docs reached the store pre-filtered. The Kustomization path (KS controller → \`kustomize.RenderFlux\` → \`manifest.SplitDocs\` → \`AddObject\` / \`AddRendered\`) stored every doc unfiltered — downstream KS / HR controllers rely on Secret + ConfigMap objects being in the store for \`valuesFrom\` / \`substituteFrom\` resolution, so the filter **can't** move into the KS controller without breaking those references.

**Filter at emit time** in the CLI instead. Two consumers of \`Result.Manifests\` need the drop:

- \`writeRendered\` — applies \`kustomize.DropKinds\` after sort, before emit. \`--only-crds\` stays intact (it sets \`skipCRDs=false\` via \`applyBuildFlags\` so they're mutually exclusive).
- \`gatherArtifacts\` (diff path) — applies \`DropKinds\` per id when feeding docs into \`diff.Doc\`.

**Implementation**:
- \`kustomize.DropKinds(docs, drop)\` is the symmetric counterpart of the existing \`FilterKinds\`. \`drop=nil\` is a no-op.
- \`commonFlags.skipResourceKinds()\` returns the canonical union (\`--skip-kinds\` + \`"CustomResourceDefinition"\` when skipCRDs + \`"Secret"\` when skipSecrets). Same shape as \`helm.Options.SkipResourceKinds()\`.

The double-filter on HR output is idempotent (helm.TemplateDocs already dropped the same kinds). No behavior change for HR; KS docs now honor the flags.

**New testdata/skip-kinds/** fixture: a Flux KS emitting a ConfigMap, a Secret, and a CRD from kustomize (no HelmRelease). Three e2e subtests cover defaults / flags-disabled / \`--skip-kinds=ConfigMap\`.

## Test plan
- [x] new \`TestE2E_SkipKindsAppliesToKustomizationOutput\` (3 subtests) passes
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] Manual verification: \`flate build all --path testdata/skip-kinds\` now emits only the ConfigMap (was emitting all three).

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)