### PR TITLE
fix(change): extend keep set when KS controller emits rendered children

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -2,6 +2,7 @@ package change
 
 import (
 	"slices"
+	"sync"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -10,11 +11,24 @@ import (
 // against a keep-set resolved from a file-level diff. Construct via
 // NewFilter — the zero value is the "no filtering" sentinel and
 // returns true from ShouldReconcile for every id.
+//
+// The keep set is built once at construction and then extended at
+// runtime by Add: a parent KS already in the keep set may render and
+// emit child KS / HR resources that the file-walk discovery phase
+// couldn't see (kustomize component + replacement patterns generate
+// Flux Kustomizations on the fly). Those children inherit the
+// parent's in-scope-ness because the parent only reconciled by
+// passing the filter in the first place. See issue #204.
 type Filter struct {
 	changes     *Set
 	sourceFiles map[manifest.NamedResource]string
 	repoRoot    string
-	keep        map[manifest.NamedResource]struct{}
+
+	// mu guards keep + keepByName for runtime Add(); resolve() runs
+	// once during construction before the controllers start, so it
+	// doesn't need to hold the lock.
+	mu   sync.RWMutex
+	keep map[manifest.NamedResource]struct{}
 
 	// keepByName: (Kind, Name) presence set used as an O(1) fallback
 	// when either side of a lookup has an empty namespace.
@@ -64,6 +78,8 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	if !f.Enabled() {
 		return true
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	if _, ok := f.keep[id]; ok {
 		return true
 	}
@@ -75,6 +91,30 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 		return true
 	}
 	return false
+}
+
+// Add extends the keep set with id at runtime. Used by the KS
+// controller when a parent in the keep set emits id as a rendered
+// child — the file walk that built the keep set can't see those
+// emissions, but they're conceptually in-scope because the parent
+// only reconciled by passing the filter. Without this, the kustomize
+// component+replacement pattern (a parent KS emitting a per-app KS
+// via a ConfigMap-driven replacement) produces silent gaps in
+// changed-only diffs: the leaf KS isn't keep-set'd, never reconciles,
+// and its render output is missing from the diff. Issue #204.
+//
+// No-op when the filter is disabled. Safe for concurrent use.
+func (f *Filter) Add(id manifest.NamedResource) {
+	if !f.Enabled() {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.keep[id]; ok {
+		return
+	}
+	f.keep[id] = struct{}{}
+	f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
 }
 
 func (f *Filter) resolve(objs ObjectLister) {
@@ -174,12 +214,19 @@ func (f *Filter) Size() int {
 	if f == nil {
 		return 0
 	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	return len(f.keep)
 }
 
 // KeepNames returns the resolved keep-set as sorted strings for logs.
 func (f *Filter) KeepNames() []string {
-	if f == nil || f.keep == nil {
+	if f == nil {
+		return nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.keep == nil {
 		return nil
 	}
 	out := make([]string, 0, len(f.keep))
@@ -194,7 +241,12 @@ func (f *Filter) KeepNames() []string {
 // or nil when no scope can be derived (disabled, empty, or
 // cluster-scoped only).
 func (f *Filter) KeepNamespaces() map[string]struct{} {
-	if f == nil || f.keep == nil {
+	if f == nil {
+		return nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.keep == nil {
 		return nil
 	}
 	out := make(map[string]struct{})

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -325,6 +325,56 @@ func TestFilter_DependsOnNotFollowed(t *testing.T) {
 	}
 }
 
+// TestFilter_AddExtendsKeepSetAtRuntime pins issue #204: a parent
+// KS in the keep set may render and emit a child KS that wasn't
+// discoverable at filter-build time (kustomize component +
+// replacement patterns generate per-app Kustomizations on the fly).
+// The KS controller calls Filter.Add(child) before AddObject so the
+// listener's PreGate filter check sees the extended keep set.
+//
+// Without this, the kept parent reconciles but every render-emitted
+// child gets marked Ready "unchanged" by PreGate, never reconciles,
+// and the child's own render output is silently absent from the
+// diff (the user's repo: 37 of 40 OCIRepository digest changes
+// missing because their `components/ks/app` pattern emits the leaf
+// KS via replacements).
+func TestFilter_AddExtendsKeepSetAtRuntime(t *testing.T) {
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "database"}
+	child := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "database", Name: "leaf-app"}
+
+	f := NewFilter(
+		NewSet([]string{"apps/database/parent.yaml"}),
+		map[manifest.NamedResource]string{parent: "apps/database/parent.yaml"},
+		"",
+		emptyLister{},
+	)
+	if !f.ShouldReconcile(parent) {
+		t.Fatalf("parent must be in keep set from file change; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(child) {
+		t.Fatalf("precondition: child must NOT be in keep set before Add; keep=%v", f.KeepNames())
+	}
+
+	f.Add(child)
+	if !f.ShouldReconcile(child) {
+		t.Errorf("Add(child) should extend keep set; ShouldReconcile(child)=false; keep=%v", f.KeepNames())
+	}
+}
+
+// TestFilter_AddOnDisabledFilterIsNoOp protects against accidentally
+// activating the keep-set semantics when the filter is disabled
+// (no --path-orig). A disabled filter must continue to return true
+// for everything regardless of Add() calls.
+func TestFilter_AddOnDisabledFilterIsNoOp(t *testing.T) {
+	var f Filter
+	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}
+	f.Add(id)
+	other := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "y"}
+	if !f.ShouldReconcile(other) {
+		t.Errorf("disabled filter must still keep everything after Add()")
+	}
+}
+
 func TestFilter_ShouldReconcileEmptyNamespaceFallback(t *testing.T) {
 	hrLoaded := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "", Name: "x"}
 	hrLookup := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "media", Name: "x"}

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -261,6 +261,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			continue
 		}
 		if p.reconcilable {
+			c.keepEmitted(p.obj.Named())
 			c.Store.AddObject(p.obj)
 			c.markRendered(p.obj.Named())
 		} else {
@@ -270,9 +271,27 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	// Pass 2 — leaf reconcilables.
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
+			c.keepEmitted(p.obj.Named())
 			c.Store.AddObject(p.obj)
 			c.markRendered(p.obj.Named())
 		}
+	}
+}
+
+// keepEmitted extends the change filter's keep set so render-emitted
+// children pass the changed-only-mode PreGate check. Without this,
+// kustomize component+replacement patterns (parent KS emitting a
+// per-app KS via ConfigMap-driven replacements) produce silent gaps
+// in `flate diff`: the leaf KS isn't keep-set'd at filter-build time
+// because it didn't exist on disk, never reconciles, and its render
+// output never reaches the diff comparison. Issue #204.
+//
+// Called BEFORE Store.AddObject so the listener that fires
+// synchronously during AddObject sees the extended keep set when it
+// invokes PreGate.
+func (c *Controller) keepEmitted(id manifest.NamedResource) {
+	if f := c.Filter(); f != nil {
+		f.Add(id)
 	}
 }
 


### PR DESCRIPTION
## Summary

Make the change filter mutable post-build: KS controller calls `Filter.Add(child)` before `Store.AddObject(child)` in `emitRenderedChildren` so the listener's `PreGate` filter check sees the extended keep set. Render-emitted children inherit the parent's in-scope-ness because the parent only reconciled by passing the filter in the first place.

Fixes #204

## Why

The change filter's keep set was built once at construction from objects already in the Store. Kustomize component + replacement patterns (e.g. [aclerici38/home-ops' `components/ks/app`](https://github.com/aclerici38/home-ops/tree/main/kubernetes/components/ks) — a `Kustomization` template patched via a ConfigMap-driven replacement to substitute the app name) emit their per-app KSes only when the namespace KS renders. Those children don't exist on disk, so the file-walk-based keep-set construction can't see them.

Result in the reporter's PR: 37 of 40 OCIRepository digest changes silently dropped. The three that survived (cilium, rook-ceph, flux-meta) were artifacts of accidents:
- **cilium / rook-ceph** — the namespace KS and the app KS happen to share a name (`cilium` ↔ `cilium`), so the keep-set's `keepByName` fallback (designed for namespace-inheritance ambiguity) matched the child by coincidence.
- **flux-meta** — its OCIRepository lives in `flux/meta/`, statically owned by the `flux-meta` KS directly. No render-emit involved.

## Trade-offs

- **Concurrency:** filter is now mutable. `Add` takes a write lock, `ShouldReconcile` / `Size` / `KeepNames` / `KeepNamespaces` take read locks. Roughly +20ns per lookup. Acceptable given filter checks are infrequent on the hot path.
- **Cascade:** broader keep sets may surface other depwait failures (e.g. a leaf KS with `dependsOn` on something that's still out of scope). That's a different issue — the reporter's full 48-file PR has a wide enough keep set for chains to resolve naturally; single-file repros may not. Worth a follow-up if it bites users.

## Test plan

- [x] `TestFilter_AddExtendsKeepSetAtRuntime` — pins the exact #204 scenario: parent in keep set, child added at runtime, ShouldReconcile(child) returns true.
- [x] `TestFilter_AddOnDisabledFilterIsNoOp` — protects the "filter disabled = keep everything" contract from accidental activation.
- [x] `go test ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] Manual smoke against aclerici38/home-ops: the cloudnative-pg KS now reconciles in changed-only mode (was previously filtered out and silent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)