### PR TITLE
feat(resourceset): implement spec.inputStrategy: Permute (#109)

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -144,9 +144,20 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	// pass discovered, plus ResourceSets that may emit further KSes.
 	// PreferExisting lets repeated AddObject re-emission be a no-op so
 	// the loop terminates on convergence (no new objects added).
+	//
+	// ResourceSets are re-rendered every iteration rather than memoized,
+	// because a RS's inputsFrom selector may match RSIPs that only
+	// arrive after a downstream Kustomization chain expands. Without
+	// the retry, a RS whose RSIPs are produced by a child KS renders
+	// to zero docs on first pass and never recovers — observed in
+	// tholinka/home-ops where `dragonfly-acls` (a Permute RS) selects
+	// RSIPs created by an unrelated `dragonfly/manual` component
+	// applied through `renovate-operator-jobs-jobs`. Re-rendering is
+	// safe: renderResourceSet skips already-present objects in the
+	// store, so a steady-state RS contributes 0 new docs and the loop
+	// converges via the `added == 0` exit.
 	l.PreferExisting = true
 	ksExpanded := map[manifest.NamedResource]struct{}{}
-	rsExpanded := map[manifest.NamedResource]struct{}{}
 	for {
 		added := 0
 		for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
@@ -180,11 +191,6 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			if !ok {
 				continue
 			}
-			id := rs.Named()
-			if _, ok := rsExpanded[id]; ok {
-				continue
-			}
-			rsExpanded[id] = struct{}{}
 			n, err := d.renderResourceSet(rs)
 			if err != nil {
 				return err

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -135,6 +135,84 @@ spec:
 	}
 }
 
+// TestRun_ResourceSetReExpandsForLateRSIPs pins a discovery-loop
+// fix: a ResourceSet whose RSIP providers only become visible in a
+// later iteration (because they live behind a Kustomization path
+// that hasn't been walked yet) must be re-rendered, not memoized
+// after its first empty render. Without the fix, the RS would
+// render to zero docs on the first pass — when no RSIPs were in
+// the store — and never recover when the deeper KS expansion
+// produced them.
+func TestRun_ResourceSetReExpandsForLateRSIPs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Root: a parent KS that points at apps/, plus an RS at the same
+	// level. The RS selects RSIPs by label in its own namespace.
+	mustWrite(t, filepath.Join(dir, "flux", "parent.yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: parent, namespace: flux-system}
+spec:
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system}
+  interval: 10m
+`)
+	mustWrite(t, filepath.Join(dir, "flux", "rs.yaml"), `---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata: {name: late-rs, namespace: flux-system}
+spec:
+  inputsFrom:
+    - apiVersion: fluxcd.controlplane.io/v1
+      kind: ResourceSetInputProvider
+      selector:
+        matchLabels: {role: db}
+  resourcesTemplate: |
+    ---
+    apiVersion: kustomize.toolkit.fluxcd.io/v1
+    kind: Kustomization
+    metadata: {name: child-<< index (index inputs "provider") "name" >>, namespace: flux-system}
+    spec:
+      path: ./child
+      sourceRef: {kind: GitRepository, name: flux-system}
+`)
+	// RSIP lives BEHIND the parent KS's path — discovery must expand
+	// that path before the RSIP is in the store. Re-rendering the RS
+	// on a later iter is what makes the child-rsip Kustomization show
+	// up at all.
+	mustWrite(t, filepath.Join(dir, "apps", "rsip.yaml"), `---
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: rsip
+  namespace: flux-system
+  labels: {role: db}
+spec:
+  type: Static
+  defaultValues:
+    user: alice
+`)
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The RS render produces a Kustomization named "child-rsip" — present
+	// only when the RS re-renders after the RSIP gets loaded.
+	want := manifest.NamedResource{
+		Kind:      manifest.KindKustomization,
+		Namespace: "flux-system",
+		Name:      "child-rsip",
+	}
+	if st.GetObject(want) == nil {
+		t.Errorf("expected RS-emitted Kustomization %s in store; the RS likely rendered before its RSIP was loaded and was never retried", want)
+	}
+}
+
 func TestRun_RequiresStoreAndLoader(t *testing.T) {
 	t.Parallel()
 	if _, err := discovery.Run(context.Background(), discovery.Config{Path: t.TempDir()}); err == nil {

--- a/pkg/resourceset/permute.go
+++ b/pkg/resourceset/permute.go
@@ -1,0 +1,138 @@
+package resourceset
+
+import (
+	"fmt"
+	"hash/adler32"
+	"strings"
+	"unicode"
+)
+
+// maxPermutations caps the Cartesian product at the same threshold
+// flux-operator/internal/inputs/permuter.go uses. A ResourceSet that
+// asks for more wins a fail-loud error rather than burning host RAM
+// on a runaway combination set.
+const maxPermutations = 10000
+
+// permute returns the Cartesian product across groups, with each
+// provider's input set nested under its normalized name. Each output
+// map carries an `id` field — an adler32 hash of the
+// "<name>=<index>/..." selection — matching upstream's permuter.go.
+//
+// includeEmpty controls behavior when a provider exports zero input
+// sets: when false (the default, matching upstream), the empty
+// provider is silently dropped from the product; when true, the
+// product collapses to zero results.
+func permute(groups []providerInputs, includeEmpty bool) ([]map[string]any, error) {
+	// Validate names + project to per-provider scoped lists. The
+	// normalized name keys the nested wrapper; templates access values
+	// via `inputs.<normalized-name>.foo`.
+	scoped := make([]scopedProvider, 0, len(groups))
+	expected := uint64(1)
+	for _, g := range groups {
+		if !includeEmpty && len(g.inputs) == 0 {
+			continue
+		}
+		norm := normalizeKeyForTemplate(g.name)
+		if norm == "" {
+			return nil, fmt.Errorf("permute: provider name %q normalizes to empty", g.name)
+		}
+		if len(scoped) == 0 {
+			expected = uint64(len(g.inputs))
+		} else {
+			expected *= uint64(len(g.inputs))
+		}
+		if expected > maxPermutations {
+			return nil, fmt.Errorf("permute: would exceed %d permutations (provider %q contributes %d inputs)",
+				maxPermutations, g.name, len(g.inputs))
+		}
+		scoped = append(scoped, scopedProvider{name: norm, sets: g.inputs})
+	}
+	if len(scoped) == 0 {
+		return nil, nil
+	}
+	// One empty provider collapses the product. Matches upstream:
+	// computePermutationsWithBacktracking returns early if any
+	// scoped list is empty.
+	for _, p := range scoped {
+		if len(p.sets) == 0 {
+			return nil, nil
+		}
+	}
+
+	out := make([]map[string]any, 0, expected)
+	// Index vector — selectedInputs[i] is the index of the chosen
+	// input set within provider i. Standard mixed-radix counter.
+	sel := make([]int, len(scoped))
+	for {
+		perm := make(map[string]any, len(scoped)+1)
+		idParts := make([]string, 0, len(scoped))
+		for i, p := range scoped {
+			perm[p.name] = p.sets[sel[i]]
+			idParts = append(idParts, fmt.Sprintf("%s=%d", p.name, sel[i]))
+		}
+		perm["id"] = permID(strings.Join(idParts, "/"))
+		out = append(out, perm)
+
+		// Increment from the rightmost provider, carrying as needed.
+		i := len(scoped) - 1
+		for i >= 0 {
+			sel[i]++
+			if sel[i] < len(scoped[i].sets) {
+				break
+			}
+			sel[i] = 0
+			i--
+		}
+		if i < 0 {
+			break // overflowed the leftmost — done.
+		}
+	}
+	return out, nil
+}
+
+// scopedProvider holds one provider's input list keyed by the
+// normalized name templates will use to dereference it.
+type scopedProvider struct {
+	name string
+	sets []map[string]any
+}
+
+// permID is upstream's id-format for permutations: an adler32 hash
+// of the slash-joined selection string, rendered as a decimal. Keeps
+// flate's render byte-equivalent with what flux-operator computes
+// in-cluster so diffs surface the actual configuration delta rather
+// than an id-format mismatch.
+func permID(s string) string {
+	return fmt.Sprintf("%d", adler32.Checksum([]byte(s)))
+}
+
+// normalizeKeyForTemplate mirrors flux-operator/internal/inputs/keys.go:
+// lowercase, replace whitespace + punctuation with "_", drop characters
+// outside [a-z0-9_], then collapse runs of "_" to a single "_" with
+// leading/trailing trimmed. The output is the key under which a
+// provider's input set sits in the rendered permutation, so flate
+// MUST match upstream exactly or templates that work in-cluster
+// would silently fail to dereference here.
+//
+// Used here rather than re-exporting from upstream because flux-operator's
+// inputs package is in internal/.
+func normalizeKeyForTemplate(s string) string {
+	mapped := strings.Map(func(r rune) rune {
+		r = unicode.ToLower(r)
+		if unicode.IsSpace(r) || unicode.IsPunct(r) {
+			return '_'
+		}
+		if ('a' <= r && r <= 'z') || ('0' <= r && r <= '9') {
+			return r
+		}
+		return -1
+	}, s)
+	parts := strings.Split(mapped, "_")
+	out := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return strings.Join(out, "_")
+}

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -12,6 +12,12 @@
 //     via the ProviderResolver passed to Render. Dynamic providers
 //     (GitHubBranch, OCIArtifactTag, ExternalService, …) need network
 //     access flate doesn't have and contribute zero input sets.
+//   - spec.inputStrategy: Flatten (default) AND Permute. Permute
+//     Cartesian-products inputs across providers and scopes each
+//     under its normalized name; templates access values via
+//     `inputs.<provider>.foo`. ID generation matches upstream's
+//     adler32 scheme so renders are byte-equivalent to flux-operator
+//     output. Capped at 10000 permutations.
 //   - spec.resources (typed JSON template list)
 //   - spec.resourcesTemplate (multi-document YAML string)
 //   - spec.commonMetadata (labels + annotations applied to every emitted object)
@@ -19,7 +25,6 @@
 //   - Default-namespace fallback to the ResourceSet's own namespace
 //
 // Deferred:
-//   - spec.inputStrategy: Permute — start with the implicit Flatten.
 //   - fluxcd.controlplane.io/copyFrom / convertKubeConfigFrom / checksumFrom
 //     annotations — those need live cluster data flate does not have.
 package resourceset
@@ -71,6 +76,15 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	if err != nil {
 		return nil, fmt.Errorf("ResourceSet %s: %w", rs.NamespacedName(), err)
 	}
+	// Under Permute, an empty input slice means the Cartesian product
+	// genuinely collapsed (every-provider-empty with includeEmpty=true,
+	// or no providers contributed). Render zero docs rather than
+	// falling through to renderResources' "no matrix → render once
+	// with nil" fallback, which only applies under Flatten where an
+	// empty matrix legitimately means "static resources, no inputs".
+	if len(inputs) == 0 && rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
+		return nil, nil
+	}
 	var docs []map[string]any
 	seen := map[string]struct{}{}
 	appendUnique := func(doc map[string]any) {
@@ -112,41 +126,76 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	return docs, nil
 }
 
-// buildInputSets returns the flattened input matrix. The ResourceSet's
-// own inline spec.inputs come first (with a provider block pointing at
-// the ResourceSet itself), followed by every input set exported by each
-// referenced ResourceSetInputProvider (with a provider block pointing
-// at the RSIP). Matches upstream's Flatten strategy: simple concat,
-// order = rset's inline inputs first, then providers in sorted
-// (kind, namespace, name) order.
+// providerInputs is one per-provider list of input sets carrying its
+// raw (un-normalized) name. Used to dispatch on spec.inputStrategy:
+// Flatten concatenates; Permute scopes by name and Cartesian-products.
+type providerInputs struct {
+	name   string             // raw provider name (rs.Name for inline; RSIP.Name otherwise)
+	inputs []map[string]any   // each set already carries its `provider` block
+}
+
+// buildInputSets gathers per-provider input lists then dispatches on
+// spec.inputStrategy. The ResourceSet's own inline spec.inputs are
+// treated as "provider 0", followed by each referenced
+// ResourceSetInputProvider in upstream's sorted order (matching
+// flux-operator/internal/inputs/combine.go).
+//
+// Flatten (default) concatenates: each input set is rendered once
+// against the templates, top-level access (`inputs.foo`).
+//
+// Permute Cartesian-products across providers: each result map has
+// the providers' input sets nested under their normalized names
+// (`inputs.<provider>.foo`) plus an `id` field — an adler32 hash of
+// the provider=index path matching upstream's flux-operator/internal/
+// inputs/permuter.go. Per-provider input lists are scoped before the
+// product so authors can disambiguate "rset.x" from "rsip.x". A 10000
+// permutation cap (also matching upstream) prevents pathological
+// Cartesian blowups.
 //
 // inputs.id is left to the provider when it's a Static RSIP; inline-
 // only inputs see no synthetic id under Flatten.
-//
-// Permute (Cartesian product) is rejected with a clear error rather
-// than silently falling through to Flatten — Flatten produces wrong
-// cardinality for a ResourceSet that requested Permute. Real Flux's
-// flux-operator/internal/inputs/combine.go dispatches on
-// spec.inputStrategy.name and would emit the Cartesian product;
-// any flate render that doesn't would silently disagree with cluster.
 func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]any, error) {
-	if rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
-		return nil, fmt.Errorf("%w: ResourceSet %s/%s requests spec.inputStrategy.name=Permute, which flate does not yet implement (#109)",
-			manifest.ErrInput, rs.Namespace, rs.Name)
+	groups, err := collectProviderInputs(rs, resolve)
+	if err != nil {
+		return nil, err
 	}
+
+	if rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
+		return permute(groups, rs.InputStrategy.IncludeEmptyProviders)
+	}
+	// Default: Flatten — concatenate every provider's input list.
 	var out []map[string]any
+	for _, g := range groups {
+		out = append(out, g.inputs...)
+	}
+	return out, nil
+}
+
+// collectProviderInputs assembles the per-provider input lists: rs's
+// inline inputs as provider 0 (named after the ResourceSet itself),
+// then every resolved ResourceSetInputProvider in (namespace, name)
+// order. Each input set is stamped with a `provider` block so
+// templates can recover which CR sourced the values.
+func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) ([]providerInputs, error) {
+	var groups []providerInputs
+
+	// Provider 0: the ResourceSet itself with its inline spec.inputs.
+	inlineProv := map[string]any{
+		"apiVersion": fluxopv1.GroupVersion.String(),
+		"kind":       manifest.KindResourceSet,
+		"name":       rs.Name,
+		"namespace":  rs.Namespace,
+	}
+	inline := make([]map[string]any, 0, len(rs.Inputs))
 	for _, in := range rs.Inputs {
 		decoded := decodeInputSet(in)
-		decoded["provider"] = map[string]any{
-			"apiVersion": fluxopv1.GroupVersion.String(),
-			"kind":       manifest.KindResourceSet,
-			"name":       rs.Name,
-			"namespace":  rs.Namespace,
-		}
-		out = append(out, decoded)
+		decoded["provider"] = inlineProv
+		inline = append(inline, decoded)
 	}
+	groups = append(groups, providerInputs{name: rs.Name, inputs: inline})
+
 	if resolve == nil || len(rs.InputsFrom) == 0 {
-		return out, nil
+		return groups, nil
 	}
 
 	seen := make(map[string]struct{})
@@ -184,17 +233,20 @@ func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[s
 				"provider", p.NamespacedName(),
 				"type", p.Type)
 		}
-		for _, set := range exported {
-			set["provider"] = map[string]any{
-				"apiVersion": fluxopv1.GroupVersion.String(),
-				"kind":       manifest.KindResourceSetInputProvider,
-				"name":       p.Name,
-				"namespace":  p.Namespace,
-			}
-			out = append(out, set)
+		provBlock := map[string]any{
+			"apiVersion": fluxopv1.GroupVersion.String(),
+			"kind":       manifest.KindResourceSetInputProvider,
+			"name":       p.Name,
+			"namespace":  p.Namespace,
 		}
+		pInputs := make([]map[string]any, 0, len(exported))
+		for _, set := range exported {
+			set["provider"] = provBlock
+			pInputs = append(pInputs, set)
+		}
+		groups = append(groups, providerInputs{name: p.Name, inputs: pInputs})
 	}
-	return out, nil
+	return groups, nil
 }
 
 func decodeInputSet(in fluxopv1.ResourceSetInput) map[string]any {

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -11,34 +11,214 @@ import (
 	"github.com/home-operations/flate/pkg/resourceset"
 )
 
-// TestRender_PermuteIsRejected locks the upstream-fidelity guard: a
-// ResourceSet requesting spec.inputStrategy.name=Permute fails loud
-// rather than silently falling through to Flatten. Flatten produces
-// wrong cardinality for a Permute consumer — flate would render
-// differently from what flux-operator emits in cluster.
-func TestRender_PermuteIsRejected(t *testing.T) {
+// TestRender_PermuteScopesByProviderName locks the core Permute
+// semantic: each provider's input set is nested under its normalized
+// name, so templates dereference `inputs.<provider>.foo` instead of
+// the flat `inputs.foo`. Matches flux-operator/internal/inputs/
+// permuter.go. With one RSET-inline input and one Static RSIP, the
+// Cartesian product is 1×1=1 — the cardinality match is the same as
+// Flatten, but the SCOPING differs, which is the observable change.
+func TestRender_PermuteScopesByProviderName(t *testing.T) {
 	rs := &manifest.ResourceSet{
-		Name: "apps", Namespace: "flux-system",
+		Name: "myrset", Namespace: "default",
 		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputStrategy: &fluxopv1.InputStrategySpec{
-				Name: fluxopv1.InputStrategyPermute,
-			},
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"x": jsonTmpl(t, `"a"`)},
-				{"x": jsonTmpl(t, `"b"`)},
-			},
+			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+			Inputs:        []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
+			InputsFrom: []fluxopv1.InputProviderReference{{
+				Kind: manifest.KindResourceSetInputProvider, Name: "myrsip",
+			}},
+			// Permute templates dereference inputs by provider name.
+			// `myrset` (the rs.Name) wraps the inline input;
+			// `myrsip` wraps the RSIP's defaultValues.
 			ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: << .input.x >>`,
+  name: << index inputs "myrset" "env" >>-<< index inputs "myrsip" "tenant" >>
+  namespace: default`,
+		},
+	}
+	rsip := &manifest.ResourceSetInputProvider{
+		Name: "myrsip", Namespace: "default",
+		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+			Type:          fluxopv1.InputProviderStatic,
+			DefaultValues: fluxopv1.ResourceSetInput{"tenant": jsonTmpl(t, `"alpha"`)},
+		},
+	}
+	resolver := func(ref fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
+		if ref.Name == "myrsip" {
+			return []*manifest.ResourceSetInputProvider{rsip}, nil
+		}
+		return nil, nil
+	}
+
+	docs, err := resourceset.Render(rs, resolver)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected 1 doc (1 inline × 1 static = 1), got %d:\n%+v", len(docs), docs)
+	}
+	md, _ := docs[0]["metadata"].(map[string]any)
+	if got, _ := md["name"].(string); got != "prod-alpha" {
+		t.Errorf("expected name=prod-alpha, got %q", got)
+	}
+}
+
+// TestRender_PermuteMultiInlineCartesian covers the Cartesian
+// expansion across provider rows: 2 RSET-inline inputs × 1 Static
+// RSIP = 2 permutations, each combining the inline value with the
+// shared RSIP value.
+func TestRender_PermuteMultiInlineCartesian(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "rset", Namespace: "default",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+			Inputs: []fluxopv1.ResourceSetInput{
+				{"env": jsonTmpl(t, `"prod"`)},
+				{"env": jsonTmpl(t, `"stage"`)},
+			},
+			InputsFrom: []fluxopv1.InputProviderReference{{
+				Kind: manifest.KindResourceSetInputProvider, Name: "rsip",
+			}},
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << index inputs "rset" "env" >>-<< index inputs "rsip" "tenant" >>
+  namespace: default`,
+		},
+	}
+	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
+		return []*manifest.ResourceSetInputProvider{{
+			Name: "rsip", Namespace: "default",
+			ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+				Type:          fluxopv1.InputProviderStatic,
+				DefaultValues: fluxopv1.ResourceSetInput{"tenant": jsonTmpl(t, `"alpha"`)},
+			},
+		}}, nil
+	}
+	docs, err := resourceset.Render(rs, resolver)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 perm docs (2 inline × 1 rsip), got %d:\n%+v", len(docs), docs)
+	}
+	gotNames := map[string]struct{}{}
+	for _, d := range docs {
+		md, _ := d["metadata"].(map[string]any)
+		name, _ := md["name"].(string)
+		gotNames[name] = struct{}{}
+	}
+	for _, want := range []string{"prod-alpha", "stage-alpha"} {
+		if _, ok := gotNames[want]; !ok {
+			t.Errorf("missing permutation %q; got %v", want, gotNames)
+		}
+	}
+}
+
+// TestRender_PermuteSkipsEmptyProviderByDefault matches upstream:
+// when a provider exports zero input sets, the default (includeEmpty=
+// false) silently drops it from the product. Only the non-empty
+// provider's inputs survive — and their scoping is preserved.
+func TestRender_PermuteSkipsEmptyProviderByDefault(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "rset", Namespace: "default",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+			Inputs:        []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
+			InputsFrom: []fluxopv1.InputProviderReference{{
+				Kind: manifest.KindResourceSetInputProvider, Name: "dyn",
+			}},
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << index inputs "rset" "env" >>
+  namespace: default`,
+		},
+	}
+	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
+		// Dynamic provider (GitHubBranch etc.) — flate can't fetch
+		// remote APIs offline, so it exports zero input sets.
+		return []*manifest.ResourceSetInputProvider{{
+			Name: "dyn", Namespace: "default",
+			ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+				Type: fluxopv1.InputProviderGitHubBranch,
+			},
+		}}, nil
+	}
+	docs, err := resourceset.Render(rs, resolver)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Errorf("expected 1 doc (dyn provider dropped, 1 inline remains); got %d:\n%+v", len(docs), docs)
+	}
+}
+
+// TestRender_PermuteIncludeEmptyProvidersCollapses verifies the
+// IncludeEmptyProviders=true branch: the empty provider participates
+// in the Cartesian product and collapses it to zero results, matching
+// upstream's "permutes to empty when includeEmptyProviders is true"
+// test in combine_test.go.
+func TestRender_PermuteIncludeEmptyProvidersCollapses(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "rset", Namespace: "default",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputStrategy: &fluxopv1.InputStrategySpec{
+				Name:                  fluxopv1.InputStrategyPermute,
+				IncludeEmptyProviders: true,
+			},
+			Inputs: []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
+			InputsFrom: []fluxopv1.InputProviderReference{{
+				Kind: manifest.KindResourceSetInputProvider, Name: "dyn",
+			}},
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata: {name: x, namespace: default}`,
+		},
+	}
+	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
+		return []*manifest.ResourceSetInputProvider{{
+			Name: "dyn", Namespace: "default",
+			ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+				Type: fluxopv1.InputProviderGitHubBranch,
+			},
+		}}, nil
+	}
+	docs, err := resourceset.Render(rs, resolver)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 0 {
+		t.Errorf("expected 0 docs (Cartesian product with an empty provider), got %d:\n%+v", len(docs), docs)
+	}
+}
+
+// TestRender_PermuteMaxPermutationsRejected guards the 10000-cap that
+// matches upstream's permuter.go. flate must fail loud rather than
+// burn host RAM on a pathological combination set. With 10001 inline
+// inputs, even the single-RSET-provider case crosses the threshold.
+func TestRender_PermuteMaxPermutationsRejected(t *testing.T) {
+	inputs := make([]fluxopv1.ResourceSetInput, 10001)
+	for i := range inputs {
+		inputs[i] = fluxopv1.ResourceSetInput{"i": jsonTmpl(t, `"x"`)}
+	}
+	rs := &manifest.ResourceSet{
+		Name: "rset", Namespace: "default",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+			Inputs:        inputs,
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata: {name: x, namespace: default}`,
 		},
 	}
 	_, err := resourceset.Render(rs, nil)
 	if err == nil {
-		t.Fatal("expected Permute to be rejected; got nil error")
+		t.Fatal("expected Render to reject the >10000-permutation case")
 	}
-	if !strings.Contains(err.Error(), "Permute") {
-		t.Errorf("error should mention Permute; got %v", err)
+	if !strings.Contains(err.Error(), "permutations") {
+		t.Errorf("error should mention permutations; got %v", err)
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -228,20 +228,24 @@ func TestE2E_DiffImagesRequiresPathOrig(t *testing.T) {
 }
 
 // TestE2E_BootstrapErrorSurfacesNotMasked pins the contract that
-// when discovery itself fails (e.g. an unimplemented ResourceSet
-// inputStrategy, a YAML schema rejection), the actual error reaches
+// when discovery itself fails (e.g. a ResourceSet template that
+// fails to parse, a YAML schema rejection), the actual error reaches
 // the user instead of getting drowned under a wall of phantom
 // "FAILED (no status reported)" rows from the testrunner running on
-// a partial Store. Surfaced by tholinka/home-ops where a `Permute`
-// ResourceSet produced 247 generic failure rows instead of the
-// "not yet implemented (#109)" message.
+// a partial Store. Surfaced by tholinka/home-ops where an
+// unimplemented inputStrategy: Permute ResourceSet produced 247
+// generic failure rows instead of the actual message. Now that
+// Permute is implemented, the test triggers Bootstrap failure with
+// a malformed template — same code path through
+// runOrchestratorCfg's `res == nil` guard.
 func TestE2E_BootstrapErrorSurfacesNotMasked(t *testing.T) {
 	dir := t.TempDir()
-	// Minimal repo: one Kustomization + one Permute ResourceSet.
-	// Discovery's render pass hits Permute, returns the input-error,
-	// Bootstrap returns it, Render nils the Result, the CLI must
-	// surface the underlying error rather than running the testrunner
-	// on partial state.
+	// Minimal repo: one Kustomization + one ResourceSet whose template
+	// references an undefined function ("nope"). text/template's Parse
+	// rejects it; the ResourceSet render returns an error; Bootstrap
+	// returns it; Render nils the Result; the CLI must surface the
+	// underlying error rather than running the testrunner on partial
+	// state.
 	if err := os.WriteFile(filepath.Join(dir, "ks.yaml"), []byte(`---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -255,14 +259,12 @@ spec:
 	if err := os.WriteFile(filepath.Join(dir, "rs.yaml"), []byte(`---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
-metadata: {name: permute-rs, namespace: flux-system}
+metadata: {name: broken-rs, namespace: flux-system}
 spec:
-  inputStrategy:
-    name: Permute
   resourcesTemplate: |
     apiVersion: v1
     kind: ConfigMap
-    metadata: {name: x, namespace: ns}
+    metadata: {name: << nope >>, namespace: ns}
 `), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -271,8 +273,9 @@ spec:
 	if code == 0 {
 		t.Fatalf("expected non-zero exit; got 0:\n%s", out)
 	}
-	if !strings.Contains(out, "Permute") {
-		t.Errorf("error must mention Permute (the actual Bootstrap failure); got:\n%s", out)
+	// The template parse error mentions the undefined function.
+	if !strings.Contains(out, "nope") {
+		t.Errorf("error must mention the underlying Bootstrap failure (template parse rejecting `nope`); got:\n%s", out)
 	}
 	// Guard against the regression: the testrunner used to run on
 	// the partial Store and emit one "FAILED (no status reported)"


### PR DESCRIPTION
## Summary

- Implements `spec.inputStrategy: Permute` for `ResourceSet`: Cartesian-products input sets across providers, scoping each provider's input set under its normalized name (`inputs.<provider>.foo`). adler32 ID format and 10000-permutation cap match flux-operator's `permuter.go` byte-for-byte so renders are interchangeable with the in-cluster controller's output.
- Fixes a discovery-loop ordering bug: a ResourceSet whose RSIPs live behind a later-walked Kustomization path used to render once to zero docs and stay memoized as "done." Without this fix, Permute would have rendered nothing for tholinka/home-ops's `dragonfly-acls` RS (RSIPs produced through a sibling Kustomization chain). The `rsExpanded` gate is removed; convergence still terminates via Store dedup + the existing `added == 0` exit.
- Replaces the e2e Bootstrap-error-surfacing test's trigger (was a Permute rejection) with an undefined-template-function trigger now that Permute is implemented.

## Test plan
- [x] `go test ./...` — all packages green
- [x] `go test -race ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Unit tests: `TestRender_PermuteScopesByProviderName`, `TestRender_PermuteMultiInlineCartesian`, `TestRender_PermuteSkipsEmptyProviderByDefault`, `TestRender_PermuteIncludeEmptyProvidersCollapses`, `TestRender_PermuteMaxPermutationsRejected`
- [x] Discovery loop regression test: `TestRun_ResourceSetReExpandsForLateRSIPs`
- [x] Smoke: minimal Permute fixture (RS + two RSIPs with `role: db`) produces two scoped Kustomizations (`rsip_a-app`, `rsip_b-app`) via the discovery loop — confirms the normalized-name scoping flows end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)