### PR TITLE
fix(manifest): Flux-native envsubst handling — defaults + template skip

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -153,6 +153,18 @@ func (l *Loader) loadFile(path string) (int, error) {
 			continue
 		}
 		id := obj.Named()
+		// Skip resources whose name or namespace contains a literal
+		// `${VAR}` reference — those are templates the user expects a
+		// parent Kustomization's postBuild.substitute(From) to resolve
+		// at render time. Real Flux never sees them as in-cluster CRs
+		// (the K8s API would reject `$` in metadata.name) and flate
+		// shouldn't try to reconcile them either; the substituted copy
+		// emitted by the parent KS's render is the reconcilable one.
+		if manifest.HasEnvsubstReference(id.Name) || manifest.HasEnvsubstReference(id.Namespace) {
+			slog.Debug("loader: skipped template file (unresolved envsubst in name/namespace)",
+				"path", path, "id", id.String())
+			continue
+		}
 		if l.PreferExisting && l.Store.GetObject(id) != nil {
 			continue
 		}

--- a/pkg/manifest/envsubst.go
+++ b/pkg/manifest/envsubst.go
@@ -42,3 +42,31 @@ func maybeHasEnvsubst(s string) bool {
 	}
 	return false
 }
+
+// envsubstReferenceRE matches any unresolved envsubst reference —
+// `${VAR}`, `${VAR:?msg}`, etc. — that survived
+// ResolveEnvsubstDefaults. The character class `[}:]` rules out
+// random literal `${` followed by alphanumerics that aren't actually
+// envsubst (rare but possible in shell/CEL strings).
+var envsubstReferenceRE = regexp.MustCompile(`\$\{[A-Za-z_][A-Za-z0-9_]*[}:]`)
+
+// HasEnvsubstReference reports whether s contains a `${VAR}` style
+// reference that survived ResolveEnvsubstDefaults — i.e. a bare
+// `${VAR}` with no default. Used by the file walker to detect
+// template files whose metadata.name / namespace was meant to be
+// substituted by a parent Kustomization's postBuild.substitute(From).
+//
+// Real Flux never sees such resources as CRs in-cluster: the K8s
+// API would reject the `$` character in metadata.name, and Flux's
+// reconcile model is "watch what's in the cluster." flate's
+// file-driven discovery picks them up anyway and tries to reconcile,
+// producing FAILED rows for resources that don't exist in any real
+// sense. Skipping them at load time matches Flux's behavior — the
+// substituted version emitted by the parent KS's render is the
+// reconcilable one.
+func HasEnvsubstReference(s string) bool {
+	if !maybeHasEnvsubst(s) {
+		return false
+	}
+	return envsubstReferenceRE.MatchString(s)
+}

