### PR TITLE
feat(diff): restore --strip-attr (same defaults) as a pre-dyff filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Every command takes `--path <dir>` (default `.`); `--path-orig <dir>` switches i
 | `diff` | `ks`, `hr`, `images` | Path-keyed diff against `--path-orig`, rendered via [dyff](https://github.com/homeport/dyff) in `--output github` mode. K8s-aware: list entries match by identifier (container name, env-var name), so a reorder shows as `⇆ order changed` instead of a wall of phantom value churn. |
 | `test` | `ks`, `hr`, `all` | Pytest-style `PASS` / `FAIL` / `SKIPPED` per resource. Non-zero exit on any failure. |
 
-`get` and `diff` accept `-l/--selector key=value` for label filtering.
+`get` and `diff` accept `-l/--selector key=value` for label filtering. `diff` accepts `--strip-attr <key>` (repeatable) to drop annotation/label keys before comparison; the default set covers chart-bump noise (`helm.sh/chart`, `checksum/config`, `app.kubernetes.io/version`, `chart`).
 
 ## Changed-only mode
 

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -25,22 +25,43 @@ func newDiffCmd() *cobra.Command {
 	return cmd
 }
 
+// defaultStripAttrs is the default `--strip-attr` list — annotations
+// and labels that Helm + kustomize rotate on every chart bump and
+// which contribute pure noise to PR-time diff review.
+var defaultStripAttrs = []string{
+	"helm.sh/chart",
+	"checksum/config",
+	"app.kubernetes.io/version",
+	"chart",
+}
+
+type diffFlags struct {
+	stripAttrs []string
+}
+
+func bindDiffFlags(cmd *cobra.Command, d *diffFlags) {
+	cmd.Flags().StringArrayVar(&d.stripAttrs, "strip-attr", defaultStripAttrs,
+		"metadata annotation/label key to strip before diffing (repeatable; supplying any value replaces the default set)")
+}
+
 func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
+	d := &diffFlags{}
 	cmd := &cobra.Command{
 		Use:     use,
 		Aliases: aliases,
 		Short:   short,
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiff(cmd, c, h, kind, firstArg(args))
+			return runDiff(cmd, c, h, d, kind, firstArg(args))
 		},
 	}
 	bindCommon(cmd.Flags(), c)
 	if rendersHelm([]string{kind}) {
 		bindHelmFlags(cmd.Flags(), h)
 	}
+	bindDiffFlags(cmd, d)
 	return cmd
 }
 
@@ -98,7 +119,7 @@ func imageSetDiff(orig, current map[string]struct{}, includeRemoved bool) []stri
 	return out
 }
 
