### PR TITLE
feat(orchestrator): --allow-missing-secrets for ExternalSecret-shaped repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,15 @@ flate diff ks --path ./kubernetes --path-orig ../baseline/kubernetes
 | `Bucket` | `generic` only | `accesskey` + `secretkey`. `aws`/`gcp`/`azure` fail loud — use static creds. |
 | `ExternalArtifact` | `file://` only | `status.artifact.url` must be a local path. |
 
-PLACEHOLDER-wiped values (the always-on `--skip-secrets` behavior) are treated as missing — auth fails with a clear "missing username/password" instead of attempting auth with the placeholder string.
+PLACEHOLDER-wiped values (the always-on wipe of cleartext Secret data) are treated as missing — auth fails with a clear "missing username/password" instead of attempting auth with the placeholder string. Pass `--allow-missing-secrets` to convert these failures (and Secrets absent from the tree entirely) into a SKIPPED outcome; downstream Kustomizations and HelmReleases propagate the skip. Verify, cert, and proxy `secretRef`s are out of scope — they still fail loud, since silently dropping verification or TLS material is a security downgrade.
 
 ## Behaviors
 
 **SOPS** — `spec.decryption` is not implemented. Encrypted Secret values get wiped to `..PLACEHOLDER_<key>..`, same as cleartext values under the always-on wipe. Downstream `postBuild.substituteFrom` lookups resolve to the placeholder string rather than failing.
 
 **`spec.suspend`** — honored on every reconcilable CR. Suspended resources mark `Ready / "suspended"` and produce no rendered output.
+
+**`--allow-missing-secrets`** — off by default. When set, a source whose auth `secretRef` is missing or PLACEHOLDER-wiped marks `Ready / "skipped: …"` instead of `Failed`, and consumers (KS `sourceRef`, HR `chartRef`) propagate the skip so `flate test` reports SKIPPED rather than a cascade of FAILED. Intended for repos that materialize auth on the live cluster via ExternalSecret / SealedSecret. Typos in `secretRef.name` are rejected at parse time so they don't silently fall into this path.
 
 **`spec.dependsOn[].readyExpr` (CEL)** — evaluated against `self` and `dep` projections, matching upstream kustomize- and helm-controller binding:
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -17,17 +17,18 @@ import (
 )
 
 type commonFlags struct {
-	path           string
-	pathOrig       string
-	namespace      string
-	labels         map[string]string
-	skipCRDs       bool
-	skipSecrets    bool
-	skipKinds      []string
-	output         string
-	enableOCI      bool
-	registryConfig string
-	concurrency    int
+	path               string
+	pathOrig           string
+	namespace          string
+	labels             map[string]string
+	skipCRDs           bool
+	skipSecrets        bool
+	allowMissingSecrets bool
+	skipKinds          []string
+	output             string
+	enableOCI          bool
+	registryConfig     string
+	concurrency        int
 }
 
 func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
@@ -38,6 +39,10 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 		"limit to this namespace (default: every namespace, or just the changed ones when --path-orig is set)")
 	fs.BoolVar(&f.skipCRDs, "skip-crds", true, "exclude CRD objects from rendered output")
 	fs.BoolVar(&f.skipSecrets, "skip-secrets", true, "exclude Secret objects from rendered output")
+	fs.BoolVar(&f.allowMissingSecrets, "allow-missing-secrets", false,
+		"soft-skip sources whose auth Secret is missing or has PLACEHOLDER-wiped values "+
+			"(typical when the live cluster materializes auth via ExternalSecret); dependent "+
+			"Kustomizations/HelmReleases propagate the skip. Verify/cert/proxy secretRefs still fail loud.")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")
 	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, yaml, json, name")
 	fs.BoolVar(&f.enableOCI, "enable-oci", true, "reconcile OCIRepository objects")
