### PR TITLE
perf(helmrelease): skip duplicate render via parent gate + fingerprint dedup

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -9,8 +9,13 @@ package helmrelease
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -23,7 +28,7 @@ import (
 )
 
 // Controller orchestrates HelmRelease reconciliation. Reconcile-shaping
-// state (Filter) flows in via Configure exactly once before Start.
+// state (Filter, ParentOf) flows in via Configure exactly once before Start.
 type Controller struct {
 	*base.Controller
 
@@ -36,14 +41,24 @@ type Controller struct {
 	// templates.
 	WipeSecrets bool
 
+	// parentOf maps each file-loaded HR to the enclosing Flux KS whose
+	// spec.path covers it. Reconcile depwaits on the parent's Ready so
+	// the first render reads the post-patch HR rather than the file-
+	// loaded pre-patch copy.
+	parentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
 // wires onto the controller. Filter narrows reconciliation to changed
 // HelmReleases (and their referenced sources/values) in changed-only
-// mode.
+// mode. ParentOf maps each file-loaded HR to the enclosing KS whose
+// spec.path covers it; reconcile depwaits on the parent before
+// rendering so spec patches (driftDetection / upgrade strategy /
+// CRD policy at the cluster KS level, post-build substitutions,
+// kustomize replacements) land before the first helm.Template call.
 type ReconcileOptions struct {
-	Filter *change.Filter
+	Filter   *change.Filter
+	ParentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
 // New constructs a HelmRelease controller.
@@ -61,6 +76,7 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 // read-only once dispatch begins.
 func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
+	c.parentOf = opts.ParentOf
 }
 
 // Start registers the listeners. The controller runs until Close.
@@ -95,6 +111,40 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {
 	id := hr.Named()
 
+	// Parent gate: if this HR was file-loaded under a Flux KS's
+	// spec.path, wait for that KS to finish reconciling before
+	// rendering. The KS may apply patches / replacements / postBuild
+	// substitutions that mutate spec — without the wait, the first
+	// render uses stale (pre-patch) values and a second render
+	// follows once the KS controller emits the patched copy via
+	// AddObject, doubling helm-template work for every HR under a
+	// parent-patching chain (tholinka/home-ops's cluster KS applies
+	// driftDetection / install.crds / upgrade strategy / rollback to
+	// every HR, so all of them were hit by this).
+	if parent, ok := c.parentOf[id]; ok {
+		c.Store.UpdateStatus(id, store.StatusPending, "waiting for parent KS")
+		var sum depwait.Summary
+		c.Tasks.YieldSlot(func() {
+			w := &depwait.Waiter{
+				Store:   c.Store,
+				Parent:  id,
+				Timeout: depwait.TimeoutFromSpec(hr.Timeout),
+			}
+			sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: parent}}))
+		})
+		if sum.AnyFailed() {
+			return fmt.Errorf("%w: parent Kustomization %s not ready: %s",
+				manifest.ErrObjectNotFound, parent.String(), sum.Messages[parent])
+		}
+		// The parent's render may have replaced this HR in the store
+		// with a patched copy; re-read so the rest of reconcile uses
+		// the canonical spec instead of the pre-patch snapshot we
+		// were dispatched with.
+		if obj, ok := c.Store.GetObject(id).(*manifest.HelmRelease); ok {
+			hr = obj
+		}
+	}
+
 	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
 	// each dependency reaching Ready before this HR reconciles.
 	// YieldSlot releases the worker-pool slot during the wait so the
@@ -127,6 +177,21 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	hr, err := helm.Prepare(hr, c.Helm.Resolver().HelmChart, values.NewStoreProvider(c.Store))
 	if err != nil {
 		return err
+	}
+
+	// Fingerprint dedup: when the same HR id gets re-AddObject'd with
+	// the same effective spec (e.g. the parent KS render stamps
+	// kustomize.toolkit.fluxcd.io/{name,namespace} labels onto a
+	// previously-loaded HR and re-emits it via Store.AddObject), skip
+	// the helm render — its output would be byte-identical. Without
+	// this, flate runs helm.Template twice for every HR a parent KS
+	// owns, which surfaces as duplicate "warning: cannot overwrite
+	// table..." log lines from helm's coalescer and roughly doubles
+	// the HR-render time on real-world trees.
+	fp := helmReleaseFingerprint(hr)
+	if existing, ok := c.Store.GetArtifact(id).(*store.HelmReleaseArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
+		slog.Debug("helmrelease: skipped re-render (fingerprint unchanged)", "id", id.String())
+		return nil
 	}
 
 	// Wait for chart source (HelmRepository / OCIRepository / GitRepository)
