### PR TITLE
fix(helm): use @ separator for OCIRepository digest refs

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -294,6 +294,23 @@ func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (
 	return c.fetchOCIChart(ctx, r.URL, ver)
 }
 
+// ociPullRef joins an OCI repo URL and an optional ref into the form
+// the helm registry client expects. A digest ref (`sha256:<hex>` and
+// friends) joins with `@`; a tag joins with `:`. Per OCI tag spec a
+// tag can never contain `:`, so its presence in `version` is an
+// unambiguous digest signal — without this branch, the helm client
+// rejects `repo:sha256:<hex>` as an invalid tag.
+func ociPullRef(ref, version string) string {
+	if version == "" {
+		return ref
+	}
+	sep := ":"
+	if strings.Contains(version, ":") {
+		sep = "@"
+	}
+	return ref + sep + version
+}
+
 // fetchOCIChart pulls an OCI chart via the helm registry client.
 func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string, error) {
 	if c.registry == nil {
@@ -311,10 +328,7 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 		return target, nil
 	}
 
-	pullRef := ref
-	if version != "" {
-		pullRef = ref + ":" + version
-	}
+	pullRef := ociPullRef(ref, version)
 	_ = ctx // reserved for future per-pull cancellation when helm supports it
 	result, err := c.registry.Pull(pullRef)
 	if err != nil {

--- a/pkg/helm/repo_test.go
+++ b/pkg/helm/repo_test.go
@@ -1,0 +1,25 @@
+package helm
+
+import "testing"
+
+func TestOCIPullRef(t *testing.T) {
+	const repo = "oci://ghcr.io/bjw-s-labs/helm/app-template"
+	for _, tc := range []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{"empty version", "", repo},
+		{"semver tag", "1.2.3", repo + ":1.2.3"},
+		{"named tag", "latest", repo + ":latest"},
+		{"sha256 digest", "sha256:70a7cb6766eb468068c2c1700c8450253070dc671a9fbbd1a6346a66545e2b2b",
+			repo + "@sha256:70a7cb6766eb468068c2c1700c8450253070dc671a9fbbd1a6346a66545e2b2b"},
+		{"sha512 digest", "sha512:deadbeef", repo + "@sha512:deadbeef"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ociPullRef(repo, tc.version); got != tc.want {
+				t.Errorf("ociPullRef(%q, %q) = %q, want %q", repo, tc.version, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Detect digest refs (`sha256:<hex>`, `sha512:<hex>`, …) when building the helm OCI pull URL and join with `@` instead of `:`. OCI tag spec forbids `:` in tags, so its presence in `version` is an unambiguous digest signal.
- Extract the join into a pure `ociPullRef` helper plus a table-driven unit test covering empty version, tags, and digests.

## Bug

Given an OCIRepository pinned to `spec.ref.digest: sha256:70a7…`, flate built `oci://ghcr.io/owner/chart:sha256:70a7…` which the helm registry client rejects (`invalid tag "sha256:70a7…"`). The correct form is `…/chart@sha256:70a7…`.

Fixes #165

## Test plan

- [x] `go test ./pkg/helm/... ./pkg/source/oci/...`
- [x] `golangci-lint run ./pkg/helm/...`
- [ ] Reproduce the issue's fixture (OCIRepository with `spec.ref.digest` + HelmRelease via `chartRef`) and confirm `flate test hr` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)