### PR TITLE
feat(orchestrator): surface RS-rendered non-Flux docs in parent KS output

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -250,8 +250,12 @@ func (d *discoverer) renderResourceSet(rs *manifest.ResourceSet) (int, error) {
 		}
 		if _, ok := obj.(*manifest.RawObject); ok {
 			// Generic / unrecognized kinds: not something flate
-			// reconciles further. Skip them rather than polluting the
-			// store with opaque entries.
+			// reconciles further. Skipped here; the orchestrator's
+			// post-Run RS expansion pass picks them up and attributes
+			// them to the owning KS for `flate build` visibility.
+			// That late pass sees RSIPs emitted from KS reconcile
+			// (kustomize-substituted dragonfly-${APP} style) which
+			// this discovery pass would miss.
 			continue
 		}
 		id := obj.Named()

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -11,6 +11,8 @@ import (
 	"slices"
 	"strings"
 
+	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/helmrelease"
 	"github.com/home-operations/flate/pkg/controllers/kustomization"
@@ -19,6 +21,7 @@ import (
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/resourceset"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/bucket"
 	"github.com/home-operations/flate/pkg/source/external"
@@ -115,6 +118,13 @@ type Orchestrator struct {
 	// from genuine successes. Keyed by id, value is the original
 	// failure message.
 	orphans map[manifest.NamedResource]string
+
+	// rsExtensions holds non-Flux docs produced by ResourceSet renders,
+	// keyed by the owning structural-parent Kustomization. Populated
+	// during Bootstrap (from discovery.Result.RSExtensions); merged
+	// into Result.Manifests at Render time so `flate build` surfaces
+	// what the RS would create in-cluster.
+	rsExtensions map[manifest.NamedResource][]map[string]any
 }
 
 // Result is the structured output of Orchestrator.Render: the rendered
@@ -540,6 +550,13 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 		return nil, err
 	}
 	runErr := o.Run(ctx)
+	// Post-Run RS expansion: re-render every ResourceSet now that
+	// KS-controller-emitted RSIPs (kustomize-substituted dynamic
+	// names like dragonfly-${APP}) are in the store. Discovery's
+	// pre-Bootstrap renders see only literal-file RSIPs and miss
+	// these. The output attributes non-Flux children to the owning
+	// parent KS so `flate build` surfaces them.
+	o.expandResourceSetsPostRun()
 	res := &Result{
 		Manifests: map[manifest.NamedResource][]map[string]any{},
 		Failed:    map[manifest.NamedResource]store.StatusInfo{},
@@ -559,11 +576,22 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
 		for _, obj := range o.store.ListObjects(kind) {
 			id := obj.Named()
+			var mans []map[string]any
 			if art, ok := o.store.GetArtifact(id).(store.RenderedArtifact); ok {
-				mans := manifest.DropKinds(art.RenderedManifests(), skip)
-				if len(mans) > 0 {
-					res.Manifests[id] = mans
+				mans = art.RenderedManifests()
+			}
+			// Append any ResourceSet-rendered non-Flux docs whose
+			// owning KS is this one. The RS doc itself stays in the
+			// parent's render output (kustomize emitted it); these
+			// are its synthetic children that flate evaluates offline.
+			if kind == manifest.KindKustomization {
+				if ext := o.rsExtensions[id]; len(ext) > 0 {
+					mans = append(mans, ext...)
 				}
+			}
+			mans = manifest.DropKinds(mans, skip)
+			if len(mans) > 0 {
+				res.Manifests[id] = mans
 			}
 		}
 	}
@@ -578,6 +606,174 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 	}
 	maps.Copy(res.Orphans, o.orphans)
 	return res, runErr
+}
+
+// expandResourceSetsPostRun re-renders every ResourceSet using the
+// post-Run store state and attributes any non-Flux child docs to the
+// owning structural-parent Kustomization. Fires after Run so it sees
+// RSIPs the KS controller emitted from kustomize substitution (the
+// `dragonfly-${APP}` -> `dragonfly-renovate-operator-jobs` etc.
+// pattern in tholinka/home-ops, which discovery's pre-Bootstrap RS
+// pass cannot see because the substitution hasn't happened yet).
+//
+// Flux-kind children (Kustomization, HelmRelease, …) are intentionally
+// NOT re-emitted here — they would have failed reconcile anyway since
+// it's too late in the pipeline to add reconcilable objects. Discovery
+// is the canonical seeding point for Flux-kind RS children; this pass
+// only handles the visibility gap for non-Flux output.
+func (o *Orchestrator) expandResourceSetsPostRun() {
+	rsList := o.store.ListObjects(manifest.KindResourceSet)
+	if len(rsList) == 0 {
+		return
+	}
+	// Owner index keyed by deepest spec.path prefix wins, mirroring
+	// loader.BuildParentIndex. The RS's source-file path lives below
+	// some KS's spec.path — that KS becomes its visibility parent.
+	type owner struct {
+		prefix string
+		id     manifest.NamedResource
+	}
+	var owners []owner
+	for _, obj := range o.store.ListObjects(manifest.KindKustomization) {
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok || ks.Path == "" {
+			continue
+		}
+		p := filepath.ToSlash(ks.Path)
+		p = strings.TrimPrefix(p, "./")
+		if !strings.HasSuffix(p, "/") {
+			p += "/"
+		}
+		owners = append(owners, owner{prefix: p, id: ks.Named()})
+	}
+	slices.SortFunc(owners, func(a, b owner) int {
+		return cmp.Compare(len(b.prefix), len(a.prefix))
+	})
+
+	// A RS that arrived through file discovery has a sourceFile; a RS
+	// that arrived through KS-controller emission (kustomize bakes the
+	// parent's targetNamespace into a duplicate copy) does not. Build
+	// a name-keyed sourceFile fallback so we can attribute the
+	// namespace-resolved variant — which is the one with RSIPs visible
+	// to its selectors — through its file-loaded sibling.
+	sourceByName := map[string]string{}
+	for id, f := range o.sourceFiles {
+		if id.Kind != manifest.KindResourceSet || f == "" {
+			continue
+		}
+		if _, exists := sourceByName[id.Name]; !exists {
+			sourceByName[id.Name] = f
+		}
+	}
+
+	// Dedupe by (apiVersion, kind, ns, name) across the union of every
+	// RS's render — a name-grouped RS may legitimately render the same
+	// child from each namespace variant, and we don't want to double-
+	// emit it under the parent KS.
+	seen := map[string]struct{}{}
+	out := map[manifest.NamedResource][]map[string]any{}
+	for _, obj := range rsList {
+		rs, ok := obj.(*manifest.ResourceSet)
+		if !ok {
+			continue
+		}
+		docs, err := resourceset.Render(rs, o.resolveInputProvider)
+		if err != nil || len(docs) == 0 {
+			continue
+		}
+		file := o.sourceFiles[rs.Named()]
+		if file == "" {
+			file = sourceByName[rs.Name]
+		}
+		if file == "" {
+			continue
+		}
+		slashFile := filepath.ToSlash(file)
+		var parentKS manifest.NamedResource
+		var matched bool
+		for _, w := range owners {
+			if strings.HasPrefix(slashFile, w.prefix) {
+				parentKS = w.id
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			continue
+		}
+		for _, doc := range docs {
+			parsed, perr := manifest.ParseDoc(doc, manifest.ParseDocOptions{WipeSecrets: o.cfg.WipeSecrets})
+			if perr != nil {
+				continue
+			}
+			if _, raw := parsed.(*manifest.RawObject); !raw {
+				continue
+			}
+			key := dedupKeyForDoc(doc)
+			if key == "" {
+				continue
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			out[parentKS] = append(out[parentKS], doc)
+		}
+	}
+	o.rsExtensions = out
+}
+
+// dedupKeyForDoc keys a rendered doc by (apiVersion, kind, namespace,
+// name). Empty string when any required component is missing —
+// signals "drop this doc" rather than collide with other emptys.
+func dedupKeyForDoc(doc map[string]any) string {
+	apiVersion, _ := doc["apiVersion"].(string)
+	kind, _ := doc["kind"].(string)
+	md, _ := doc["metadata"].(map[string]any)
+	name, _ := md["name"].(string)
+	ns, _ := md["namespace"].(string)
+	if kind == "" || name == "" {
+		return ""
+	}
+	return apiVersion + "|" + kind + "|" + ns + "|" + name
+}
+
+// resolveInputProvider mirrors discovery.resolveInputProvider but
+// against the post-Run store, which now includes RSIPs emitted by
+// the KS controller from kustomize substitution. Same semantics:
+// name-only refs hit the exact id; selector refs walk the requested
+// namespace's RSIPs and filter by metadata.labels.
+func (o *Orchestrator) resolveInputProvider(ref fluxopv1.InputProviderReference, namespace string) ([]*manifest.ResourceSetInputProvider, error) {
+	if ref.Name != "" {
+		id := manifest.NamedResource{
+			Kind:      manifest.KindResourceSetInputProvider,
+			Namespace: namespace,
+			Name:      ref.Name,
+		}
+		obj, _ := o.store.GetObject(id).(*manifest.ResourceSetInputProvider)
+		if obj == nil {
+			return nil, nil
+		}
+		return []*manifest.ResourceSetInputProvider{obj}, nil
+	}
+	if ref.Selector == nil {
+		return nil, nil
+	}
+	var out []*manifest.ResourceSetInputProvider
+	for _, obj := range o.store.ListObjects(manifest.KindResourceSetInputProvider) {
+		p, ok := obj.(*manifest.ResourceSetInputProvider)
+		if !ok || p.Namespace != namespace {
+			continue
+		}
+		match, err := resourceset.MatchSelector(ref.Selector, p.Labels)
+		if err != nil {
+			return nil, err
+		}
+		if match {
+			out = append(out, p)
+		}
+	}
+	return out, nil
 }
 
 // Stop shuts the controllers down in reverse-construction order and

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -201,6 +201,97 @@ data: {k: v}
 	}
 }
 
