### PR TITLE
fix(helmrelease): dispatch chart-rendered source CRs through AddObject

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -245,11 +245,48 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			slog.Debug("helmrelease: skipped doc", "id", id.String(), "err", err)
 			continue
 		}
-		c.Store.AddRendered(obj)
+		// Source CRs rendered by a chart (e.g. tofu-controller emits an
+		// OCIRepository for its TF state bundle) need to flow through
+		// the source controller's listener so they actually get
+		// fetched and produce a Ready status. Without AddObject the
+		// rendered source sits in the Store with no status and
+		// `flate test` reports it as "FAILED (no status reported)".
+		// Real Flux reconciles these the same way.
+		//
+		// Other kinds — Deployments, Services, ConfigMaps emitted as
+		// chart workload output — go via AddRendered: they're the
+		// chart's final cluster manifests, not anything flate
+		// reconciles further.
+		if isFluxSourceKind(obj) {
+			c.Store.AddObject(obj)
+		} else {
+			c.Store.AddRendered(obj)
+		}
 	}
 
 	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs, Fingerprint: fp})
 	return nil
+}
+
+// isFluxSourceKind reports whether obj is a Flux source CR — one
+// the source controller is registered to reconcile. Mirrors the
+// subset of kustomization.shouldDispatchAsObject that the HR
+// controller actually wants to re-emit: only sources are
+// chart-rendered in the wild (tofu-controller's OCIRepository, ESO
+// chart's HelmRepository fallback). Charts that render KS / HR are
+// rare and risky — restricting the AddObject dispatch to sources
+// keeps the blast radius small.
+func isFluxSourceKind(obj manifest.BaseManifest) bool {
+	switch obj.(type) {
+	case *manifest.GitRepository,
+		*manifest.OCIRepository,
+		*manifest.HelmRepository,
+		*manifest.Bucket,
+		*manifest.HelmChartSource,
+		*manifest.ExternalArtifact:
+		return true
+	}
+	return false
 }
 
 // helmReleaseFingerprint produces a stable hash of the inputs that

--- a/pkg/controllers/helmrelease/reconcile_test.go
+++ b/pkg/controllers/helmrelease/reconcile_test.go
@@ -95,6 +95,40 @@ func TestReconcile_ParentGateWaits(t *testing.T) {
 
 // TestReconcile_NoChartRefBypassDepwait covers a degenerate HR with
 // neither chartRef nor sourceRef — chart resolution writes
+// TestIsFluxSourceKind enumerates the chart-render dispatch matrix:
+// source CRs go through AddObject (so the source controller picks
+// them up and writes a status); other kinds go through AddRendered.
+// Pins the fix for the m00nwtchr report where tofu-controller's
+// chart-rendered OCIRepository/aws-package surfaced as "FAILED
+// (no status reported)" because the HR controller used to
+// AddRendered every doc unconditionally.
+func TestIsFluxSourceKind(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  manifest.BaseManifest
+		want bool
+	}{
+		{"GitRepository", &manifest.GitRepository{}, true},
+		{"OCIRepository", &manifest.OCIRepository{}, true},
+		{"HelmRepository", &manifest.HelmRepository{}, true},
+		{"Bucket", &manifest.Bucket{}, true},
+		{"HelmChartSource", &manifest.HelmChartSource{}, true},
+		{"ExternalArtifact", &manifest.ExternalArtifact{}, true},
+		{"ConfigMap is not a source", &manifest.ConfigMap{}, false},
+		{"Secret is not a source", &manifest.Secret{}, false},
+		{"Kustomization is not a source", &manifest.Kustomization{}, false},
+		{"HelmRelease is not a source", &manifest.HelmRelease{}, false},
+		{"RawObject is not a source", &manifest.RawObject{Kind: "Deployment"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isFluxSourceKind(tc.obj); got != tc.want {
+				t.Errorf("isFluxSourceKind(%T) = %v, want %v", tc.obj, got, tc.want)
+			}
+		})
+	}
+}
+
 // "missing spec.chart" via helm.Prepare, surfacing as Failed without
 // ever entering depwait.
 func TestReconcile_MissingChartFails(t *testing.T) {


### PR DESCRIPTION
## Summary

A chart that renders a Flux source CR (e.g. tofu-controller emits an `OCIRepository` carrying its terraform-state bundle; the External Secrets chart can emit a `HelmRepository`) used to land in the Store via `Store.AddRendered`. That path skips the listener dispatch — the source controller never saw the new id, never fetched it, and `flate test` reported it as **"FAILED (no status reported)"** because the artifact existed in the store but no controller had written a `StatusReady` for it.

Real Flux reconciles these: the helm-controller writes the CR to the cluster, the source-controller picks it up. flate now matches: source kinds get `Store.AddObject` (which fires `EventObjectAdded` and the source controller's listener); everything else (Deployments, Services, ConfigMaps — the chart's final cluster workload) keeps going through `AddRendered`.

## Scope

Intentionally narrow: only Flux source kinds (`GitRepository`, `OCIRepository`, `HelmRepository`, `Bucket`, `HelmChartSource`, `ExternalArtifact`) get the `AddObject` treatment. Charts rendering KS / HR are exotic and would create infinite-loop risk; that's the pattern the Kustomization controller handles through its two-pass emit, which HR doesn't currently need.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestIsFluxSourceKind` — enumerates the dispatch matrix
- [x] m00nwtchr/homelab-cluster `flate test all`:
  - Before: `OCIRepository/flux-system/aws-package` (emitted by `tofu-controller` chart) FAILED
  - After: `aws-package` PASSED + `HelmRepository/observability/opentelemetry` (emitted by `otel-operator` chart) PASSED
- [x] tholinka/home-ops: 266 passed, 0 failed
- [x] buroa/k8s-gitops: 166 passed, 0 failed

Stacks cleanly on top of #229 (which addresses the unrelated `git`-binary dependency / broken-URL slowness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)