### PR TITLE
perf(kustomize): dedup remote-resource fetches across preflight passes

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -102,7 +102,7 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, subPath st
 	// to `exec.Command("git", "fetch", ...)`. See preflight.go for
 	// the why. Walks the entire staged tree because Components and
 	// nested overlays may reference URL resources from below subPath.
-	if err := preflightRemoteResources(ctx, staged); err != nil {
+	if err := preflightRemoteResources(ctx, cache, staged); err != nil {
 		return nil, fmt.Errorf("preflight remote resources: %w", err)
 	}
 

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -43,13 +42,14 @@ var remoteFetchClient = &http.Client{Timeout: remoteFetchTimeout}
 //
 // On a fetch failure (timeout, 4xx, 5xx, DNS), a YAML-comment-only
 // tombstone file is written so kustomize completes the build with
-// one fewer resource. The failure surfaces via slog.Warn rather
-// than a misleading "URL is a git repository" error.
+// one fewer resource. The failure surfaces via one slog.Warn per
+// URL (StagingCache.FetchRemote dedupes both the network call AND
+// the log line across every preflight pass in one orchestrator run).
 //
 // Walks all three valid kustomization filenames (kustomization.yaml,
 // kustomization.yml, Kustomization). Only mutates the staged copy
 // the caller owns; the user's source tree is never touched.
-func preflightRemoteResources(ctx context.Context, root string) error {
+func preflightRemoteResources(ctx context.Context, cache *StagingCache, root string) error {
 	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -61,14 +61,14 @@ func preflightRemoteResources(ctx context.Context, root string) error {
 		if name != "kustomization.yaml" && name != "kustomization.yml" && name != "Kustomization" {
 			return nil
 		}
-		return rewriteURLResources(ctx, path)
+		return rewriteURLResources(ctx, cache, path)
 	})
 }
 
 // rewriteURLResources rewrites URL entries in one kustomization file.
 // Reads the file as a generic YAML doc to preserve unknown fields,
 // rewrites the resources list, writes the file back.
-func rewriteURLResources(ctx context.Context, ksFile string) error {
+func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string) error {
 	body, err := os.ReadFile(ksFile) //nolint:gosec // ksFile is a tree-walk result under our staged copy
 	if err != nil {
 		return err
@@ -97,10 +97,11 @@ func rewriteURLResources(ctx context.Context, ksFile string) error {
 		if !isHTTPURL(urlStr) {
 			continue
 		}
-		localFile, fetchErr := fetchRemoteResource(ctx, dir, urlStr)
+		localFile, fetchErr := fetchRemoteResource(ctx, cache, dir, urlStr)
 		if fetchErr != nil {
-			slog.Warn("kustomize: remote resource fetch failed; emitting tombstone",
-				"url", urlStr, "err", fetchErr)
+			// Warning already logged inside cache.FetchRemote — the
+			// first fetch emits the WARN, subsequent cache hits stay
+			// quiet.
 			rawRes[i] = "./" + writeFetchTombstone(dir, urlStr, fetchErr)
 		} else {
 			rawRes[i] = "./" + localFile
@@ -123,25 +124,13 @@ func isHTTPURL(s string) bool {
 }
 
 // fetchRemoteResource fetches the URL into a .flate-remote-<hash>.yaml
-// file next to the kustomization that referenced it. The local name
-// is deterministic per URL so re-runs reuse the same on-disk file
-// (kustomize sees a stable input, which keeps its own caching honest).
-func fetchRemoteResource(ctx context.Context, dir, urlStr string) (string, error) {
-	fetchCtx, cancel := context.WithTimeout(ctx, remoteFetchTimeout)
-	defer cancel()
-	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, urlStr, nil)
-	if err != nil {
-		return "", err
-	}
-	resp, err := remoteFetchClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return "", fmt.Errorf("HTTP %d", resp.StatusCode)
-	}
-	body, err := io.ReadAll(resp.Body)
+// file next to the kustomization that referenced it. The actual HTTP
+// fetch is deduped via cache.FetchRemote — multiple kustomization
+// files referencing the same URL share one network call. The local
+// filename is deterministic per URL so re-runs reuse the same on-disk
+// file (kustomize sees a stable input).
+func fetchRemoteResource(ctx context.Context, cache *StagingCache, dir, urlStr string) (string, error) {
+	body, err := cache.FetchRemote(ctx, urlStr)
 	if err != nil {
 		return "", err
 	}
@@ -150,6 +139,27 @@ func fetchRemoteResource(ctx context.Context, dir, urlStr string) (string, error
 		return "", err
 	}
 	return name, nil
+}
+
+// httpGetURL is the actual network call cache.FetchRemote dispatches
+// through OnceValues. Lives here (not on the StagingCache) because
+// it's a preflight detail — the cache only owns the dedup discipline.
+func httpGetURL(ctx context.Context, urlStr string) ([]byte, error) {
+	fetchCtx, cancel := context.WithTimeout(ctx, remoteFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := remoteFetchClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
 }
 
 // writeFetchTombstone emits a YAML-comment-only file in place of a
@@ -168,3 +178,4 @@ func urlHash(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:8])
 }
+

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -26,7 +27,7 @@ func TestPreflightRemoteResources_RewritesSuccessfulFetch(t *testing.T) {
 	ks := filepath.Join(stage, "kustomization.yaml")
 	mustWriteFile(t, ks, "resources:\n  - "+srv.URL+"/foo.yaml\n")
 
-	if err := preflightRemoteResources(context.Background(), stage); err != nil {
+	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 
@@ -71,7 +72,7 @@ func TestPreflightRemoteResources_TombstoneOnFailure(t *testing.T) {
 	ks := filepath.Join(stage, "kustomization.yaml")
 	mustWriteFile(t, ks, "resources:\n  - "+srv.URL+"/missing.yaml\n")
 
-	if err := preflightRemoteResources(context.Background(), stage); err != nil {
+	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 
@@ -102,7 +103,7 @@ func TestPreflightRemoteResources_IgnoresLocalEntries(t *testing.T) {
 	body := "resources:\n  - ./local.yaml\n  - ../shared/cm.yaml\n"
 	mustWriteFile(t, ks, body)
 
-	if err := preflightRemoteResources(context.Background(), stage); err != nil {
+	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 
@@ -131,7 +132,7 @@ func TestPreflightRemoteResources_WalksNestedKustomizations(t *testing.T) {
 	mustWriteFile(t, filepath.Join(nested, "kustomization.yaml"),
 		"resources:\n  - "+srv.URL+"/nested.yaml\n")
 
-	if err := preflightRemoteResources(context.Background(), stage); err != nil {
+	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 	body, _ := os.ReadFile(filepath.Join(nested, "kustomization.yaml")) //nolint:gosec // t.TempDir
@@ -154,7 +155,7 @@ func TestPreflightRemoteResources_HonorsAlternateFilenames(t *testing.T) {
 			stage := t.TempDir()
 			mustWriteFile(t, filepath.Join(stage, name),
 				"resources:\n  - "+srv.URL+"/x.yaml\n")
-			if err := preflightRemoteResources(context.Background(), stage); err != nil {
+			if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 				t.Fatalf("preflight: %v", err)
 			}
 			body, _ := os.ReadFile(filepath.Join(stage, name)) //nolint:gosec // t.TempDir
@@ -162,6 +163,64 @@ func TestPreflightRemoteResources_HonorsAlternateFilenames(t *testing.T) {
 				t.Errorf("%s URL not rewritten:\n%s", name, body)
 			}
 		})
+	}
+}
+
+// TestPreflightRemoteResources_FetchesEachURLOnce pins the dedup
+// contract: a URL referenced from N kustomization files (parent +
+// nested child + sibling overlay …) must hit the network exactly
+// once per orchestrator run. The fix for the m00nwtchr report
+// where the same broken URL emitted 6 WARNs per `flate test all`.
+func TestPreflightRemoteResources_FetchesEachURLOnce(t *testing.T) {
+	var hits int32
+	mu := &sync.Mutex{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		hits++
+		mu.Unlock()
+		_, _ = w.Write([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata: {name: shared}\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	stage := t.TempDir()
+	// Three kustomization files, all referencing the same URL.
+	for _, sub := range []string{"a", "b", "c"} {
+		dir := filepath.Join(stage, sub)
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		mustWriteFile(t, filepath.Join(dir, "kustomization.yaml"),
+			"resources:\n  - "+srv.URL+"/shared.yaml\n")
+	}
+
+	cache := newPreflightCache(t)
+	if err := preflightRemoteResources(context.Background(), cache, stage); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("expected 1 network call, got %d", hits)
+	}
+
+	// Each kustomization still got its own local copy written.
+	for _, sub := range []string{"a", "b", "c"} {
+		matches, _ := filepath.Glob(filepath.Join(stage, sub, ".flate-remote-*.yaml"))
+		if len(matches) != 1 {
+			t.Errorf("%s: expected one local copy, got %v", sub, matches)
+		}
+	}
+
+	// Running preflight again on the same cache must NOT re-fetch.
+	// (Tests the dedup spans across multiple preflight calls, which
+	// is the actual production pattern — one preflight per
+	// RenderFlux invocation.)
+	stage2 := t.TempDir()
+	mustWriteFile(t, filepath.Join(stage2, "kustomization.yaml"),
+		"resources:\n  - "+srv.URL+"/shared.yaml\n")
+	if err := preflightRemoteResources(context.Background(), cache, stage2); err != nil {
+		t.Fatalf("second preflight: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("expected 1 network call across both runs, got %d", hits)
 	}
 }
 
@@ -173,4 +232,16 @@ func mustWriteFile(t *testing.T, path, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// newPreflightCache returns a fresh StagingCache so each test gets
+// its own remote-fetch dedup table (no cross-test cache hits).
+func newPreflightCache(t *testing.T) *StagingCache {
+	t.Helper()
+	c, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
 }

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -1,10 +1,12 @@
 package kustomize
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -25,6 +27,17 @@ type StagingCache struct {
 	mu     sync.Mutex
 	stages map[string]*stage
 	root   string
+	// remoteFetches dedupes URL fetches across every preflight pass in
+	// one orchestrator run. A single kustomization.yaml URL may be
+	// reached via multiple Flux Kustomizations (parent emits a child
+	// that shares the same path; multiple KSes whose subPath crosses
+	// the same nested kustomization). Without this, every reconcile
+	// re-fetches the same URL and re-emits the same WARN line.
+	remoteFetches sync.Map // url string -> *remoteFetch
+}
+
+type remoteFetch struct {
+	once func() ([]byte, error)
 }
 
 type stage struct {
@@ -45,6 +58,26 @@ func NewStagingCache(parent string) (*StagingCache, error) {
 		stages: make(map[string]*stage),
 		root:   parent,
 	}, nil
+}
+
+// FetchRemote returns the body of urlStr, fetched at most once per
+// StagingCache lifetime. Both successful bodies and errors are
+// cached — concurrent callers block on a single sync.OnceValues and
+// every caller sees the same result. The warning log lives inside
+// the OnceValues so the user sees one WARN per broken URL per run,
+// not one per kustomization that referenced it.
+func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, error) {
+	actual, _ := c.remoteFetches.LoadOrStore(urlStr, &remoteFetch{
+		once: sync.OnceValues(func() ([]byte, error) {
+			body, err := httpGetURL(ctx, urlStr)
+			if err != nil {
+				slog.Warn("kustomize: remote resource fetch failed",
+					"url", urlStr, "err", err)
+			}
+			return body, err
+		}),
+	})
+	return actual.(*remoteFetch).once()
 }
 
 // Stage returns the on-disk staged copy of source. The copy is created


### PR DESCRIPTION
## Summary

After #229, every Flux Kustomization that crossed the staged tree re-invoked `preflightRemoteResources`, which walked the full stage and re-fetched every URL it found. For m00nwtchr/homelab-cluster's one broken stunner-crd URL, that meant **6 HTTP 404 attempts and 6 WARN lines** per `flate test all` — one per kustomization that touched the affected path (parent KS, file-loaded child KS, parent-emitted stamped copy, coalescer pending-re-run …).

## Fix

A `sync.Map` of `sync.OnceValues`-wrapped fetchers on `StagingCache`. The cache is per-orchestrator-run (cleaned up at `Close`). Concurrent callers block on a single `OnceValues`, so even a parallel race collapses to one network call. The WARN log moved inside the `OnceValues` — first failure logs, subsequent cache hits stay quiet.

Tombstone files and locally-cached bodies are still written per-kustomization-directory (relative-path resolution needs them there); only the network round-trip is shared.

## Numbers (m00nwtchr/homelab-cluster, `flate test all`)

| | Before #229 | After #229 | After this PR |
|---|---|---|---|
| Wall time | 14.1s | 7.25s | **6.09s** |
| WARN lines (broken URL) | n/a (`git fetch` err) | 6 | **1** |
| CPU util | 73% | 497% | **595%** |
| 477/477 pass | yes | yes | yes |

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New: `TestPreflightRemoteResources_FetchesEachURLOnce` — locks the dedup contract across both within-one-preflight (3 sibling kustomizations referencing the same URL → 1 fetch) and across-multiple-preflights (a fresh stage reusing the same cache → still 0 additional fetches)
- [x] tholinka/home-ops: 266 passed, 0 failed
- [x] buroa/k8s-gitops: 166 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)