@@ -183,8 +248,50 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		c.Store.AddRendered(obj)
 	}
 
-	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs})
+	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs, Fingerprint: fp})
 	return nil
+}
+
+// helmReleaseFingerprint produces a stable hash of the inputs that
+// determine helm.Template's output for hr. Excludes metadata.labels
+// and metadata.annotations on purpose — kustomize-controller-emitted
+// HRs differ from their file-loaded sources only in label stamping,
+// and re-rendering on a label diff is pure waste. Returns "" when
+// json.Marshal fails (degrades safely: an empty fingerprint never
+// matches, so the dedup short-circuit is skipped and we re-render).
+func helmReleaseFingerprint(hr *manifest.HelmRelease) string {
+	raw, err := json.Marshal(helmReleaseFingerprintPayload(hr))
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func helmReleaseFingerprintPayload(hr *manifest.HelmRelease) any {
+	return struct {
+		ReleaseName              string
+		ReleaseNamespace         string
+		Chart                    manifest.HelmChart
+		Values                   map[string]any
+		Spec                     helmv2.HelmReleaseSpec
+		ChartValuesFiles         []string
+		IgnoreMissingValuesFiles bool
+		CRDsPolicy               string
+		DisableSchemaValidation  bool
+		DisableOpenAPIValidation bool
+	}{
+		ReleaseName:              hr.ReleaseName(),
+		ReleaseNamespace:         hr.ReleaseNamespace(),
+		Chart:                    hr.Chart,
+		Values:                   hr.Values,
+		Spec:                     hr.HelmReleaseSpec,
+		ChartValuesFiles:         hr.ChartValuesFiles,
+		IgnoreMissingValuesFiles: hr.IgnoreMissingValuesFiles,
+		CRDsPolicy:               hr.CRDsPolicy,
+		DisableSchemaValidation:  hr.DisableSchemaValidation,
+		DisableOpenAPIValidation: hr.DisableOpenAPIValidation,
+	}
 }
 
 // collectHRDeps returns hr's typed dependsOn entries (carrying any

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
@@ -112,6 +113,54 @@ func TestController_HelmChartSourceResolvedViaResolver(t *testing.T) {
 		t.Errorf("resolver returned wrong source: %+v", got)
 	}
 }
