### PR TITLE
refactor(orchestrator): RenderTracker carries parent KS provenance

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -50,11 +50,17 @@ type Controller struct {
 }
 
 // RenderTracker is the tiny seam the controller uses to report
-// "this id was emitted by a parent KS render" to the orchestrator.
-// Nil is OK — the controller no-ops. Used by orchestrator.detectOrphans
-// to distinguish stale-on-disk KSes from real failures.
+// "this child id was emitted by THIS parent KS's render" to the
+// orchestrator. Nil is OK — the controller no-ops.
+//
+// The parent linkage is consumed by detectOrphans and (in later
+// steps of the render-driven discovery migration) by the parent
+// index, change filter, and ResourceSet extension attribution —
+// every place that today relies on `sourceFiles[id]` for
+// file-loaded resources gains the ability to query parent
+// provenance for render-emitted ones.
 type RenderTracker interface {
-	MarkRendered(id manifest.NamedResource)
+	MarkRendered(parent, child manifest.NamedResource)
 }
 
 // Options carries the post-bootstrap state the orchestrator wires onto
@@ -90,12 +96,12 @@ func (c *Controller) Configure(opts Options) {
 	c.renderTracker = opts.RenderTracker
 }
 
-// markRendered reports id to the orchestrator's render tracker if one
-// is wired; no-op otherwise. Centralizes the nil-check so the
-// reconcile body stays readable.
-func (c *Controller) markRendered(id manifest.NamedResource) {
+// markRendered reports a parent→child render emission to the
+// orchestrator's tracker if one is wired; no-op otherwise.
+// Centralizes the nil-check so the reconcile body stays readable.
+func (c *Controller) markRendered(parent, child manifest.NamedResource) {
 	if c.renderTracker != nil {
-		c.renderTracker.MarkRendered(id)
+		c.renderTracker.MarkRendered(parent, child)
 	}
 }
 
@@ -311,7 +317,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		if p.reconcilable {
 			c.keepEmitted(p.obj.Named())
 			c.Store.AddObject(p.obj)
-			c.markRendered(p.obj.Named())
+			c.markRendered(id, p.obj.Named())
 		} else {
 			c.Store.AddRendered(p.obj)
 		}
@@ -321,7 +327,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			c.keepEmitted(p.obj.Named())
 			c.Store.AddObject(p.obj)
-			c.markRendered(p.obj.Named())
+			c.markRendered(id, p.obj.Named())
 		}
 	}
 }

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -53,7 +53,7 @@ func TestDetectOrphans(t *testing.T) {
 	}
 	// Mark emittedChild as rendered by its parent — simulates the
 	// AddObject + MarkRendered call cluster-apps's render would make.
