### PR TITLE
fix(loader): skip configMapGenerator/secretGenerator data files

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -1,0 +1,172 @@
+package loader
+
+import (
+	"context"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// kustomization is the subset of sigs.k8s.io/kustomize/api/types.Kustomization
+// the loader inspects to decide what each tree-walk file is — a manifest,
+// a Component fragment, or a generator data source. Adding fields here
+// is the supported way to widen the loader's understanding of kustomize
+// declarations; we deliberately do not import the upstream type to
+// avoid pulling its full transitive dep tree into the load path.
+type kustomization struct {
+	Kind               string            `json:"kind"                         yaml:"kind"`
+	Resources          []string          `json:"resources,omitempty"          yaml:"resources,omitempty"`
+	ConfigMapGenerator []kvPairGenerator `json:"configMapGenerator,omitempty" yaml:"configMapGenerator,omitempty"`
+	SecretGenerator    []kvPairGenerator `json:"secretGenerator,omitempty"    yaml:"secretGenerator,omitempty"`
+}
+
+// kvPairGenerator captures the file/env entries of a configMap or
+// secret generator. Literals are inline strings and stay out of scope.
+type kvPairGenerator struct {
+	Files []string `json:"files,omitempty" yaml:"files,omitempty"`
+	Envs  []string `json:"envs,omitempty"  yaml:"envs,omitempty"`
+}
+
+// kustomizationFileNames is the ordered list kustomize checks; first
+// match wins.
+var kustomizationFileNames = []string{
+	"kustomization.yaml",
+	"kustomization.yml",
+	"kustomization.json",
+}
+
+// readKustomization opens dir/kustomization.{yaml,yml,json} and decodes
+// the subset of fields the loader uses. Returns nil when no
+// kustomization file exists in dir or when decode fails — the latter
+// is treated as "absent" because krusty's render path will surface the
+// real error later with better context than the loader can.
+func readKustomization(dir string) *kustomization {
+	for _, name := range kustomizationFileNames {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path) //nolint:gosec // path joined under the user-supplied scan root
+		if err != nil {
+			continue
+		}
+		var k kustomization
+		if err := yaml.Unmarshal(data, &k); err != nil {
+			continue
+		}
+		return &k
+	}
+	return nil
+}
+
+// collectGeneratorDataFiles walks root and decodes every kustomization
+// file it finds, returning the set of absolute file paths declared as
+// configMapGenerator/secretGenerator data sources (files + envs).
+//
+// Files that are ALSO declared in `resources:` are removed from the
+// set so a resource-and-data conflict still loads as a manifest: the
+// `resources:` entry is an authoritative "this IS a Flux manifest"
+// declaration, and the kustomize spec doesn't actually forbid the
+// same path from appearing in both lists (though it'd be unusual).
+//
+// Honors ctx cancellation and the same shouldSkipDir rules as the
+// main walk so we don't descend into `.git`, `templates/`, Component
+// dirs, or ignore-matched paths.
+func collectGeneratorDataFiles(ctx context.Context, root string, ignore *ignoreSet) (map[string]struct{}, error) {
+	data := map[string]struct{}{}
+	resources := map[string]struct{}{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if cerr := ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if shouldSkipDir(d.Name(), path, root, ignore) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isKustomizationFileName(d.Name()) {
+			return nil
+		}
+		k := readKustomization(filepath.Dir(path))
+		if k == nil {
+			return nil
+		}
+		base := filepath.Dir(path)
+		for _, r := range k.Resources {
+			if abs, ok := resolveDataPath(base, r); ok {
+				resources[abs] = struct{}{}
+			}
+		}
+		addEntries := func(entries []string, parseKey bool) {
+			for _, e := range entries {
+				p := e
+				if parseKey {
+					p = stripFileEntryKey(e)
+				}
+				if abs, ok := resolveDataPath(base, p); ok {
+					data[abs] = struct{}{}
+				}
+			}
+		}
+		for _, g := range k.ConfigMapGenerator {
+			addEntries(g.Files, true)
+			addEntries(g.Envs, false)
+		}
+		for _, g := range k.SecretGenerator {
+			addEntries(g.Files, true)
+			addEntries(g.Envs, false)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Resource interpretation wins over data interpretation if the same
+	// path appears in both lists across any kustomization.yaml in the
+	// tree.
+	for r := range resources {
+		delete(data, r)
+	}
+	if len(data) > 0 {
+		slog.Debug("loader: data files excluded from manifest scan", "count", len(data))
+	}
+	return data, nil
+}
+
+// stripFileEntryKey returns the path portion of a kustomize
+// configMapGenerator/secretGenerator `files:` entry. Per the spec
+// (sigs.k8s.io/kustomize/api/types/kvsources.go), entries take the
+// form "[KEY=]PATH"; the first `=` separates an optional ConfigMap
+// key from the on-disk path. Entries with no `=` are pure paths.
+func stripFileEntryKey(s string) string {
+	if _, after, ok := strings.Cut(s, "="); ok {
+		return after
+	}
+	return s
+}
+
+// resolveDataPath joins rel against base and cleans the result. An
+// empty rel is rejected (kustomize would reject it too). Absolute
+// paths pass through verbatim — kustomize doesn't forbid them and
+// some generated manifests use them.
+func resolveDataPath(base, rel string) (string, bool) {
+	if rel == "" {
+		return "", false
+	}
+	if filepath.IsAbs(rel) {
+		return filepath.Clean(rel), true
+	}
+	return filepath.Clean(filepath.Join(base, rel)), true
+}
+
+// isKustomizationFileName reports whether name matches one of the
+// three kustomize-recognized filenames.
+func isKustomizationFileName(name string) bool {
+	return slices.Contains(kustomizationFileNames, name)
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"sigs.k8s.io/yaml"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -70,6 +68,17 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 		return 0, err
 	}
 
+	// Pre-pass: decode every kustomization.yaml in the tree and
+	// collect the set of files referenced as configMapGenerator /
+	// secretGenerator data sources. The main walk skips those — they
+	// are valid YAML data files, not Flux manifests, and would
+	// otherwise trip the generic decode-as-map fallback with noisy
+	// WARN logs that look like real failures (issue #192).
+	dataFiles, err := collectGeneratorDataFiles(ctx, abs, ignore)
+	if err != nil {
+		return 0, err
+	}
+
 	count := 0
 	err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
 		if cerr := ctx.Err(); cerr != nil {
@@ -88,6 +97,14 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 			return nil
 		}
 		if ignore.matches(path, abs) {
+			return nil
+		}
+		if _, isData := dataFiles[path]; isData {
+			// Declared as configMapGenerator/secretGenerator data by
+			// a kustomization.yaml in the tree. krusty handles the
+			// file correctly at render time; the loader's job is to
+			// stay out of the way.
+			slog.Debug("loader: skipping generator data file", "path", path)
 			return nil
 		}
 		n, err := l.loadFile(path)
@@ -200,26 +217,9 @@ func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 }
 
 // isKustomizeComponent reports whether dir contains a kustomization
-// file declaring `kind: Component`. Decodes the file via sigs.k8s.io/
-// yaml (JSON-compatible) and inspects the `kind` field — catches YAML,
-// JSON, and terse no-space-after-colon shapes that a substring check
-// would miss.
+// file declaring `kind: Component`. Catches YAML, JSON, and terse
+// no-space-after-colon shapes that a substring check would miss.
 func isKustomizeComponent(dir string) bool {
-	for _, name := range []string{"kustomization.yaml", "kustomization.yml", "kustomization.json"} {
-		path := filepath.Join(dir, name)
-		data, err := os.ReadFile(path) //nolint:gosec // path joined under the user-supplied scan root
-		if err != nil {
-			continue
-		}
-		var doc struct {
-			Kind string `json:"kind" yaml:"kind"`
-		}
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			continue
-		}
-		if doc.Kind == "Component" {
-			return true
-		}
-	}
-	return false
+	k := readKustomization(dir)
+	return k != nil && k.Kind == "Component"
 }

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -127,6 +127,174 @@ spec:
 	}
 }
 
