### PR TITLE
refactor(helm): route HelmChartSource through SourceResolver

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -11,8 +11,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"maps"
-	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -38,8 +36,6 @@ type Controller struct {
 	// templates.
 	WipeSecrets bool
 
-	chartSourcesMu sync.RWMutex
-	chartSources   map[string]*manifest.HelmChartSource
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -53,11 +49,10 @@ type ReconcileOptions struct {
 // New constructs a HelmRelease controller.
 func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wipeSecrets bool) *Controller {
 	return &Controller{
-		Controller:   base.New(s, t),
-		Helm:         h,
-		Options:      opts,
-		WipeSecrets:  wipeSecrets,
-		chartSources: map[string]*manifest.HelmChartSource{},
+		Controller:  base.New(s, t),
+		Helm:        h,
+		Options:     opts,
+		WipeSecrets: wipeSecrets,
 	}
 }
 
@@ -81,31 +76,19 @@ func (c *Controller) Start(ctx context.Context) {
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	return func(id manifest.NamedResource, payload any) {
-		switch id.Kind {
-		case manifest.KindHelmChart:
-			// HelmChartSource is a flate-internal projection of a Flux
-			// HelmChart CR. Maintain an index so HR.ResolveChartRef can
-			// look up the producing source for a chartRef reference.
-			// Re-read from the Store to win the listener-ordering race
-			// (s.fire dispatches after s.mu releases).
-			_ = payload
-			if s, ok := c.Store.GetObject(id).(*manifest.HelmChartSource); ok {
-				c.chartSourcesMu.Lock()
-				c.chartSources[s.ResourceFullName()] = s
-				c.chartSourcesMu.Unlock()
-			}
-		case manifest.KindHelmRelease:
-			hr, ok := payload.(*manifest.HelmRelease)
-			if !ok {
-				return
-			}
-			if c.PreGate(id, hr.Suspend) {
-				return
-			}
-			c.Submit(ctx, id, func(ctx context.Context) {
-				base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
-			})
+		if id.Kind != manifest.KindHelmRelease {
+			return
 		}
+		hr, ok := payload.(*manifest.HelmRelease)
+		if !ok {
+			return
+		}
+		if c.PreGate(id, hr.Suspend) {
+			return
+		}
+		c.Submit(ctx, id, func(ctx context.Context) {
+			base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
+		})
 	}
 }
 
@@ -141,7 +124,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// the same pre-render dance an embedder calling TemplateDocs
 	// directly performs. Keeping one canonical implementation here
 	// means changes to the contract only land in one place.
-	hr, err := helm.Prepare(hr, c.gatherHelmChartSources(), values.NewStoreProvider(c.Store))
+	hr, err := helm.Prepare(hr, c.Helm.Resolver().HelmChart, values.NewStoreProvider(c.Store))
 	if err != nil {
 		return err
 	}
@@ -206,14 +189,3 @@ func (c *Controller) collectHRDeps(hr *manifest.HelmRelease) []manifest.Dependen
 	return append([]manifest.DependencyRef(nil), hr.DependsOn...)
 }
 
-// gatherHelmChartSources returns a snapshot of the HelmChart lookup
-// map. The cache is maintained incrementally by onObjectAdded — every
-// HelmChart added to the store (initial parse phase or later, e.g. via
-// a Kustomization render) flows through the same listener.
-func (c *Controller) gatherHelmChartSources() map[string]*manifest.HelmChartSource {
-	c.chartSourcesMu.RLock()
-	defer c.chartSourcesMu.RUnlock()
-	out := make(map[string]*manifest.HelmChartSource, len(c.chartSources))
-	maps.Copy(out, c.chartSources)
-	return out
-}

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -23,6 +23,10 @@ func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store
 	if err != nil {
 		t.Fatalf("helm.NewClient: %v", err)
 	}
+	// Mirror the orchestrator's production wiring: the HR controller
+	// resolves source CRs (HelmRepository, OCIRepository, HelmChart)
+	// through the Store via the helm client's SourceResolver.
+	hc.SetSourceResolver(helm.NewStoreSourceResolver(st))
 	c := New(st, ts, hc, helm.Options{}, false)
 	c.Configure(ReconcileOptions{Filter: filter})
 	c.Start(context.Background())
@@ -78,7 +82,13 @@ func TestController_FilterUnchangedShortCircuitsToReady(t *testing.T) {
 	}
 }
 