-	o.rendered.MarkRendered(emittedChild.Named())
+	o.rendered.MarkRendered(parent.Named(), emittedChild.Named())
 
 	failed := map[manifest.NamedResource]store.StatusInfo{
 		orphan.Named():       {Status: store.StatusFailed, Message: "TIMEZONE undefined"},

--- a/pkg/orchestrator/rendered.go
+++ b/pkg/orchestrator/rendered.go
@@ -7,37 +7,58 @@ import (
 )
 
 // renderedSet tracks IDs emitted by a parent Kustomization's render
-// output (in addition to or instead of the file walker's static load).
-// detectOrphans reads it to distinguish "loaded but never wired into
-// any parent" from "loaded and emitted" — orphans get demoted from
-// Failed to Ready/orphan so a stale on-disk KS doesn't fail the run.
+// output AND records which parent emitted each one. The parent
+// linkage is the foundation for render-driven discovery — consumers
+// that today rely on `sourceFiles[id]` for file-loaded resources
+// (parent index, change filter, orphan detection, RS extension
+// attribution) can query ParentOf for resources that arrive via a
+// KS render instead.
 //
-// Lives here rather than on Store because nothing else cares: only the
-// KS controller writes, only detectOrphans reads. Keeping it on
-// Store was a layering smell flagged in iter-15 — the Store became a
-// dumping ground for orchestrator-internal bookkeeping just because
-// it keyed by NamedResource.
+// detectOrphans reads `Has` to distinguish "loaded but never wired
+// into any parent" from "loaded and emitted" — orphans get demoted
+// from Failed to Ready/orphan so a stale on-disk KS doesn't fail
+// the run.
+//
+// Lives here rather than on Store because nothing else cares: only
+// the KS controller writes, only orchestrator-side consumers read.
+// Keeping it on Store was a layering smell flagged in iter-15 —
+// the Store became a dumping ground for orchestrator-internal
+// bookkeeping just because it keyed by NamedResource.
 type renderedSet struct {
-	mu  sync.RWMutex
-	ids map[manifest.NamedResource]struct{}
+	mu      sync.RWMutex
+	parents map[manifest.NamedResource]manifest.NamedResource
 }
 
 func newRenderedSet() *renderedSet {
-	return &renderedSet{ids: make(map[manifest.NamedResource]struct{})}
+	return &renderedSet{parents: make(map[manifest.NamedResource]manifest.NamedResource)}
 }
 
 // MarkRendered satisfies kustomization.RenderTracker. Called by the
-// KS controller for every reconcilable child it emits from a render.
-func (r *renderedSet) MarkRendered(id manifest.NamedResource) {
+// KS controller for every reconcilable child it emits from a render,
+// passing the parent KS's id alongside the child's. The parent
+// linkage replaces the previous file-path prefix-match used by
+// loader.BuildParentIndexForKind — render-emitted children have no
+// source file, but they DO have a known parent.
+func (r *renderedSet) MarkRendered(parent, child manifest.NamedResource) {
 	r.mu.Lock()
-	r.ids[id] = struct{}{}
+	r.parents[child] = parent
 	r.mu.Unlock()
 }
 
 // has reports whether id was ever marked rendered.
 func (r *renderedSet) has(id manifest.NamedResource) bool {
 	r.mu.RLock()
-	_, ok := r.ids[id]
+	_, ok := r.parents[id]
 	r.mu.RUnlock()
 	return ok
+}
+
+// ParentOf returns the parent KS that emitted id, or (zero, false)
+// when id was never marked rendered (i.e. it was file-loaded, or
+// it's the bootstrap-injected GitRepository).
+func (r *renderedSet) ParentOf(id manifest.NamedResource) (manifest.NamedResource, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	parent, ok := r.parents[id]
+	return parent, ok
 }

--- a/pkg/orchestrator/rendered_test.go
+++ b/pkg/orchestrator/rendered_test.go
@@ -1,0 +1,59 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestRenderedSet_RecordsAndQueriesParent locks the foundation of
+// render-driven discovery: each child carries an explicit parent KS
+// reference that downstream consumers (parent index, change filter,
+// orphan detection, RS extension attribution) can query when the
+// child has no source file.
+func TestRenderedSet_RecordsAndQueriesParent(t *testing.T) {
+	r := newRenderedSet()
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster"}
+	child := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "demo"}
+
+	if r.has(child) {
+		t.Fatal("expected child to be absent before MarkRendered")
+	}
+	if _, ok := r.ParentOf(child); ok {
+		t.Fatal("ParentOf should return ok=false for unknown id")
+	}
+
+	r.MarkRendered(parent, child)
+
+	if !r.has(child) {
+		t.Error("expected child to be present after MarkRendered")
+	}
+	got, ok := r.ParentOf(child)
+	if !ok {
+		t.Fatal("ParentOf should return ok=true after MarkRendered")
+	}
+	if got != parent {
+		t.Errorf("ParentOf = %v, want %v", got, parent)
+	}
+}
+
+// TestRenderedSet_LastWriterWins documents the overwrite semantic:
+// when a child id is rendered by two parents in the same run (rare,
+// but theoretically possible if a child KS is referenced from
+// multiple parent paths), the most recent emission wins. This
+// matches kustomize's semantics and the AddObject DeepEqual gate's
+// "last write wins" pattern.
+func TestRenderedSet_LastWriterWins(t *testing.T) {
+	r := newRenderedSet()
+	child := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "n", Name: "demo"}
+	parentA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "a"}
+	parentB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "b"}
+
+	r.MarkRendered(parentA, child)
+	r.MarkRendered(parentB, child)
+
+	got, _ := r.ParentOf(child)
+	if got != parentB {
+		t.Errorf("ParentOf = %v, want last writer %v", got, parentB)
+	}
+}


### PR DESCRIPTION
## Step 1 of the render-driven discovery migration

Foundation work that doesn't visibly change behavior — it just gives downstream consumers a way to ask "which parent KS emitted this render-emitted resource" without going through file-path prefix matching.

## Background

The full migration plan (from the review of #236's follow-up scope):

1. **This PR** — RenderTracker records parent provenance for each rendered child.
2. Update parent index / change filter / orphan detection / RS extension attribution to query \`ParentOf\` when \`sourceFiles[id]\` is empty.
3. Add \`postBuild.substituteFrom\` as a real depwait edge (KS-A waits for KS-B if its substituteFrom ConfigMap comes from KS-B's render).
4. Flip the loader filter (file walker loads only Kustomizations; everything else flows from KS render).

Each step is independently verifiable and reversible. The review of step-4-in-one-shot uncovered 10 specific failure modes; this multi-PR sequence addresses each one in isolation.

## What this PR does

Extends the existing \`RenderTracker\` interface:

\`\`\`go
// Before:
MarkRendered(child NamedResource)

// After:
MarkRendered(parent, child NamedResource)
\`\`\`

\`renderedSet\` stores \`parents map[child]parent\` and exposes \`ParentOf(child) (parent, ok)\`.

The KS controller's \`emitRenderedChildren\` passes its own id along with each child it emits. No consumer of \`ParentOf\` exists yet — that arrives in step 2.

## Tests

- New: \`TestRenderedSet_RecordsAndQueriesParent\` and \`TestRenderedSet_LastWriterWins\` lock the API contract.
- Updated: \`TestOrchestrator_DetectOrphans\` for the new MarkRendered signature.
- Smoke: tholinka/home-ops 266/266, buroa/k8s-gitops 166/166, m00nwtchr/homelab-cluster 475/477 (same 2 stunner failures as before #235).

🤖 Generated with [Claude Code](https://claude.com/claude-code)