### PR TITLE
refactor(discovery): unify ParentOf + HRParentOf into one index

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -39,20 +39,18 @@ type Result struct {
 	// SourceFiles maps each loaded resource to the repo-relative path
 	// it was parsed from. Consumed by the change filter.
 	SourceFiles map[manifest.NamedResource]string
-	// ParentOf maps each Flux Kustomization to its structural-parent KS
-	// (the enclosing KS whose spec.path contains this one's source
-	// file). Empty when no parent enforcement applies.
+	// ParentOf maps each reconcilable resource (Kustomization or
+	// HelmRelease) to its structural-parent Kustomization — the KS
+	// whose spec.path is the deepest strict ancestor of the child's
+	// source file. KS children honor it as a depwait dep so any
+	// parent-render-time spec mutations (replacements: injecting
+	// targetNamespace) are visible before the child renders;
+	// HR children honor it so the first render reads the post-patch
+	// spec (driftDetection / upgrade strategy / CRD policy overrides
+	// applied at the cluster-KS level) instead of the pre-patch
+	// file-loaded copy. Keyed by NamedResource so KS and HR entries
+	// never collide. Empty when no parent enforcement applies.
 	ParentOf map[manifest.NamedResource]manifest.NamedResource
-	// HRParentOf maps each file-loaded HelmRelease to the structural-
-	// parent Kustomization that will re-emit it during reconcile.
-	// The HR controller depwaits on the parent so its first render
-	// uses the post-patch HR (drift detection / upgrade strategy /
-	// CRD policy overrides applied at the cluster KS level) rather
-	// than the pre-patch file-loaded copy. Without this, every HR
-	// under such a cluster patch chain rendered twice — once stale,
-	// once canonical — doubling helm-render time and any warnings
-	// the chart emits during coalesce.
-	HRParentOf map[manifest.NamedResource]manifest.NamedResource
 }
 
 // Config is the input contract for Run. Store is mandatory.
@@ -85,14 +83,37 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}
 	d.aliasBootstrapSources(repoRoot)
 	loader.ApplyNamespaceInheritance(d.cfg.Store, d.sourceFiles, repoRoot)
-	parentOf := loader.BuildParentIndex(d.cfg.Store, d.sourceFiles)
-	hrParentOf := loader.BuildParentIndexForKind(d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease)
+	// Unified parent index over every reconcilable kind that uses a
+	// parent gate. KS and HR keys never collide because NamedResource
+	// includes Kind; downstream controllers look up by their own id
+	// and naturally filter to their own kind.
+	parentOf := mergeParents(
+		loader.BuildParentIndex(d.cfg.Store, d.sourceFiles),
+		loader.BuildParentIndexForKind(d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease),
+	)
 	return &Result{
 		RepoRoot:    repoRoot,
 		SourceFiles: d.sourceFiles,
 		ParentOf:    parentOf,
-		HRParentOf:  hrParentOf,
 	}, nil
+}
+
+// mergeParents combines per-kind parent maps into one. Earlier
+// arguments win on collision (which can't happen in practice — keys
+// are NamedResource with distinct Kind components — but the rule is
+// explicit so future callers don't accidentally clobber a KS parent
+// with an HR-built rebuild).
+func mergeParents(maps ...map[manifest.NamedResource]manifest.NamedResource) map[manifest.NamedResource]manifest.NamedResource {
+	out := map[manifest.NamedResource]manifest.NamedResource{}
+	for _, m := range maps {
+		for k, v := range m {
+			if _, exists := out[k]; exists {
+				continue
+			}
+			out[k] = v
+		}
+	}
+	return out
 }
 
 type discoverer struct {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -101,19 +101,12 @@ type Orchestrator struct {
 	sourceFiles map[manifest.NamedResource]string
 
 	// parentOf is the structural-parent index Bootstrap computes after
-	// loadManifests + namespace inheritance. Configured onto the
-	// kustomization controller at Run-time, never mutated thereafter.
+	// loadManifests + namespace inheritance — keyed by every
+	// reconcilable id that uses a parent gate (KS and HR). KS lookups
+	// only see KS entries and HR lookups only see HR entries because
+	// NamedResource includes Kind; the single map keeps controller
+	// wiring symmetric.
 	parentOf map[manifest.NamedResource]manifest.NamedResource
-
-	// hrParentOf maps each file-loaded HelmRelease to its structural-
-	// parent KS so the HR controller can depwait on the parent's
-	// reconcile before rendering. Without this, an HR underneath a
-	// parent KS that applies spec-mutating patches (e.g. tholinka's
-	// cluster-wide driftDetection/upgrade/crds override) renders
-	// twice: once with the file-loaded pre-patch spec, once with the
-	// emitted post-patch spec. Both renders are legitimate but the
-	// first is pure waste.
-	hrParentOf map[manifest.NamedResource]manifest.NamedResource
 
 	// rendered tracks IDs the KS controller emitted from a parent
 	// render (vs. only loaded by the file walker). detectOrphans reads
@@ -257,7 +250,6 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	}
 	o.sourceFiles = res.SourceFiles
 	o.parentOf = res.ParentOf
-	o.hrParentOf = res.HRParentOf
 
 	o.validateDependsOn()
 	o.breakDependsOnCycles()
@@ -439,7 +431,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		ParentOf:      o.parentOf,
 		RenderTracker: o.rendered,
 	})
-	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter, ParentOf: o.hrParentOf})
+	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter, ParentOf: o.parentOf})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
 	o.hrc.Start(ctx)


### PR DESCRIPTION
## Summary

`discovery.Result` carried two parent maps (`ParentOf` for KS, `HRParentOf` for HR) and the orchestrator mirrored both as separate fields. Both were keyed by `NamedResource` (Kind included), so KS and HR keys can't collide — the split was bookkeeping cost without isolation benefit.

## Changes

- `discovery.Result.HRParentOf` dropped; `ParentOf` documented as the unified index covering both kinds
- new `mergeParents` helper composes per-kind index builds (one call per kind, currently KS + HR; trivially extensible if a third kind ever needs a parent gate)
- `orchestrator.hrParentOf` field dropped; same `parentOf` passed to both `ksc.Configure` and `hrc.Configure`
- HR controller's lookup `parentOf[hr.Named()]` naturally filters to HR entries; KS controller's `parentOf[ks.Named()]` filters to KS entries — no controller-side change

## What this PR deliberately does NOT do

This is the conservative version of the architectural cleanup the audit flagged. It does **not** introduce a `ParentResolver` interface — that would be speculative scaffolding for a single implementation. If a future need arrives (a parent gate keyed by something other than file-path prefix, or a Store-query-backed resolver), the interface can be extracted then with one real consumer in mind.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] tholinka/home-ops `flate test all`: 266 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)