+// TestOrchestrator_Render_RSExtensionAttributedToParentKS verifies
+// the post-Run ResourceSet expansion lands non-Flux RS children
+// (ExternalSecret, ConfigMap-as-data, etc.) in the manifest stream
+// of the structural-parent Kustomization. Without this, dragonfly-
+// acls-style RSes that emit ExternalSecrets from kustomize-substituted
+// RSIPs (the tholinka/home-ops `dragonfly-${APP}` pattern) would
+// silently drop their output — flate would render zero docs for the
+// RS even though the in-cluster controller would produce one.
+func TestOrchestrator_Render_RSExtensionAttributedToParentKS(t *testing.T) {
+	dir := t.TempDir()
+	// Parent KS at the repo root scans ./apps.
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", `resources:
+- rs.yaml
+- rsip.yaml
+`)
+	// RS with a selector-based inputsFrom emitting a RawObject
+	// (ExternalSecret) — the kind flate doesn't track natively.
+	testutil.WriteFile(t, dir, "apps/rs.yaml", `apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata: {name: acl, namespace: flux-system}
+spec:
+  inputsFrom:
+    - apiVersion: fluxcd.controlplane.io/v1
+      kind: ResourceSetInputProvider
+      selector:
+        matchLabels: {role: db}
+  resourcesTemplate: |
+    ---
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: acl
+      namespace: flux-system
+    spec:
+      target: {name: acl}
+`)
+	testutil.WriteFile(t, dir, "apps/rsip.yaml", `apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSetInputProvider
+metadata:
+  name: rsip
+  namespace: flux-system
+  labels: {role: db}
+spec:
+  type: Static
+  defaultValues: {user: alice}
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	mans := res.Manifests[ksID]
+	var found bool
+	for _, doc := range mans {
+		md, _ := doc["metadata"].(map[string]any)
+		name, _ := md["name"].(string)
+		kind, _ := doc["kind"].(string)
+		if kind == "ExternalSecret" && name == "acl" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ExternalSecret/acl in res.Manifests[%s] (the RS-rendered child); kinds in stream: %v",
+			ksID, kindsOf(mans))
+	}
+}
+
+func kindsOf(docs []map[string]any) []string {
+	out := make([]string, 0, len(docs))
+	for _, d := range docs {
+		k, _ := d["kind"].(string)
+		out = append(out, k)
+	}
+	return out
+}
+
 // TestOrchestrator_Render_AppliesSkipKinds locks the iter-16
 // embed-facing follow-on to #169: HelmOptions.SkipResourceKinds()
 // applies uniformly to BOTH HR and KS docs in Result.Manifests, not


