### PR TITLE
refactor(controllers): ParentOf is a resolver func, queries both sources

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -41,24 +41,29 @@ type Controller struct {
 	// templates.
 	WipeSecrets bool
 
-	// parentOf maps each file-loaded HR to the enclosing Flux KS whose
-	// spec.path covers it. Reconcile depwaits on the parent's Ready so
-	// the first render reads the post-patch HR rather than the file-
-	// loaded pre-patch copy.
-	parentOf map[manifest.NamedResource]manifest.NamedResource
+	// parentOf resolves each HR to its enclosing Flux KS at lookup
+	// time. The closure unifies two parent sources:
+	//   - file-loaded HRs: pre-built path-prefix index from
+	//     loader.BuildParentIndexForKind.
+	//   - render-emitted HRs (chart-of-charts, KS-substituted copies):
+	//     the orchestrator's renderedSet.ParentOf, populated when the
+	//     parent KS's emitRenderedChildren fires.
+	// Nil means "no parent enforcement"; matches pre-#221 behavior.
+	parentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
 // wires onto the controller. Filter narrows reconciliation to changed
 // HelmReleases (and their referenced sources/values) in changed-only
-// mode. ParentOf maps each file-loaded HR to the enclosing KS whose
-// spec.path covers it; reconcile depwaits on the parent before
-// rendering so spec patches (driftDetection / upgrade strategy /
-// CRD policy at the cluster KS level, post-build substitutions,
-// kustomize replacements) land before the first helm.Template call.
+// mode. ParentOf resolves each HR to its enclosing KS at lookup time
+// (combines the file-loaded path-prefix index with the runtime
+// renderedSet); reconcile depwaits on the parent before rendering so
+// spec patches (driftDetection / upgrade strategy / CRD policy at the
+// cluster KS level, post-build substitutions, kustomize replacements)
+// land before the first helm.Template call.
 type ReconcileOptions struct {
 	Filter   *change.Filter
-	ParentOf map[manifest.NamedResource]manifest.NamedResource
+	ParentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
 }
 
 // New constructs a HelmRelease controller.
@@ -77,6 +82,16 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
+}
+
+// lookupParent reports the structural parent KS of id via the
+// configured resolver, or (zero, false) when no parent exists or no
+// resolver was configured.
+func (c *Controller) lookupParent(id manifest.NamedResource) (manifest.NamedResource, bool) {
+	if c.parentOf == nil {
+		return manifest.NamedResource{}, false
+	}
+	return c.parentOf(id)
 }
 
 // Start registers the listeners. The controller runs until Close.
@@ -121,7 +136,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// parent-patching chain (tholinka/home-ops's cluster KS applies
 	// driftDetection / install.crds / upgrade strategy / rollback to
 	// every HR, so all of them were hit by this).
