### PR TITLE
feat(diff): emit per-resource header only when there's more than one

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -129,14 +129,20 @@ func Render(diffs []ResourceDiff, format Format) ([]byte, error) {
 	switch format {
 	case "", FormatDiff:
 		var b bytes.Buffer
+		// Emit a `# <resource>` comment line above each body ONLY
+		// when there's more than one resource diff — with a single
+		// resource the dyff `@@ <path> @@` is unambiguous on its
+		// own, so the header would be pure noise. With multiple,
+		// dyff's path header doesn't identify the owning resource
+		// (`spec.template.spec.containers.app.image` could belong
+		// to any HelmRelease's Deployment), so we add a one-line
+		// `#`-prefixed identifier — dyff's own comment convention,
+		// rendered magenta by GitHub's diff lexer.
+		emitHeader := len(diffs) > 1
 		for _, d := range diffs {
-			h := d.Header()
-			// Per-resource header framed with `---` / `+++` so GitHub's
-			// diff lexer renders it as the file-name banner above each
-			// resource's body. The body itself is dyff `github`-mode
-			// output (path-keyed `@@` hunks, `+`/`-` value lines, `!`
-			// change-type markers).
-			fmt.Fprintf(&b, "--- %s\n+++ %s\n", h, h)
+			if emitHeader {
+				fmt.Fprintf(&b, "# %s\n", d.Header())
+			}
 			b.WriteString(d.Diff)
 			if !strings.HasSuffix(d.Diff, "\n") {
 				b.WriteByte('\n')

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -196,6 +196,53 @@ func TestRun_ContainerByNameImageChange(t *testing.T) {
 	}
 }
 
+// TestRender_DiffHeaderOnlyWhenMultiple pins the per-resource header
+// policy: a single diff renders bare (no `# ...` line), but two or
+// more diffs each get a `#`-prefixed identifier so the reader can
+// tell which resource a `@@ <path> @@` block belongs to. dyff's
+// path doesn't carry the owning resource, so headers are load-
+// bearing exactly when ambiguity is possible — and only then.
+func TestRender_DiffHeaderOnlyWhenMultiple(t *testing.T) {
+	mkDiff := func(name string) ResourceDiff {
+		return ResourceDiff{
+			Parent: Parent{Kind: "HelmRelease", Namespace: "media", Name: name},
+			Kind:   "Deployment", Namespace: "media", Name: name,
+			Diff: "\n@@ spec.replicas @@\n! ± value change\n- 1\n+ 2\n",
+		}
+	}
+
+	t.Run("single resource renders without header", func(t *testing.T) {
+		out, err := Render([]ResourceDiff{mkDiff("qui")}, FormatDiff)
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		if strings.Contains(string(out), "# HelmRelease") {
+			t.Errorf("single-resource output should not include a header line; got:\n%s", out)
+		}
+		if !strings.Contains(string(out), "@@ spec.replicas @@") {
+			t.Errorf("body should pass through verbatim; got:\n%s", out)
+		}
+	})
+
+	t.Run("multiple resources each get a header", func(t *testing.T) {
+		out, err := Render([]ResourceDiff{mkDiff("qui"), mkDiff("plex")}, FormatDiff)
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		s := string(out)
+		if !strings.Contains(s, "# HelmRelease: media/qui Deployment: media/qui") {
+			t.Errorf("missing qui header:\n%s", s)
+		}
+		if !strings.Contains(s, "# HelmRelease: media/plex Deployment: media/plex") {
+			t.Errorf("missing plex header:\n%s", s)
+		}
+		// And critically: NO flux-local-style `--- / +++` twin banners.
+		if strings.Contains(s, "--- HelmRelease") || strings.Contains(s, "+++ HelmRelease") {
+			t.Errorf("output reintroduced the --- / +++ twin banner:\n%s", s)
+		}
+	})
+}
+
 func TestFormat_JSON(t *testing.T) {
 	diffs := []ResourceDiff{{Kind: "ConfigMap", Name: "a", Diff: "..."}}
 	out, err := Render(diffs, FormatJSON)


### PR DESCRIPTION
## Summary

Stop wrapping every dyff body in the flux-local-style \`--- / +++\` twin banner. Two changes:

1. **Drop the twin banner entirely** — `--- HelmRelease: media/qui Deployment: media/qui` / `+++ HelmRelease: media/qui Deployment: media/qui` was just visual noise.
2. **Emit a single `# <resource>` header line, but only when there's more than one diff.** dyff's path (`@@ spec.template.spec.containers.app.image @@`) doesn't carry the owning resource, so identical paths across multiple HelmReleases are ambiguous — but a single-diff output is unambiguous on its own and needs no header.

## Before / after on buroa/k8s-gitops

Smoke-tested by bumping the image tag on `qui` (and optionally `plex`):

**Single resource (just qui bumped) — no header:**
\`\`\`

@@ spec.template.spec.containers.app.image @@
! ± value change
- ghcr.io/autobrr/qui:v1.19.0@sha256:baa0...
+ ghcr.io/autobrr/qui:v1.20.0@sha256:c0ff...
\`\`\`

**Multiple resources (qui + plex bumped) — single `#` header per body:**
\`\`\`
# HelmRelease: media/plex Deployment: media/plex

@@ spec.template.spec.containers.app.image @@
! ± value change
- ghcr.io/home-operations/plex-next:1.43.2.10687@sha256:b7b3...
+ ghcr.io/home-operations/plex-next:1.44.0.11000@sha256:dead...

# HelmRelease: media/qui Deployment: media/qui

@@ spec.template.spec.containers.app.image @@
! ± value change
- ghcr.io/autobrr/qui:v1.19.0@sha256:baa0...
+ ghcr.io/autobrr/qui:v1.20.0@sha256:c0ff...
\`\`\`

The `#` prefix is dyff's own comment convention (the \`DiffSyntaxReport.RootDescriptionPrefix\` we already use). GitHub's diff lexer renders it as a magenta comment line — no special framing required.

`FormatObject` (the structural embed format) still emits a header unconditionally; per-resource grouping is the whole point of that mode.

## Test plan

- [x] New `TestRender_DiffHeaderOnlyWhenMultiple` pins both branches: single-resource output has no `# HelmRelease` line, multi-resource output has one per body — and asserts no `--- /+++` regression.
- [x] `go test ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] Manual smoke against buroa/k8s-gitops (qui+plex image bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)