+
+// TestHelmReleaseFingerprint_StableAcrossLabelStamping locks the
+// dedup contract: an HR re-AddObject'd with kustomize ownership
+// labels (the typical pattern when the parent KS emits a
+// re-stamped copy) must produce the same fingerprint as the file-
+// loaded original — otherwise the dedup short-circuit can't fire
+// and helm.Template runs twice for one logical release.
+func TestHelmReleaseFingerprint_StableAcrossLabelStamping(t *testing.T) {
+	base := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			Interval: metav1Duration(time.Hour),
+		},
+		Chart:  manifest.HelmChart{Name: "podinfo", RepoName: "podinfo", RepoNamespace: "flux-system", RepoKind: manifest.KindHelmRepository},
+		Values: map[string]any{"replicas": 2},
+	}
+	stamped := base.Clone()
+	stamped.Labels = map[string]string{
+		"kustomize.toolkit.fluxcd.io/name":      "parent-ks",
+		"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+	}
+	stamped.Annotations = map[string]string{"reconcile.fluxcd.io/requestedAt": "now"}
+
+	if got, want := helmReleaseFingerprint(stamped), helmReleaseFingerprint(base); got != want {
+		t.Errorf("fingerprint changed under label/annotation stamping; got %q want %q", got, want)
+	}
+}
+
+// TestHelmReleaseFingerprint_DifferentOnSpecChange flips the
+// invariant: if patches mutate spec (tholinka's cluster KS pattern
+// — driftDetection, install.crds, upgrade.* injected via
+// kustomize), the fingerprint MUST differ so the controller
+// renders the canonical post-patch values.
+func TestHelmReleaseFingerprint_DifferentOnSpecChange(t *testing.T) {
+	base := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{Interval: metav1Duration(time.Hour)},
+		Chart:           manifest.HelmChart{Name: "podinfo"},
+	}
+	patched := base.Clone()
+	patched.DriftDetection = &helmv2.DriftDetection{Mode: helmv2.DriftDetectionEnabled}
+
+	if got := helmReleaseFingerprint(base); got == helmReleaseFingerprint(patched) {
+		t.Errorf("fingerprint should differ when spec.driftDetection mutates; both = %q", got)
+	}
+}
+
+func metav1Duration(d time.Duration) metav1.Duration { return metav1.Duration{Duration: d} }
 
 func TestController_CollectHRDepsClone(t *testing.T) {
 	c, _ := newTestController(t, nil)

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -43,6 +43,16 @@ type Result struct {
 	// (the enclosing KS whose spec.path contains this one's source
 	// file). Empty when no parent enforcement applies.
 	ParentOf map[manifest.NamedResource]manifest.NamedResource
+	// HRParentOf maps each file-loaded HelmRelease to the structural-
+	// parent Kustomization that will re-emit it during reconcile.
+	// The HR controller depwaits on the parent so its first render
+	// uses the post-patch HR (drift detection / upgrade strategy /
+	// CRD policy overrides applied at the cluster KS level) rather
+	// than the pre-patch file-loaded copy. Without this, every HR
+	// under such a cluster patch chain rendered twice — once stale,
+	// once canonical — doubling helm-render time and any warnings
+	// the chart emits during coalesce.
+	HRParentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
 // Config is the input contract for Run. Store is mandatory.
@@ -76,10 +86,12 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	d.aliasBootstrapSources(repoRoot)
 	loader.ApplyNamespaceInheritance(d.cfg.Store, d.sourceFiles, repoRoot)
 	parentOf := loader.BuildParentIndex(d.cfg.Store, d.sourceFiles)
+	hrParentOf := loader.BuildParentIndexForKind(d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease)
 	return &Result{
 		RepoRoot:    repoRoot,
 		SourceFiles: d.sourceFiles,
 		ParentOf:    parentOf,
+		HRParentOf:  hrParentOf,
 	}, nil
 }
 

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -26,6 +26,22 @@ import (
 // sourceFiles is the orchestrator's NamedResource → repo-relative
 // source-file map; entries without a recorded file are skipped.
 func BuildParentIndex(s *store.Store, sourceFiles map[manifest.NamedResource]string) map[manifest.NamedResource]manifest.NamedResource {
+	return buildParentIndexForKind(s, sourceFiles, manifest.KindKustomization)
+}
+
+// BuildParentIndexForKind extends BuildParentIndex to map any kind to
+// its enclosing Flux Kustomization. The HR controller uses this to
+// gate reconcile on the parent KS — without that gate, the file-
+// loaded HR renders once with stale spec, the parent KS applies
+// `replacements:` / `patches:` and re-emits a mutated HR, the HR
+// controller renders again with the canonical spec, and helm runs
+// twice for one logical resource. Same parent-prefix logic as
+// BuildParentIndex, just iterating the requested child kind.
+func BuildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResource]string, childKind string) map[manifest.NamedResource]manifest.NamedResource {
+	return buildParentIndexForKind(s, sourceFiles, childKind)
+}
+
+func buildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResource]string, childKind string) map[manifest.NamedResource]manifest.NamedResource {
 	type owner struct {
 		prefix string
 		id     manifest.NamedResource
@@ -46,12 +62,8 @@ func BuildParentIndex(s *store.Store, sourceFiles map[manifest.NamedResource]str
 		return cmp.Compare(len(b.prefix), len(a.prefix))
 	})
 	out := map[manifest.NamedResource]manifest.NamedResource{}
-	for _, obj := range s.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok {
-			continue
-		}
-		id := ks.Named()
+	for _, obj := range s.ListObjects(childKind) {
+		id := obj.Named()
 		file, ok := sourceFiles[id]
 		if !ok {
 			continue

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -105,6 +105,16 @@ type Orchestrator struct {
 	// kustomization controller at Run-time, never mutated thereafter.
 	parentOf map[manifest.NamedResource]manifest.NamedResource
 
+	// hrParentOf maps each file-loaded HelmRelease to its structural-
+	// parent KS so the HR controller can depwait on the parent's
+	// reconcile before rendering. Without this, an HR underneath a
+	// parent KS that applies spec-mutating patches (e.g. tholinka's
+	// cluster-wide driftDetection/upgrade/crds override) renders
+	// twice: once with the file-loaded pre-patch spec, once with the
+	// emitted post-patch spec. Both renders are legitimate but the
+	// first is pure waste.
+	hrParentOf map[manifest.NamedResource]manifest.NamedResource
+
 	// rendered tracks IDs the KS controller emitted from a parent
 	// render (vs. only loaded by the file walker). detectOrphans reads
 	// it to demote stale-on-disk resources to "orphan" rather than
@@ -247,6 +257,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	}
 	o.sourceFiles = res.SourceFiles
 	o.parentOf = res.ParentOf
+	o.hrParentOf = res.HRParentOf
 
 	o.validateDependsOn()
 	o.breakDependsOnCycles()
@@ -428,7 +439,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		ParentOf:      o.parentOf,
 		RenderTracker: o.rendered,
 	})
-	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter})
+	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter, ParentOf: o.hrParentOf})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
 	o.hrc.Start(ctx)

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -56,8 +56,19 @@ func (*KustomizationArtifact) artifact() {}
 func (a *KustomizationArtifact) RenderedManifests() []map[string]any { return a.Manifests }
 
 // HelmReleaseArtifact is the rendered output of a HelmRelease template.
