### PR TITLE
fix(change): scope keepByName fallback to empty-namespace entries only

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -71,9 +71,19 @@ func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repo
 func (f *Filter) Enabled() bool { return f != nil && f.changes != nil }
 
 // ShouldReconcile reports whether the controller for id should do work
-// (true when filtering is disabled). Lookups tolerate an empty
-// namespace on either side because parent-Kustomization targetNamespace
-// inheritance is applied lazily.
+// (true when filtering is disabled). The (Kind, Name) fallback below
+// bridges parent-Kustomization targetNamespace inheritance: a
+// resource loaded from disk with no namespace (entry kept with
+// Namespace="") and queried later with the inherited namespace
+// (lookup with Namespace=X) refers to the same logical resource.
+//
+// The fallback ONLY indexes keep-entries whose Namespace is empty —
+// so a fully-namespaced lookup never matches an unrelated fully-
+// namespaced entry that happens to share (Kind, Name). Without this
+// asymmetry the keep set would silently expand across namespaces
+// (e.g. a kept `Kustomization/cluster-infra/external-secrets`
+// dragging an unrelated `Kustomization/database/external-secrets`
+// into scope on name match alone).
 func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	if !f.Enabled() {
 		return true
@@ -83,10 +93,6 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	if _, ok := f.keep[id]; ok {
 		return true
 	}
-	// Fall back to a (Kind, Name)-only lookup when EITHER side has an
-	// empty namespace — parent-KS targetNamespace inheritance is lazy,
-	// so a keep-set entry from disk-load (namespace=="") and a lookup
-	// after inheritance (namespace set) refer to the same resource.
 	if _, ok := f.keepByName[nameKey{id.Kind, id.Name}]; ok {
 		return true
 	}
@@ -114,7 +120,9 @@ func (f *Filter) Add(id manifest.NamedResource) {
 		return
 	}
 	f.keep[id] = struct{}{}
-	f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+	if id.Namespace == "" {
+		f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+	}
 }
 
 func (f *Filter) resolve(objs ObjectLister) {
@@ -199,13 +207,16 @@ func (f *Filter) resolve(objs ObjectLister) {
 	}
 	f.keep = keep
 
-	// Index every keep-set entry by (kind, name) so the namespace-tolerant
-	// lookup path (ShouldReconcile when either side's namespace is empty)
-	// finds it. The full id is still required for the primary keep map —
-	// this is purely the namespace-degenerate fallback.
-	f.keepByName = make(map[nameKey]struct{}, len(keep))
+	// Index ONLY empty-namespace keep entries by (Kind, Name) — see
+	// ShouldReconcile's doc for the asymmetry rationale. Indexing
+	// every keep entry (regardless of namespace) would let one kept
+	// resource silently scope-in every same-(Kind, Name) resource in
+	// other namespaces.
+	f.keepByName = make(map[nameKey]struct{})
 	for id := range keep {
-		f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+		if id.Namespace == "" {
+			f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+		}
 	}
 }
 

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -390,3 +390,36 @@ func TestFilter_ShouldReconcileEmptyNamespaceFallback(t *testing.T) {
 		t.Fatalf("(Kind, Name) fallback didn't match; keep=%v", f.KeepNames())
 	}
 }
+
+// TestFilter_KeepByNameDoesNotLeakAcrossNamespaces pins the
+// asymmetric-fallback contract: a fully-namespaced keep entry must
+// NOT match a fully-namespaced lookup that happens to share
+// (Kind, Name). Without this, a kept
+// Kustomization/cluster-infra/external-secrets would silently scope-in
+// an unrelated Kustomization/database/external-secrets (and likewise
+// for the runtime Filter.Add path), broadening changed-only mode in
+// ways the user can't see. The empty-namespace bridge in
+// TestFilter_ShouldReconcileEmptyNamespaceFallback is preserved
+// because it indexes only entries whose Namespace is empty.
+func TestFilter_KeepByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
+	kept := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "cluster-infra", Name: "external-secrets"}
+	collider := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "database", Name: "external-secrets"}
+	f := NewFilter(
+		NewSet([]string{"apps/cluster-infra/external-secrets/ks.yaml"}),
+		map[manifest.NamedResource]string{kept: "apps/cluster-infra/external-secrets/ks.yaml"},
+		"",
+		emptyLister{},
+	)
+	if !f.ShouldReconcile(kept) {
+		t.Fatalf("precondition: cluster-infra/external-secrets must be in keep; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(collider) {
+		t.Errorf("keepByName leaked across namespaces: database/external-secrets matched on name alone; keep=%v", f.KeepNames())
+	}
+
+	// Same invariant via the runtime Add path (issue #204 surface).
+	f.Add(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "cert-manager"})
+	if f.ShouldReconcile(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "monitoring-system", Name: "cert-manager"}) {
+		t.Errorf("Add() leaked across namespaces: monitoring-system/cert-manager matched on name alone; keep=%v", f.KeepNames())
+	}
+}


### PR DESCRIPTION
## Summary

The change filter's `keepByName` `(Kind, Name)` fallback was indexing every keep entry and firing on every primary-keep miss — silently expanding the keep set across namespaces.

A kept `Kustomization/cluster-infra/external-secrets` matched a lookup for `Kustomization/database/external-secrets` on name alone. The cilium / rook-ceph "happens to work" pattern from #204/#205 was the same bug in beneficial guise: the parent namespace-KS and the child app-KS shared a name, and the fallback collision quietly kept them in scope.

## Fix

The fallback's actual purpose is bridging parent-`targetNamespace` inheritance: a resource loaded with no namespace (entry kept with `Namespace=""`) and queried later with the inherited namespace refer to the same resource. Only the empty-namespace case needs the (Kind, Name) bridge.

- `resolve()` indexes only `Namespace==""` entries into `keepByName`.
- `Add()` does the same for runtime additions.
- `ShouldReconcile` keeps its existing two-tier lookup; the bridge now only catches the legitimate case.

The cilium/rook-ceph scenario (#204) reaches the keep set via the explicit `Filter.Add(child)` from `emitRenderedChildren` instead of the keepByName collision — which is the principled path that #205 introduced.

## Test plan

- [x] **New `TestFilter_KeepByNameDoesNotLeakAcrossNamespaces`** pins the asymmetry for both `resolve()` and `Add()` code paths.
- [x] **`TestFilter_ShouldReconcileEmptyNamespaceFallback`** (the legitimate bridge case) still passes — its keep entry has `Namespace=""`.
- [x] `go test ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] Smoke against aclerici38/home-ops (the #204 repro): cloudnative-pg KS still enters reconcile via `Filter.Add` from `emitRenderedChildren` — the keepByName tightening doesn't regress #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)