-	if parent, ok := c.parentOf[id]; ok {
+	if parent, ok := c.lookupParent(id); ok {
 		c.Store.UpdateStatus(id, store.StatusPending, "waiting for parent KS")
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -23,7 +23,11 @@ func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store
 
 func newTestControllerWithParentOf(t *testing.T, parentOf map[manifest.NamedResource]manifest.NamedResource) (*Controller, *store.Store) {
 	t.Helper()
-	return newTestControllerWithOptions(t, ReconcileOptions{ParentOf: parentOf})
+	resolver := func(id manifest.NamedResource) (manifest.NamedResource, bool) {
+		parent, ok := parentOf[id]
+		return parent, ok
+	}
+	return newTestControllerWithOptions(t, ReconcileOptions{ParentOf: resolver})
 }
 
 func newTestControllerWithOptions(t *testing.T, opts ReconcileOptions) (*Controller, *store.Store) {

--- a/pkg/controllers/helmrelease/reconcile_test.go
+++ b/pkg/controllers/helmrelease/reconcile_test.go
@@ -93,6 +93,38 @@ func TestReconcile_ParentGateWaits(t *testing.T) {
 	}
 }
 
+// TestReconcile_ParentGateViaResolverFunc verifies the parent gate
+// works when ParentOf is a closure (the production wiring path —
+// orchestrator combines the pre-built path-prefix index with the
+// renderedSet to support both file-loaded and render-emitted HRs).
+// Locks the contract that any resolver implementation is honored,
+// not just the static-map shape.
+func TestReconcile_ParentGateViaResolverFunc(t *testing.T) {
+	parent := &manifest.Kustomization{Name: "apps", Namespace: "flux-system"}
+	hr := &manifest.HelmRelease{
+		Name: "child", Namespace: "flux-system",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			Timeout: ptrDuration(80 * time.Millisecond),
+		},
+	}
+	// Resolver returns the parent for the HR only — closes over
+	// captured state, the production shape (which combines a map +
+	// a renderedSet lookup).
+	resolver := func(id manifest.NamedResource) (manifest.NamedResource, bool) {
+		if id == hr.Named() {
+			return parent.Named(), true
+		}
+		return manifest.NamedResource{}, false
+	}
+	_, st := newTestControllerWithOptions(t, ReconcileOptions{ParentOf: resolver})
+	st.AddObject(parent) // never reaches Ready
+	st.AddObject(hr)
+	info := waitForStatus(t, st, hr.Named(), store.StatusFailed)
+	if !strings.Contains(info.Message, "parent") {
+		t.Errorf("expected parent-not-ready error via resolver, got %q", info.Message)
+	}
+}
+
 // TestReconcile_NoChartRefBypassDepwait covers a degenerate HR with
 // neither chartRef nor sourceRef — chart resolution writes
 // TestIsFluxSourceKind enumerates the chart-render dispatch matrix:

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -45,7 +45,7 @@ type Controller struct {
 	WipeSecrets bool
 
 	// Set via Configure() — see Options.
-	parentOf      map[manifest.NamedResource]manifest.NamedResource
+	parentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
 	renderTracker RenderTracker
 }
 
@@ -74,7 +74,7 @@ type RenderTracker interface {
 // receives every reconcilable child this KS emits during render.
 type Options struct {
 	Filter        *change.Filter
-	ParentOf      map[manifest.NamedResource]manifest.NamedResource
+	ParentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
 	RenderTracker RenderTracker
 }
 
@@ -428,8 +428,10 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 			},
 		})
 	}
-	if parent, ok := c.parentOf[ks.Named()]; ok {
-		deps = append(deps, manifest.DependencyRef{NamedResource: parent})
+	if c.parentOf != nil {
+		if parent, ok := c.parentOf(ks.Named()); ok {
+			deps = append(deps, manifest.DependencyRef{NamedResource: parent})
+		}
 	}
 	return deps
 }

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -18,9 +18,9 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{ParentOf: map[manifest.NamedResource]manifest.NamedResource{
+	c.Configure(Options{ParentOf: mapResolver(map[manifest.NamedResource]manifest.NamedResource{
 		child.Named(): parent,
-	}})
+	})})
 	deps := c.collectDeps(child)
 	for _, d := range deps {
 		if d.NamedResource == parent {
@@ -31,12 +31,23 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 }
 
 // TestCollectDeps_NoParentNoExtraDep guards against ParentOf-less
-// controllers (e.g. unit-test setups) panicking on a nil map.
+// controllers (e.g. unit-test setups) panicking on a nil resolver.
 func TestCollectDeps_NoParentNoExtraDep(t *testing.T) {
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
 	c := New(store.New(), nil, nil, false) // ParentOf nil
 	deps := c.collectDeps(child)
 	if len(deps) != 0 {
 		t.Errorf("expected no deps for KS without sourceRef/dependsOn/parent; got %+v", deps)
+	}
+}
+
+// mapResolver wraps a static parent map into the func resolver shape
+// the controllers consume. Used by tests that want to verify
+// behavior on a known parent index without standing up the full
+// orchestrator wiring (which combines this with the renderedSet).
+func mapResolver(m map[manifest.NamedResource]manifest.NamedResource) func(manifest.NamedResource) (manifest.NamedResource, bool) {
+	return func(id manifest.NamedResource) (manifest.NamedResource, bool) {
+		parent, ok := m[id]
+		return parent, ok
 	}
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -426,12 +426,26 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		Filter:             o.filter,
 		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
 	})
+	// parentResolver unifies the two sources of structural-parent info:
+	// (1) the pre-built file-path prefix index for file-loaded
+	// resources (o.parentOf), and (2) the renderedSet's parent-of
+	// linkage for resources that arrive via a KS render's
+	// emitRenderedChildren (populated at Run-time, not at Bootstrap).
+	// Controllers query through this single seam; later migration
+	// steps swap (1) for the full render-driven version without
+	// touching controller code.
+	parentResolver := func(id manifest.NamedResource) (manifest.NamedResource, bool) {
+		if parent, ok := o.parentOf[id]; ok {
+			return parent, true
+		}
+		return o.rendered.ParentOf(id)
+	}
 	o.ksc.Configure(kustomization.Options{
 		Filter:        o.filter,
-		ParentOf:      o.parentOf,
+		ParentOf:      parentResolver,
 		RenderTracker: o.rendered,
 	})