-func TestController_HelmChartSourceIndexed(t *testing.T) {
+// TestController_HelmChartSourceResolvedViaResolver locks the iter-16
+// contract: the HR controller no longer maintains a chartSources
+// push-registry; HelmChartSource lookups go through
+// helm.Client.Resolver().HelmChart against the canonical Store. After
+// AddObject lands a HelmChartSource the resolver MUST surface it
+// immediately — that's what helm.Prepare relies on at reconcile time.
+func TestController_HelmChartSourceResolvedViaResolver(t *testing.T) {
 	c, st := newTestController(t, nil)
 	src := &manifest.HelmChartSource{
 		Name: "podinfo", Namespace: "flux-system",
@@ -90,19 +100,17 @@ func TestController_HelmChartSourceIndexed(t *testing.T) {
 	}
 	st.AddObject(src)
 
-	// Listener handles AddObject synchronously from the store mu wake;
-	// give the dispatch a tick.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		c.chartSourcesMu.RLock()
-		_, ok := c.chartSources[src.ResourceFullName()]
-		c.chartSourcesMu.RUnlock()
-		if ok {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	resolver := c.Helm.Resolver()
+	if resolver == nil {
+		t.Fatal("HelmClient has no resolver wired")
 	}
-	t.Fatal("HelmChartSource was not indexed in chartSources map")
+	got := resolver.HelmChart(src.Namespace, src.Name)
+	if got == nil {
+		t.Fatalf("resolver.HelmChart(%q, %q) returned nil; expected the just-added source", src.Namespace, src.Name)
+	}
+	if got.Chart != "podinfo" {
+		t.Errorf("resolver returned wrong source: %+v", got)
+	}
 }
 
 func TestController_CollectHRDepsClone(t *testing.T) {

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -98,6 +98,16 @@ func (c *Client) SetSourceResolver(r SourceResolver) {
 	c.resolver = r
 }
 
+// Resolver returns the configured SourceResolver, or nil when none
+// has been wired. Exposed so the HelmRelease controller (and embedders
+// calling Prepare) can pass resolver.HelmChart into ResolveChartRef
+// without holding a separate reference to the resolver.
+func (c *Client) Resolver() SourceResolver {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.resolver
+}
+
 func (c *Client) resolveHelmRepo(hr *manifest.HelmRelease) *manifest.HelmRepository {
 	c.mu.RLock()
 	resolver := c.resolver

--- a/pkg/helm/prepare.go
+++ b/pkg/helm/prepare.go
@@ -10,10 +10,11 @@ import (
 //
 //  1. Clone hr so subsequent mutations don't touch the store-canonical
 //     copy (the immutability contract every flate controller honors).
-//  2. Resolve hr.spec.chartRef against the supplied HelmChartSource
-//     index. A chartRef points at a Flux HelmChart CR — typically
-//     emitted by a parent Kustomization render — and is rewritten
-//     into the concrete hr.Chart projection.
+//  2. Resolve hr.spec.chartRef via the supplied lookup. A chartRef
+//     points at a Flux HelmChart CR — typically emitted by a parent
+//     Kustomization render — and is rewritten into the concrete
+//     hr.Chart projection. Pass SourceResolver.HelmChart when an
+//     orchestrator is available, or a custom lookup otherwise.
 //  3. Expand values / valuesFrom against the supplied provider so
 //     hr.Values reflects the merged result a render would consume.
 //
@@ -21,9 +22,9 @@ import (
 // orchestrator's HR controller call Prepare then TemplateDocs. The
 // returned *HelmRelease is the cloned, resolved one — pass it to
 // Template / TemplateDocs and discard once rendered.
-func Prepare(hr *manifest.HelmRelease, charts map[string]*manifest.HelmChartSource, provider values.Provider) (*manifest.HelmRelease, error) {
+func Prepare(hr *manifest.HelmRelease, lookup manifest.HelmChartLookup, provider values.Provider) (*manifest.HelmRelease, error) {
 	hr = hr.Clone()
-	if err := hr.ResolveChartRef(charts); err != nil {
+	if err := hr.ResolveChartRef(lookup); err != nil {
 		return nil, err
 	}
 	if err := values.ExpandValueReferences(hr, provider); err != nil {

--- a/pkg/helm/resolver.go
+++ b/pkg/helm/resolver.go
@@ -28,6 +28,10 @@ type SourceResolver interface {
 	// live at <artifact.LocalPath>/<hr.Chart.Name> for any of those
 	// three sourceRef.kind values.
 	LocalSourceArtifact(kind, namespace, name string) *store.SourceArtifact
+	// HelmChart returns the HelmChartSource at the given (ns, name) or
+	// nil. Used by HelmRelease.ResolveChartRef to materialize a
+	// spec.chartRef into a concrete chart reference.
+	HelmChart(namespace, name string) *manifest.HelmChartSource
 }
 
 // NewStoreSourceResolver returns a SourceResolver backed by the
@@ -55,4 +59,9 @@ func (r *storeResolver) LocalSourceArtifact(kind, namespace, name string) *store
 	id := manifest.NamedResource{Kind: kind, Namespace: namespace, Name: name}
 	art, _ := r.store.GetArtifact(id).(*store.SourceArtifact)
 	return art
+}
+
+func (r *storeResolver) HelmChart(namespace, name string) *manifest.HelmChartSource {
+	obj, _ := r.store.GetByName(manifest.KindHelmChart, namespace, name).(*manifest.HelmChartSource)
+	return obj
 }

--- a/pkg/manifest/helm.go
+++ b/pkg/manifest/helm.go
@@ -280,11 +280,17 @@ func (h *HelmRelease) ReleaseNamespace() string {
 // NamespacedName is "<namespace>/<name>".
 func (h *HelmRelease) NamespacedName() string { return h.Namespace + "/" + h.Name }
 
+// HelmChartLookup returns the HelmChartSource at (namespace, name) or
+// nil when not present. The shape ResolveChartRef accepts so callers
+// can pass either a SourceResolver method (orchestrator path) or a
+// custom lookup (embedders with their own source registry).
+type HelmChartLookup func(namespace, name string) *HelmChartSource
+
 // ResolveChartRef replaces a chartRef placeholder with the resolved
-// source. helmCharts is keyed by ResourceFullName. When the chartRef
-// resolves to a HelmChart CRD, its spec.valuesFiles +
-// spec.ignoreMissingValuesFiles propagate onto the HelmRelease so the
-// rendering pipeline can merge them ahead of HR.Values.
+// source. When the chartRef resolves to a HelmChart CRD, its
+// spec.valuesFiles + spec.ignoreMissingValuesFiles propagate onto the
+// HelmRelease so the rendering pipeline can merge them ahead of
+// HR.Values.
 //
 // The chart rewrite is unconditional once we find the source — even
 // when the HelmChart CRD has no spec.version, we need RepoKind to flip
@@ -292,12 +298,12 @@ func (h *HelmRelease) NamespacedName() string { return h.Namespace + "/" + h.Nam
 // OCIRepository / GitRepository) so downstream chart loading can
 // dispatch. Without it, LocateChart would see RepoKind=HelmChart and
 // fall through with an "unsupported chart repo kind" error.
-func (h *HelmRelease) ResolveChartRef(helmCharts map[string]*HelmChartSource) error {
+func (h *HelmRelease) ResolveChartRef(lookup HelmChartLookup) error {
 	if h.Chart.RepoKind != KindHelmChart || h.Chart.Version != "" {
 		return nil
 	}
-	src, ok := helmCharts[h.Chart.RepoFullName()]
-	if !ok {
+	src := lookup(h.Chart.RepoNamespace, h.Chart.RepoName)
+	if src == nil {
 		return fmt.Errorf("%w: HelmChartSource %s not found for HelmRelease %s",
 			ErrObjectNotFound, h.Chart.RepoFullName(), h.NamespacedName())
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -744,7 +744,13 @@ spec:
 			},
 		},
 	}
-	if err := hr.ResolveChartRef(map[string]*HelmChartSource{src.ResourceFullName(): src}); err != nil {
+	lookup := func(namespace, name string) *HelmChartSource {
+		if namespace == src.Namespace && name == src.Name {
+			return src
+		}
+		return nil
+	}
+	if err := hr.ResolveChartRef(lookup); err != nil {
 		t.Fatalf("ResolveChartRef: %v", err)
 	}
 	if hr.Chart.Version != "6.3.2" || hr.Chart.Name != "podinfo" {
@@ -752,7 +758,8 @@ spec:
 	}
 
 	missing := &HelmRelease{Chart: HelmChart{RepoKind: KindHelmChart, RepoName: "absent", RepoNamespace: "ns"}}
-	if err := missing.ResolveChartRef(map[string]*HelmChartSource{}); !errors.Is(err, ErrObjectNotFound) {
+	none := func(_, _ string) *HelmChartSource { return nil }
+	if err := missing.ResolveChartRef(none); !errors.Is(err, ErrObjectNotFound) {
 		t.Errorf("expected ErrObjectNotFound, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
**Iter-12 PR #155 cleanup completion.** That iteration removed three push-registries on \`helm.Client\` (HelmRepository, OCIRepository, LocalSourceArtifact) in favor of the \`SourceResolver\` pulling from the canonical Store. **HelmChartSource was missed** — the HR controller kept a parallel \`chartSources\` map guarded by its own RWMutex, populated via a KindHelmChart listener that re-read from Store to win an event-ordering race (the band-aid comment "Re-read from the Store to win the listener-ordering race" was already conceding the issue).

**Fix** mirrors the iter-12 sweep:
- \`helm.SourceResolver\` grows \`HelmChart(ns, name) *HelmChartSource\`. \`storeResolver\` implements it via \`Store.GetByName\`.
- \`helm.Client.Resolver()\` exposes the configured resolver.
- \`manifest.HelmChartLookup func(ns, name string) *HelmChartSource\` replaces the map-keyed \`ResolveChartRef\` argument. \`SourceResolver.HelmChart\` satisfies it directly.
- \`helm.Prepare\` signature: \`(hr, lookup, provider)\` instead of \`(hr, charts, provider)\`.

**Deleted from the HR controller**: \`chartSources\` field, \`chartSourcesMu\` RWMutex, the KindHelmChart listener arm, \`gatherHelmChartSources()\`, \`sync\` + \`maps\` imports. Net **−30 LOC**, one race window gone, \`helm.Client\` is now the single source of truth for all four source-CR kinds.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] TestController_HelmChartSourceResolvedViaResolver covers the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)