### PR TITLE
chore(oci): demote cosign keyless-skip log from WARN to DEBUG

### DIFF
--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -101,7 +101,7 @@ func (f *Fetcher) verifyCosignSignature(
 		// Keyless (OIDC) — flate can't reach Fulcio/Rekor offline and
 		// doesn't carry the sigstore trust roots. Log and proceed so the
 		// chart still renders for diff purposes.
-		slog.Warn("cosign keyless verification skipped; rendering unverified artifact",
+		slog.Debug("cosign keyless verification skipped; rendering unverified artifact",
 			"ociRepository", repo.Namespace+"/"+repo.Name,
 			"digest", pulledDigest)
 		return nil


### PR DESCRIPTION
## Summary

Most repos that use `OCIRepository.verify` configure keyless (Fulcio/Rekor). flate can't reach Fulcio/Rekor offline and doesn't ship the sigstore trust roots, so we already log + render the unverified artifact. The WARN fires for every OCI source in every run though, which fills `flate test all` output with N+ identical lines (m00nwtchr's repo had 25+) that the user can't act on.

Demote to DEBUG — visible with `--log-level debug` for anyone investigating cosign verification, invisible by default. The unverified state is still surfaced by the rendered output itself; users who want strict verification configure keyed cosign (`spec.verify.secretRef` with PEM keys) which flate enforces end-to-end via stdlib crypto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)