### PR DESCRIPTION
## Summary

Adds a post-Run ResourceSet expansion pass to `Orchestrator.Render` so non-Flux children of a `ResourceSet` (ExternalSecret, ConfigMap-as-data, etc.) flow into the parent Kustomization's `res.Manifests`. Without this, `flate build` silently dropped them — for tholinka/home-ops, the dragonfly-acls `ExternalSecret` rendered by the Permute RS was invisible in flate's output even though the in-cluster RS controller would create it.

## Why post-Run, not during discovery

RSIPs matched by `inputsFrom.selector` are frequently emitted from a sibling Kustomization's reconcile — tholinka's `dragonfly-${APP}` template substitutes to `dragonfly-renovate-operator-jobs`, `dragonfly-immich`, etc. only when the parent KS reconciles, then the KS controller stashes them via `Store.AddRendered`. Discovery's RS expansion happens before any KS reconcile, so it sees zero matching RSIPs; the post-Run pass sees all of them.

## How attribution works

- Deepest-`spec.path`-prefix match on the RS's source file (same shape `loader.BuildParentIndex` uses for KSes).
- The KS controller emits a namespace-substituted copy of each RS (the variant whose selectors actually resolve), which has no `sourceFile`. The implementation walks every RS variant, dedupes children by `(apiVersion, kind, namespace, name)`, and falls back to a name-keyed `sourceFile` lookup for the KS-emitted variant.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestOrchestrator_Render_RSExtensionAttributedToParentKS` — verifies an `ExternalSecret` rendered by a selector-based RS lands in the parent KS's manifest stream.
- [x] Verified against tholinka/home-ops: `flate build all` now emits `ExternalSecret/database/dragonfly-acls` with combined users from all 4 dynamically-discovered RSIPs (`immich`, `paperless`, `renovate-operator-jobs`, `searxng`).
- [x] `flate test all` against tholinka: 266 passed, 0 failed, 0 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)