### PR TITLE
fix(discovery): alias bootstrap GitRepositories in any namespace

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -299,12 +299,22 @@ func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, n
 }
 
 // aliasBootstrapSources seeds a working-tree SourceArtifact for every
-// `flux-system/<name>` GitRepository referenced by a loaded
-// Kustomization whose definition isn't in the repo itself. Targets the
-// chkpwd-ops / flux-bootstrap pattern: the user's entry-point KSes
-// reference a custom-named GitRepository installed by `flux bootstrap`
-// but never committed. Without aliasing, every downstream KS fails
-// "source artifact not found".
+// GitRepository referenced by a loaded Kustomization whose definition
+// isn't in the repo itself. Targets `flux bootstrap` / flux-operator
+// FluxInstance patterns: the cluster's root GitRepository is created
+// out-of-band (the source that delivers the rest of the manifests
+// cannot, by construction, be one of the manifests it delivers), so
+// no static manifest exists in the tree to discover. Without aliasing,
+// every Kustomization referencing it via `sourceRef` fails depwait
+// with "dependency not found" (issue #199).
+//
+// All namespaces are aliased, not just `flux-system` — the convention
+// of running Flux in a non-default namespace (e.g. `gitops-system`)
+// is widespread, and the bootstrap-source-points-at-the-local-tree
+// property is identical regardless of where the user happens to deploy
+// Flux. A typo'd sourceRef name will silently render against the
+// working tree instead of failing fast — same trade-off the
+// `flux-system` path already accepted.
 func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 	known := make(map[manifest.NamedResource]struct{})
 	for _, obj := range d.cfg.Store.ListObjects(manifest.KindGitRepository) {
@@ -314,9 +324,6 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 	for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
 		ks, ok := obj.(*manifest.Kustomization)
 		if !ok || ks.SourceKind != manifest.KindGitRepository {
-			continue
-		}
-		if ks.SourceNamespace != manifest.DefaultNamespace {
 			continue
 		}
 		id := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: ks.SourceNamespace, Name: ks.SourceName}

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -85,6 +85,56 @@ spec:
 	}
 }
 
+// TestRun_AliasesNonDefaultNamespaceBootstrap pins issue #199: a
+// Kustomization whose sourceRef points at a GitRepository in a
+// non-`flux-system` namespace (typical of the flux-operator /
+// FluxInstance pattern, where Flux runs in `gitops-system` and the
+// root GitRepository is created out-of-band by the operator) must
+// have that GitRepository aliased to the working tree so depwait
+// resolves it. Without the fix, every consumer fails with
+// `dependency not found: GitRepository/gitops-system/gitops-system`.
+func TestRun_AliasesNonDefaultNamespaceBootstrap(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	mustWrite(t, filepath.Join(dir, "flux", "cluster.yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: flux-repositories
+  namespace: gitops-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: gitops-system
+    namespace: gitops-system
+  interval: 1h
+`)
+	mustWrite(t, filepath.Join(dir, "apps", "kustomization.yaml"), "resources: []\n")
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	aliased := manifest.NamedResource{
+		Kind: manifest.KindGitRepository, Namespace: "gitops-system", Name: "gitops-system",
+	}
+	if st.GetObject(aliased) == nil {
+		t.Errorf("expected GitRepository/gitops-system/gitops-system to be aliased; alias scoped only to flux-system would leave this case broken")
+	}
+	if st.GetArtifact(aliased) == nil {
+		t.Errorf("aliased GitRepository should have a SourceArtifact so depwait resolves")
+	}
+	info, ok := st.GetStatus(aliased)
+	if !ok || info.Status != store.StatusReady {
+		t.Errorf("aliased GitRepository should be Ready; got ok=%v info=%+v", ok, info)
+	}
+}
+
 func TestRun_RequiresStoreAndLoader(t *testing.T) {
 	t.Parallel()
 	if _, err := discovery.Run(context.Background(), discovery.Config{Path: t.TempDir()}); err == nil {


### PR DESCRIPTION
## Summary

Drop the `namespace == flux-system` gate from `aliasBootstrapSources`. Any unresolved GitRepository `sourceRef` referenced by a loaded Kustomization is now aliased to the working tree, regardless of which namespace Flux is deployed into.

Fixes #199

## Why

`aliasBootstrapSources` already existed to handle the flux-bootstrap pattern: the root GitRepository is created out-of-band (by `flux bootstrap`, a FluxInstance CR, a Talos extra-manifest, etc.) and never committed to the tree — by construction the source that delivers the rest of the manifests cannot be one of the manifests it delivers. Without aliasing, every consumer KS hits depwait with `dependency not found`.

But the alias was scoped to `flux-system`-namespace refs only. The flux-operator / FluxInstance pattern (controlplaneio-fluxcd, the reporter's setup) installs Flux into `gitops-system` and creates `GitRepository/gitops-system/gitops-system` via a `FluxInstance` CR at runtime. Same property — bootstrap source points at the local working tree — different namespace. The gate is the bug.

## Smoke-test against soulwhisper/home-ops (the reporter's repo, 127 KSes / 110 HRs)

**Before:**
```
reconcile complete kustomizations=127 helmReleases=110 failed=2
```
Two direct failures (`flux-repositories`, `cluster-apps`) plus ~38 cascade-orphans, all surfacing as `dependency not found: GitRepository/gitops-system/gitops-system`.

**After:**
```
reconcile complete kustomizations=127 helmReleases=110 failed=0
```

## Trade-off, called out in the doc comment

A typo'd `sourceRef.name` will now silently render against the working tree instead of failing fast. This is exactly the trade-off the `flux-system`-namespace path already made; extending to other namespaces is consistent.

## Test plan

- [x] `TestRun_AliasesNonDefaultNamespaceBootstrap` pins the fix: a KS with `sourceRef.namespace: gitops-system` must produce an aliased GitRepository in the store after `discovery.Run`. Without the fix this would have asserted-failed.
- [x] `go test ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] Manual smoke against the reporter's actual repo (soulwhisper/home-ops): `failed=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)