### PR TITLE
fix(cli,testrunner): diff-images coercion, bootstrap-GR test filter, get-helm gate

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -84,8 +84,15 @@ func newDiffImagesCmd() *cobra.Command {
 }
 
 func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemoved bool) error {
-	// diff images emits a flat list — only json/yaml are honored.
-	if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+	// diff images emits a flat list of image refs — json/yaml/name
+	// are the meaningful shapes. The CLI default `-o table` would
+	// otherwise leak through `requireOutput`'s table-passthrough
+	// (common.go:requireOutput) and fall into emitImageList's
+	// newline-per-image branch, producing identical output to
+	// `-o name` with no signposting that the format was effectively
+	// coerced. Allow `-o name` explicitly, then route `table` →
+	// `name` so the default and the explicit form match.
+	if err := c.requireOutput(format.OutputYAML, format.OutputJSON, format.OutputName); err != nil {
 		return err
 	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
@@ -93,7 +100,11 @@ func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemo
 		return runErr
 	}
 	imgs := imageSetDiff(collectImages(orig.O, orig.Res, c), collectImages(current.O, current.Res, c), includeRemoved)
-	if err := emitImageList(cmd.OutOrStdout(), imgs, c.output); err != nil {
+	out := c.output
+	if out == string(format.OutputTable) {
+		out = string(format.OutputName)
+	}
+	if err := emitImageList(cmd.OutOrStdout(), imgs, out); err != nil {
 		return err
 	}
 	return runErr

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -196,7 +196,14 @@ func resourceListCmd[T manifest.BaseManifest](
 	}
 	bindCommon(cmd.Flags(), c)
 	bindSelector(cmd.Flags(), c)
-	bindHelmFlags(cmd.Flags(), h)
+	// Only attach helm-template flags when the kind being listed
+	// actually depends on Helm rendering — `get ks` listings don't,
+	// so showing --show-only / --no-hooks / --kube-version etc.
+	// confuses readers who'll wonder why the KS table cares about
+	// chart templating. Same gate `build` / `diff` / `test` use.
+	if rendersHelm([]string{kind}) {
+		bindHelmFlags(cmd.Flags(), h)
+	}
 	return cmd
 }
 

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -96,6 +96,18 @@ func Run(j Job) Report {
 			if j.Name != "" && id.Name != j.Name {
 				continue
 			}
+			// Skip the synthetic bootstrap GitRepository the
+			// discovery phase seeds for `spec.path` anchoring (see
+			// pkg/discovery.seedBootstrapSource). It carries the
+			// status message "bootstrap" so users running
+			// `flate test all` on a repo that doesn't actually
+			// declare flux-system/flux-system don't see a phantom
+			// PASSED row for an internal artifact.
+			if id == manifest.BootstrapSourceID {
+				if info, ok := j.Store.GetStatus(id); ok && info.Message == "bootstrap" {
+					continue
+				}
+			}
 			c := classify(j.Store, id)
 			switch c.Outcome {
 			case OutcomePassed:


### PR DESCRIPTION
## Summary

Three small UX bugs the latest review pass surfaced. Each is independent.

1. **`flate diff images -o table` silently emits a name-list.** Sibling `runDiff` coerces `table → diff`; `runDiffImages` did not. Explicitly accept `-o name` in `requireOutput` and coerce `table → name` so the default and the explicit form match.

2. **`flate test all` on a repo without `flux-system/flux-system` shows a phantom `PASSED`** for the synthetic bootstrap `GitRepository` the discovery phase seeds for `spec.path` anchoring. Skip that single entry — it carries `info.Message == "bootstrap"` precisely so callers can identify it as an internal artifact.

3. **`resourceListCmd` (the generic `get <kind>` builder) bound helm-template flags unconditionally.** `flate get ks --help` was advertising `--show-only`, `--no-hooks`, `--kube-version`, none of which influence the KS table. Gate via `rendersHelm()` like `build`/`diff`/`test` already do.

## Test plan

- [x] `go test ./...` clean; `golangci-lint run ./...` clean.
- [x] `flate diff images --help` lists name/json/yaml.
- [x] `flate get ks --help` no longer mentions helm-template knobs.
- [x] `flate get all --help` still shows them (intentional — get all renders HRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)