@@ -171,13 +176,14 @@ func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 
 func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	return orchestrator.Config{
-		Path:           c.path,
-		PathOrig:       c.pathOrig,
-		HelmOptions:    c.helmOptions(h),
-		WipeSecrets:    true,
-		EnableOCI:      c.enableOCI,
-		RegistryConfig: c.registryConfig,
-		Concurrency:    c.concurrency,
+		Path:               c.path,
+		PathOrig:           c.pathOrig,
+		HelmOptions:        c.helmOptions(h),
+		WipeSecrets:        true,
+		EnableOCI:          c.enableOCI,
+		RegistryConfig:     c.registryConfig,
+		Concurrency:        c.concurrency,
+		AllowMissingSecrets: c.allowMissingSecrets,
 	}
 }
 

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -22,8 +22,15 @@ func newTestCmd() *cobra.Command {
 			"Validate HelmReleases", cobra.MaximumNArgs(1),
 			manifest.KindHelmRelease),
 		testCmd("all", nil,
-			"Validate every Kustomization and HelmRelease", cobra.NoArgs,
-			manifest.KindKustomization, manifest.KindHelmRelease),
+			"Validate every Kustomization, HelmRelease, and Flux source CR", cobra.NoArgs,
+			// Source kinds are included so a soft-skipped source (e.g.
+			// --allow-missing-secrets on an OCIRepository whose auth Secret
+			// is materialized live via ExternalSecret) shows up on its own
+			// line as SKIPPED instead of only as a parenthetical reason
+			// on its downstream KS/HR.
+			manifest.KindKustomization, manifest.KindHelmRelease,
+			manifest.KindGitRepository, manifest.KindOCIRepository,
+			manifest.KindHelmRepository, manifest.KindBucket),
 	)
 	return cmd
 }

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -124,6 +124,15 @@ func classify(s *store.Store, id manifest.NamedResource) Case {
 		return Case{ID: id, Outcome: OutcomeFailed, Reason: manifest.TrimSentinelPrefix(info.Message)}
 	case info.Status == store.StatusReady && info.Message == "unchanged":
 		return Case{ID: id, Outcome: OutcomeSkipped, Reason: "unchanged"}
+	case store.IsSkipped(info):
+		// Strip the `skipped: ` convention prefix from the stored
+		// message — the column already prints SKIPPED, so leading the
+		// reason with "skipped:" again is duplicate labeling. Inner
+		// propagated "skipped:" prefixes (a consumer wrapping its
+		// source's skip message) survive verbatim — they're load-
+		// bearing for the user (KS → which OCIRepo? why?).
+		return Case{ID: id, Outcome: OutcomeSkipped,
+			Reason: strings.TrimSpace(strings.TrimPrefix(info.Message, store.SkippedPrefix))}
 	case info.Status == store.StatusReady:
 		return Case{ID: id, Outcome: OutcomePassed}
 	default:

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -41,6 +41,26 @@ func TestRun_OneFailed(t *testing.T) {
 	}
 }
 
+func TestRun_SkippedReasonReportedAsSkipped(t *testing.T) {
+	// A KS that soft-skipped (e.g. source was --allow-missing-secrets'd)
+	// reports as SKIPPED, not PASSED or FAILED.
+	s := store.New()
+	s.AddObject(&manifest.Kustomization{Name: "apps", Namespace: "flux-system"})
+	s.UpdateStatus(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"},
+		store.StatusReady, "skipped: source GitRepository/flux-system/sealed missing auth")
+
+	rep := Run(Job{Store: s})
+	if rep.AnyFailed() {
+		t.Errorf("skipped-reason case must not fail: %+v", rep)
+	}
+	if rep.Skipped != 1 || rep.Passed != 0 {
+		t.Errorf("expected 1 skipped, 0 passed; got %+v", rep)
+	}
+	if !strings.Contains(rep.Cases[0].Reason, "missing auth") {
+		t.Errorf("skip reason should carry the underlying message; got %q", rep.Cases[0].Reason)
+	}
+}
+
 func TestRun_NoStatus(t *testing.T) {
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{Name: "x", Namespace: "ns"})

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -14,6 +14,7 @@ package base
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync/atomic"
@@ -150,6 +151,16 @@ func RunWithStatus[T manifest.BaseManifest](
 		return
 	}
 	if err := fn(ctx, obj); err != nil {
+		// ErrSourceSkipped propagates a soft-skip from a referenced
+		// source (e.g. --allow-missing-secrets on its auth secret) up
+		// to this consumer. Mark Ready with a "skipped:" message
+		// rather than Failed so depwait treats us as ready and the
+		// test runner reports SKIPPED, matching the source's outcome.
+		if errors.Is(err, manifest.ErrSourceSkipped) {
+			s.UpdateStatus(id, store.StatusReady,
+				store.SkippedPrefix+" "+manifest.TrimSentinelPrefix(err.Error()))
+			return
+		}
 		s.UpdateStatus(id, store.StatusFailed, err.Error())
 		return
 	}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -148,6 +148,14 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return fmt.Errorf("%w: chart source %s not ready: %s",
 			manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
 	}
