### PR TITLE
fix(kustomize): split remote-fetch failures — WARN unreachable, DEBUG non-2xx

### DIFF
--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -141,6 +141,20 @@ func fetchRemoteResource(ctx context.Context, cache *StagingCache, dir, urlStr s
 	return name, nil
 }
 
+// httpStatusError signals a non-2xx response — the URL was reachable
+// but the server didn't serve the resource. Distinct from transport
+// errors (DNS, timeout, connection refused) so FetchRemote can log
+// the two at different levels: server-said-no is a user-repo concern
+// and stays DEBUG; can't-reach-the-server is environment-side and
+// warrants WARN.
+type httpStatusError struct {
+	code int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d", e.code)
+}
+
 // httpGetURL is the actual network call cache.FetchRemote dispatches
 // through OnceValues. Lives here (not on the StagingCache) because
 // it's a preflight detail — the cache only owns the dedup discipline.
@@ -157,7 +171,7 @@ func httpGetURL(ctx context.Context, urlStr string) ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+		return nil, &httpStatusError{code: resp.StatusCode}
 	}
 	return io.ReadAll(resp.Body)
 }

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -63,16 +63,32 @@ func NewStagingCache(parent string) (*StagingCache, error) {
 // FetchRemote returns the body of urlStr, fetched at most once per
 // StagingCache lifetime. Both successful bodies and errors are
 // cached — concurrent callers block on a single sync.OnceValues and
-// every caller sees the same result. The warning log lives inside
-// the OnceValues so the user sees one WARN per broken URL per run,
-// not one per kustomization that referenced it.
+// every caller sees the same result. Logging lives inside the
+// OnceValues so users see one line per URL per run.
+//
+// Log level depends on the failure mode:
+//
+//   - WARN: the HTTP client couldn't reach the URL (DNS, connection
+//     refused, timeout). The user's environment is the suspect —
+//     they need to know.
+//   - DEBUG: the server responded with non-2xx (404, 410, 500…). The
+//     URL is reachable; it just doesn't host that resource. That's
+//     a user-repo issue, surfaced separately by the missing resource
+//     in the rendered output — no need to spam WARN.
+//   - nothing on success.
 func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, error) {
 	actual, _ := c.remoteFetches.LoadOrStore(urlStr, &remoteFetch{
 		once: sync.OnceValues(func() ([]byte, error) {
 			body, err := httpGetURL(ctx, urlStr)
 			if err != nil {
-				slog.Warn("kustomize: remote resource fetch failed",
-					"url", urlStr, "err", err)
+				var httpErr *httpStatusError
+				if errors.As(err, &httpErr) {
+					slog.Debug("kustomize: remote resource returned non-2xx",
+						"url", urlStr, "status", httpErr.code)
+				} else {
+					slog.Warn("kustomize: remote resource unreachable",
+						"url", urlStr, "err", err)
+				}
 			}
 			return body, err
 		}),


### PR DESCRIPTION
## Summary

PR #232 collapsed every kustomization-URL fetch failure to one WARN per URL, but conflated two different failure modes:

| Failure mode | Cause | Should log as |
|---|---|---|
| **Server unreachable** (DNS, connection refused, timeout) | User's environment | **WARN** — they need to notice |
| **HTTP non-2xx** (404, 410, 5xx) | URL is reachable, resource missing | **DEBUG** — already visible via the missing resource in rendered output |

m00nwtchr's case (stunner-crd URL 404'ing) is the second category — the request actually completed, the server told us the resource doesn't exist. That's a repo-side problem, not a flate problem.

## Fix

Adds a typed `httpStatusError` that `FetchRemote` distinguishes via `errors.As`:

- non-2xx → `slog.Debug("kustomize: remote resource returned non-2xx", "url", ..., "status", ...)`
- transport error → `slog.Warn("kustomize: remote resource unreachable", "url", ..., "err", ...)`

The tombstone file is still written either way so kustomize.Build completes.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] m00nwtchr/homelab-cluster default: no WARN for the stunner 404
- [x] `--log-level debug`: visible as `kustomize: remote resource returned non-2xx ... status=404`

🤖 Generated with [Claude Code](https://claude.com/claude-code)