### PR TITLE
fix(cli): gate helm-only flags off KS-only subcommands

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -78,7 +78,9 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	bindHelmFlags(cmd.Flags(), h)
+	if rendersHelm(kinds) {
+		bindHelmFlags(cmd.Flags(), h)
+	}
 	bindBuildFlags(cmd.Flags(), b)
 	return cmd
 }

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -121,6 +121,22 @@ type helmFlags struct {
 	skipSchemaValidation bool
 }
 
+// rendersHelm reports whether the supplied kinds slice contains
+// KindHelmRelease, used to gate bindHelmFlags off of subcommands
+// (`build ks`, `diff ks`, `test ks`) that only render Kustomizations.
+// Without this gate the helm-template flags were silently accepted
+// on KS-only subcommands and no-op'd — confusing to users who set
+// e.g. `--show-only templates/foo.yaml` on `flate build ks` and
+// wondered why nothing changed.
+func rendersHelm(kinds []string) bool {
+	for _, k := range kinds {
+		if k == "HelmRelease" {
+			return true
+		}
+	}
+	return false
+}
+
 func bindHelmFlags(fs *pflag.FlagSet, h *helmFlags) {
 	// Default to the Kubernetes minor version bundled with the k8s.io/api
 	// dependency. Charts gated on KubeVersion (e.g. >=1.33 for ImageVolume)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -58,7 +58,9 @@ func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	bindHelmFlags(cmd.Flags(), h)
+	if rendersHelm([]string{kind}) {
+		bindHelmFlags(cmd.Flags(), h)
+	}
 	bindDiffFlags(cmd, d)
 	return cmd
 }

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -58,6 +58,8 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	bindHelmFlags(cmd.Flags(), h)
+	if rendersHelm(kinds) {
+		bindHelmFlags(cmd.Flags(), h)
+	}
 	return cmd
 }


### PR DESCRIPTION
## Summary
Iter-16 CLI/controller symmetry audit caught a confusing flag-binding asymmetry: \`--show-only\`, \`--kube-version\`, \`--api-versions\`, \`--no-hooks\`, \`--enable-dns\`, \`--is-upgrade\`, \`--skip-schema-validation\` were silently accepted on \`flate build ks\`, \`flate diff ks\`, and \`flate test ks\` — but none of them apply to Kustomization rendering. A user setting \`--show-only templates/foo.yaml\` on \`build ks\` got no feedback that the flag had no effect.

**Fix**: add a tiny \`rendersHelm(kinds []string)\` helper. \`buildCmd\` / \`diffCmd\` / \`testCmd\` skip \`bindHelmFlags\` when it returns false. The mixed subcommands (\`*hr\`, \`*all\`, and all \`get\` variants which transitively run the HR controller) keep binding them.

**Verified**:
\`\`\`
$ flate build ks --help       # no helm flags shown
$ flate build hr --help       # helm flags listed
$ flate build all --help      # helm flags listed
$ flate build ks --show-only X
flate error: unknown flag: --show-only
\`\`\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)