### PR TITLE
feat(diff): always emit per-resource header, even for single diffs

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -128,20 +128,17 @@ func Render(diffs []ResourceDiff, format Format) ([]byte, error) {
 	switch format {
 	case "", FormatDiff:
 		var b bytes.Buffer
-		// Emit a `# <resource>` comment line above each body ONLY
-		// when there's more than one resource diff — with a single
-		// resource the dyff `@@ <path> @@` is unambiguous on its
-		// own, so the header would be pure noise. With multiple,
-		// dyff's path header doesn't identify the owning resource
-		// (`spec.template.spec.containers.app.image` could belong
-		// to any HelmRelease's Deployment), so we add a one-line
-		// `#`-prefixed identifier — dyff's own comment convention,
-		// rendered magenta by GitHub's diff lexer.
-		emitHeader := len(diffs) > 1
+		// Emit a `# <resource>` comment line above every body. dyff's
+		// `@@ <path> @@` identifies the data path that changed but
+		// not the owning resource (`spec.template.spec.containers
+		// .app.image` is which Deployment from which HelmRelease?),
+		// so the header is load-bearing even when there's only one
+		// diff — a reviewer scanning a PR comment shouldn't have to
+		// infer the resource from the body. `#`-prefixed lines are
+		// dyff's own comment convention; GitHub's diff lexer renders
+		// them magenta.
 		for _, d := range diffs {
-			if emitHeader {
-				fmt.Fprintf(&b, "# %s\n", d.Header())
-			}
+			fmt.Fprintf(&b, "# %s\n", d.Header())
 			b.WriteString(d.Diff)
 			if !strings.HasSuffix(d.Diff, "\n") {
 				b.WriteByte('\n')

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -196,13 +196,14 @@ func TestRun_ContainerByNameImageChange(t *testing.T) {
 	}
 }
 
-// TestRender_DiffHeaderOnlyWhenMultiple pins the per-resource header
-// policy: a single diff renders bare (no `# ...` line), but two or
-// more diffs each get a `#`-prefixed identifier so the reader can
-// tell which resource a `@@ <path> @@` block belongs to. dyff's
-// path doesn't carry the owning resource, so headers are load-
-// bearing exactly when ambiguity is possible — and only then.
-func TestRender_DiffHeaderOnlyWhenMultiple(t *testing.T) {
+// TestRender_DiffHeaderAlwaysEmitted pins the per-resource header
+// policy: every diff body gets a `#`-prefixed identifier, even when
+// there's only one diff in the output. dyff's `@@ <path> @@`
+// identifies the data path but not the owning resource, so a
+// reviewer scanning a PR comment shouldn't have to infer the
+// resource from the body. Critically: NO flux-local-style `---/+++`
+// twin banner — the single `#` line is the load-bearing identifier.
+func TestRender_DiffHeaderAlwaysEmitted(t *testing.T) {
 	mkDiff := func(name string) ResourceDiff {
 		return ResourceDiff{
 			Parent: Parent{Kind: "HelmRelease", Namespace: "media", Name: name},
@@ -211,16 +212,17 @@ func TestRender_DiffHeaderOnlyWhenMultiple(t *testing.T) {
 		}
 	}
 
-	t.Run("single resource renders without header", func(t *testing.T) {
+	t.Run("single resource still gets a header", func(t *testing.T) {
 		out, err := Render([]ResourceDiff{mkDiff("qui")}, FormatDiff)
 		if err != nil {
 			t.Fatalf("Render: %v", err)
 		}
-		if strings.Contains(string(out), "# HelmRelease") {
-			t.Errorf("single-resource output should not include a header line; got:\n%s", out)
+		s := string(out)
+		if !strings.Contains(s, "# HelmRelease: media/qui Deployment: media/qui") {
+			t.Errorf("single-resource output must still include the header; got:\n%s", s)
 		}
-		if !strings.Contains(string(out), "@@ spec.replicas @@") {
-			t.Errorf("body should pass through verbatim; got:\n%s", out)
+		if !strings.Contains(s, "@@ spec.replicas @@") {
+			t.Errorf("body should pass through verbatim; got:\n%s", s)
 		}
 	})
 
@@ -236,7 +238,7 @@ func TestRender_DiffHeaderOnlyWhenMultiple(t *testing.T) {
 		if !strings.Contains(s, "# HelmRelease: media/plex Deployment: media/plex") {
 			t.Errorf("missing plex header:\n%s", s)
 		}
-		// And critically: NO flux-local-style `--- / +++` twin banners.
+		// Critically: NO flux-local-style `--- / +++` twin banners.
 		if strings.Contains(s, "--- HelmRelease") || strings.Contains(s, "+++ HelmRelease") {
 			t.Errorf("output reintroduced the --- / +++ twin banner:\n%s", s)
 		}


### PR DESCRIPTION
## Summary

Revert the \"only when \`len(diffs) > 1\`\" gate from #200. Always emit \`# <resource>\` above each diff body, regardless of how many diffs are in the output.

## Why

The conditional saved one line on single-resource output but cost the reviewer context: dyff's \`@@ <path> @@\` identifies the data path that changed, not the owning resource. Even with one diff, a reviewer scanning a PR comment shouldn't have to infer \"which Deployment from which HelmRelease\" from the body content.

User asked for this directly: \"keep the headers, even if it's just one. Makes it easier to determine what object changed.\"

## Test plan

- [x] \`TestRender_DiffHeaderAlwaysEmitted\` renamed from \`TestRender_DiffHeaderOnlyWhenMultiple\`; pins the new always-on behavior for both single- and multi-resource cases. Guard against re-introducing the \`---/+++\` twin banner stays.
- [x] \`go test ./...\` clean; \`golangci-lint run ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)