### PR TITLE
refactor(orchestrator,kustomization): extract finalize + emitRenderedChildren

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -204,45 +204,58 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
-	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
-	// Two-pass emission. Pass 1 lands "data" kinds (ConfigMap, Secret,
-	// sources) into the store so child Kustomization / HelmRelease
-	// reconciles in pass 2 see a complete store — substituteFrom and
-	// chart-source lookups would race otherwise, since AddObject for a
-	// reconcilable kind fires its controller on a separate goroutine
-	// immediately. Within each pass the controller renders the docs in
-	// kustomize's emission order; passes themselves are ordered so the
-	// data backing a reconcile always arrives first.
+	c.emitRenderedChildren(id, docs)
+
+	c.Store.SetArtifact(id, &store.KustomizationArtifact{
+		Path:      filepath.Join(sourceRoot, ks.Path),
+		Manifests: docs,
+	})
+	return nil
+}
+
+// emitRenderedChildren parses the rendered docs and lands them in the
+// store using a two-pass emission strategy:
+//
+//   - Pass 1 — non-leaf "data" kinds (ConfigMap, Secret, sources, etc.)
+//     go into the store first. Sources go through AddObject because
+//     they have their own status to track; ConfigMap/Secret have no
+//     controller so AddObject's event dispatch is a no-op for them.
+//     Either way they're in the store before pass 2 fires.
+//
+//   - Pass 2 — leaf reconcilables (Kustomization, HelmRelease). Their
+//     substituteFrom / chartRef lookups now see the data from pass 1.
+//
+// Without the two passes, AddObject for a reconcilable kind fires its
+// controller on a separate goroutine immediately, racing the parent's
+// "data first" emission. Within each pass the controller renders docs
+// in kustomize's emission order; passes themselves are ordered so the
+// data backing a reconcile always arrives first.
+//
+// Parse errors on inline resources are debug-logged and skipped — they
+// may be raw Kubernetes manifests flate doesn't track. SOPS-encrypted
+// secrets are debug-noted; ParseSecret wipes their values to the
+// PLACEHOLDER token the same way --wipe-secrets does for cleartext.
+func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[string]any) {
 	type parsed struct {
 		obj          manifest.BaseManifest
 		reconcilable bool
 	}
+	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
 	objs := make([]parsed, 0, len(docs))
 	for _, doc := range docs {
 		if manifest.IsEncryptedSecret(doc) {
-			// flate can't decrypt SOPS offline. ParseSecret will wipe
-			// the encrypted values to PLACEHOLDER below — same as it
-			// does for cleartext Secret data when --wipe-secrets is on
-			// — so downstream substituteFrom lookups succeed with a
-			// clearly-marked placeholder rather than failing.
 			name, ns := manifest.DocMetadata(doc)
 			slog.Debug("kustomization: SOPS-encrypted resource wiped to placeholder",
 				"id", id.String(), "ref", manifest.DocKind(doc)+" "+ns+"/"+name)
 		}
 		obj, err := manifest.ParseDoc(doc, opts)
 		if err != nil {
-			// Don't fail on parse errors of inline resources — they may
-			// be raw kubernetes manifests flate doesn't track. Log and
-			// continue.
 			slog.Debug("kustomization: skipped doc", "id", id.String(), "err", err)
 			continue
 		}
 		objs = append(objs, parsed{obj: obj, reconcilable: shouldDispatchAsObject(obj)})
 	}
-	// Pass 1 — data first. Sources go through AddObject because they
-	// have their own status to track; ConfigMap/Secret have no
-	// controller, so AddObject's event dispatch is a no-op for them.
-	// Either way they're in the store before pass 2 fires.
+	// Pass 1 — data first.
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			continue
@@ -254,20 +267,13 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 			c.Store.AddRendered(p.obj)
 		}
 	}
-	// Pass 2 — leaf reconcilables (Kustomization, HelmRelease). Their
-	// substituteFrom / chartRef lookups now see the data from pass 1.
+	// Pass 2 — leaf reconcilables.
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			c.Store.AddObject(p.obj)
 			c.markRendered(p.obj.Named())
 		}
 	}
-
-	c.Store.SetArtifact(id, &store.KustomizationArtifact{
-		Path:      filepath.Join(sourceRoot, ks.Path),
-		Manifests: docs,
-	})
-	return nil
 }
 
 // substituteDoc marshals a single manifest doc, runs envsubst over it,

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -397,7 +397,9 @@ func (o *Orchestrator) attachFilter(f *change.Filter) {
 }
 
 // Run starts every controller, blocks until the task service drains,