-	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter, ParentOf: o.parentOf})
+	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter, ParentOf: parentResolver})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
 	o.hrc.Start(ctx)
@@ -684,25 +698,41 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		if err != nil || len(docs) == 0 {
 			continue
 		}
-		file := o.sourceFiles[rs.Named()]
-		if file == "" {
-			file = sourceByName[rs.Name]
-		}
-		if file == "" {
-			continue
-		}
-		slashFile := filepath.ToSlash(file)
+		// Resolve parent KS in priority order:
+		//
+		//   1. renderedSet.ParentOf — most direct; set when the RS
+		//      arrived via emitRenderedChildren (the render-driven
+		//      path that increasingly dominates as the migration
+		//      progresses). No prefix matching needed.
+		//   2. sourceFiles + path-prefix match — covers file-loaded
+		//      RSes (today's typical case).
+		//   3. Name-keyed sourceFile fallback — covers the
+		//      KS-substituted variant whose namespace shifted at
+		//      emit time, identified by sharing a name with a
+		//      file-loaded sibling.
 		var parentKS manifest.NamedResource
 		var matched bool
-		for _, w := range owners {
-			if strings.HasPrefix(slashFile, w.prefix) {
-				parentKS = w.id
-				matched = true
-				break
+		if parent, ok := o.rendered.ParentOf(rs.Named()); ok {
+			parentKS, matched = parent, true
+		} else {
+			file := o.sourceFiles[rs.Named()]
+			if file == "" {
+				file = sourceByName[rs.Name]
 			}
-		}
-		if !matched {
-			continue
+			if file == "" {
+				continue
+			}
+			slashFile := filepath.ToSlash(file)
+			for _, w := range owners {
+				if strings.HasPrefix(slashFile, w.prefix) {
+					parentKS = w.id
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
 		}
 		for _, doc := range docs {
 			parsed, perr := manifest.ParseDoc(doc, manifest.ParseDocOptions{WipeSecrets: o.cfg.WipeSecrets})


### PR DESCRIPTION
## Step 2 of the render-driven discovery migration

Before this PR, both controllers' \`ParentOf\` was a static \`map[id]parent\` built at Bootstrap from the file-walker's \`sourceFiles\`. Render-emitted resources had no entry in that map — their parent linkage lives in \`renderedSet\`, populated when the KS controller emits children during Run. **The two sources never met.**

## What changes

\`ParentOf\` becomes a \`func(id) (parent, bool)\` resolver. The orchestrator wires a single resolver closure that combines:

1. The pre-built file-path prefix index (file-loaded resources).
2. \`renderedSet.ParentOf\` (render-emitted resources, from #238).

Controllers query the resolver and don't care which source matched.

## Consumers updated

- **HR parent-gate** (#221) — now works for HRs that arrive from KS render output, not just file walker.
- **KS parent-gate** — same, for KSes.
- **\`expandResourceSetsPostRun\`** — direct \`ParentOf\` check first; falls back to existing \`sourceFiles\` + name-keyed lookup for file-loaded RSes.

## What this PR does NOT do

- Doesn't flip the loader filter yet — file walker still loads all kinds. ParentOf stays a no-op for resources the file walker covers; \`renderedSet\` still wins for KS-emitted children. The full render-driven flip is step 4.
- \`expandResourceSetsPostRun\` keeps its existing sourceFiles + name-keyed fallback for now. Pruning happens once the loader filter flips.

## Test plan

- New: \`TestReconcile_ParentGateViaResolverFunc\` — locks the func-shape contract end-to-end via a closure that mimics the orchestrator's combined resolver.
- \`TestRenderedSet_*\` from #238 — still pass.
- All existing parent-gate tests adapted to the func shape.

Smoke:
- tholinka/home-ops: 266/266
- buroa/k8s-gitops: 166/166
- m00nwtchr/homelab-cluster: 475/477 (same 2 stunner)
- JJGadgets/Biohazard: 382/391 (same upstream chart issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)