### PR TITLE
fix(cli): surface Bootstrap errors instead of drowning them in test report

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -247,6 +247,22 @@ func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config) (*orchestr
 		return nil, nil, err
 	}
 	res, err := o.Render(ctx)
+	// Render nils the result only when Bootstrap fails (Run-time
+	// per-resource failures still produce a non-nil Result). Drop
+	// the partial orchestrator in that case: every CLI verb gates
+	// on `o == nil` to surface the underlying error, but without
+	// this nil-out the verb would proceed to read a Store that's
+	// partially populated by the discovery pre-Bootstrap walk and
+	// produce confusing output — e.g. `flate test all` reporting
+	// every loaded resource as "FAILED (no status reported)"
+	// instead of surfacing the actual Bootstrap error (an
+	// unimplemented ResourceSet inputStrategy, a YAML schema
+	// rejection, etc.). Issue surfaced by tholinka/home-ops where
+	// a Permute ResourceSet drowned the real "not yet implemented"
+	// message under 247 phantom failures.
+	if res == nil {
+		return nil, nil, err
+	}
 	return o, res, err
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -227,6 +227,62 @@ func TestE2E_DiffImagesRequiresPathOrig(t *testing.T) {
 	}
 }
 
+// TestE2E_BootstrapErrorSurfacesNotMasked pins the contract that
+// when discovery itself fails (e.g. an unimplemented ResourceSet
+// inputStrategy, a YAML schema rejection), the actual error reaches
+// the user instead of getting drowned under a wall of phantom
+// "FAILED (no status reported)" rows from the testrunner running on
+// a partial Store. Surfaced by tholinka/home-ops where a `Permute`
+// ResourceSet produced 247 generic failure rows instead of the
+// "not yet implemented (#109)" message.
+func TestE2E_BootstrapErrorSurfacesNotMasked(t *testing.T) {
+	dir := t.TempDir()
+	// Minimal repo: one Kustomization + one Permute ResourceSet.
+	// Discovery's render pass hits Permute, returns the input-error,
+	// Bootstrap returns it, Render nils the Result, the CLI must
+	// surface the underlying error rather than running the testrunner
+	// on partial state.
+	if err := os.WriteFile(filepath.Join(dir, "ks.yaml"), []byte(`---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "rs.yaml"), []byte(`---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata: {name: permute-rs, namespace: flux-system}
+spec:
+  inputStrategy:
+    name: Permute
+  resourcesTemplate: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata: {name: x, namespace: ns}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runCLIExpectErr(t, "test", "all", "--path", dir)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit; got 0:\n%s", out)
+	}
+	if !strings.Contains(out, "Permute") {
+		t.Errorf("error must mention Permute (the actual Bootstrap failure); got:\n%s", out)
+	}
+	// Guard against the regression: the testrunner used to run on
+	// the partial Store and emit one "FAILED (no status reported)"
+	// row per loaded object. Collect-N where N is the partial count
+	// is the signature.
+	if strings.Contains(out, "no status reported") {
+		t.Errorf("Bootstrap failure should NOT trigger testrunner output; got:\n%s", out)
+	}
+}
+
 // TestE2E_ComponentChangePropagatesToAllConsumers — the fixture has
 // two apps (app-a, app-b) consuming components/shared; mutating the
 // shared component must show up in both consumers' diffs.


### PR DESCRIPTION
## Summary

When discovery itself fails — unimplemented `ResourceSet` inputStrategy (e.g. `Permute`, the actual user trigger), YAML schema rejection, a `dependsOn` cycle — `Orchestrator.Render` returns `(nil, err)`. But `runOrchestratorCfg` was returning `(orchestrator, nil, err)`, so every verb's `if o == nil` gate let execution proceed. `flate test all` then ran the testrunner against the partially-loaded Store, producing one \"FAILED (no status reported)\" row per loaded object and a generic \"test failures detected\" exit — drowning the actual Bootstrap error.

## Reproduction (user's repo)

tholinka/home-ops has a `ResourceSet` with `spec.inputStrategy.name: Permute`. Before this fix, `flate test all` produced:

```
collected 247 items
Kustomization/...                    FAILED (no status reported)
Kustomization/...                    FAILED (no status reported)
... 247 lines ...
0 passed, 0 skipped, 247 failed
flate error: test failures detected
```

After the fix:
```
flate error: ResourceSet flux-system/dragonfly-acls: flux error: input error: ResourceSet flux-system/dragonfly-acls requests spec.inputStrategy.name=Permute, which flate does not yet implement (#109)
```

User called the original behavior \"nullpointer\" — colloquial for \"every resource broken, no clue why.\"

## Fix

In `runOrchestratorCfg`, drop the orchestrator when Render's result is nil:

```go
res, err := o.Render(ctx)
if res == nil {
    return nil, nil, err
}
return o, res, err
```

Render nils the result only on Bootstrap failure; Run-time per-resource failures still produce a non-nil `Result` and reach the testrunner as before. All existing `if o == nil { return runErr }` gates in `test`/`build`/`get`/`diff` then surface the real error directly.

## Test plan

- [x] `TestE2E_BootstrapErrorSurfacesNotMasked` pins both directions: the Permute mention is in the error AND \"no status reported\" never appears.
- [x] `go test ./...` clean.
- [x] `golangci-lint run ./...` clean.
- [x] Manual smoke against tholinka/home-ops: `test all` / `build all` / `get all` all surface the actual Permute error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)