### PR TITLE
fix(cli): validate -o uniformly across get all / get images / test

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -210,7 +210,9 @@ func (c *commonFlags) outputOrDefault(fallback format.Output) format.Output {
 // value (e.g. build has no concept of "name"; diff has no concept of
 // "name"). Treats "table" as accepted so the global default doesn't
 // trigger this check — callers downstream coerce "table" to their
-// own natural default via outputOrDefault.
+// own natural default via outputOrDefault. Pass no `allowed` values to
+// reject every non-default `-o`, which is how `test` (plain-text only)
+// signals "I don't honor -o" loudly instead of silently.
 func (c *commonFlags) requireOutput(allowed ...format.Output) error {
 	if c.output == string(format.OutputTable) {
 		return nil
@@ -220,11 +222,12 @@ func (c *commonFlags) requireOutput(allowed ...format.Output) error {
 			return nil
 		}
 	}
-	names := make([]string, len(allowed))
-	for i, a := range allowed {
-		names[i] = string(a)
+	names := make([]string, 0, len(allowed)+1)
+	names = append(names, string(format.OutputTable))
+	for _, a := range allowed {
+		names = append(names, string(a))
 	}
-	return fmt.Errorf("--output %q not supported by this subcommand (want one of: table, %s)",
+	return fmt.Errorf("--output %q not supported by this subcommand (want one of: %s)",
 		c.output, strings.Join(names, ", "))
 }
 

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -65,5 +67,44 @@ func TestIncludeNamespace_RespectsExplicitFilter(t *testing.T) {
 	}
 	if c.includeNamespace(&change.Filter{}, "default") {
 		t.Error("non-matching namespace must fail")
+	}
+}
+
+// TestRequireOutput_AcceptsDefaultTableAndAllowed pins the
+// short-circuit shape: "table" always passes (subcommand coerces via
+// outputOrDefault), and anything in the allowed set passes.
+func TestRequireOutput_AcceptsDefaultTableAndAllowed(t *testing.T) {
+	for _, out := range []string{"table", "yaml", "json"} {
+		c := &commonFlags{output: out}
+		if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+			t.Errorf("output=%q: unexpected error %v", out, err)
+		}
+	}
+}
+
+// TestRequireOutput_RejectsUnsupported guards the diff/drift fix:
+// `get all -o name` and `get images -o diff` used to silently coerce
+// into a different format — now they fail loud. Empty allowed-set
+// (test's pattern) must reject every non-default `-o`.
+func TestRequireOutput_RejectsUnsupported(t *testing.T) {
+	cases := []struct {
+		output  string
+		allowed []format.Output
+		wantSub string
+	}{
+		{output: "name", allowed: []format.Output{format.OutputYAML, format.OutputJSON}, wantSub: `"name"`},
+		{output: "yaml", allowed: nil, wantSub: "want one of: table"},
+		{output: "json", allowed: []format.Output{format.OutputName}, wantSub: "table, name"},
+	}
+	for _, tc := range cases {
+		c := &commonFlags{output: tc.output}
+		err := c.requireOutput(tc.allowed...)
+		if err == nil {
+			t.Errorf("output=%q allowed=%v: expected error, got nil", tc.output, tc.allowed)
+			continue
+		}
+		if !strings.Contains(err.Error(), tc.wantSub) {
+			t.Errorf("output=%q: error %q missing substring %q", tc.output, err.Error(), tc.wantSub)
+		}
 	}
 }

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -122,11 +122,17 @@ func newGetAllCmd() *cobra.Command {
 		Use:   "all",
 		Short: "Summarize every Kustomization and HelmRelease",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// printCluster emits a key/value summary; only yaml/json
+			// shape it. Reject `-o name` (which printCluster used to
+			// silently coerce to yaml) for parity with build/diff.
+			if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+				return err
+			}
 			o, _, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}
-			if err := printCluster(cmd.OutOrStdout(), o, c.output); err != nil {
+			if err := printCluster(cmd.OutOrStdout(), o, string(c.outputOrDefault(format.OutputYAML))); err != nil {
 				return err
 			}
 			return runErr
@@ -148,12 +154,18 @@ func newGetImagesCmd() *cobra.Command {
 		Use:   "images",
 		Short: "List container images across the cluster",
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Mirrors `diff images`: name is the natural default
+			// (one image per line); yaml/json are the structured
+			// alternatives. Reject anything else loudly.
+			if err := c.requireOutput(format.OutputYAML, format.OutputJSON, format.OutputName); err != nil {
+				return err
+			}
 			o, res, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}
 			imgs := slices.Sorted(maps.Keys(collectImages(o, res, c)))
-			if err := emitImageList(cmd.OutOrStdout(), imgs, c.output); err != nil {
+			if err := emitImageList(cmd.OutOrStdout(), imgs, string(c.outputOrDefault(format.OutputName))); err != nil {
 				return err
 			}
 			return runErr

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// `test` emits a human-readable reconcile report. No structured-output
+// support yet; reject any non-default `-o` so users don't silently get
+// the same plain-text output regardless of what they ask for. When
+// adding json/yaml here later, pass them through requireOutput.
+
 func newTestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "test",
@@ -44,6 +49,9 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 		Short:   short,
 		Args:    args,
 		RunE: func(cmd *cobra.Command, argv []string) error {
+			if err := c.requireOutput(); err != nil {
+				return err
+			}
 			o, _, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr


### PR DESCRIPTION
## Summary

`build` and `diff` validate `-o` via `requireOutput`; `get all`, `get images`, and `test` silently coerced or ignored unsupported values. User passing `-o name` to `get all` got yaml; passing `-o yaml` to `test` got the plain-text report with no warning.

## Changes

- **`get all`**: now requires `-o yaml|json` — rejects `name`, `diff`
- **`get images`**: now requires `-o yaml|json|name` — rejects `diff`; default (table) coerces to name
- **`test ks/hr/all`**: now rejects every non-default `-o` since the report only renders as plain text. When structured-output support lands here, pass `yaml`/`json` through `requireOutput` at that call site
- **`requireOutput` cosmetic**: error message no longer trails a comma when the allowed set is empty (e.g. `test`'s pattern). Now reads "want one of: table" instead of "want one of: table, "

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestRequireOutput_AcceptsDefaultTableAndAllowed`, `TestRequireOutput_RejectsUnsupported`
- [x] Manual smoke against tholinka/home-ops — every rejection path returns a clean `flate error: --output "..." not supported by this subcommand (want one of: ...)` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)