+// TestLoader_SkipsConfigMapGeneratorDataFile mirrors the home-ops
+// repo shape that triggered #192: a `kustomization.yaml` declares a
+// `configMapGenerator.files` entry pointing at a YAML data file
+// whose top level is a sequence (e.g. webhook hook definitions).
+// flate's loader walks every .yaml under --path, but this one is
+// data — not a manifest — and must not trip the generic decode.
+func TestLoader_SkipsConfigMapGeneratorDataFile(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+configMapGenerator:
+  - name: notifier-configmap
+    files:
+      - hooks.yaml=./resources/hooks.yaml
+`)
+	testutil.WriteFile(t, dir, "helmrelease.yaml", `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: {name: notifier, namespace: default}
+spec:
+  chart:
+    spec:
+      chart: foo
+      sourceRef: {kind: HelmRepository, name: r, namespace: ns}
+`)
+	// Top-level YAML sequence — a valid data file but not a manifest.
+	// Without the data-file pre-pass this trips
+	// "cannot construct !!seq into map[string]interface {}".
+	testutil.WriteFile(t, dir, "resources/hooks.yaml", `---
+- id: radarr-pushover
+  execute-command: /config/radarr-pushover.sh
+- id: seerr-pushover
+  execute-command: /config/seerr-pushover.sh
+`)
+
+	s := store.New()
+	n, err := New(s).Load(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Exactly one object loaded: the HelmRelease.
+	if n != 1 {
+		t.Errorf("expected 1 object loaded (HelmRelease only); got %d", n)
+	}
+	if got := s.GetObject(manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "notifier"}); got == nil {
+		t.Errorf("HelmRelease should still load")
+	}
+}
+
+// TestLoader_SkipsSecretGeneratorDataFile is the secretGenerator twin
+// — same exclusion logic, different kustomize field.
+func TestLoader_SkipsSecretGeneratorDataFile(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+  - name: tls-bundle
+    files:
+      - ca.crt=./data/ca.crt
+    envs:
+      - ./data/extra.env
+`)
+	// `.crt` extension — loader wouldn't try to parse it anyway, so
+	// this just verifies the exclusion is harmless when extension
+	// already excludes the file.
+	testutil.WriteFile(t, dir, "data/ca.crt", "-----BEGIN CERTIFICATE-----\n")
+	// `.env` is also not in manifestExtensions; same point.
+	testutil.WriteFile(t, dir, "data/extra.env", "FOO=bar\n")
+	// But: an arbitrary .yaml data file (e.g. a sealed-secret payload
+	// chunk) WOULD be parsed without the exclusion.
+	testutil.WriteFile(t, dir, "data/raw.yaml", "this: is: not: valid: yaml: ::\n")
+	// Override kustomization to also use the .yaml data file so it
+	// goes through the secretGenerator.files exclusion.
+	testutil.WriteFile(t, dir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+secretGenerator:
+  - name: tls-bundle
+    files:
+      - raw.yaml=./data/raw.yaml
+`)
+
+	s := store.New()
+	if _, err := New(s).Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+}
+
+// TestLoader_GeneratorFilesKeyParsing covers the "KEY=PATH" entry
+// shape: the loader must strip the optional `KEY=` prefix before
+// resolving the path, otherwise the exclusion never matches and the
+// data file goes through the generic decode.
+func TestLoader_GeneratorFilesKeyParsing(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: with-keys
+    files:
+      - keyed=./data/keyed.yaml
+      - ./data/unkeyed.yaml
+`)
+	testutil.WriteFile(t, dir, "data/keyed.yaml", "- top: level\n- seq: here\n")
+	testutil.WriteFile(t, dir, "data/unkeyed.yaml", "- another: top\n- level: seq\n")
+
+	s := store.New()
+	if _, err := New(s).Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// No objects added — both files excluded. The test passes as long
+	// as Load returns nil (i.e. didn't hit a decode error on either).
+}
+
+// TestLoader_ResourceWinsOverGenerator pins the conflict-resolution
+// rule from the design: if the same path is declared as both
+// `resources:` AND `configMapGenerator.files:`, the resource
+// interpretation wins. Pathological but legal per the kustomize spec.
+func TestLoader_ResourceWinsOverGenerator(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./shared.yaml
+configMapGenerator:
+  - name: also-used-as-data
+    files:
+      - ./shared.yaml
+`)
+	testutil.WriteFile(t, dir, "shared.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: shared, namespace: ns}
+`)
+	s := store.New()
+	if _, err := New(s).Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := s.GetObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "shared"}); got == nil {
+		t.Errorf("a path declared in both resources: and configMapGenerator must still load as a resource")
+	}
+}
+
+// TestLoader_NestedKustomizationDataFile checks that a data file
+// declared by a kustomization.yaml deep in the tree is excluded
+// during the load of a higher-level --path. Same exclusion logic;
+// just verifies the pre-pass actually walks recursively.
+func TestLoader_NestedKustomizationDataFile(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "apps/notifier/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - name: cm
+    files:
+      - hooks.yaml=./resources/hooks.yaml
+`)
+	testutil.WriteFile(t, dir, "apps/notifier/resources/hooks.yaml", `- id: a\n- id: b\n`)
+	testutil.WriteFile(t, dir, "apps/notifier/manifest.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: real, namespace: ns}
+`)
+	s := store.New()
+	if _, err := New(s).Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "real"}) == nil {
+		t.Errorf("the real manifest under the same kustomization dir must still load")
+	}
+}
+
 // TestLoader_RespectsCanceledContext asserts the walk bails out on
 // context cancellation. Useful when a stuck NFS mount or symlink
 // loop would otherwise block Bootstrap indefinitely.


