### PR TITLE
perf(kustomization): skip duplicate render via fingerprint dedup

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -7,11 +7,15 @@ package kustomization
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"path/filepath"
 	"strings"
 
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -172,6 +176,18 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		return err
 	}
 
+	// Fingerprint dedup: the same id may receive multiple AddObject
+	// events with the same effective spec (e.g. when the structural
+	// parent re-emits this KS after running its own render, stamping
+	// kustomize.toolkit.fluxcd.io ownership labels). kustomize.RenderFlux
+	// is the hot path; skip it and reuse the prior artifact when the
+	// post-Prepare inputs are byte-identical. Same pattern as HR (#219).
+	fp := kustomizationFingerprint(ks, sourceRoot)
+	if existing, ok := c.Store.GetArtifact(id).(*store.KustomizationArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
+		slog.Debug("kustomization: skipped re-render (fingerprint unchanged)", "id", id.String())
+		return nil
+	}
+
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering")
 	data, err := kustomize.RenderFlux(ctx, c.Staging, sourceRoot, ks.Path, ks.Contents)
 	if err != nil {
@@ -207,10 +223,42 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	c.emitRenderedChildren(id, docs)
 
 	c.Store.SetArtifact(id, &store.KustomizationArtifact{
-		Path:      filepath.Join(sourceRoot, ks.Path),
-		Manifests: docs,
+		Path:        filepath.Join(sourceRoot, ks.Path),
+		Manifests:   docs,
+		Fingerprint: fp,
 	})
 	return nil
+}
+
+// kustomizationFingerprint produces a stable hash of the post-Prepare
+// inputs that determine kustomize.RenderFlux's output for ks. The
+// resolved sourceRoot is included so a sibling KS that points at a
+// different source artifact path doesn't collide. Labels and
+// annotations are excluded on purpose: kustomize-controller-emitted
+// children carry stamped ownership labels that don't affect the
+// rendered manifests, and re-rendering on that delta is pure waste.
+// Returns "" when json.Marshal fails — empty fingerprints never
+// match, so the dedup short-circuit degrades safely into re-render.
+func kustomizationFingerprint(ks *manifest.Kustomization, sourceRoot string) string {
+	payload := struct {
+		Path                string
+		SourceRoot          string
+		Contents            map[string]any
+		PostBuildSubstitute map[string]any
+		Spec                kustomizev1.KustomizationSpec
+	}{
+		Path:                ks.Path,
+		SourceRoot:          sourceRoot,
+		Contents:            ks.Contents,
+		PostBuildSubstitute: ks.PostBuildSubstitute,
+		Spec:                ks.KustomizationSpec,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
 }
 
 // emitRenderedChildren parses the rendered docs and lands them in the

--- a/pkg/controllers/kustomization/fingerprint_test.go
+++ b/pkg/controllers/kustomization/fingerprint_test.go
@@ -1,0 +1,68 @@
+package kustomization
+
+import (
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestKustomizationFingerprint_StableAcrossLabelStamping locks the
+// dedup contract: a KS re-AddObject'd with kustomize ownership
+// labels (the typical pattern when the parent KS emits a re-stamped
+// child) must produce the same fingerprint as the file-loaded
+// original — otherwise the dedup short-circuit can't fire and
+// kustomize.RenderFlux runs twice for one logical Kustomization.
+func TestKustomizationFingerprint_StableAcrossLabelStamping(t *testing.T) {
+	base := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path:            "./apps",
+			TargetNamespace: "apps",
+		},
+	}
+	stamped := base.Clone()
+	stamped.Labels = map[string]string{
+		"kustomize.toolkit.fluxcd.io/name":      "parent-ks",
+		"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+	}
+	stamped.Annotations = map[string]string{"reconcile.fluxcd.io/requestedAt": "now"}
+
+	if got, want := kustomizationFingerprint(stamped, "/repo"), kustomizationFingerprint(base, "/repo"); got != want {
+		t.Errorf("fingerprint changed under label/annotation stamping; got %q want %q", got, want)
+	}
+}
+
+// TestKustomizationFingerprint_DifferentOnSpecChange flips the
+// invariant: when a parent KS injects spec mutations via patches /
+// replacements (TargetNamespace, postBuild.substitute, etc.), the
+// fingerprint MUST differ so the controller renders the canonical
+// post-patch values.
+func TestKustomizationFingerprint_DifferentOnSpecChange(t *testing.T) {
+	base := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps", TargetNamespace: "apps"},
+	}
+	patched := base.Clone()
+	patched.TargetNamespace = "production"
+
+	if got := kustomizationFingerprint(base, "/repo"); got == kustomizationFingerprint(patched, "/repo") {
+		t.Errorf("fingerprint should differ when spec.targetNamespace mutates; both = %q", got)
+	}
+}
+
+// TestKustomizationFingerprint_SourceRootInputs guards that a KS
+// resolving to a different on-disk root (e.g. one bootstrap-GR vs.
+// a sibling GitRepository) does NOT collide with the file-loaded
+// sibling at the same spec.path — the source content differs, so
+// the render output differs too.
+func TestKustomizationFingerprint_SourceRootInputs(t *testing.T) {
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	if a, b := kustomizationFingerprint(ks, "/repo-a"), kustomizationFingerprint(ks, "/repo-b"); a == b {
+		t.Errorf("fingerprint must differ across distinct sourceRoots; both = %q", a)
+	}
+}

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -45,9 +45,17 @@ type SourceArtifact struct {
 func (*SourceArtifact) artifact() {}
 
 // KustomizationArtifact is the rendered output of a Kustomization build.
+//
+// Fingerprint mirrors HelmReleaseArtifact: a stable hash of the inputs
+// that determine the rendered output (path, inline contents, spec,
+// expanded substitutions, resolved source root). The KS controller
+// compares it on every reconcile and skips re-running kustomize when
+// a re-AddObject event arrives with the same effective spec — the
+// same wasted-work pattern HR had before PR #219, just for KS.
 type KustomizationArtifact struct {
-	Path      string
-	Manifests []map[string]any
+	Path        string
+	Manifests   []map[string]any
+	Fingerprint string
 }
 
 func (*KustomizationArtifact) artifact() {}


### PR DESCRIPTION
## Summary

Mirrors PR #219 (HR fingerprint dedup) for the Kustomization controller. Any KS re-AddObject'd with byte-equal post-Prepare spec — the typical pattern when the parent KS emits an ownership-stamped copy via `emitRenderedChildren` — now skips `kustomize.RenderFlux` and reuses the prior `KustomizationArtifact`.

`KustomizationArtifact` gains a `Fingerprint string` field carrying SHA-256 of:
- `Path`
- resolved `sourceRoot`
- inline `Contents`
- expanded `PostBuildSubstitute`
- `KustomizationSpec`

Labels and annotations are intentionally excluded — `kustomize.toolkit.fluxcd.io/{name,namespace}` ownership stamping doesn't affect rendered output.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestKustomizationFingerprint_StableAcrossLabelStamping`, `TestKustomizationFingerprint_DifferentOnSpecChange`, `TestKustomizationFingerprint_SourceRootInputs`
- [x] tholinka/home-ops `flate test all`: 266 passed, 0 failed
- [x] tholinka/home-ops `flate build all`: **101 KS dedup hits + 60 HR dedup hits** in one run — 161 render passes saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)