+//
+// Fingerprint is a stable hash of the inputs that determine the
+// rendered output (chart identity, expanded values, install/upgrade
+// flags). The HR controller compares it on every reconcile and
+// skips the helm render — which is by far the hot path — when a
+// re-AddObject event arrives with the same effective spec. Typical
+// trigger: the parent Kustomization's render re-emits the HR with
+// `kustomize.toolkit.fluxcd.io/{name,namespace}` ownership labels
+// stamped on metadata, which fails AddObject's reflect-DeepEqual
+// gate even though the rendered output would be byte-identical.
 type HelmReleaseArtifact struct {
-	Manifests []map[string]any
+	Manifests   []map[string]any
+	Fingerprint string
 }
 
 func (*HelmReleaseArtifact) artifact() {}


### PR DESCRIPTION
## Summary

Every HelmRelease under a Flux Kustomization's `spec.path` rendered twice in flate:

1. Discovery loads the file-on-disk HR → `AddObject` → HR controller renders against the **pre-patch** spec.
2. Parent KS reconciles, kustomize bakes in patches / replacements / postBuild substitutions → KS controller emits the **post-patch** HR via `AddObject` → HR controller renders again.

On tholinka/home-ops, the cluster KS patches every HR with `driftDetection` / `install.crds: CreateReplace` / `upgrade.*` / `rollback.*`, so the two renders are legitimately different and 96 charts were rendered ~190 times. Worse, helm's chartutil coalescer emits its `cannot overwrite table with non table` warning once per render — a single chart with a type-mismatched override (e.g. `manager.extraArgs: {}` overridden by a list) logs it twice.

Two complementary mechanisms eliminate the dup:

### 1. Parent gate
- New `loader.BuildParentIndexForKind` parameterizes the existing deepest-spec.path-prefix matcher by child kind.
- `discovery.Result` gains `HRParentOf` mapping each file-loaded HR → enclosing KS.
- HR `reconcile` depwaits on the parent KS's `Ready` before calling `helm.Prepare`/`Template`, then re-reads the store so the render uses the post-patch copy the KS controller has now emitted.

### 2. Fingerprint dedup
- `HelmReleaseArtifact` gains a `Fingerprint` field (SHA-256 of release name / namespace / resolved chart / expanded values / spec / chartValuesFiles / CRDs+schema flags — **labels and annotations excluded** since the KS controller's re-emission only stamps ownership labels).
- After `helm.Prepare`, the controller compares the new fingerprint against the existing artifact. Equal → skip `helm.Template` and `SetArtifact`'s already-stored output stands. Catches the coalescer's pending-re-run after the parent gate unblocks, plus any future label-only re-AddObject.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestHelmReleaseFingerprint_StableAcrossLabelStamping` and `TestHelmReleaseFingerprint_DifferentOnSpecChange` — locks the include/exclude contract.
- [x] tholinka/home-ops, `flate test all`: 266 passed, 0 skipped, 0 failed
- [x] tholinka/home-ops, `flate build all`: dragonfly-operator coalescer warning fires **once** (was twice); 63 fingerprint dedup hits saved 63 helm renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)