--- a/pkg/manifest/envsubst.go
+++ b/pkg/manifest/envsubst.go
@@ -1,0 +1,44 @@
+package manifest
+
+import "regexp"
+
+// envsubstDefaultRE matches POSIX-style parameter expansion patterns
+// that carry an explicit default: `${VAR:=default}` and
+// `${VAR:-default}`. Captures the default in group 2.
+//
+// `${VAR}` (no default) and `${VAR:?error}` (error on unset) are NOT
+// matched — we have nothing to substitute and leave them as-is so
+// downstream postBuild substitution can still fill them in.
+//
+// The default body permits any character except `}`, which matches
+// kustomize-controller / envsubst behavior — nested expansions
+// aren't a real concern in practice.
+var envsubstDefaultRE = regexp.MustCompile(`\$\{[A-Za-z_][A-Za-z0-9_]*:[=-]([^}]+)\}`)
+
+// ResolveEnvsubstDefaults applies envsubst-style defaults to s.
+// `${VAR:=default}` and `${VAR:-default}` become `default`. Bare
+// `${VAR}` (no default) is left untouched.
+//
+// Used by the parsers to pre-resolve defaults on flate-load-time
+// fields (Kustomization spec.path, OCIRepository spec.ref.tag,
+// dependsOn names, …) so flate can find local directories and
+// remote refs even when the parent KS's postBuild.substitute hasn't
+// supplied a value. Real Flux's reconcile would resolve the same
+// pattern via postBuild substitution, just one phase later.
+func ResolveEnvsubstDefaults(s string) string {
+	if !maybeHasEnvsubst(s) {
+		return s
+	}
+	return envsubstDefaultRE.ReplaceAllString(s, "$1")
+}
+
+// maybeHasEnvsubst is a cheap precheck — most strings have no `${`
+// at all, and ReplaceAllString allocates even when nothing matches.
+func maybeHasEnvsubst(s string) bool {
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == '$' && s[i+1] == '{' {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/manifest/envsubst_test.go
+++ b/pkg/manifest/envsubst_test.go
@@ -1,0 +1,74 @@
+package manifest
+
+import "testing"
+
+func TestResolveEnvsubstDefaults(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "colon-equals default → applied",
+			in:   "./apps/${CLUSTER_NAME:=biohazard}",
+			want: "./apps/biohazard",
+		},
+		{
+			name: "colon-dash default → applied",
+			in:   "tag: ${VERSION:-v1.0.0}",
+			want: "tag: v1.0.0",
+		},
+		{
+			name: "multiple patterns in one string",
+			in:   "${A:=x}/${B:-y}",
+			want: "x/y",
+		},
+		{
+			name: "bare VAR (no default) → left as-is so postBuild can fill",
+			in:   "${REDIS_APP_NAME}-redis",
+			want: "${REDIS_APP_NAME}-redis",
+		},
+		{
+			name: "error-on-unset (:?) → left as-is",
+			in:   "${REQUIRED:?must be set}",
+			want: "${REQUIRED:?must be set}",
+		},
+		{
+			name: "mixed bare + default-bearing",
+			in:   "${NS}/${APP:=foo}",
+			want: "${NS}/foo",
+		},
+		{
+			name: "no envsubst at all → no allocation",
+			in:   "./apps/foo",
+			want: "./apps/foo",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "dollar without brace → left as-is",
+			in:   "echo $HOME",
+			want: "echo $HOME",
+		},
+		{
+			name: "default with hyphen/slash characters",
+			in:   "${IMG_TAG:=v1.2.3-alpha}",
+			want: "v1.2.3-alpha",
+		},
+		{
+			name: "real-world tholinka pattern",
+			in:   "./kube/deploy/core/storage/rook-ceph/cluster/${CLUSTER_NAME:=biohazard}",
+			want: "./kube/deploy/core/storage/rook-ceph/cluster/biohazard",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ResolveEnvsubstDefaults(tc.in); got != tc.want {
+				t.Errorf("ResolveEnvsubstDefaults(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/manifest/envsubst_test.go
+++ b/pkg/manifest/envsubst_test.go
@@ -2,6 +2,31 @@ package manifest
 
 import "testing"
 
+func TestHasEnvsubstReference(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"bare reference", "${REDIS_APP_NAME}-redis", true},
+		{"reference with :? error message", "${REQUIRED:?must be set}", true},
+		{"default already resolved → no surviving reference", "biohazard", false},
+		{"reference with default still survives the regex", "${VAR:=default}", true},
+		{"no envsubst at all", "redis-server", false},
+		{"plain dollar (no brace)", "$HOME", false},
+		{"empty", "", false},
+		{"escaped dollar", "$$HOME", false},
+		{"reference in middle of string", "prefix-${VAR}-suffix", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasEnvsubstReference(tc.in); got != tc.want {
+				t.Errorf("HasEnvsubstReference(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolveEnvsubstDefaults(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -165,6 +165,17 @@ func parseKustomization(doc map[string]any) (*Kustomization, error) {
 	if cr.Name == "" {
 		return nil, inputf("Kustomization missing metadata.name")
 	}
+	// Pre-resolve envsubst defaults so flate's path / dep resolution
+	// matches what real Flux's postBuild.substitute would produce.
+	// Bare ${VAR} (no default) is left for the postBuild step to
+	// fill — only ${VAR:=default} and ${VAR:-default} collapse here.
+	cr.Spec.Path = ResolveEnvsubstDefaults(cr.Spec.Path)
+	cr.Spec.SourceRef.Name = ResolveEnvsubstDefaults(cr.Spec.SourceRef.Name)
+	cr.Spec.SourceRef.Namespace = ResolveEnvsubstDefaults(cr.Spec.SourceRef.Namespace)
+	for i := range cr.Spec.DependsOn {
+		cr.Spec.DependsOn[i].Name = ResolveEnvsubstDefaults(cr.Spec.DependsOn[i].Name)
+		cr.Spec.DependsOn[i].Namespace = ResolveEnvsubstDefaults(cr.Spec.DependsOn[i].Namespace)
+	}
 	// sourceRef validation catches the truncated-YAML case where
 	// `name:` (no value, e.g. file ends mid-mapping) decodes silently
 	// as empty string. Without this, the failure surfaces as a

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -94,6 +94,14 @@ func parseGitRepository(doc map[string]any) (*GitRepository, error) {
 	if cr.Spec.Provider == "" {
 		cr.Spec.Provider = sourcev1.GitProviderGeneric
 	}
+	cr.Spec.URL = ResolveEnvsubstDefaults(cr.Spec.URL)
+	if r := cr.Spec.Reference; r != nil {
+		r.Branch = ResolveEnvsubstDefaults(r.Branch)
+		r.Tag = ResolveEnvsubstDefaults(r.Tag)
+		r.SemVer = ResolveEnvsubstDefaults(r.SemVer)
+		r.Commit = ResolveEnvsubstDefaults(r.Commit)
+		r.Name = ResolveEnvsubstDefaults(r.Name)
+	}
 	if v := cr.Spec.Verification; v != nil {
 		// GetMode normalizes the legacy "head" alias to "HEAD" and
 		// applies the schema default. Write it back so consumers see a
@@ -203,6 +211,16 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	}
 	if cr.Spec.Provider == "" {
 		cr.Spec.Provider = sourcev1.GenericOCIProvider
+	}
+	// Pre-resolve envsubst defaults on ref fields so a chart pin like
+	// `tag: "${FLUXCD_VERSION:=v2.8.5}"` becomes "v2.8.5" before the
+	// fetcher tries to resolve it. Bare ${VAR} (no default) is left
+	// for postBuild substitution.
+	cr.Spec.URL = ResolveEnvsubstDefaults(cr.Spec.URL)
+	if r := cr.Spec.Reference; r != nil {
+		r.Tag = ResolveEnvsubstDefaults(r.Tag)
+		r.SemVer = ResolveEnvsubstDefaults(r.SemVer)
+		r.Digest = ResolveEnvsubstDefaults(r.Digest)
 	}
 	owner := cr.Namespace + "/" + cr.Name
 	if r := cr.Spec.SecretRef; r != nil {


### PR DESCRIPTION
## Summary

Make flate match real Flux's behavior around envsubst patterns. Two changes (separate commits, one cohesive intent):

### 1. Pre-resolve `${VAR:=default}` and `${VAR:-default}` defaults at parse time

Fields flate reads at load time — KS `spec.path`, KS `spec.dependsOn[].name/namespace`, KS / source `sourceRef`, OCI/Git `spec.ref.*`, `spec.url` — get collapsed from their default value when one is provided. Real Flux's reconcile would resolve the same pattern via `postBuild.substitute`, just one phase later; pre-resolving lets flate find local directories and remote refs even before the parent KS's substitution has run.

Bare `${VAR}` (no default) is intentionally **left alone** so a downstream postBuild can still fill it; `${VAR:?error}` is also untouched.

### 2. Skip template files at load time

After step 1 runs, anything still carrying a bare `${VAR}` in `metadata.name` or `metadata.namespace` is a template — meant for a parent KS's `postBuild.substitute(From)` to resolve at render time. Real Flux never sees these as in-cluster CRs (the K8s API would reject `$` in `metadata.name`); flate's file walker was the only thing trying to reconcile them, producing FAILED rows for resources that don't actually exist.

The loader now skips such resources at parse time with a DEBUG log. The substituted version emitted by the parent KS's render flow (via `emitRenderedChildren` `AddObject`) is unchanged — that's the reconcilable one.

## Numbers

| Repo | Before | After |
|---|---|---|
| JJGadgets/Biohazard | 347 passed / 44 failed | **382 passed / 8 failed** |
| tholinka/home-ops | 266 / 0 failed | 266 / 0 failed |
| buroa/k8s-gitops | 166 / 0 failed | 166 / 0 failed |
| m00nwtchr/homelab-cluster | 475 / 2 (stunner) | 475 / 2 (same) |

Biohazard's remaining 8 are all real chart-rendering issues (schema validation in `morphos`, missing controller containers in `kiwix/dl-ifixit`, etc.) — not envsubst-related.

## What this PR deliberately does NOT do

Render-driven discovery — file walker loading only Kustomizations and letting all other CRs flow from KS render output. That would be a much larger rework affecting how every Flux repo gets discovered. The two changes here achieve the Flux-native semantic outcome (templates aren't reconciled in isolation; defaults are honored) without rewriting the discovery model.

## Test plan

- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `TestResolveEnvsubstDefaults` — 11 cases covering `:=`, `:-`, bare, `:?`, mixed
- [x] `TestHasEnvsubstReference` — 9 cases covering bare, `:?`, default-applied, plain, escaped
- [x] Smoke against tholinka/home-ops, buroa/k8s-gitops, m00nwtchr/homelab-cluster, JJGadgets/Biohazard — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)