### PR TITLE
fix(manifest): extend strip walker to CronJob jobTemplate + StatefulSet PVCs

### DIFF
--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -111,7 +111,7 @@ func (c *Controller) runFetch(ctx context.Context, id manifest.NamedResource, ob
 			// Soft-skip: leave the artifact slot empty so consumers see
 			// "no artifact" + Ready+"skipped:" status and propagate.
 			c.Store.UpdateStatus(id, store.StatusReady,
-				"skipped: "+manifest.TrimSentinelPrefix(err.Error()))
+				store.SkippedPrefix+" "+manifest.TrimSentinelPrefix(err.Error()))
 			slog.Info("source: skipped (missing secret)", "id", id.String(), "err", err)
 			return
 		}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1133,6 +1133,93 @@ func TestStripResourceAttributes(t *testing.T) {
 	}
 }
 
+// TestStripResourceAttributes_CronJob pins the CronJob walk: chart
+// labels live both on the JobTemplateSpec metadata AND on the nested
+// PodTemplateSpec metadata. Bitnami / app-template charts decorate
+// both, so chart bumps would otherwise produce two diff entries per
+// CronJob after the strip pass missed them.
+func TestStripResourceAttributes_CronJob(t *testing.T) {
+	r := map[string]any{
+		"kind": "CronJob",
+		"metadata": map[string]any{
+			"labels": map[string]any{"helm.sh/chart": "backup-1.0.0", "keep": "yes"},
+		},
+		"spec": map[string]any{
+			"jobTemplate": map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{"helm.sh/chart": "backup-1.0.0"},
+				},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"annotations": map[string]any{"checksum/config": "abc123"},
+						},
+					},
+				},
+			},
+		},
+	}
+	StripResourceAttributes(r, []string{"helm.sh/chart", "checksum/config"})
+
+	if meta := r["metadata"].(map[string]any); meta["labels"].(map[string]any)["keep"] != "yes" {
+		t.Errorf("top-level kept label lost")
+	}
+	jobTmpl := r["spec"].(map[string]any)["jobTemplate"].(map[string]any)
+	if _, ok := jobTmpl["metadata"].(map[string]any)["labels"]; ok {
+		t.Errorf("jobTemplate.metadata.labels should have been emptied + removed")
+	}
+	podTmplMeta := jobTmpl["spec"].(map[string]any)["template"].(map[string]any)["metadata"].(map[string]any)
+	if _, ok := podTmplMeta["annotations"]; ok {
+		t.Errorf("jobTemplate.spec.template.metadata.annotations should have been emptied + removed")
+	}
+}
+
+// TestStripResourceAttributes_StatefulSetPVCs pins the
+// volumeClaimTemplates walk: chart labels on StatefulSet PVC
+// templates (common pattern in Postgres / Loki / Prometheus charts)
+// must be stripped, or every chart bump produces N diff entries
+// (one per replica's PVC template).
+func TestStripResourceAttributes_StatefulSetPVCs(t *testing.T) {
+	r := map[string]any{
+		"kind": "StatefulSet",
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"labels": map[string]any{"helm.sh/chart": "pg-1.0.0"},
+				},
+			},
+			"volumeClaimTemplates": []any{
+				map[string]any{
+					"metadata": map[string]any{
+						"name":   "data",
+						"labels": map[string]any{"helm.sh/chart": "pg-1.0.0", "app": "pg"},
+					},
+				},
+				map[string]any{
+					"metadata": map[string]any{
+						"name":        "wal",
+						"annotations": map[string]any{"checksum/config": "abc"},
+					},
+				},
+			},
+		},
+	}
+	StripResourceAttributes(r, []string{"helm.sh/chart", "checksum/config"})
+
+	pvcs := r["spec"].(map[string]any)["volumeClaimTemplates"].([]any)
+	data := pvcs[0].(map[string]any)["metadata"].(map[string]any)
+	if _, ok := data["labels"].(map[string]any)["helm.sh/chart"]; ok {
+		t.Errorf("PVC[0].metadata.labels.helm.sh/chart should have been stripped")
+	}
+	if data["labels"].(map[string]any)["app"] != "pg" {
+		t.Errorf("PVC[0].metadata.labels.app (non-stripped) should remain")
+	}
+	wal := pvcs[1].(map[string]any)["metadata"].(map[string]any)
+	if _, ok := wal["annotations"]; ok {
+		t.Errorf("PVC[1].metadata.annotations should have been emptied + removed")
+	}
+}
+
 func TestParseDoc_MissingFields(t *testing.T) {
 	if _, err := ParseDoc(map[string]any{"kind": "Foo"}, DefaultParseDocOptions()); err == nil || !strings.Contains(err.Error(), "apiVersion") {
 		t.Errorf("expected apiVersion error, got %v", err)

--- a/pkg/manifest/strip.go
+++ b/pkg/manifest/strip.go
@@ -1,21 +1,65 @@
 package manifest
 
 // StripResourceAttributes removes the listed annotation/label keys
-// from the metadata of a raw Kubernetes resource and (when relevant)
-// from its pod-template metadata and the items of a List. Used to
-// cut chart-bump noise (helm.sh/chart, checksum/config, …) out of
-// diffs before they reach the diff backend — dyff matches K8s lists
-// by identifier but still flags string-value changes verbatim, so
-// annotations whose values rotate on every chart update would
-// otherwise produce one entry per resource.
+// from a raw Kubernetes resource's metadata, the pod-template
+// metadata for every workload shape Helm charts decorate, and the
+// items of a List. Used to cut chart-bump noise (helm.sh/chart,
+// checksum/config, …) out of diffs before they reach the diff
+// backend — dyff matches K8s lists by identifier but still flags
+// string-value changes verbatim, so annotations whose values rotate
+// on every chart update would otherwise produce one entry per
+// resource.
+//
+// Coverage:
+//
+//   - .metadata (every resource)
+//   - .spec.template.metadata (Deployment, StatefulSet, DaemonSet,
+//     ReplicaSet, Job — anything with a pod template)
+//   - .spec.jobTemplate.metadata AND
+//     .spec.jobTemplate.spec.template.metadata (CronJob — both the
+//     JobTemplateSpec and its nested PodTemplateSpec)
+//   - .spec.volumeClaimTemplates[*].metadata (StatefulSet — Helm
+//     charts decorate PVC templates with chart labels too)
+//   - List.items[*].metadata (recursing one level into each item)
+//
+// Without these extra walks, real chart bumps on bitnami/postgresql,
+// kube-prometheus-stack, app-template CronJobs, etc. produce diff
+// noise on every chart-version rotation despite the strip pass.
 func StripResourceAttributes(resource map[string]any, attrs []string) {
 	if metadata, ok := resource["metadata"].(map[string]any); ok {
 		stripAttrs(metadata, attrs)
 	}
 	if spec, ok := resource["spec"].(map[string]any); ok {
+		// Deployment / StatefulSet / DaemonSet / ReplicaSet / Job pod
+		// template.
 		if tmpl, ok := spec["template"].(map[string]any); ok {
 			if meta, ok := tmpl["metadata"].(map[string]any); ok {
 				stripAttrs(meta, attrs)
+			}
+		}
+		// CronJob jobTemplate + its nested pod template.
+		if jobTmpl, ok := spec["jobTemplate"].(map[string]any); ok {
+			if meta, ok := jobTmpl["metadata"].(map[string]any); ok {
+				stripAttrs(meta, attrs)
+			}
+			if jobSpec, ok := jobTmpl["spec"].(map[string]any); ok {
+				if podTmpl, ok := jobSpec["template"].(map[string]any); ok {
+					if meta, ok := podTmpl["metadata"].(map[string]any); ok {
+						stripAttrs(meta, attrs)
+					}
+				}
+			}
+		}
+		// StatefulSet PVC templates — Helm puts chart labels here too.
+		if pvcs, ok := spec["volumeClaimTemplates"].([]any); ok {
+			for _, pvc := range pvcs {
+				m, ok := pvc.(map[string]any)
+				if !ok {
+					continue
+				}
+				if meta, ok := m["metadata"].(map[string]any); ok {
+					stripAttrs(meta, attrs)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`StripResourceAttributes` only walked `.metadata` and `.spec.template.metadata`. Real Helm charts decorate two more shapes that produce noisy diffs every chart bump:

- **CronJob:** `.spec.jobTemplate.metadata` AND `.spec.jobTemplate.spec.template.metadata` (the JobTemplateSpec itself + the nested PodTemplateSpec).
- **StatefulSet:** `.spec.volumeClaimTemplates[*].metadata` (Postgres / Loki / Prometheus charts all label PVC templates).

These are exactly the workloads users care most about — backups, databases, observability — and every chart bump rotated `helm.sh/chart` / `app.kubernetes.io/version` on them, surviving the strip pass.

Also routes the source controller's `"skipped: "` literal through `store.SkippedPrefix` so the prefix has one source of truth (`base.RunWithStatus` already does this).

## Test plan

- [x] `TestStripResourceAttributes_CronJob` — pins jobTemplate + nested pod-template strip.
- [x] `TestStripResourceAttributes_StatefulSetPVCs` — pins PVC-template strip on a multi-PVC fixture.
- [x] Existing `TestStripResourceAttributes` (Deployment shape) still passes.
- [x] `go test ./...` clean; `golangci-lint run ./...` clean; `go mod tidy` no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)