### PR TITLE
chore: StatusReady message constants + Filter.Add ordering godoc

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -137,12 +137,11 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 				continue
 			}
 		} else {
-			// --skip-secrets / --skip-crds / --skip-kinds apply across
-			// every source. HelmRelease output was pre-filtered by
-			// helm.TemplateDocs (no-op here), but KS-rendered docs
-			// reach the store unfiltered (downstream KS / HR resolve
-			// valuesFrom / substituteFrom against them). This emit-time
-			// drop ensures the user sees consistent filtering. See #169.
+			// Defensive re-drop. Orchestrator.Render already filters
+			// Result.Manifests at the embed boundary using the same
+			// kind set (orchestrator.go:555), so this is a no-op for
+			// the CLI path. Kept for SDK callers who hand-build a
+			// Result and pass it through writeRendered. See #169.
 			docs = manifest.DropKinds(docs, c.skipResourceKinds())
 			if len(docs) == 0 {
 				continue

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -176,9 +176,12 @@ func joinRunErrors(orig, curr error) error {
 // shows it for KS parents).
 func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
 	var out []diff.Doc
-	// Drop kinds the user opted out of (--skip-secrets / --skip-crds /
-	// --skip-kinds). KS-rendered docs reach Result.Manifests unfiltered;
-	// see comment in writeRendered. See #169.
+	// Defensive re-drop of --skip-secrets / --skip-crds / --skip-kinds.
+	// Orchestrator.Render already applies the same set to Result.Manifests
+	// at the embed boundary (orchestrator.go:555), so this is a no-op for
+	// CLI callers. It still pulls weight for SDK consumers who hand-build
+	// a Result and pass it through the CLI helpers in tests / harnesses.
+	// See #169.
 	var skip []string
 	if c != nil {
 		skip = c.skipResourceKinds()

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -134,8 +134,8 @@ func classify(s *store.Store, id manifest.NamedResource) Case {
 		// layers of bureaucracy. Same treatment the orchestrator gives
 		// its aggregated error.
 		return Case{ID: id, Outcome: OutcomeFailed, Reason: manifest.TrimSentinelPrefix(info.Message)}
-	case info.Status == store.StatusReady && info.Message == "unchanged":
-		return Case{ID: id, Outcome: OutcomeSkipped, Reason: "unchanged"}
+	case store.IsUnchanged(info):
+		return Case{ID: id, Outcome: OutcomeSkipped, Reason: store.MsgUnchanged}
 	case store.IsSkipped(info):
 		// Strip the `skipped: ` convention prefix from the stored
 		// message — the column already prints SKIPPED, so leading the

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -109,6 +109,13 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 // changed-only diffs: the leaf KS isn't keep-set'd, never reconciles,
 // and its render output is missing from the diff. Issue #204.
 //
+// Ordering contract for embedders: call Add(child) BEFORE the
+// emitting Store.AddObject(child). Store events fire synchronously
+// on the calling goroutine, so the controller's listener invokes
+// PreGate (and thus ShouldReconcile) inside that AddObject — if
+// Add ran after, the listener sees the old keep set and short-
+// circuits to Ready/"unchanged".
+//
 // No-op when the filter is disabled. Safe for concurrent use.
 func (f *Filter) Add(id manifest.NamedResource) {
 	if !f.Enabled() {

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -109,11 +109,11 @@ func (c *Controller) Submit(ctx context.Context, id manifest.NamedResource, fn f
 //   - otherwise → returns false, caller proceeds to Submit/reconcile
 func (c *Controller) PreGate(id manifest.NamedResource, suspended bool) bool {
 	if suspended {
-		c.Store.UpdateStatus(id, store.StatusReady, "suspended")
+		c.Store.UpdateStatus(id, store.StatusReady, store.MsgSuspended)
 		return true
 	}
 	if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
-		c.Store.UpdateStatus(id, store.StatusReady, "unchanged")
+		c.Store.UpdateStatus(id, store.StatusReady, store.MsgUnchanged)
 		return true
 	}
 	return false

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -8,17 +8,49 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-// SkippedPrefix is the message prefix UpdateStatus carries when a
-// resource was soft-skipped (e.g. by --allow-missing-secrets). Status
-// remains StatusReady — depwait treats the resource as ready so deps
-// unblock — but consumers can detect the skip via IsSkipped to
-// propagate it (KS resolveSourceRoot, test runner classification).
-const SkippedPrefix = "skipped:"
+// Canonical StatusReady message vocabulary. flate overloads
+// StatusReady with several "ready but…" sub-states encoded in the
+// message text — depwait treats them uniformly as ready (so deps
+// unblock), while consumers branch on the message to decide UI /
+// propagation.
+//
+// Three sub-states exist today:
+//
+//   - SkippedPrefix — a resource soft-skipped by --allow-missing-
+//     secrets (or by a consumer propagating a source-skip). Detect
+//     via IsSkipped. Message format: "skipped: <reason>".
+//   - MsgUnchanged — the change-filter excluded this resource
+//     because its sources weren't in the diff. Detect via
+//     IsUnchanged. Used by `flate test` for SKIPPED outcomes.
+//   - MsgSuspended — spec.suspend was honored. Detect via
+//     IsSuspended.
+//
+// All three are kept in one place so the literal-vs-helper drift
+// (testrunner's `info.Message == "unchanged"` direct compare, etc.)
+// has exactly one source of truth and a future rephrasing in
+// controllers/base only requires updating the constant here.
+const (
+	SkippedPrefix = "skipped:"
+	MsgUnchanged  = "unchanged"
+	MsgSuspended  = "suspended"
+)
 
 // IsSkipped reports whether info represents a soft-skip — i.e. a
 // StatusReady whose message starts with SkippedPrefix.
 func IsSkipped(info StatusInfo) bool {
 	return info.Status == StatusReady && strings.HasPrefix(info.Message, SkippedPrefix)
+}
+
+// IsUnchanged reports whether info represents a change-filter
+// exclusion (StatusReady + MsgUnchanged).
+func IsUnchanged(info StatusInfo) bool {
+	return info.Status == StatusReady && info.Message == MsgUnchanged
+}
+
+// IsSuspended reports whether info represents a spec.suspend honor
+// (StatusReady + MsgSuspended).
+func IsSuspended(info StatusInfo) bool {
+	return info.Status == StatusReady && info.Message == MsgSuspended
 }
 
 // Status is the processing state of a resource as projected from its


### PR DESCRIPTION
## Summary

Three small drift items from the latest review:

1. **`MsgUnchanged` / `MsgSuspended` constants** matching the existing `SkippedPrefix`. `base.PreGate` wrote the literals; the testrunner classified `"unchanged"` via raw `info.Message == "unchanged"` compare. Now all three are centralized in `pkg/store/status.go` with paired `IsUnchanged` / `IsSuspended` helpers, and `base.PreGate` + testrunner route through them. Future rephrasing only requires updating the constant.

2. **`Filter.Add` godoc missed the ordering contract.** The README documents "call BEFORE `Store.AddObject(child)`" (because the store fires `EventObjectAdded` synchronously and the listener runs PreGate inside the AddObject call); the package doc didn't. Extend it.

3. **`gatherArtifacts` + `writeRendered` comments stale.** They claimed "KS-rendered docs reach the store unfiltered" — true historically, but `Orchestrator.Render` now drops at the embed boundary (`orchestrator.go:555`), so the CLI re-drop is a no-op for CLI callers and defensive only for SDK callers building `Result` by hand. Clarify.

## Test plan

- [x] `go test ./...` clean; `golangci-lint run ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)