### PR TITLE
refactor(manifest): unexport per-kind Parse helpers (internal-only API)

### DIFF
--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -30,9 +30,9 @@ func (b *Bucket) Named() NamedResource {
 // Suspended reports whether reconciliation is paused on this resource.
 func (b *Bucket) Suspended() bool { return b.Suspend }
 
-// ParseBucket decodes a Bucket CR via the source-controller typed
+// parseBucket decodes a Bucket CR via the source-controller typed
 // schema.
-func ParseBucket(doc map[string]any) (*Bucket, error) {
+func parseBucket(doc map[string]any) (*Bucket, error) {
 	if err := checkAPIVersion(doc, SourceDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/configmap.go
+++ b/pkg/manifest/configmap.go
@@ -18,8 +18,8 @@ func (c *ConfigMap) Named() NamedResource {
 	return NamedResource{Kind: KindConfigMap, Namespace: c.Namespace, Name: c.Name}
 }
 
-// ParseConfigMap decodes a core/v1 ConfigMap.
-func ParseConfigMap(doc map[string]any) (*ConfigMap, error) {
+// parseConfigMap decodes a core/v1 ConfigMap.
+func parseConfigMap(doc map[string]any) (*ConfigMap, error) {
 	if err := checkAPIVersion(doc, "v1"); err != nil {
 		return nil, err
 	}
@@ -51,8 +51,8 @@ func (s *Secret) Named() NamedResource {
 	return NamedResource{Kind: KindSecret, Namespace: s.Namespace, Name: s.Name}
 }
 
-// ParseSecret decodes a Secret, wiping cleartext when wipeSecrets is true.
-func ParseSecret(doc map[string]any, wipeSecrets bool) (*Secret, error) {
+// parseSecret decodes a Secret, wiping cleartext when wipeSecrets is true.
+func parseSecret(doc map[string]any, wipeSecrets bool) (*Secret, error) {
 	if err := checkAPIVersion(doc, "v1"); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/helmchartsource.go
+++ b/pkg/manifest/helmchartsource.go
@@ -25,9 +25,9 @@ func (h *HelmChartSource) ResourceFullName() string {
 	return h.Namespace + "-" + h.Name
 }
 
-// ParseHelmChartSource decodes a standalone HelmChart CRD via the
+// parseHelmChartSource decodes a standalone HelmChart CRD via the
 // source-controller typed schema.
-func ParseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
+func parseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 	if err := checkAPIVersion(doc, SourceDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -259,10 +259,10 @@ func (h *HelmRelease) ResolveChartRef(lookup HelmChartLookup) error {
 	return nil
 }
 
-// ParseHelmRelease decodes a HelmRelease CR via the helm-controller
+// parseHelmRelease decodes a HelmRelease CR via the helm-controller
 // typed schema (helm-controller/api/v2). The chart vs chartRef
 // normalization is preserved by chartFromHelmRelease.
-func ParseHelmRelease(doc map[string]any) (*HelmRelease, error) {
+func parseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 	if err := checkAPIVersion(doc, HelmReleaseDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/helmrepository.go
+++ b/pkg/manifest/helmrepository.go
@@ -22,9 +22,9 @@ func (h *HelmRepository) Named() NamedResource {
 // RepoName is "<namespace>-<name>".
 func (h *HelmRepository) RepoName() string { return h.Namespace + "-" + h.Name }
 
-// ParseHelmRepository decodes a HelmRepository CR via the
+// parseHelmRepository decodes a HelmRepository CR via the
 // source-controller typed schema.
-func ParseHelmRepository(doc map[string]any) (*HelmRepository, error) {
+func parseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 	if err := checkAPIVersion(doc, SourceDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -150,11 +150,11 @@ func (k *Kustomization) UpdatePostBuildSubstitutions(subs map[string]any) {
 	maps.Copy(sub, subs)
 }
 
-// ParseKustomization decodes a Flux Kustomization CR via the
+// parseKustomization decodes a Flux Kustomization CR via the
 // kustomize-controller typed schema. The raw doc is retained in
 // Contents because RenderFlux still feeds it to fluxcd/pkg/kustomize
 // as an unstructured.Unstructured.
-func ParseKustomization(doc map[string]any) (*Kustomization, error) {
+func parseKustomization(doc map[string]any) (*Kustomization, error) {
 	if err := checkAPIVersion(doc, FluxKustomizeDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -57,9 +57,9 @@ spec:
       chart: c
       sourceRef: {kind: HelmRepository, name: r, namespace: ns}
 `)
-	hr, err := ParseHelmRelease(doc)
+	hr, err := parseHelmRelease(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRelease: %v", err)
+		t.Fatalf("parseHelmRelease: %v", err)
 	}
 	if !hr.Suspend {
 		t.Errorf("expected Suspend=true; got false")
@@ -78,9 +78,9 @@ spec:
       chart: c
       sourceRef: {kind: HelmRepository, name: r, namespace: ns}
 `)
-	hr, err := ParseHelmRelease(doc)
+	hr, err := parseHelmRelease(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRelease: %v", err)
+		t.Fatalf("parseHelmRelease: %v", err)
 	}
 	if hr.ServiceAccountName != "privileged-installer" {
 		t.Errorf("ServiceAccountName = %q, want %q", hr.ServiceAccountName, "privileged-installer")
@@ -156,9 +156,9 @@ spec:
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			hr, err := ParseHelmRelease(mustYAML(t, tc.yaml))
+			hr, err := parseHelmRelease(mustYAML(t, tc.yaml))
 			if err != nil {
-				t.Fatalf("ParseHelmRelease: %v", err)
+				t.Fatalf("parseHelmRelease: %v", err)
 			}
 			if hr.CRDsPolicy != tc.want {
 				t.Errorf("CRDsPolicy = %q, want %q", hr.CRDsPolicy, tc.want)
@@ -177,9 +177,9 @@ spec:
   reconcileStrategy: Revision
   sourceRef: {kind: HelmRepository, name: r}
 `)
-	hc, err := ParseHelmChartSource(doc)
+	hc, err := parseHelmChartSource(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmChartSource: %v", err)
+		t.Fatalf("parseHelmChartSource: %v", err)
 	}
 	if hc.ReconcileStrategy != "Revision" {
 		t.Errorf("ReconcileStrategy = %q, want %q", hc.ReconcileStrategy, "Revision")
@@ -211,9 +211,9 @@ spec:
       name: trusted-pgp-keys
   interval: 5m
 `)
-			g, err := ParseGitRepository(doc)
+			g, err := parseGitRepository(doc)
 			if err != nil {
-				t.Fatalf("ParseGitRepository: %v", err)
+				t.Fatalf("parseGitRepository: %v", err)
 			}
 			if g.Verification == nil {
 				t.Fatalf("expected Verify parsed")
@@ -246,7 +246,7 @@ spec:
   interval: 5m
 `,
 			get: func(d map[string]any) (*LocalObjectReference, error) {
-				g, err := ParseGitRepository(d)
+				g, err := parseGitRepository(d)
 				if err != nil {
 					return nil, err
 				}
@@ -285,7 +285,7 @@ spec:
   interval: 5m
 `,
 			get: func(d map[string]any) (*LocalObjectReference, error) {
-				b, err := ParseBucket(d)
+				b, err := parseBucket(d)
 				if err != nil {
 					return nil, err
 				}
@@ -318,9 +318,9 @@ spec:
     - kubernetes/components/shared
   interval: 5m
 `)
-	g, err := ParseGitRepository(doc)
+	g, err := parseGitRepository(doc)
 	if err != nil {
-		t.Fatalf("ParseGitRepository: %v", err)
+		t.Fatalf("parseGitRepository: %v", err)
 	}
 	wantDirs := []string{"kubernetes/apps/media", "kubernetes/components/shared"}
 	if !slices.Equal(g.SparseCheckout, wantDirs) {
@@ -340,9 +340,9 @@ spec:
   recurseSubmodules: true
   interval: 5m
 `)
-	g, err := ParseGitRepository(doc)
+	g, err := parseGitRepository(doc)
 	if err != nil {
-		t.Fatalf("ParseGitRepository: %v", err)
+		t.Fatalf("parseGitRepository: %v", err)
 	}
 	if g.Reference == nil || g.Reference.Name != "refs/pull/420/head" {
 		t.Errorf("Reference.Name = %q", g.Reference)
@@ -372,7 +372,7 @@ spec:
     name: ""
   interval: 5m
 `)
-	_, err := ParseKustomization(doc)
+	_, err := parseKustomization(doc)
 	if err == nil {
 		t.Fatal("expected parse error for empty sourceRef.name with kind set")
 	}
@@ -392,9 +392,9 @@ spec:
   sourceRef: {kind: GitRepository, name: src, namespace: ns}
   interval: 5m
 `)
-	ks, err := ParseKustomization(doc)
+	ks, err := parseKustomization(doc)
 	if err != nil {
-		t.Fatalf("ParseKustomization: %v", err)
+		t.Fatalf("parseKustomization: %v", err)
 	}
 	if !ks.Suspend {
 		t.Errorf("expected Suspend=true; got false")
@@ -418,9 +418,9 @@ spec:
     name: minio-creds
   interval: 5m
 `)
-	b, err := ParseBucket(doc)
+	b, err := parseBucket(doc)
 	if err != nil {
-		t.Fatalf("ParseBucket: %v", err)
+		t.Fatalf("parseBucket: %v", err)
 	}
 	if b.Provider != "generic" {
 		t.Errorf("default Provider should be 'generic', got %q", b.Provider)
@@ -474,7 +474,7 @@ spec:
   url: https://example/x.git
   secretRef: {name: ""}`,
 			want:  "spec.secretRef.name is empty",
-			parse: func(d map[string]any) error { _, err := ParseGitRepository(d); return err },
+			parse: func(d map[string]any) error { _, err := parseGitRepository(d); return err },
 		},
 		{
 			name: "HelmRepository spec.secretRef.name empty",
@@ -485,7 +485,7 @@ spec:
   url: https://example.com/charts
   secretRef: {name: ""}`,
 			want:  "spec.secretRef.name is empty",
-			parse: func(d map[string]any) error { _, err := ParseHelmRepository(d); return err },
+			parse: func(d map[string]any) error { _, err := parseHelmRepository(d); return err },
 		},
 		{
 			name: "Bucket spec.secretRef.name empty",
@@ -497,7 +497,7 @@ spec:
   endpoint: e
   secretRef: {name: ""}`,
 			want:  "spec.secretRef.name is empty",
-			parse: func(d map[string]any) error { _, err := ParseBucket(d); return err },
+			parse: func(d map[string]any) error { _, err := parseBucket(d); return err },
 		},
 	}
 	for _, tc := range cases {
@@ -525,9 +525,9 @@ spec:
   endpoint: e
   interval: 5m
 `)
-	b, err := ParseBucket(doc)
+	b, err := parseBucket(doc)
 	if err != nil {
-		t.Fatalf("ParseBucket: %v", err)
+		t.Fatalf("parseBucket: %v", err)
 	}
 	if !b.Suspend {
 		t.Errorf("expected Suspend=true")
@@ -551,9 +551,9 @@ spec:
       metadata:
         name: << inputs.tenant >>-cm
 `)
-	rs, err := ParseResourceSet(doc)
+	rs, err := parseResourceSet(doc)
 	if err != nil {
-		t.Fatalf("ParseResourceSet: %v", err)
+		t.Fatalf("parseResourceSet: %v", err)
 	}
 	if rs.Name != "apps" || rs.Namespace != "flux-system" {
 		t.Errorf("unexpected name/ns: %s/%s", rs.Namespace, rs.Name)
@@ -574,9 +574,9 @@ metadata:
   name: apps
 spec: {}
 `)
-	rs, err := ParseResourceSet(doc)
+	rs, err := parseResourceSet(doc)
 	if err != nil {
-		t.Fatalf("ParseResourceSet: %v", err)
+		t.Fatalf("parseResourceSet: %v", err)
 	}
 	if rs.Namespace != DefaultNamespace {
 		t.Errorf("namespace=%q want %q", rs.Namespace, DefaultNamespace)
@@ -602,9 +602,9 @@ status:
     revision: v1.2.3@sha256:abc
     digest: sha256:abc
 `)
-	ea, err := ParseExternalArtifact(doc)
+	ea, err := parseExternalArtifact(doc)
 	if err != nil {
-		t.Fatalf("ParseExternalArtifact: %v", err)
+		t.Fatalf("parseExternalArtifact: %v", err)
 	}
 	if ea.Name != "pulled-tarball" || ea.Namespace != "apps" {
 		t.Errorf("identity: %+v", ea)
@@ -634,9 +634,9 @@ spec:
         object.status.conditions.exists(c, c.type == "InfraInitialized" && c.status == "True")
   interval: 5m
 `)
-	k, err := ParseKustomization(doc)
+	k, err := parseKustomization(doc)
 	if err != nil {
-		t.Fatalf("ParseKustomization: %v", err)
+		t.Fatalf("parseKustomization: %v", err)
 	}
 	if len(k.DependsOn) != 1 {
 		t.Fatalf("DependsOn len = %d", len(k.DependsOn))
@@ -663,9 +663,9 @@ spec:
       chart: c
       sourceRef: {kind: HelmRepository, name: r, namespace: ns}
 `)
-	hr, err := ParseHelmRelease(doc)
+	hr, err := parseHelmRelease(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRelease: %v", err)
+		t.Fatalf("parseHelmRelease: %v", err)
 	}
 	if got, want := len(hr.DependsOn), 2; got != want {
 		t.Fatalf("DependsOn len = %d, want %d", got, want)
@@ -703,9 +703,9 @@ spec:
       valuesKey: values.yaml
       optional: true
 `)
-	hr, err := ParseHelmRelease(doc)
+	hr, err := parseHelmRelease(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRelease: %v", err)
+		t.Fatalf("parseHelmRelease: %v", err)
 	}
 
 	cases := []struct {
@@ -745,9 +745,9 @@ spec:
       chart: c
       sourceRef: {kind: HelmRepository, name: r, namespace: ns}
 `)
-	hr, err := ParseHelmRelease(doc)
+	hr, err := parseHelmRelease(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRelease: %v", err)
+		t.Fatalf("parseHelmRelease: %v", err)
 	}
 	if hr.HelmReleaseSpec.ReleaseName != "my-explicit-release" {
 		t.Errorf("HelmReleaseSpec.ReleaseName = %q, want my-explicit-release", hr.HelmReleaseSpec.ReleaseName)
@@ -799,9 +799,9 @@ spec:
     name: my-chart
     namespace: flux-system
 `)
-	hr, err := ParseHelmRelease(doc)
+	hr, err := parseHelmRelease(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRelease: %v", err)
+		t.Fatalf("parseHelmRelease: %v", err)
 	}
 	if hr.Chart.RepoKind != KindHelmChart || hr.Chart.Version != "" {
 		t.Fatalf("expected unresolved chartRef, got %+v", hr.Chart)
@@ -847,9 +847,9 @@ spec:
   url: oci://ghcr.io/stefanprodan/charts
   type: oci
 `)
-	r, err := ParseHelmRepository(doc)
+	r, err := parseHelmRepository(doc)
 	if err != nil {
-		t.Fatalf("ParseHelmRepository: %v", err)
+		t.Fatalf("parseHelmRepository: %v", err)
 	}
 	if r.Type != "oci" {
 		t.Errorf("RepoType = %q", r.Type)
@@ -868,9 +868,9 @@ spec:
   ref:
     tag: v1.2.3
 `)
-	g, err := ParseGitRepository(doc)
+	g, err := parseGitRepository(doc)
 	if err != nil {
-		t.Fatalf("ParseGitRepository: %v", err)
+		t.Fatalf("parseGitRepository: %v", err)
 	}
 	if g.Reference == nil {
 		t.Fatalf("expected Reference parsed")
@@ -904,9 +904,9 @@ spec:
         name: cluster-vars
         optional: true
 `)
-	k, err := ParseKustomization(doc)
+	k, err := parseKustomization(doc)
 	if err != nil {
-		t.Fatalf("ParseKustomization: %v", err)
+		t.Fatalf("parseKustomization: %v", err)
 	}
 	if len(k.DependsOn) != 2 {
 		t.Fatalf("DependsOn len = %d, want 2", len(k.DependsOn))
@@ -987,9 +987,9 @@ metadata:
 data:
   DOMAIN: example.com
 `)
-	cm, err := ParseConfigMap(doc)
+	cm, err := parseConfigMap(doc)
 	if err != nil {
-		t.Fatalf("ParseConfigMap: %v", err)
+		t.Fatalf("parseConfigMap: %v", err)
 	}
 	if cm.Data["DOMAIN"] != "example.com" {
 		t.Errorf("data = %+v", cm.Data)
@@ -1007,9 +1007,9 @@ stringData:
   apiKey: real-key
 `
 	t.Run("wiped", func(t *testing.T) {
-		s, err := ParseSecret(mustYAML(t, yamlDoc), true)
+		s, err := parseSecret(mustYAML(t, yamlDoc), true)
 		if err != nil {
-			t.Fatalf("ParseSecret: %v", err)
+			t.Fatalf("parseSecret: %v", err)
 		}
 		wantPlaceholder := fmt.Sprintf(ValuePlaceholderTemplate, "password")
 		wantB64 := base64.StdEncoding.EncodeToString([]byte(wantPlaceholder))
@@ -1022,9 +1022,9 @@ stringData:
 	})
 
 	t.Run("preserved", func(t *testing.T) {
-		s, err := ParseSecret(mustYAML(t, yamlDoc), false)
+		s, err := parseSecret(mustYAML(t, yamlDoc), false)
 		if err != nil {
-			t.Fatalf("ParseSecret: %v", err)
+			t.Fatalf("parseSecret: %v", err)
 		}
 		if s.Data["password"] != "dGVzdA==" {
 			t.Errorf("data was wiped despite false: %v", s.Data["password"])
@@ -1083,7 +1083,7 @@ metadata: {name: x}`, "Foo"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			obj, err := ParseDoc(mustYAML(t, tc.yaml), DefaultParseDocOptions())
+			obj, err := ParseDoc(mustYAML(t, tc.yaml), defaultParseDocOptions())
 			if err != nil {
 				t.Fatalf("ParseDoc: %v", err)
 			}
@@ -1221,12 +1221,12 @@ func TestStripResourceAttributes_StatefulSetPVCs(t *testing.T) {
 }
 
 func TestParseDoc_MissingFields(t *testing.T) {
-	if _, err := ParseDoc(map[string]any{"kind": "Foo"}, DefaultParseDocOptions()); err == nil || !strings.Contains(err.Error(), "apiVersion") {
+	if _, err := ParseDoc(map[string]any{"kind": "Foo"}, defaultParseDocOptions()); err == nil || !strings.Contains(err.Error(), "apiVersion") {
 		t.Errorf("expected apiVersion error, got %v", err)
 	}
 	// Bare data files (no kind:) are silently dropped as RawObjects —
 	// helm values, config blobs, etc. that aren't k8s resources.
-	obj, err := ParseDoc(map[string]any{"apiVersion": "v1"}, DefaultParseDocOptions())
+	obj, err := ParseDoc(map[string]any{"apiVersion": "v1"}, defaultParseDocOptions())
 	if err != nil {
 		t.Errorf("missing-kind docs should not error, got %v", err)
 	}

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -69,8 +69,8 @@ type ParseDocOptions struct {
 	WipeSecrets bool
 }
 
-// DefaultParseDocOptions returns the standard options — secrets wiped.
-func DefaultParseDocOptions() ParseDocOptions {
+// defaultParseDocOptions returns the standard options — secrets wiped.
+func defaultParseDocOptions() ParseDocOptions {
 	return ParseDocOptions{WipeSecrets: true}
 }
 
@@ -98,31 +98,31 @@ func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
 
 	switch {
 	case kind == KindKustomization && strings.HasPrefix(apiVersion, FluxKustomizeDomain):
-		return ParseKustomization(doc)
+		return parseKustomization(doc)
 	case kind == KindHelmRelease:
-		return ParseHelmRelease(doc)
+		return parseHelmRelease(doc)
 	case kind == KindHelmRepository:
-		return ParseHelmRepository(doc)
+		return parseHelmRepository(doc)
 	case kind == KindHelmChart && strings.HasPrefix(apiVersion, SourceDomain):
-		return ParseHelmChartSource(doc)
+		return parseHelmChartSource(doc)
 	case kind == KindGitRepository:
-		return ParseGitRepository(doc)
+		return parseGitRepository(doc)
 	case kind == KindOCIRepository:
 		return ParseOCIRepository(doc)
 	case kind == KindExternalArtifact && strings.HasPrefix(apiVersion, SourceDomain):
-		return ParseExternalArtifact(doc)
+		return parseExternalArtifact(doc)
 	case kind == KindBucket && strings.HasPrefix(apiVersion, SourceDomain):
-		return ParseBucket(doc)
+		return parseBucket(doc)
 	case kind == KindResourceSet && strings.HasPrefix(apiVersion, FluxOperatorDomain):
-		return ParseResourceSet(doc)
+		return parseResourceSet(doc)
 	case kind == KindResourceSetInputProvider && strings.HasPrefix(apiVersion, FluxOperatorDomain):
-		return ParseResourceSetInputProvider(doc)
+		return parseResourceSetInputProvider(doc)
 	case kind == KindConfigMap:
-		return ParseConfigMap(doc)
+		return parseConfigMap(doc)
 	case kind == KindSecret:
-		return ParseSecret(doc, opts.WipeSecrets)
+		return parseSecret(doc, opts.WipeSecrets)
 	}
-	return ParseRawObject(doc)
+	return parseRawObject(doc)
 }
 
 // checkAPIVersion enforces an api group prefix on a raw document.

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -40,9 +40,9 @@ func (r *ResourceSet) Named() NamedResource {
 // NamespacedName is "<namespace>/<name>".
 func (r *ResourceSet) NamespacedName() string { return r.Namespace + "/" + r.Name }
 
-// ParseResourceSet decodes a ResourceSet CR via the flux-operator
+// parseResourceSet decodes a ResourceSet CR via the flux-operator
 // typed schema (controlplane.io/v1).
-func ParseResourceSet(doc map[string]any) (*ResourceSet, error) {
+func parseResourceSet(doc map[string]any) (*ResourceSet, error) {
 	if err := checkAPIVersion(doc, FluxOperatorDomain); err != nil {
 		return nil, err
 	}
@@ -92,8 +92,8 @@ func (p *ResourceSetInputProvider) Named() NamedResource {
 // NamespacedName is "<namespace>/<name>".
 func (p *ResourceSetInputProvider) NamespacedName() string { return p.Namespace + "/" + p.Name }
 
-// ParseResourceSetInputProvider decodes a ResourceSetInputProvider CR.
-func ParseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvider, error) {
+// parseResourceSetInputProvider decodes a ResourceSetInputProvider CR.
+func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvider, error) {
 	if err := checkAPIVersion(doc, FluxOperatorDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/sops.go
+++ b/pkg/manifest/sops.go
@@ -9,7 +9,7 @@ package manifest
 // flate runs offline and cannot decrypt; the kustomization and
 // helmrelease controllers call this to log the encrypted resource
 // then wipe its data fields to ValuePlaceholderTemplate via
-// ParseSecret, mirroring the --wipe-secrets cleartext behavior.
+// parseSecret, mirroring the --wipe-secrets cleartext behavior.
 // flate ignores spec.decryption entirely — there is no path that
 // reads the decryption Secret.
 func IsEncryptedSecret(doc map[string]any) bool {

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -74,10 +74,10 @@ func validateSecretRefName(kind, owner, field, name string) error {
 	return nil
 }
 
-// ParseGitRepository decodes a GitRepository CR via the Flux typed
+// parseGitRepository decodes a GitRepository CR via the Flux typed
 // schema (source-controller/api/v1), then projects the fields flate
 // uses into the local struct.
-func ParseGitRepository(doc map[string]any) (*GitRepository, error) {
+func parseGitRepository(doc map[string]any) (*GitRepository, error) {
 	if err := checkAPIVersion(doc, SourceDomain); err != nil {
 		return nil, err
 	}
@@ -266,9 +266,9 @@ func (e *ExternalArtifact) Named() NamedResource {
 // controller's Suspendable check is uniform.
 func (e *ExternalArtifact) Suspended() bool { return false }
 
-// ParseExternalArtifact decodes an ExternalArtifact CR via the
+// parseExternalArtifact decodes an ExternalArtifact CR via the
 // source-controller typed schema.
-func ParseExternalArtifact(doc map[string]any) (*ExternalArtifact, error) {
+func parseExternalArtifact(doc map[string]any) (*ExternalArtifact, error) {
 	if err := checkAPIVersion(doc, SourceDomain); err != nil {
 		return nil, err
 	}

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -88,8 +88,8 @@ func (r *RawObject) Named() NamedResource {
 	return NamedResource{Kind: r.Kind, Namespace: r.Namespace, Name: r.Name}
 }
 
-// ParseRawObject decodes any Kubernetes document into RawObject.
-func ParseRawObject(doc map[string]any) (*RawObject, error) {
+// parseRawObject decodes any Kubernetes document into RawObject.
+func parseRawObject(doc map[string]any) (*RawObject, error) {
 	apiVersion, _ := doc["apiVersion"].(string)
 	if apiVersion == "" {
 		return nil, inputf("missing apiVersion")


### PR DESCRIPTION
## Summary

`ParseDoc` is the canonical dispatch entry point; the per-kind `Parse*` helpers (`ParseBucket`, `ParseConfigMap`, `ParseSecret`, `ParseHelmChartSource`, `ParseHelmRelease`, `ParseHelmRepository`, `ParseKustomization`, `ParseResourceSet`, `ParseResourceSetInputProvider`, `ParseGitRepository`, `ParseExternalArtifact`, `ParseRawObject`) + `DefaultParseDocOptions` were exported but only called from within `pkg/manifest` itself.

Staticcheck U1000 missed them because same-package tests reach in directly. Lowercase to shrink the API surface and clarify intent — these are dispatch destinations, not extension points.

## What stays exported

- **`ParseDoc`** and **`ParseDocOptions`**: external callers in `discovery`, `loader`, `controllers/*`, `orchestrator`.
- **`ParseOCIRepository`**: `cosign_test.go` in `pkg/source/oci` uses it directly to round-trip an OCIRepository in an external test.
- **`BuildTLSConfig`** in `pkg/source`: `pkg/source/git/git.go` calls it cross-package.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] tholinka/home-ops `flate test all`: 266 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)