### PR DESCRIPTION
## Summary

- Pre-pass over the tree decodes every `kustomization.yaml` and collects paths referenced by `configMapGenerator.{files,envs}` and `secretGenerator.{files,envs}` (parsing the optional `KEY=` prefix on `files:` per the kustomize spec). The main walk skips those paths silently (`slog.Debug` for traceability).
- Paths declared as both `resources:` and generator data still load as resources — the manifest interpretation wins.
- `isKustomizeComponent` now goes through the same `readKustomization` helper so there's one site to extend the loader's kustomize awareness.

## Why

The loader's open-scan walked every `.yaml`/`.yml`/`.json` under `--path` and tried to decode each as `map[string]any`. A top-level YAML sequence used as `configMapGenerator.files` data (e.g. webhook hook definitions in the user's notifier app) failed with `cannot construct !!seq into map` and surfaced as a noisy `loader: file failed to parse` WARN. The render path was always fine — krusty consumes the file through `configMapGenerator` correctly. The loader just shouldn't have been looking at it.

Verified end-to-end against [@onedr0p](https://github.com/onedr0p)'s home-ops repo: the WARN is gone on `kubernetes/apps/default/notifier/app` and zero new WARNs surface across the full `kubernetes/` tree (75 KSes).

Fixes #192

## Test plan

- [x] `go test ./pkg/loader/...` — 5 new tests covering the user's reproducer shape, secretGenerator twin, `KEY=PATH` parsing, resource-vs-generator conflict resolution, and nested kustomization.yaml.
- [x] `go test ./...` and `golangci-lint run ./...` clean.
- [x] Manual smoke-test against `onedr0p/home-ops`: WARN gone on the reproducer, no new noise across the whole tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)