### PR TITLE
fix: bootstrap-GR test skip in changed-only mode + IsSuspended + log noise

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -40,7 +40,7 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 	fs.BoolVar(&f.skipCRDs, "skip-crds", true, "exclude CRD objects from rendered output")
 	fs.BoolVar(&f.skipSecrets, "skip-secrets", true, "exclude Secret objects from rendered output")
 	fs.BoolVar(&f.allowMissingSecrets, "allow-missing-secrets", false,
-		"soft-skip sources whose auth Secret is missing or has PLACEHOLDER-wiped values "+
+		"soft-skip sources whose auth Secret is missing or whose values are placeholders "+
 			"(typical when the live cluster materializes auth via ExternalSecret); dependent "+
 			"Kustomizations/HelmReleases propagate the skip. Verify/cert/proxy secretRefs still fail loud.")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -97,16 +97,17 @@ func Run(j Job) Report {
 				continue
 			}
 			// Skip the synthetic bootstrap GitRepository the
-			// discovery phase seeds for `spec.path` anchoring (see
-			// pkg/discovery.seedBootstrapSource). It carries the
-			// status message "bootstrap" so users running
-			// `flate test all` on a repo that doesn't actually
-			// declare flux-system/flux-system don't see a phantom
-			// PASSED row for an internal artifact.
+			// discovery phase seeds for `spec.path` anchoring — it's
+			// always an internal artifact. Discovery initially tags
+			// it with the "bootstrap" message, but changed-only mode's
+			// PreGate later overwrites that with MsgUnchanged, so the
+			// status-message check that PR #212 introduced misses in
+			// the typical `flate diff ks --path-orig=...` CI flow.
+			// Skip by id alone: a user who explicitly declares a
+			// GitRepository/flux-system/flux-system loses report
+			// visibility on it (rare; flate would alias to it anyway).
 			if id == manifest.BootstrapSourceID {
-				if info, ok := j.Store.GetStatus(id); ok && info.Message == "bootstrap" {
-					continue
-				}
+				continue
 			}
 			c := classify(j.Store, id)
 			switch c.Outcome {
@@ -136,6 +137,11 @@ func classify(s *store.Store, id manifest.NamedResource) Case {
 		return Case{ID: id, Outcome: OutcomeFailed, Reason: manifest.TrimSentinelPrefix(info.Message)}
 	case store.IsUnchanged(info):
 		return Case{ID: id, Outcome: OutcomeSkipped, Reason: store.MsgUnchanged}
+	case store.IsSuspended(info):
+		// spec.suspend was honored. A user-suspended KS / HR isn't
+		// rendered, so reporting PASSED would be misleading — the
+		// resource is intentionally inert, not "tests passed."
+		return Case{ID: id, Outcome: OutcomeSkipped, Reason: store.MsgSuspended}
 	case store.IsSkipped(info):
 		// Strip the `skipped: ` convention prefix from the stored
 		// message — the column already prints SKIPPED, so leading the

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -489,15 +489,18 @@ func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.Status
 
 func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]store.StatusInfo) {
 	for id, info := range failed {
-		// Include the originating source file when known so the user can
-		// jump straight to the offending YAML — `flux error: input error:`
-		// chains alone don't reveal which spec.path declared a missing
-		// directory.
+		// Demoted to Debug: the same failure list is surfaced as a
+		// structured error by aggregateFailures (with file paths
+		// included) AND echoed by the test runner / build CLI's own
+		// per-resource output. Logging at Warn here double-emits to
+		// stderr alongside the user-facing report and reads as
+		// "flate had an internal error" when it's just normal
+		// per-resource Flux failures the user expects to see.
 		args := []any{"id", id.String(), "reason", manifest.TrimSentinelPrefix(info.Message)}
 		if f := o.sourceFiles[id]; f != "" {
 			args = append(args, "file", f)
 		}
-		slog.Warn("resource failed", args...)
+		slog.Debug("resource failed", args...)
 	}
 }
 


### PR DESCRIPTION
## Summary

Four small follow-ups from the latest review.

1. **Bootstrap-GR skip in changed-only mode.** PR #212 skipped the synthetic `flux-system/flux-system` GitRepository in `flate test all` by keying on `info.Message == "bootstrap"`. That's the discovery-seed value, but changed-only mode's `PreGate` overwrites the message with `MsgUnchanged` before testrunner sees it. The skip missed in the most common CI shape (`flate diff ks --path-orig=...`), surfacing a phantom `GitRepository/flux-system/flux-system SKIPPED (unchanged)` row. Match by id alone.

2. **`IsSuspended` testrunner case.** PR #213 added the helper alongside `IsUnchanged`/`IsSkipped`, but `classify()` didn't branch on it. A user-suspended Kustomization or HelmRelease fell into the `StatusReady` arm and reported `PASSED` — misleading. Now reports `SKIPPED (suspended)`.

3. **`logResourceFailures` double-emit.** The function emitted `slog.Warn` per failure, but the same failures are also surfaced via `aggregateFailures` (returned as a structured error) and reprinted by every CLI verb's per-resource report. The Warn double-emit reads as "flate had an internal problem" when it's normal Flux per-resource failures the user expects. Demote to `Debug`; structured error and verb output stay.

4. **`--allow-missing-secrets` help text.** Dropped the unexplained "PLACEHOLDER-wiped" jargon ("values are placeholders" instead).

## Test plan

- [x] `go test ./...` clean; `golangci-lint run ./...` clean.
- [x] Manual smoke against the `flate diff ks --path-orig` flow — bootstrap GR no longer surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)