### PR TITLE
chore: post-iter-N cleanup — dead format, dedupe, alias warn, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Every command takes `--path <dir>` (default `.`); `--path-orig <dir>` switches i
 | `diff` | `ks`, `hr`, `images` | Path-keyed diff against `--path-orig`, rendered via [dyff](https://github.com/homeport/dyff) in `--output github` mode. K8s-aware: list entries match by identifier (container name, env-var name), so a reorder shows as `⇆ order changed` instead of a wall of phantom value churn. |
 | `test` | `ks`, `hr`, `all` | Pytest-style `PASS` / `FAIL` / `SKIPPED` per resource. Non-zero exit on any failure. |
 
-`get` and `diff` accept `-l/--selector key=value` for label filtering. `diff` accepts `--strip-attr <key>` (repeatable) to drop annotation/label keys before comparison; the default set covers chart-bump noise (`helm.sh/chart`, `checksum/config`, `app.kubernetes.io/version`, `chart`).
+`get ks` and `get hr` accept `-l/--selector key=value` for label filtering. `diff` accepts `--strip-attr <key>` (repeatable) to drop annotation/label keys before comparison; the default set covers chart-bump noise (`helm.sh/chart`, `checksum/config`, `app.kubernetes.io/version`, `chart`). Every subcommand accepts `--allow-missing-secrets` to soft-skip sources whose auth Secret is missing or PLACEHOLDER-wiped — see [Behaviors](#behaviors).
 
 ## Changed-only mode
 
@@ -71,7 +71,7 @@ flate diff ks --path ./kubernetes --path-orig ../baseline/kubernetes
 | `Bucket` | `generic` only | `accesskey` + `secretkey`. `aws`/`gcp`/`azure` fail loud — use static creds. |
 | `ExternalArtifact` | `file://` only | `status.artifact.url` must be a local path. |
 
-PLACEHOLDER-wiped values (the always-on wipe of cleartext Secret data) are treated as missing — auth fails with a clear "missing username/password" instead of attempting auth with the placeholder string. Pass `--allow-missing-secrets` to convert these failures (and Secrets absent from the tree entirely) into a SKIPPED outcome; downstream Kustomizations and HelmReleases propagate the skip. Verify, cert, and proxy `secretRef`s are out of scope — they still fail loud, since silently dropping verification or TLS material is a security downgrade.
+PLACEHOLDER-wiped values (the always-on wipe of cleartext Secret data) are treated as missing — auth fails with a clear "missing username/password" instead of attempting auth with the placeholder string. See [Behaviors](#behaviors) for `--allow-missing-secrets`, which soft-skips affected sources end-to-end.
 
 ## Behaviors
 
@@ -79,7 +79,7 @@ PLACEHOLDER-wiped values (the always-on wipe of cleartext Secret data) are treat
 
 **`spec.suspend`** — honored on every reconcilable CR. Suspended resources mark `Ready / "suspended"` and produce no rendered output.
 
-**`--allow-missing-secrets`** — off by default. When set, a source whose auth `secretRef` is missing or PLACEHOLDER-wiped marks `Ready / "skipped: …"` instead of `Failed`, and consumers (KS `sourceRef`, HR `chartRef`) propagate the skip so `flate test` reports SKIPPED rather than a cascade of FAILED. Intended for repos that materialize auth on the live cluster via ExternalSecret / SealedSecret. Typos in `secretRef.name` are rejected at parse time so they don't silently fall into this path.
+**`--allow-missing-secrets`** — off by default. When set, a source whose auth `secretRef` is missing or PLACEHOLDER-wiped marks `Ready / "skipped: …"` instead of `Failed`, and consumers (KS `sourceRef`, HR `chartRef`) propagate the skip so `flate test` reports SKIPPED rather than a cascade of FAILED. Intended for repos that materialize auth on the live cluster via ExternalSecret / SealedSecret. Typos in `secretRef.name` are rejected at parse time so they don't silently fall into this path. Scope is auth `secretRef` only — verify, cert, and proxy `secretRef`s still fail loud, since silently dropping verification or TLS material is a security downgrade.
 
 **`spec.dependsOn[].readyExpr` (CEL)** — evaluated against `self` and `dep` projections, matching upstream kustomize- and helm-controller binding:
 
@@ -143,6 +143,7 @@ flate is rendering-only.
 - **No cloud workload identity.** `spec.serviceAccountName` is a no-op; use static creds in a Secret.
 - **No `healthChecks`.** flate tracks resource readiness, not status conditions of rendered objects.
 - **`ResourceSetInputProvider`: `Static` only.** Dynamic providers (GitHub, GitLab, OCIArtifactTag, ExternalService) need network access and contribute zero inputs.
+- **Diff output isn't a unified-diff patch.** `flate diff` emits dyff path-keyed syntax (`@@ <path> @@`); GitHub's diff lexer renders it natively but it won't apply with `patch` / `git apply` — use the rendered output of `flate build` if you need a literal patch.
 
 ## Development
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -51,25 +51,22 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 		"max parallel reconcile bodies (0 = unbounded)")
 }
 
-// skipResourceKinds returns the union of canonical kinds (CRDs +
-// Secrets when their corresponding boolean flags are set) and any
-// user-supplied `--skip-kinds` entries. Build / diff write paths
-// apply this against rendered docs from BOTH HelmRelease and
-// Kustomization sources — helm.TemplateDocs pre-filters HR output
-// inside the controller, but KS-rendered docs go through unfiltered
-// (the docs must reach the Store unfiltered so downstream HRs can
-// resolve valuesFrom / substituteFrom against them). The CLI applies
+// skipResourceKinds delegates to helm.Options.SkipResourceKinds so
+// the CLI write paths (build/diff emit) and the orchestrator's
+// in-controller filtering use one canonical union of canonical
+// kinds (CRDs + Secrets when their flags are set) plus any
+// user-supplied `--skip-kinds` entries. KS-rendered docs reach the
+// Store unfiltered (downstream HRs need them for valuesFrom /
+// substituteFrom resolution); HR-rendered docs are pre-filtered
+// inside the controller via helm.TemplateDocs. The CLI applies
 // this union at emit time so the user sees consistent filtering
 // regardless of which controller produced the resource.
 func (c *commonFlags) skipResourceKinds() []string {
-	out := append([]string{}, c.skipKinds...)
-	if c.skipCRDs {
-		out = append(out, "CustomResourceDefinition")
-	}
-	if c.skipSecrets {
-		out = append(out, "Secret")
-	}
-	return out
+	return helm.Options{
+		SkipCRDs:    c.skipCRDs,
+		SkipSecrets: c.skipSecrets,
+		SkipKinds:   c.skipKinds,
+	}.SkipResourceKinds()
 }
 
 // bindSelector wires the `-l/--selector` flag. Scoped to commands that

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -24,10 +24,9 @@ const (
 	// fence. K8s-aware: list entries are matched by identifier
 	// (container name, env-var name, etc.), so reordering a list
 	// produces no diff churn.
-	FormatDiff   Format = "diff"
-	FormatObject Format = "object"
-	FormatYAML   Format = "yaml"
-	FormatJSON   Format = "json"
+	FormatDiff Format = "diff"
+	FormatYAML Format = "yaml"
+	FormatJSON Format = "json"
 )
 
 // Options tunes Run behavior.
@@ -143,17 +142,6 @@ func Render(diffs []ResourceDiff, format Format) ([]byte, error) {
 			if emitHeader {
 				fmt.Fprintf(&b, "# %s\n", d.Header())
 			}
-			b.WriteString(d.Diff)
-			if !strings.HasSuffix(d.Diff, "\n") {
-				b.WriteByte('\n')
-			}
-		}
-		return b.Bytes(), nil
-	case FormatObject:
-		var b bytes.Buffer
-		for _, d := range diffs {
-			b.WriteString(d.Header())
-			b.WriteByte('\n')
 			b.WriteString(d.Diff)
 			if !strings.HasSuffix(d.Diff, "\n") {
 				b.WriteByte('\n')

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -14,14 +14,16 @@
 // `checksum/config`, …) that rotates on every Helm upgrade but
 // carries no review-relevant signal.
 //
-// Four output flavors are supported:
+// Three output flavors are supported:
 //
-//   - Diff   — concatenated dyff bodies, one per resource, with a
-//     per-resource `--- / +++` header banner (the default).
-//   - Object — a per-resource heading followed by the dyff body.
-//   - YAML   — structured YAML where each entry is a resource and its
+//   - Diff — concatenated dyff bodies, one per resource. Multi-
+//     resource output prefixes each body with a single `#`-style
+//     header line identifying the parent KS/HR; single-resource
+//     output omits the header because dyff's `@@ <path> @@` is
+//     unambiguous on its own (the default).
+//   - YAML — structured YAML where each entry is a resource and its
 //     dyff body.
-//   - JSON   — same shape as YAML, marshaled as JSON.
+//   - JSON — same shape as YAML, marshaled as JSON.
 //
 // [dyff]: https://github.com/homeport/dyff
 package diff

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -321,6 +321,7 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 		known[obj.Named()] = struct{}{}
 	}
 	seen := make(map[manifest.NamedResource]struct{})
+	var aliased []manifest.NamedResource
 	for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
 		ks, ok := obj.(*manifest.Kustomization)
 		if !ok || ks.SourceKind != manifest.KindGitRepository {
@@ -346,6 +347,21 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 		d.cfg.Store.UpdateStatus(id, store.StatusReady, "bootstrap alias")
 		slog.Debug("discovery: aliased bootstrap GitRepository",
 			"id", id.String(), "localPath", repoRoot)
+		aliased = append(aliased, id)
+	}
+	// Multiple unresolved GitRepositories is the cross-repo footgun:
+	// each gets aliased to the SAME working tree, so a real upstream
+	// shared-infra GitRepository would render against the wrong files
+	// without any user-visible signal. Warn so an operator can spot
+	// the divergence; the single-source case stays Debug because
+	// that's the intended flux-bootstrap shape.
+	if len(aliased) > 1 {
+		names := make([]string, len(aliased))
+		for i, id := range aliased {
+			names[i] = id.String()
+		}
+		slog.Warn("discovery: aliased multiple GitRepositories to the working tree; cross-repo refs render against the wrong tree",
+			"count", len(aliased), "ids", names, "localPath", repoRoot)
 	}
 }
 


### PR DESCRIPTION
## Summary

Five small follow-ups from the latest review pass:

1. **Drop dead `FormatObject`.** Unreachable since the dyff swap (`requireOutput` rejects everything except table/yaml/json). Removes one const, one switch branch, one stale doc bullet.

2. **Dedup CLI `skipResourceKinds`.** Was identical to `helm.Options.SkipResourceKinds`. Route the CLI through the helm.Options method so the next added kind lands in one place.

3. **`aliasBootstrapSources` Warn on multi-alias.** Single-alias is the intended flux-bootstrap shape (Debug stays). When **more than one** GitRepository gets aliased to the same working tree, that's the cross-repo footgun — a legitimate upstream shared-infra GitRepository would render against the wrong files with no signal. `slog.Warn` so operators can spot it.

4. **README — `-l/--selector` accuracy.** Only `get ks`/`get hr` bind the flag, not `diff`. Also promotes `--allow-missing-secrets` to the headline summary and dedupes the Source-kinds-and-auth footer against the Behaviors entry (was two slightly-different descriptions of the same flag).

5. **README Limits — dyff-output-isn't-a-patch.** Adds a one-liner so users don't try to feed `flate diff` output through `patch` / `git apply` — the `@@ <path> @@` syntax looks unified-diff-shaped enough to mislead.

## Test plan

- [x] `go test ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] `go mod tidy` produced no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)