-// then aggregates and returns any failures.
+// then aggregates and returns any failures. The post-drain reporting
+// + error-string assembly lives in finalize so Run reads as a clean
+// start → drain → finalize sequence.
 func (o *Orchestrator) Run(ctx context.Context) error {
 	o.src.Configure(sourcectrl.FetchOptions{Filter: o.filter})
 	o.ksc.Configure(kustomization.Options{
@@ -412,15 +414,41 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	defer o.Stop()
 
 	o.tasks.BlockTillDone()
+	return o.finalize()
+}
 
+// finalize is the post-BlockTillDone reporting phase: demote orphans
+// from Failed → Ready, log per-resource warnings, and assemble the
+// aggregated error string. Pulled out of Run so the lifecycle entry
+// point reads as start → drain → finalize.
+func (o *Orchestrator) finalize() error {
 	failed := o.store.FailedResources()
-	// Filter out orphans: Kustomizations / HelmReleases whose source
-	// files sit under another Kustomization's spec.path but were never
-	// emitted by that parent's render. Real Flux would not reconcile
-	// them either — the file walker only loaded them because flate
-	// scans the whole tree. Surface as warnings instead of failures so
-	// the test isn't gated on stale on-disk files the user has not
-	// wired into their kustomize tree.
+	o.demoteOrphans(failed)
+	o.logSummary(failed)
+	o.logResourceFailures(failed)
+
+	if len(failed) == 0 {
+		// Controllers attribute panics by marking the resource StatusFailed
+		// (see kustomization/helmrelease/source controllers). This catches
+		// any panic that escaped attribution — e.g. inside a future task
+		// dispatched outside the per-resource recover.
+		if n := o.tasks.Failures(); n > 0 {
+			return fmt.Errorf("%d task(s) panicked without per-resource attribution; check logs", n)
+		}
+		return nil
+	}
+	return o.aggregateFailures(failed)
+}
+
+// demoteOrphans filters out resources whose source files sit under
+// another Kustomization's spec.path but were never emitted by that
+// parent's render. Real Flux wouldn't reconcile them either — the
+// file walker only loaded them because flate scans the whole tree.
+// Surface as warnings instead of failures so the test isn't gated on
+// stale on-disk files the user has not wired into their kustomize
+// tree. Mutates the failed map in place; the demoted ids land in
+// o.orphans for Render() to surface.
+func (o *Orchestrator) demoteOrphans(failed map[manifest.NamedResource]store.StatusInfo) {
 	o.orphans = map[manifest.NamedResource]string{}
 	for id := range o.detectOrphans(failed) {
 		info := failed[id]
@@ -431,6 +459,9 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			"reason", info.Message)
 		delete(failed, id)
 	}
+}
+
+func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.StatusInfo) {
 	ksCount := len(o.store.ListObjects(manifest.KindKustomization))
 	hrCount := len(o.store.ListObjects(manifest.KindHelmRelease))
 	slog.Info("reconcile complete",
@@ -443,7 +474,9 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	if ksCount == 0 && hrCount == 0 {
 		slog.Warn("no Flux Kustomization or HelmRelease objects found under --path; check the path is correct")
 	}
+}
 
+func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]store.StatusInfo) {
 	for id, info := range failed {
 		// Include the originating source file when known so the user can
 		// jump straight to the offending YAML — `flux error: input error:`
@@ -455,23 +488,15 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		}
 		slog.Warn("resource failed", args...)
 	}
+}
 
-	if len(failed) == 0 {
-		// Controllers attribute panics by marking the resource StatusFailed
-		// (see kustomization/helmrelease/source controllers). This catches
-		// any panic that escaped attribution — e.g. inside a future task
-		// dispatched outside the per-resource recover.
-		if n := o.tasks.Failures(); n > 0 {
-			return fmt.Errorf("%d task(s) panicked without per-resource attribution; check logs", n)
-		}
-		return nil
-	}
+func (o *Orchestrator) aggregateFailures(failed map[manifest.NamedResource]store.StatusInfo) error {
 	msgs := make([]string, 0, len(failed))
 	for id, info := range failed {
 		// Strip the `flux error: …: ` chain from user-facing messages —
 		// it's three layers of noise before the actual cause. The
 		// sentinels are still wired up for errors.Is callers (e.g.
-		// embedders branching on ErrObjectNotFound), this only affects
+		// embedders branching on ErrObjectNotFound); this only affects
 		// the formatted text the CLI ultimately prints.
 		msg := manifest.TrimSentinelPrefix(info.Message)
 		if f := o.sourceFiles[id]; f != "" {


### PR DESCRIPTION
## Summary
Two readability extractions from iter-16's senior-eng secondary list.

1. **\`Orchestrator.Run\`** was 86 LOC mixing controller dispatch with the post-BlockTillDone reporting half. Split into:
   - \`finalize()\` — top-level coordinator
   - \`demoteOrphans(failed)\` — orphan filtering + status update
   - \`logSummary(failed)\` — reconcile-complete INFO + empty-tree WARN
   - \`logResourceFailures()\` — per-resource WARN with source file
   - \`aggregateFailures()\` — deterministic-sorted error string

   Run now reads as **start → drain → finalize**.

2. **KS \`Controller.reconcile\`** was 150 LOC with a self-contained ~50-LOC two-pass emission block. Pulled into \`emitRenderedChildren(id, docs)\` carrying the full doc-comment about why the two passes matter (AddObject for a reconcilable kind fires its controller on another goroutine; data kinds must land first so downstream substituteFrom/chartRef lookups don't race).

No behavior change; outputs byte-identical to the prior monoliths.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 30 packages pass
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)