+	// A chart source that soft-skipped (--allow-missing-secrets on its
+	// auth) marks Ready but writes no artifact and almost certainly
+	// can't be pulled anonymously either. Propagate the skip instead
+	// of letting TemplateDocs fail at the registry.
+	if info, ok := c.Store.GetStatus(srcID); ok && store.IsSkipped(info) {
+		return fmt.Errorf("%w: chart source %s %s",
+			manifest.ErrSourceSkipped, srcID.String(), info.Message)
+	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering chart")
 	docs, err := c.Helm.TemplateDocs(ctx, hr, hr.Values, c.Options)

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -380,6 +380,13 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 	}
 	art := c.Store.GetArtifact(srcID)
 	if art == nil {
+		// A source that soft-skipped (--allow-missing-secrets) reports
+		// Ready with a "skipped:" reason but writes no artifact. Surface
+		// that as a typed skip so the caller can mark the KS skipped too
+		// rather than reporting a generic "artifact not found" failure.
+		if info, ok := c.Store.GetStatus(srcID); ok && store.IsSkipped(info) {
+			return "", fmt.Errorf("%w: source %s %s", manifest.ErrSourceSkipped, srcID.String(), info.Message)
+		}
 		return "", fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())
 	}
 	if sa, ok := art.(*store.SourceArtifact); ok {

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -11,6 +11,7 @@ package source
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -32,13 +33,19 @@ type Controller struct {
 	// disables a kind (e.g. EnableOCI=false simply omits OCIRepository
 	// from the map). Exposed for Orchestrator.WithFetcher.
 	Fetchers map[string]src.Fetcher
+
+	// allowMissingSecrets converts ErrMissingSecret fetch errors into a
+	// skip (StatusReady with reason starting "skipped: "). Wired from
+	// Config.AllowMissingSecrets via Configure.
+	allowMissingSecrets bool
 }
 
 // FetchOptions carries the post-bootstrap state the orchestrator wires
 // onto the controller. Filter narrows fetches to sources referenced by
 // changed resources in changed-only mode.
 type FetchOptions struct {
-	Filter *change.Filter
+	Filter             *change.Filter
+	AllowMissingSecrets bool
 }
 
 // New constructs a source controller. Register fetchers on the
@@ -54,6 +61,7 @@ func New(s *store.Store, t *task.Service) *Controller {
 // Start.
 func (c *Controller) Configure(opts FetchOptions) {
 	c.SetFilter(opts.Filter)
+	c.allowMissingSecrets = opts.AllowMissingSecrets
 }
 
 // Start registers listeners on the Store. The controller runs until
@@ -99,6 +107,14 @@ func (c *Controller) runFetch(ctx context.Context, id manifest.NamedResource, ob
 	slog.Debug("source: fetch", "id", id.String())
 	artifact, err := fetcher.Fetch(ctx, obj)
 	if err != nil {
+		if c.allowMissingSecrets && errors.Is(err, manifest.ErrMissingSecret) {
+			// Soft-skip: leave the artifact slot empty so consumers see
+			// "no artifact" + Ready+"skipped:" status and propagate.
+			c.Store.UpdateStatus(id, store.StatusReady,
+				"skipped: "+manifest.TrimSentinelPrefix(err.Error()))
+			slog.Info("source: skipped (missing secret)", "id", id.String(), "err", err)
+			return
+		}
 		c.Store.UpdateStatus(id, store.StatusFailed, err.Error())
 		return
 	}

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -3,6 +3,8 @@ package source
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +142,54 @@ func TestController_UnregisteredKindIgnored(t *testing.T) {
 	}
 	st.AddObject(oci)
 	waitForStatus(t, st, oci.Named(), store.StatusReady)
+}
+
+func TestController_AllowMissingSecretsConvertsFailureToSkip(t *testing.T) {
+	f := &fakeFetcher{err: fmt.Errorf("%w: OCIRepository ns/r: secret ns/ghcr-creds not found",
+		manifest.ErrMissingSecret)}
+
+	st := store.New()
+	ts := task.New()
+	c := New(st, ts)
+	c.Fetchers[manifest.KindOCIRepository] = f
+	c.Configure(FetchOptions{AllowMissingSecrets: true})
+	c.Start(context.Background())
+	t.Cleanup(func() {
+		c.Close()
+		ts.BlockTillDone()
+	})
+
+	repo := &manifest.OCIRepository{
+		Name: "r", Namespace: "ns",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+	}
+	st.AddObject(repo)
+
+	info := waitForStatus(t, st, repo.Named(), store.StatusReady)
+	if !store.IsSkipped(info) {
+		t.Errorf("expected skipped status, got %+v", info)
+	}
+	if !strings.Contains(info.Message, "ghcr-creds") {
+		t.Errorf("skip message should preserve the underlying error; got %q", info.Message)
+	}
+	if art := st.GetArtifact(repo.Named()); art != nil {
+		t.Errorf("skipped source must not produce an artifact; got %+v", art)
+	}
+}
+
+func TestController_AllowMissingSecretsOffStillFails(t *testing.T) {
+	// Same error, but flag is off — should fail.
+	f := &fakeFetcher{err: fmt.Errorf("%w: OCIRepository ns/r: secret ns/ghcr-creds not found",
+		manifest.ErrMissingSecret)}
+	_, st := newController(t, map[string]src.Fetcher{manifest.KindOCIRepository: f})
+
+	repo := &manifest.OCIRepository{
+		Name: "r", Namespace: "ns",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+	}
+	st.AddObject(repo)
+
+	waitForStatus(t, st, repo.Named(), store.StatusFailed)
 }
 
 func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -157,14 +157,17 @@ func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Optio
 	}
 	sec := getSec(r.Namespace, r.SecretRef.Name)
 	if sec == nil {
-		return nil, fmt.Errorf("HelmRepository %s/%s: secret %s/%s not found",
-			r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
+		return nil, fmt.Errorf("%w: HelmRepository %s/%s: secret %s/%s not found",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
 	}
 	username := source.StringFromSecret(sec, "username")
 	password := source.StringFromSecret(sec, "password")
 	if username == "" || password == "" {
-		return nil, fmt.Errorf("HelmRepository %s/%s: secret %s/%s missing username/password",
-			r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
+		// Empty covers both missing-key and PLACEHOLDER-wiped values
+		// (the ExternalSecret case). Same sentinel so
+		// --allow-missing-secrets covers both shapes.
+		return nil, fmt.Errorf("%w: HelmRepository %s/%s: secret %s/%s missing username/password",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
 	}
 	opts := []getter.Option{getter.WithBasicAuth(username, password)}
 	if r.PassCredentials {

--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -52,6 +52,22 @@ func ParseBucket(doc map[string]any) (*Bucket, error) {
 	if cr.Spec.Provider == "" {
 		cr.Spec.Provider = sourcev1.BucketProviderGeneric
 	}
+	owner := cr.Namespace + "/" + cr.Name
+	if r := cr.Spec.SecretRef; r != nil {
+		if err := validateSecretRefName("Bucket", owner, "spec.secretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if r := cr.Spec.CertSecretRef; r != nil {
+		if err := validateSecretRefName("Bucket", owner, "spec.certSecretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if r := cr.Spec.ProxySecretRef; r != nil {
+		if err := validateSecretRefName("Bucket", owner, "spec.proxySecretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
 	return &Bucket{
 		Name:       cr.Name,
 		Namespace:  cr.Namespace,

--- a/pkg/manifest/errors.go
+++ b/pkg/manifest/errors.go
@@ -34,7 +34,9 @@ func TrimSentinelPrefix(msg string) string {
 		"object not found",
 		"invalid values reference",
 		"invalid substitute reference",
-		"command error":
+		"command error",
+		"missing secret",
+		"source skipped":
 		return rest[i+2:]
 	}
 	return rest
@@ -50,6 +52,24 @@ var (
 	ErrInvalidValuesReference     = fmt.Errorf("%w: invalid values reference", ErrFlux)
 	ErrInvalidSubstituteReference = fmt.Errorf("%w: invalid substitute reference", ErrFlux)
 	ErrCommand                    = fmt.Errorf("%w: command error", ErrFlux)
+	// ErrMissingSecret signals that a source's auth SecretRef couldn't
+	// be resolved — either the referenced Secret isn't in the offline
+	// tree, or it's present but its values were wiped to PLACEHOLDER
+	// strings by --wipe-secrets (the typical ExternalSecret case: the
+	// Secret manifest exists but its data is materialized live, not in
+	// git). The orchestrator's --allow-missing-secrets flag turns this
+	// into a skip rather than a failure.
+	//
+	// Scope: auth secretRef ONLY. Verify (cosign/PGP), certSecretRef,
+	// and proxySecretRef sites intentionally still fail loud — silently
+	// dropping verification or proxy/TLS material is a security
+	// downgrade flate refuses to make implicit.
+	ErrMissingSecret = fmt.Errorf("%w: missing secret", ErrFlux)
+	// ErrSourceSkipped signals that a downstream consumer (KS sourceRef,
+	// HR chartRef) cannot proceed because its source was skipped —
+	// typically by --allow-missing-secrets. Consumers translate this
+	// into their own skip rather than a hard failure.
+	ErrSourceSkipped = fmt.Errorf("%w: source skipped", ErrFlux)
 )
 
 // inputf formats an input error.

--- a/pkg/manifest/helmrepository.go
+++ b/pkg/manifest/helmrepository.go
@@ -41,6 +41,17 @@ func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 	if cr.Spec.Type == "" {
 		cr.Spec.Type = RepoTypeDefault
 	}
+	owner := cr.Namespace + "/" + cr.Name
+	if r := cr.Spec.SecretRef; r != nil {
+		if err := validateSecretRefName("HelmRepository", owner, "spec.secretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if r := cr.Spec.CertSecretRef; r != nil {
+		if err := validateSecretRefName("HelmRepository", owner, "spec.certSecretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
 	return &HelmRepository{
 		Name:               cr.Name,
 		Namespace:          cr.Namespace,

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -442,6 +442,78 @@ spec:
 	}
 }
 
+// TestParse_EmptySecretRefNameRejected pins the schema check that
+// turns a typo'd `secretRef: {}` into a hard parse error. Without
+// it, the empty name would fall through to a runtime lookup of
+// "<ns>/" → "secret not found" → with --allow-missing-secrets on,
+// silent soft-skip — masking the typo entirely.
+func TestParse_EmptySecretRefNameRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+		parse func(map[string]any) error
+	}{
+		{
+			name: "OCIRepository spec.secretRef.name empty",
+			yaml: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata: {name: x, namespace: ns}
+spec:
+  url: oci://example/x
+  secretRef: {name: ""}`,
+			want:  "spec.secretRef.name is empty",
+			parse: func(d map[string]any) error { _, err := ParseOCIRepository(d); return err },
+		},
+		{
+			name: "GitRepository spec.secretRef.name empty",
+			yaml: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: x, namespace: ns}
+spec:
+  url: https://example/x.git
+  secretRef: {name: ""}`,
+			want:  "spec.secretRef.name is empty",
+			parse: func(d map[string]any) error { _, err := ParseGitRepository(d); return err },
+		},
+		{
+			name: "HelmRepository spec.secretRef.name empty",
+			yaml: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata: {name: x, namespace: ns}
+spec:
+  url: https://example.com/charts
+  secretRef: {name: ""}`,
+			want:  "spec.secretRef.name is empty",
+			parse: func(d map[string]any) error { _, err := ParseHelmRepository(d); return err },
+		},
+		{
+			name: "Bucket spec.secretRef.name empty",
+			yaml: `apiVersion: source.toolkit.fluxcd.io/v1
+kind: Bucket
+metadata: {name: x, namespace: ns}
+spec:
+  bucketName: b
+  endpoint: e
+  secretRef: {name: ""}`,
+			want:  "spec.secretRef.name is empty",
+			parse: func(d map[string]any) error { _, err := ParseBucket(d); return err },
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := mustYAML(t, tc.yaml)
+			err := tc.parse(doc)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("expected error containing %q, got %q", tc.want, err.Error())
+			}
+		})
+	}
+}
+
 func TestParseBucket_Suspend(t *testing.T) {
 	doc := mustYAML(t, `
 apiVersion: source.toolkit.fluxcd.io/v1

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -58,6 +58,22 @@ func (g *GitRepository) Suspended() bool { return g.Suspend }
 // RepoName is "<namespace>-<name>".
 func (g *GitRepository) RepoName() string { return g.Namespace + "-" + g.Name }
 
+// validateSecretRefName rejects a Secret/LocalObjectReference whose
+// Name is empty. Without this check, a typo'd YAML like
+// `secretRef: {}` would fall through to a runtime lookup of
+// "<ns>/" — and with --allow-missing-secrets enabled, would silently
+// soft-skip the source. That converts a schema typo into invisible
+// behavior change. Reject upfront with a clear pointer to the field.
+//
+// kind/owner/field are formatted into the error: e.g. ("OCIRepository",
+// "default/private-app", "spec.secretRef").
+func validateSecretRefName(kind, owner, field, name string) error {
+	if name == "" {
+		return inputf("%s %s: %s.name is empty", kind, owner, field)
+	}
+	return nil
+}
+
 // ParseGitRepository decodes a GitRepository CR via the Flux typed
 // schema (source-controller/api/v1), then projects the fields flate
 // uses into the local struct.
@@ -83,6 +99,22 @@ func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
 		// applies the schema default. Write it back so consumers see a
 		// canonical mode regardless of source casing.
 		v.Mode = v.GetMode()
+	}
+	owner := cr.Namespace + "/" + cr.Name
+	if r := cr.Spec.SecretRef; r != nil {
+		if err := validateSecretRefName("GitRepository", owner, "spec.secretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if r := cr.Spec.ProxySecretRef; r != nil {
+		if err := validateSecretRefName("GitRepository", owner, "spec.proxySecretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if v := cr.Spec.Verification; v != nil {
+		if err := validateSecretRefName("GitRepository", owner, "spec.verify.secretRef", v.SecretRef.Name); err != nil {
+			return nil, err
+		}
 	}
 	return &GitRepository{
 		Name:              cr.Name,
@@ -171,6 +203,27 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	}
 	if cr.Spec.Provider == "" {
 		cr.Spec.Provider = sourcev1.GenericOCIProvider
+	}
+	owner := cr.Namespace + "/" + cr.Name
+	if r := cr.Spec.SecretRef; r != nil {
+		if err := validateSecretRefName("OCIRepository", owner, "spec.secretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if r := cr.Spec.CertSecretRef; r != nil {
+		if err := validateSecretRefName("OCIRepository", owner, "spec.certSecretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if r := cr.Spec.ProxySecretRef; r != nil {
+		if err := validateSecretRefName("OCIRepository", owner, "spec.proxySecretRef", r.Name); err != nil {
+			return nil, err
+		}
+	}
+	if v := cr.Spec.Verify; v != nil && v.SecretRef != nil {
+		if err := validateSecretRefName("OCIRepository", owner, "spec.verify.secretRef", v.SecretRef.Name); err != nil {
+			return nil, err
+		}
 	}
 	return &OCIRepository{
 		Name:              cr.Name,

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -44,6 +44,14 @@ type Config struct {
 	WipeSecrets bool
 	// EnableOCI turns on OCIRepository reconciliation.
 	EnableOCI bool
+	// AllowMissingSecrets converts auth-secret-not-found errors during
+	// source fetch into a skip rather than a failure. Use when secrets
+	// are materialized on the live cluster (ExternalSecret, etc.) and
+	// can't appear in the offline tree. Skipped sources mark Ready with
+	// a "skipped:" reason and produce no artifact; downstream KS / HR
+	// consumers propagate the skip so the dependency chain doesn't
+	// surface as a cascade of failures in `flate test`.
+	AllowMissingSecrets bool
 
 	// RegistryConfig is the docker config.json used for OCI auth.
 	RegistryConfig string
@@ -401,7 +409,10 @@ func (o *Orchestrator) attachFilter(f *change.Filter) {
 // + error-string assembly lives in finalize so Run reads as a clean
 // start → drain → finalize sequence.
 func (o *Orchestrator) Run(ctx context.Context) error {
-	o.src.Configure(sourcectrl.FetchOptions{Filter: o.filter})
+	o.src.Configure(sourcectrl.FetchOptions{
+		Filter:             o.filter,
+		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
+	})
 	o.ksc.Configure(kustomization.Options{
 		Filter:        o.filter,
 		ParentOf:      o.parentOf,

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -269,6 +269,133 @@ stringData: {password: hunter2}
 	}
 }
 
+// TestOrchestrator_AllowMissingSecretsPropagates locks the #190 fix:
+// when --allow-missing-secrets is on AND a source's auth Secret isn't
+// in the offline tree, the source soft-skips (Ready+"skipped:") and
+// the downstream KS that consumes it propagates the skip rather than
+// failing with "source artifact not found". `flate test` then reports
+// SKIPPED, not FAILED.
+func TestOrchestrator_AllowMissingSecretsPropagates(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "oci.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: private-app
+  namespace: default
+spec:
+  interval: 5m
+  url: oci://example.invalid/private/app
+  secretRef:
+    name: ghcr-creds
+`)
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: private-app
+  namespace: default
+spec:
+  interval: 5m
+  path: ./
+  sourceRef:
+    kind: OCIRepository
+    name: private-app
+    namespace: default
+`)
+
+	o, err := New(Config{
+		Path:                dir,
+		EnableOCI:           true,
+		AllowMissingSecrets: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	ociID := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "default", Name: "private-app"}
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "default", Name: "private-app"}
+
+	if _, failed := res.Failed[ociID]; failed {
+		t.Errorf("OCIRepository must not be in Failed when --allow-missing-secrets is on; got %v", res.Failed[ociID])
+	}
+	if _, failed := res.Failed[ksID]; failed {
+		t.Errorf("dependent KS must propagate skip, not fail; got %v", res.Failed[ksID])
+	}
+
+	ociInfo, ok := o.Store().GetStatus(ociID)
+	if !ok || !store.IsSkipped(ociInfo) {
+		t.Errorf("OCIRepository should be Ready+skipped; got %+v", ociInfo)
+	}
+	ksInfo, ok := o.Store().GetStatus(ksID)
+	if !ok || !store.IsSkipped(ksInfo) {
+		t.Errorf("KS should be Ready+skipped; got %+v", ksInfo)
+	}
+}
+
+// TestOrchestrator_AllowMissingSecretsHRSkipsBeforePull locks the
+// silent-anonymous-pull regression the iter-17 edge-case review
+// flagged: an HR with chartRef → OCIRepository whose auth Secret is
+// missing MUST propagate the skip BEFORE helm.TemplateDocs runs.
+// Without the pre-check, the source-controller's soft-skip leaves
+// no on-disk artifact but the helm client's locateOCIChart would
+// still try an oras-pull against the registry — succeeding silently
+// against a public mirror, or failing with an opaque registry error.
+// Either way the user's "the auth is missing" signal is lost.
+func TestOrchestrator_AllowMissingSecretsHRSkipsBeforePull(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "oci.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: oci://example.invalid/private/chart
+  secretRef:
+    name: ghcr-creds
+`)
+	testutil.WriteFile(t, dir, "hr.yaml", `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: demo
+  namespace: default
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+`)
+
+	o, err := New(Config{
+		Path:                dir,
+		EnableOCI:           true,
+		AllowMissingSecrets: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	hrID := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "demo"}
+	if _, failed := res.Failed[hrID]; failed {
+		t.Errorf("HR must propagate skip before helm.TemplateDocs runs; got %v", res.Failed[hrID])
+	}
+	hrInfo, ok := o.Store().GetStatus(hrID)
+	if !ok || !store.IsSkipped(hrInfo) {
+		t.Errorf("HR should be Ready+skipped (chart source skipped); got %+v. "+
+			"If status is Failed with a registry-pull error, the pre-check is missing and "+
+			"helm tried an anonymous pull — exactly the silent-downgrade the pre-check exists to prevent.",
+			hrInfo)
+	}
+}
+
 func keysOf[V any](m map[manifest.NamedResource]V) []manifest.NamedResource {
 	out := make([]manifest.NamedResource, 0, len(m))
 	for k := range m {

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -155,14 +155,17 @@ func (f *Fetcher) resolveCredentials(b *manifest.Bucket) (*credentials.Credentia
 	}
 	sec := f.Secrets(b.Namespace, b.SecretRef.Name)
 	if sec == nil {
-		return nil, fmt.Errorf("bucket %s/%s: secret %s/%s not found",
-			b.Namespace, b.Name, b.Namespace, b.SecretRef.Name)
+		return nil, fmt.Errorf("%w: bucket %s/%s: secret %s/%s not found",
+			manifest.ErrMissingSecret, b.Namespace, b.Name, b.Namespace, b.SecretRef.Name)
 	}
 	access := source.StringFromSecret(sec, "accesskey")
 	secret := source.StringFromSecret(sec, "secretkey")
 	if access == "" || secret == "" {
-		return nil, fmt.Errorf("bucket %s/%s: secret %s/%s missing accesskey/secretkey",
-			b.Namespace, b.Name, b.Namespace, b.SecretRef.Name)
+		// Empty covers both missing-key and PLACEHOLDER-wiped values
+		// (the ExternalSecret case). Same sentinel so
+		// --allow-missing-secrets covers both shapes.
+		return nil, fmt.Errorf("%w: bucket %s/%s: secret %s/%s missing accesskey/secretkey",
+			manifest.ErrMissingSecret, b.Namespace, b.Name, b.Namespace, b.SecretRef.Name)
 	}
 	return credentials.NewStaticV4(access, secret, ""), nil
 }

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -139,14 +139,17 @@ func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMetho
 	}
 	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
 	if sec == nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s not found",
-			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+		return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s not found",
+			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 	}
 	if isSSHURL(repo.URL) {
 		identity := source.StringFromSecret(sec, "identity")
 		if identity == "" {
-			return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s missing 'identity' for SSH auth",
-				repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+			// Empty covers both missing-key and PLACEHOLDER-wiped values
+			// (the ExternalSecret case). Same sentinel so
+			// --allow-missing-secrets covers both shapes.
+			return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s missing 'identity' for SSH auth",
+				manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 		}
 		password := source.StringFromSecret(sec, "password")
 		user := sshUserFromURL(repo.URL)
@@ -179,8 +182,11 @@ func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMetho
 	username := source.StringFromSecret(sec, "username")
 	password := source.StringFromSecret(sec, "password")
 	if username == "" || password == "" {
-		return nil, fmt.Errorf("GitRepository %s/%s: secret %s/%s missing username/password (or bearerToken) for HTTPS auth",
-			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+		// Empty covers both missing-key and PLACEHOLDER-wiped values
+		// (the ExternalSecret case). Same sentinel so
+		// --allow-missing-secrets covers both shapes.
+		return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s missing username/password (or bearerToken) for HTTPS auth",
+			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 	}
 	return &githttp.BasicAuth{Username: username, Password: password}, nil
 }

--- a/pkg/source/oci/auth_test.go
+++ b/pkg/source/oci/auth_test.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -186,6 +187,14 @@ func TestFetcher_ResolveConfig_SecretMissingDockerConfigJSON(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), ".dockerconfigjson") {
 		t.Errorf("expected missing-.dockerconfigjson error; got %v", err)
 	}
+	// The wrong-shape / placeholder case must wrap ErrMissingSecret so
+	// --allow-missing-secrets covers it. This is the actual #190 case:
+	// an ExternalSecret materializes the Secret manifest in-tree but
+	// the values get PLACEHOLDER-wiped, so StringFromSecret returns ""
+	// and we land here, not in the "not found" branch.
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("expected ErrMissingSecret wrap so --allow-missing-secrets handles ExternalSecret/placeholder case; got %v", err)
+	}
 }
 
 func TestFetcher_ResolveConfig_SecretRefWithoutGetter(t *testing.T) {
@@ -211,5 +220,8 @@ func TestFetcher_ResolveConfig_SecretNotFound(t *testing.T) {
 	cleanup()
 	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {
 		t.Errorf("expected secret-not-found error; got %v", err)
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("expected ErrMissingSecret wrap; got %v", err)
 	}
 }

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -113,15 +113,23 @@ func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, f
 	}
 	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
 	if sec == nil {
-		return "", noCleanup, fmt.Errorf("OCIRepository %s/%s: secret %s/%s not found",
-			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+		return "", noCleanup, fmt.Errorf("%w: OCIRepository %s/%s: secret %s/%s not found",
+			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 	}
 	configJSON := source.StringFromSecret(sec, ".dockerconfigjson")
 	if configJSON == "" {
+		// Empty here covers both (a) the Secret has no .dockerconfigjson
+		// key at all and (b) the key exists but `--wipe-secrets` (always
+		// on) replaced its value with PLACEHOLDER, which StringFromSecret
+		// returns as "". The ExternalSecret case in #190 hits (b): the
+		// Secret manifest is in-tree but its data is materialized live.
+		// Same ErrMissingSecret sentinel so --allow-missing-secrets
+		// covers both — matching only the literal "secret not found"
+		// path would leave the actual reporter's case still failing.
 		return "", noCleanup, fmt.Errorf(
-			"OCIRepository %s/%s: secret %s/%s missing .dockerconfigjson "+
+			"%w: OCIRepository %s/%s: secret %s/%s missing .dockerconfigjson "+
 				"(must be type kubernetes.io/dockerconfigjson)",
-			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
 	}
 	tmp, err := os.CreateTemp("", "flate-oci-creds-*.json")
 	if err != nil {

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -1,10 +1,25 @@
 package store
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
+
+// SkippedPrefix is the message prefix UpdateStatus carries when a
+// resource was soft-skipped (e.g. by --allow-missing-secrets). Status
+// remains StatusReady — depwait treats the resource as ready so deps
+// unblock — but consumers can detect the skip via IsSkipped to
+// propagate it (KS resolveSourceRoot, test runner classification).
+const SkippedPrefix = "skipped:"
+
+// IsSkipped reports whether info represents a soft-skip — i.e. a
+// StatusReady whose message starts with SkippedPrefix.
+func IsSkipped(info StatusInfo) bool {
+	return info.Status == StatusReady && strings.HasPrefix(info.Message, SkippedPrefix)
+}
 
 // Status is the processing state of a resource as projected from its
 // Ready condition. Kept as a high-level rollup for callers (depwait,


### PR DESCRIPTION
## Summary

- New flag `--allow-missing-secrets` (default off) that soft-skips sources whose auth `secretRef` can't be resolved — either absent from the tree or PLACEHOLDER-wiped by the always-on `--wipe-secrets` (the typical ExternalSecret / SealedSecret case the issue reporter hit).
- Skip propagates: source marks `Ready / "skipped: …"`; KS `resolveSourceRoot` and HR chart-source pre-check return `ErrSourceSkipped`; `base.RunWithStatus` catches the sentinel and writes Ready+skipped on the consumer instead of Failed.
- Test runner classifies the convention as `OutcomeSkipped` and `flate test all` now reports source kinds too so a soft-skip surfaces on its own line.
- Scope is deliberately narrow: auth `secretRef` only. Verify (cosign / PGP), cert, and proxy `secretRef`s still fail loud — silently downgrading verification or TLS material is a security cost flate refuses to make implicit.
- Empty `secretRef.name` is now a parse-time error across OCI / Git / Helm / Bucket so a typo can't silently fall into the soft-skip path.

Fixes #190

## Why a quorum review before coding

The first attempt missed the actual repro: with ExternalSecret, the Secret manifest IS in the tree but its values are PLACEHOLDER-wiped, so the fetcher errors at `"missing .dockerconfigjson"` (oci.go:121) not `"secret not found"` (oci.go:116). Wrapping only the latter site would have shipped a fix that didn't fix #190. Three fresh-eyes agents (architecture / UX / edge-cases) surfaced that gap along with the flag-name collision (`--skip-missing-secrets` vs existing `--skip-secrets`), the verify-secret security concern, and the silent-anonymous-pull risk for HR with chartRef → soft-skipped OCIRepository.

## Test plan

- [x] `go test ./...` clean
- [x] `golangci-lint run ./...` clean (0 issues)
- [x] Manual smoke-test against issue's exact fixture (OCIRepository + digest + secretRef + HelmRelease via chartRef): FAILED → SKIPPED with flag on, FAILED preserved with flag off.
- [x] Manual smoke-test of the actual ExternalSecret case (in-tree Secret with PLACEHOLDER values): SKIPPED with flag on. This is the regression the iter-17 review caught — the obvious implementation would have missed it.
- [x] Manual verification HR with chartRef → soft-skipped OCIRepo does NOT call into helm registry (covered by `TestOrchestrator_AllowMissingSecretsHRSkipsBeforePull`).
- [x] Manual verification empty `secretRef.name` is a hard parse error (covered by `TestParse_EmptySecretRefNameRejected`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)