### PR TITLE
fix(kustomize): skip broken symlinks during stage instead of aborting

### DIFF
--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -116,6 +116,16 @@ func (c *StagingCache) copyTree(src string) (string, error) {
 		// Read regular files (or follow symlinks to regular files).
 		info, err := os.Stat(path)
 		if err != nil {
+			// A dangling symlink in the user's working tree (a common
+			// local-only state for editor lockfiles, gitignored
+			// .pre-commit-config.yaml, IDE caches) used to abort the
+			// entire stage. flate doesn't need the link target — Flux's
+			// reconcile wouldn't either — so skip silently when the
+			// target is missing. Other Stat errors (permissions, I/O)
+			// still surface.
+			if d.Type()&fs.ModeSymlink != 0 && errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 		if !info.Mode().IsRegular() {

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -1,0 +1,89 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStagingCache_CopyTree_SkipsBrokenSymlink locks the fix for
+// m00nwtchr/homelab-cluster's `.pre-commit-config.yaml` regression: a
+// dangling symlink in the user's working tree (common for editor
+// lockfiles, gitignored CI configs, IDE caches that point at
+// machine-local paths) used to abort the entire stage with
+// "stat <path>: no such file or directory". Flux's reconcile would
+// happily skip the same link in-cluster; flate now matches that.
+func TestStagingCache_CopyTree_SkipsBrokenSymlink(t *testing.T) {
+	src := t.TempDir()
+
+	// One real file Flux cares about.
+	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+
+	// One dangling symlink at the root — the exact shape m00nwtchr's
+	// .pre-commit-config.yaml landed as in their local checkout.
+	if err := os.Symlink("/nonexistent/.pre-commit-config.yaml",
+		filepath.Join(src, ".pre-commit-config.yaml")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	staged, err := cache.Stage(src)
+	if err != nil {
+		t.Fatalf("Stage should ignore broken symlinks; got %v", err)
+	}
+
+	// The real file made it through.
+	if _, err := os.Stat(filepath.Join(staged, "kustomization.yaml")); err != nil {
+		t.Errorf("kustomization.yaml missing from stage: %v", err)
+	}
+	// The broken symlink did NOT get copied (good — we'd just propagate
+	// the dangling reference into the stage).
+	if _, err := os.Lstat(filepath.Join(staged, ".pre-commit-config.yaml")); err == nil {
+		t.Error("broken symlink should not appear in stage")
+	}
+}
+
+// TestStagingCache_CopyTree_FollowsLiveSymlink confirms we still
+// follow symlinks that resolve to real files — the skip applies only
+// to the "target doesn't exist" arm.
+func TestStagingCache_CopyTree_FollowsLiveSymlink(t *testing.T) {
+	src := t.TempDir()
+	target := filepath.Join(src, "real.yaml")
+	mustWrite(t, target, "kind: ConfigMap\n")
+	if err := os.Symlink(target, filepath.Join(src, "alias.yaml")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	staged, err := cache.Stage(src)
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(staged, "alias.yaml")) //nolint:gosec // staged is t.TempDir
+	if err != nil {
+		t.Fatalf("read alias: %v", err)
+	}
+	if string(got) != "kind: ConfigMap\n" {
+		t.Errorf("symlink target lost; got %q", got)
+	}
+}
+
+func mustWrite(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

Reported by m00nwtchr ([gist](https://gist.github.com/m00nwtchr/755c7d3b7a1e7e17b904079728d229d6)) against their [homelab-cluster](https://github.com/m00nwtchr/homelab-cluster) repo.

**No, flate is not over-scanning** — it only walks inside the source root. The bug is that during stage-copy, a dangling symlink **inside the repo root** aborts the whole walk before reaching its skip-decision.

## Root cause

`pkg/kustomize/stage.go::copyTree` walks the source root with `filepath.WalkDir`, then calls `os.Stat(path)` to decide whether the entry is a regular file worth copying. `os.Stat` follows symlinks; a symlink whose target is missing (the user's local `.pre-commit-config.yaml` pointed at a tool path that doesn't exist on their machine) returns `ErrNotExist`, the callback returns that error, and the whole walk unwinds with:

```
stage /repo: stat /repo/.pre-commit-config.yaml: no such file or directory
```

Every Kustomization downstream of `cluster-meta` (whose render needed the same source root) then cascaded as "dependencies failed: cluster-meta: stage ...".

Real Flux's reconcile ignores the same dangling link because the target isn't part of any Kustomization's resource set. flate now matches that.

## Fix

`copyTree` detects symlink entries via `d.Type()&fs.ModeSymlink` and treats `ErrNotExist` on the Stat as "skip silently." Other Stat errors (permission, I/O) still surface — those are real failures.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestStagingCache_CopyTree_SkipsBrokenSymlink` + `TestStagingCache_CopyTree_FollowsLiveSymlink` — locks both the skip semantic and the "still follows live symlinks" invariant
- [x] Reproduced on m00nwtchr/homelab-cluster with a synthetic dangling `.pre-commit-config.yaml` symlink at the repo root: before → every cluster-meta dependent orphaned; after → 473 passed, 4 unrelated upstream HTTP 404 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)