-func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, kind, name string) error {
+func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kind, name string) error {
 	// diff has no `name` output mode; only diff/yaml/json/object are
 	// meaningful. Reject early so the user sees a clear error instead
 	// of "unknown diff format" from pkg/diff.
@@ -116,7 +137,10 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, kind, name string
 	if outFormat == "table" {
 		outFormat = "diff"
 	}
-	diffs, err := diff.Run(origDocs, currentDocs, diff.Options{Format: diff.Format(outFormat)})
+	diffs, err := diff.Run(origDocs, currentDocs, diff.Options{
+		Format:     diff.Format(outFormat),
+		StripAttrs: d.stripAttrs,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -34,6 +34,15 @@ const (
 type Options struct {
 	// Format selects the output flavor. Default FormatDiff.
 	Format Format
+	// StripAttrs lists annotation/label keys removed from each
+	// manifest's metadata (and pod-template metadata) before the diff
+	// is computed. Cuts chart-bump noise — annotations like
+	// `helm.sh/chart` or `checksum/config` whose values rotate on
+	// every chart bump would otherwise produce a diff entry per
+	// resource. dyff matches K8s lists by identifier but still
+	// reports string-value changes verbatim, so this pre-filter still
+	// pulls its weight after the dyff swap.
+	StripAttrs []string
 }
 
 // Parent identifies the Flux Kustomization or HelmRelease that
@@ -93,7 +102,9 @@ func joinNS(ns, name string) string {
 // (parent, kind, namespace, name) so a Deployment rendered by
 // HelmRelease A doesn't accidentally diff against the same-named
 // Deployment from HelmRelease B.
-func Run(left, right []Doc, _ Options) ([]ResourceDiff, error) {
+func Run(left, right []Doc, opts Options) ([]ResourceDiff, error) {
+	left = applyStrip(left, opts.StripAttrs)
+	right = applyStrip(right, opts.StripAttrs)
 	pairs := pair(left, right)
 	out := make([]ResourceDiff, 0, len(pairs))
 	for _, p := range pairs {
@@ -207,5 +218,22 @@ func pair(left, right []Doc) []pairedResource {
 		}
 		return cmp.Compare(a.name, b.name)
 	})
+	return out
+}
+
+// applyStrip clones each Doc's manifest and removes the listed
+// annotation/label keys before the diff runs. Deep-copies so the
+// original tree (used by other consumers in the same orchestrator
+// run) is untouched.
+func applyStrip(docs []Doc, attrs []string) []Doc {
+	if len(attrs) == 0 {
+		return docs
+	}
+	out := make([]Doc, len(docs))
+	for i, d := range docs {
+		copyDoc := manifest.DeepCopyMap(d.Manifest)
+		manifest.StripResourceAttributes(copyDoc, attrs)
+		out[i] = Doc{Manifest: copyDoc, Parent: d.Parent}
+	}
 	return out
 }

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -230,6 +230,47 @@ func TestResourceDiff_Header(t *testing.T) {
 	}
 }
 
+// TestRun_StripAttrsRemovesNoise pins that Options.StripAttrs is
+// applied before the dyff comparison: rotating a stripped annotation
+// without changing anything else yields zero diffs. This is the
+// chart-bump noise filter — `helm.sh/chart` changes on every chart
+// upgrade and would otherwise produce one entry per rendered
+// resource even with the K8s-aware dyff backend.
+func TestRun_StripAttrsRemovesNoise(t *testing.T) {
+	mk := func(chartLabel string) []Doc {
+		return []Doc{{
+			Manifest: map[string]any{
+				"kind": "Deployment",
+				"metadata": map[string]any{
+					"name":      "x",
+					"namespace": "ns",
+					"annotations": map[string]any{
+						"helm.sh/chart": chartLabel,
+					},
+				},
+			},
+		}}
+	}
+	diffs, err := Run(mk("myapp-1.2.3"), mk("myapp-1.2.4"),
+		Options{StripAttrs: []string{"helm.sh/chart"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diffs) != 0 {
+		t.Errorf("stripped annotation should produce no diff entries; got %d:\n%+v", len(diffs), diffs)
+	}
+
+	// Sanity: without --strip-attr, the same change DOES surface as
+	// a diff — proves the strip is what's suppressing the entry.
+	diffs, err = Run(mk("myapp-1.2.3"), mk("myapp-1.2.4"), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diffs) != 1 {
+		t.Errorf("control: unstripped annotation change should surface; got %d diffs", len(diffs))
+	}
+}
+
 // TestRun_DistinguishesByParent locks the parent-aware pairing: two
 // HelmReleases each rendering a same-named Deployment are tracked
 // independently — a change to HR/a's copy doesn't leak into a phantom

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -9,6 +9,11 @@
 // reordering a list produces an `⇆ order changed` marker instead of
 // a wall of phantom value-line churn.
 //
+// Options.StripAttrs is applied to a deep-copied tree before the
+// comparison runs — used to drop chart-bump noise (`helm.sh/chart`,
+// `checksum/config`, …) that rotates on every Helm upgrade but
+// carries no review-relevant signal.
+//
 // Four output flavors are supported:
 //
 //   - Diff   — concatenated dyff bodies, one per resource, with a

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1095,6 +1095,44 @@ metadata: {name: x}`, "Foo"},
 }
 
 
+func TestStripResourceAttributes(t *testing.T) {
+	r := map[string]any{
+		"kind": "Deployment",
+		"metadata": map[string]any{
+			"annotations": map[string]any{"helm.sh/chart": "myapp-1.2.3", "keep": "yes"},
+			"labels":      map[string]any{"app.kubernetes.io/version": "1.2.3"},
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{"checksum/config": "abc123"},
+				},
+			},
+		},
+	}
+	StripResourceAttributes(r, []string{
+		"helm.sh/chart",
+		"app.kubernetes.io/version",
+		"checksum/config",
+	})
+
+	meta := r["metadata"].(map[string]any)
+	ann := meta["annotations"].(map[string]any)
+	if _, ok := ann["helm.sh/chart"]; ok {
+		t.Errorf("annotation not stripped")
+	}
+	if ann["keep"] != "yes" {
+		t.Errorf("kept annotation lost")
+	}
+	if _, ok := meta["labels"]; ok {
+		t.Errorf("empty labels map should have been removed")
+	}
+	tplMeta := r["spec"].(map[string]any)["template"].(map[string]any)["metadata"].(map[string]any)
+	if _, ok := tplMeta["annotations"]; ok {
+		t.Errorf("template annotation not stripped (empty map should have been removed)")
+	}
+}
+
 func TestParseDoc_MissingFields(t *testing.T) {
 	if _, err := ParseDoc(map[string]any{"kind": "Foo"}, DefaultParseDocOptions()); err == nil || !strings.Contains(err.Error(), "apiVersion") {
 		t.Errorf("expected apiVersion error, got %v", err)

--- a/pkg/manifest/strip.go
+++ b/pkg/manifest/strip.go
@@ -1,0 +1,50 @@
+package manifest
+
+// StripResourceAttributes removes the listed annotation/label keys
+// from the metadata of a raw Kubernetes resource and (when relevant)
+// from its pod-template metadata and the items of a List. Used to
+// cut chart-bump noise (helm.sh/chart, checksum/config, …) out of
+// diffs before they reach the diff backend — dyff matches K8s lists
+// by identifier but still flags string-value changes verbatim, so
+// annotations whose values rotate on every chart update would
+// otherwise produce one entry per resource.
+func StripResourceAttributes(resource map[string]any, attrs []string) {
+	if metadata, ok := resource["metadata"].(map[string]any); ok {
+		stripAttrs(metadata, attrs)
+	}
+	if spec, ok := resource["spec"].(map[string]any); ok {
+		if tmpl, ok := spec["template"].(map[string]any); ok {
+			if meta, ok := tmpl["metadata"].(map[string]any); ok {
+				stripAttrs(meta, attrs)
+			}
+		}
+	}
+	if kind, _ := resource["kind"].(string); kind == "List" {
+		if items, ok := resource["items"].([]any); ok {
+			for _, it := range items {
+				m, ok := it.(map[string]any)
+				if !ok {
+					continue
+				}
+				if meta, ok := m["metadata"].(map[string]any); ok {
+					stripAttrs(meta, attrs)
+				}
+			}
+		}
+	}
+}
+
+func stripAttrs(metadata map[string]any, attrs []string) {
+	for _, key := range []string{"annotations", "labels"} {
+		val, ok := metadata[key].(map[string]any)
+		if !ok || val == nil {
+			continue
+		}
+		for _, a := range attrs {
+			delete(val, a)
+		}
+		if len(val) == 0 {
+			delete(metadata, key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Restore the `--strip-attr` flag dropped in #196 with its original four-entry default:

- `helm.sh/chart`
- `checksum/config`
- `app.kubernetes.io/version`
- `chart`

The strip is applied to a deep-copied tree before dyff runs, so the source store is untouched.

## Why

dyff is K8s-aware enough that most diff noise vanished after the swap — list reorders no longer explode, value changes report at semantic paths, etc. But annotations like `helm.sh/chart` and `checksum/config` are plain string values from dyff's perspective: every chart bump rotates them and would otherwise surface one diff entry per rendered resource (Deployment, Service, ConfigMap, …). The strip filter still pulls its weight as a pre-pass.

Re-restored `pkg/manifest.StripResourceAttributes` along with it (used to be only consumed by diff; cleaned up in #196 because the swap dropped its caller).

## Test plan

- [x] `go test ./pkg/diff/... ./pkg/manifest/...` — new `TestRun_StripAttrsRemovesNoise` pins that rotating a stripped annotation yields zero diffs, with a sanity control verifying the same change DOES surface without `--strip-attr`. Restored `TestStripResourceAttributes` covers the helper directly.
- [x] `golangci-lint run ./...` clean.
- [x] `flate diff ks --help` shows the flag with the four-entry default visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)