### PR TITLE
fix(testrunner,orchestrator): apply TrimSentinelPrefix at user-facing boundaries

### DIFF
--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -117,12 +117,17 @@ func classify(s *store.Store, id manifest.NamedResource) Case {
 	case !ok:
 		return Case{ID: id, Outcome: OutcomeFailed, Reason: "no status reported"}
 	case info.Status == store.StatusFailed:
-		return Case{ID: id, Outcome: OutcomeFailed, Reason: info.Message}
+		// Strip the `flux error: input error:` sentinel chain so the
+		// `flate test` table shows the actual cause rather than two
+		// layers of bureaucracy. Same treatment the orchestrator gives
+		// its aggregated error.
+		return Case{ID: id, Outcome: OutcomeFailed, Reason: manifest.TrimSentinelPrefix(info.Message)}
 	case info.Status == store.StatusReady && info.Message == "unchanged":
 		return Case{ID: id, Outcome: OutcomeSkipped, Reason: "unchanged"}
 	case info.Status == store.StatusReady:
 		return Case{ID: id, Outcome: OutcomePassed}
 	default:
-		return Case{ID: id, Outcome: OutcomeFailed, Reason: "still " + string(info.Status) + ": " + info.Message}
+		return Case{ID: id, Outcome: OutcomeFailed,
+			Reason: "still " + string(info.Status) + ": " + manifest.TrimSentinelPrefix(info.Message)}
 	}
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -529,6 +529,12 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 		}
 	}
 	for id, info := range o.store.FailedResources() {
+		// Strip the `flux error: <subcategory>:` sentinel chain from the
+		// rendered message so embedders get the actual cause first.
+		// The Status field and the Store entry stay untouched — only
+		// the user-visible string is reshaped, matching the treatment
+		// the aggregated Run error and the WARN log already give.
+		info.Message = manifest.TrimSentinelPrefix(info.Message)
 		res.Failed[id] = info
 	}
 	maps.Copy(res.Orphans, o.orphans)


### PR DESCRIPTION
## Summary
Iter-15 PR #181 moved \`trimFluxPrefix\` from orchestrator into \`manifest.TrimSentinelPrefix\` so the sentinel whitelist stayed next to the sentinels. But the helper was only invoked at two sites inside \`orchestrator.go\`: the per-resource WARN line and the aggregated \`Run\` error. Two other user-visible boundaries still emitted raw \`flux error: input error:\` chains:

1. **\`Orchestrator.Render\`** populated \`Result.Failed[id].Message\` verbatim from \`Store.FailedResources()\`. SDK embedders iterating \`Result.Failed\` saw the noisy chain that the CLI's aggregated error had already trimmed.
2. **\`internal/testrunner/runner.go\`** \`classify()\` built \`Case.Reason\` directly from \`info.Message\`, so \`flate test\` printed the raw chain in its pytest-style output even though \`flate build\` stripped it.

Apply \`TrimSentinelPrefix\` at both sites. \`Status\` field and Store entry remain untouched; only the user-visible rendered text is reshaped.

**Repro pre-fix:**
\`\`\`
flate test all --path <repo-with-broken-spec.path>
→ FAILED (flux error: input error: kustomization path does not exist: ...)
\`\`\`
**Post-fix:**
\`\`\`
→ FAILED (kustomization path does not exist: ...)
\`\`\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] Manual: `flate test` output verified — no more `flux error:` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)