### PR TITLE
fix(kustomize): propagate URL fetch failures as real reconcile errors

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -100,10 +100,13 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, subPath st
 	// Pre-fetch any HTTP/HTTPS entries in kustomization `resources:`
 	// so kustomize.Build sees local files only and never falls back
 	// to `exec.Command("git", "fetch", ...)`. See preflight.go for
-	// the why. Walks the entire staged tree because Components and
-	// nested overlays may reference URL resources from below subPath.
-	if err := preflightRemoteResources(ctx, cache, staged); err != nil {
-		return nil, fmt.Errorf("preflight remote resources: %w", err)
+	// the why. Scoped to stagedSub (not the whole stage) so a URL
+	// failure in one Kustomization's tree fails only that
+	// Kustomization's reconcile, not unrelated sibling KSes that
+	// share the source root. Components reaching `../` paths outside
+	// stagedSub are an acknowledged blind spot.
+	if err := preflightRemoteResources(ctx, cache, stagedSub); err != nil {
+		return nil, err
 	}
 
 	u := &unstructured.Unstructured{Object: rawSpec}

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -27,24 +27,24 @@ const remoteFetchTimeout = 5 * time.Second
 var remoteFetchClient = &http.Client{Timeout: remoteFetchTimeout}
 
 // preflightRemoteResources walks every kustomization file under root
-// and replaces any HTTP/HTTPS entry in `resources:` with a locally-
-// fetched copy. Without this pass, kustomize.Build falls back to
-// `exec.Command("git", "fetch", ...)` whenever a URL returns non-2xx
-// AND its shape looks git-like (raw.githubusercontent.com URLs do).
-// Two reasons we route URLs through our own client instead:
+// and pre-fetches HTTP/HTTPS `resources:` entries via flate's own
+// HTTP client so kustomize.Build sees only local files — never
+// invoking its built-in `exec.Command("git", "fetch", ...)` fallback
+// (which silently adds a git-binary dependency and a 10s+ timeout
+// on broken URLs).
 //
-//  1. **Hidden binary dependency.** flate is meant to be a single
-//     statically-linked binary; the kustomize git fallback silently
-//     requires `git` in PATH and `exec.LookPath` succeeding.
-//  2. **No timeout.** A broken URL pays kustomize's full HTTP timeout
-//     plus the git-fetch failure path — observed at ~13s per broken
-//     URL against m00nwtchr/homelab-cluster.
+// root is the **subPath dir**, not the whole stage. Scoping the walk
+// makes URL-fetch failures localized: a broken URL in one
+// Kustomization's tree fails only that Kustomization's reconcile
+// without poisoning unrelated ones. Components that reference `../`
+// paths outside subPath are an acknowledged blind spot — uncommon
+// in practice and easy to extend later if needed.
 //
-// On a fetch failure (timeout, 4xx, 5xx, DNS), a YAML-comment-only
-// tombstone file is written so kustomize completes the build with
-// one fewer resource. The failure surfaces via one slog.Warn per
-// URL (StagingCache.FetchRemote dedupes both the network call AND
-// the log line across every preflight pass in one orchestrator run).
+// On a URL fetch failure (timeout, 4xx, 5xx, DNS, connection refused)
+// preflight returns the error immediately. The KS controller's
+// reconcile propagates it through RunWithStatus, which surfaces it
+// in `flate test` as a real reconcile failure — no silent tombstone
+// that lets the build pass with a missing resource.
 //
 // Walks all three valid kustomization filenames (kustomization.yaml,
 // kustomization.yml, Kustomization). Only mutates the staged copy
@@ -67,7 +67,10 @@ func preflightRemoteResources(ctx context.Context, cache *StagingCache, root str
 
 // rewriteURLResources rewrites URL entries in one kustomization file.
 // Reads the file as a generic YAML doc to preserve unknown fields,
-// rewrites the resources list, writes the file back.
+// rewrites the resources list, writes the file back. Returns the
+// first URL fetch failure encountered so the caller can fail the
+// Kustomization's reconcile rather than silently dropping the
+// missing resource.
 func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string) error {
 	body, err := os.ReadFile(ksFile) //nolint:gosec // ksFile is a tree-walk result under our staged copy
 	if err != nil {
@@ -99,13 +102,9 @@ func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string
 		}
 		localFile, fetchErr := fetchRemoteResource(ctx, cache, dir, urlStr)
 		if fetchErr != nil {
-			// Warning already logged inside cache.FetchRemote — the
-			// first fetch emits the WARN, subsequent cache hits stay
-			// quiet.
-			rawRes[i] = "./" + writeFetchTombstone(dir, urlStr, fetchErr)
-		} else {
-			rawRes[i] = "./" + localFile
+			return fmt.Errorf("remote resource %s: %w", urlStr, fetchErr)
 		}
+		rawRes[i] = "./" + localFile
 		changed = true
 	}
 	if !changed {
@@ -126,9 +125,9 @@ func isHTTPURL(s string) bool {
 // fetchRemoteResource fetches the URL into a .flate-remote-<hash>.yaml
 // file next to the kustomization that referenced it. The actual HTTP
 // fetch is deduped via cache.FetchRemote — multiple kustomization
-// files referencing the same URL share one network call. The local
-// filename is deterministic per URL so re-runs reuse the same on-disk
-// file (kustomize sees a stable input).
+// files referencing the same URL share one network call and one
+// cached result. The local filename is deterministic per URL so
+// re-runs reuse the same on-disk file (kustomize sees a stable input).
 func fetchRemoteResource(ctx context.Context, cache *StagingCache, dir, urlStr string) (string, error) {
 	body, err := cache.FetchRemote(ctx, urlStr)
 	if err != nil {
@@ -162,20 +161,7 @@ func httpGetURL(ctx context.Context, urlStr string) ([]byte, error) {
 	return io.ReadAll(resp.Body)
 }
 
-// writeFetchTombstone emits a YAML-comment-only file in place of a
-// failed URL fetch. Kustomize parses it as zero resources, so the
-// build completes; the comment block makes the failure visible when
-// inspecting the staged tree.
-func writeFetchTombstone(dir, urlStr string, fetchErr error) string {
-	name := ".flate-tombstone-" + urlHash(urlStr) + ".yaml"
-	body := fmt.Sprintf("# flate: remote resource fetch failed\n# url: %s\n# error: %v\n",
-		urlStr, fetchErr)
-	_ = os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600)
-	return name
-}
-
 func urlHash(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:8])
 }
-

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -56,13 +56,14 @@ func TestPreflightRemoteResources_RewritesSuccessfulFetch(t *testing.T) {
 	}
 }
 
-// TestPreflightRemoteResources_TombstoneOnFailure locks the
-// fail-fast behavior: a URL returning 404 → tombstone written →
-// kustomization.yaml points at the tombstone (not at the URL, not
-// at the git fallback). Verifies the fix for m00nwtchr's case where
-// a broken URL used to cascade 10+ seconds through kustomize's
-// HTTP-then-git path.
-func TestPreflightRemoteResources_TombstoneOnFailure(t *testing.T) {
+// TestPreflightRemoteResources_PropagatesFailure locks the contract:
+// a URL fetch failure returns an error to the caller — the KS
+// controller surfaces it as a real reconcile failure rather than
+// silently tombstoning and letting the build pass with a missing
+// resource. The error wraps the URL and the underlying status/IO
+// error so `flate test` shows the user what's actually broken in
+// their repo.
+func TestPreflightRemoteResources_PropagatesFailure(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -72,26 +73,15 @@ func TestPreflightRemoteResources_TombstoneOnFailure(t *testing.T) {
 	ks := filepath.Join(stage, "kustomization.yaml")
 	mustWriteFile(t, ks, "resources:\n  - "+srv.URL+"/missing.yaml\n")
 
-	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
-		t.Fatalf("preflight: %v", err)
+	err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage)
+	if err == nil {
+		t.Fatal("expected error on 404; got nil (preflight would silently swallow the failure)")
 	}
-
-	body, _ := os.ReadFile(ks) //nolint:gosec // ks is t.TempDir
-	if strings.Contains(string(body), srv.URL) {
-		t.Errorf("failed URL still present (should be tombstone):\n%s", body)
+	if !strings.Contains(err.Error(), srv.URL) {
+		t.Errorf("error should name the URL; got %q", err)
 	}
-	if !strings.Contains(string(body), ".flate-tombstone-") {
-		t.Errorf("expected tombstone rewrite:\n%s", body)
-	}
-
-	matches, _ := filepath.Glob(filepath.Join(stage, ".flate-tombstone-*.yaml"))
-	if len(matches) != 1 {
-		t.Fatalf("expected one tombstone, got %v", matches)
-	}
-	tomb, _ := os.ReadFile(matches[0]) //nolint:gosec // matches[0] is t.TempDir
-	if !strings.Contains(string(tomb), "remote resource fetch failed") ||
-		!strings.Contains(string(tomb), "HTTP 404") {
-		t.Errorf("tombstone missing diagnostic info:\n%s", tomb)
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("error should name the status code; got %q", err)
 	}
 }
 

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -63,18 +62,15 @@ func NewStagingCache(parent string) (*StagingCache, error) {
 // FetchRemote returns the body of urlStr, fetched at most once per
 // StagingCache lifetime. Both successful bodies and errors are
 // cached — concurrent callers block on a single sync.OnceValues and
-// every caller sees the same result. The warning log lives inside
-// the OnceValues so the user sees one WARN per broken URL per run,
-// not one per kustomization that referenced it.
+// every caller sees the same result. The error (if any) is returned
+// to the caller; logging is left to whichever reconcile path
+// surfaces the failure, so the user sees one structured error in
+// `flate test`'s report rather than a separate log line per call
+// site.
 func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, error) {
 	actual, _ := c.remoteFetches.LoadOrStore(urlStr, &remoteFetch{
 		once: sync.OnceValues(func() ([]byte, error) {
-			body, err := httpGetURL(ctx, urlStr)
-			if err != nil {
-				slog.Warn("kustomize: remote resource fetch failed",
-					"url", urlStr, "err", err)
-			}
-			return body, err
+			return httpGetURL(ctx, urlStr)
 		}),
 	})
 	return actual.(*remoteFetch).once()


### PR DESCRIPTION
## Summary

The tombstone behavior from #229 / #232 hid broken URLs: a 404 in m00nwtchr/homelab-cluster's `stunner-crds` kustomization rendered to zero resources, the build "succeeded," and `flate test all` reported **PASSED**. The CRDs happened to be bundled into the stunner Helm chart, so the cluster state was still correct — but flate had no way to surface the dead URL.

## Three changes

1. **Drop the tombstone.** On URL fetch failure, return the error instead of writing a YAML-comment-only file. The error propagates through `kustomize.RenderFlux` → KS controller's `reconcile` → `RunWithStatus` → `flate test`'s report. The user now sees:

   ```
   Kustomization/flux-system/stunner-system-apps FAILED
     (remote resource https://...: HTTP 404)
   ```

   instead of a silent PASS.

2. **Scope preflight to `stagedSub`.** The walk previously covered the entire stage so URL failures in any kustomization poisoned every reconcile sharing the source root. Walking only `stagedSub` keeps the blast radius to the failing Kustomization's tree; unrelated sibling KSes are unaffected. Components reaching `../` paths outside `stagedSub` are an acknowledged blind spot — uncommon and easy to revisit if needed.

3. **Drop the WARN on cache hit.** With the error propagating structurally, the user already sees the URL in the test report. A separate WARN log line per URL was duplicate signal.

## Verified

| Repo | Before | After |
|---|---|---|
| m00nwtchr/homelab-cluster | 477 passed, 0 failed (broken URL hidden) | 475 passed, 2 failed (HTTP 404 + cascade surfaces) |
| tholinka/home-ops | 266 passed, 0 failed | 266 passed, 0 failed |
| buroa/k8s-gitops | 166 passed, 0 failed | 166 passed, 0 failed |

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] New test: `TestPreflightRemoteResources_PropagatesFailure` — replaces the old tombstone-on-failure test; locks the error-propagation contract (error wraps URL + status code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)