### PR TITLE
feat(controllers/kustomization): substituteFrom ConfigMap as depwait edge (step 3/4)

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -416,9 +416,25 @@ func isLeafReconcilable(obj manifest.BaseManifest) bool {
 
 // collectDeps assembles the dependency refs whose readiness must
 // precede this Kustomization: explicit dependsOn entries (carrying any
-// CEL ReadyExpr), the source ref, and the implicit structural parent
-// (the enclosing Flux KS that renders us — must finish first so any
-// parent-render-time spec injections land before our reconcile).
+// CEL ReadyExpr), the source ref, the implicit structural parent (the
+// enclosing Flux KS that renders us — must finish first so any
+// parent-render-time spec injections land before our reconcile), and
+// every non-Optional postBuild.substituteFrom ConfigMap.
+//
+// substituteFrom ConfigMap edges fix the race where the referenced CM
+// is emitted by another KS's render: without the edge, KS-A would
+// race KS-B and Prepare would silently expand with empty values for
+// vars that should have come from KS-B's CM. Flux's eventual-
+// consistency reconcile loop self-heals; flate is one-shot, so a
+// missed substitution shows up as broken rendered output.
+//
+// Secret refs are deliberately NOT added as depwait edges. In real
+// repos substituteFrom Secrets are almost always SOPS-encrypted or
+// ExternalSecret-managed — they live in cluster state that flate
+// cannot materialize offline. values.ExpandPostBuildSubstituteReference
+// already gracefully degrades on missing Secrets (logs DEBUG and
+// continues); adding a hard edge here would regress every offline
+// render against a Flux repo that uses secret-substitute patterns.
 func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.DependencyRef {
 	deps := append([]manifest.DependencyRef(nil), ks.DependsOn...)
 	if ks.SourceKind != "" && ks.SourceName != "" {
@@ -432,6 +448,25 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 		if parent, ok := c.parentOf(ks.Named()); ok {
 			deps = append(deps, manifest.DependencyRef{NamedResource: parent})
 		}
+	}
+	for _, ref := range ks.PostBuildSubstituteFrom {
+		if ref.Optional {
+			// Optional refs are best-effort — their absence shouldn't
+			// gate reconcile. Matches Flux's own substituteFrom
+			// semantics for Optional=true.
+			continue
+		}
+		if ref.Kind != manifest.KindConfigMap {
+			continue
+		}
+		if ref.Name == "" {
+			continue
+		}
+		deps = append(deps, manifest.DependencyRef{
+			NamedResource: manifest.NamedResource{
+				Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name,
+			},
+		})
 	}
 	return deps
 }

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -41,6 +41,79 @@ func TestCollectDeps_NoParentNoExtraDep(t *testing.T) {
 	}
 }
 
+// TestCollectDeps_AppendsSubstituteFromConfigMap is step 3 of the
+// render-driven migration: every non-Optional postBuild.substituteFrom
+// ConfigMap becomes a real depwait edge. Without this, KS-A would
+// race the CM that KS-B's render emits, and Prepare would silently
+// expand with empty values for any var that should have come from
+// KS-B's CM.
+func TestCollectDeps_AppendsSubstituteFromConfigMap(t *testing.T) {
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "cluster-settings"},
+			{Kind: manifest.KindConfigMap, Name: "maybe-missing", Optional: true},
+		},
+	}
+	c := New(store.New(), nil, nil, false)
+	deps := c.collectDeps(ks)
+
+	wantID := manifest.NamedResource{
+		Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings",
+	}
+	var found bool
+	for _, d := range deps {
+		if d.NamedResource == wantID {
+			found = true
+		}
+		if d.Kind == manifest.KindConfigMap && d.Name == "maybe-missing" {
+			t.Errorf("Optional substituteFrom ref must not gate reconcile; got %+v", d)
+		}
+	}
+	if !found {
+		t.Errorf("expected substituteFrom dep %+v in deps %+v", wantID, deps)
+	}
+}
+
+// TestCollectDeps_SubstituteFromSkipsSecrets locks the
+// SOPS/ExternalSecret carve-out: substituteFrom Secret refs are
+// resolved by values.ExpandPostBuildSubstituteReference at Prepare
+// time and gracefully degrade on missing entries. Adding a depwait
+// edge for them would regress every offline render against a Flux
+// repo using secret-substitute patterns (e.g. cnpg-objectstore,
+// cloudflare-tunnel-substitute) because those Secrets live in
+// cluster state flate cannot materialize.
+func TestCollectDeps_SubstituteFromSkipsSecrets(t *testing.T) {
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindSecret, Name: "cluster-secrets"},
+		},
+	}
+	c := New(store.New(), nil, nil, false)
+	if deps := c.collectDeps(ks); len(deps) != 0 {
+		t.Errorf("Secret substituteFrom refs must NOT gate reconcile; got %+v", deps)
+	}
+}
+
+// TestCollectDeps_SubstituteFromIgnoresMalformedRefs covers the
+// defensive branches in collectDeps: refs with an unknown Kind or
+// empty Name must be skipped rather than producing meaningless
+// depwait edges that would never resolve.
+func TestCollectDeps_SubstituteFromIgnoresMalformedRefs(t *testing.T) {
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: "Junk", Name: "x"},
+			{Kind: manifest.KindConfigMap, Name: ""},
+		},
+	}
+	c := New(store.New(), nil, nil, false)
+	if deps := c.collectDeps(ks); len(deps) != 0 {
+		t.Errorf("expected no deps from malformed substituteFrom refs; got %+v", deps)
+	}
+}
+
 // mapResolver wraps a static parent map into the func resolver shape
 // the controllers consume. Used by tests that want to verify
 // behavior on a known parent index without standing up the full


### PR DESCRIPTION
## Summary

Step 3 of the render-driven discovery migration. Adds a real depwait edge for every non-Optional `postBuild.substituteFrom` **ConfigMap** so a KS that consumes a CM emitted by a sibling KS's render waits for that emission before calling `kustomize.Prepare`.

Without the edge, KS-A races KS-B and `Prepare` silently expands with empty values for any var that should have come from KS-B's CM. Flux's eventual-consistency reconcile loop self-heals; flate is one-shot, so a missed substitution shows up as broken rendered output.

## Carve-out: Secrets are NOT added as depwait edges

In real repos `substituteFrom` Secrets are almost always SOPS-encrypted or ExternalSecret-managed — they live in cluster state flate cannot materialize offline. `values.ExpandPostBuildSubstituteReference` already gracefully degrades on missing Secrets (DEBUG-logs and continues). A hard edge here would regress every offline render against a Flux repo that uses secret-substitute patterns (`cnpg-objectstore-substitute`, `cloudflare-tunnel-substitute`, `ipv6`, `bitwarden`, ...).

## Migration status

- ✅ Step 1 (#238): `RenderTracker` parent provenance
- ✅ Step 2 (#239): `ParentOf` resolver func
- 🟢 Step 3 (**this PR**): `postBuild.substituteFrom` CM as depwait edge
- ⏳ Step 4: Flip loader filter to load only Kustomizations

## Test plan

- [x] `go test ./...` — full suite green
- [x] New unit tests in `parent_test.go`:
  - `TestCollectDeps_AppendsSubstituteFromConfigMap` — CM ref produces edge; Optional CM does not
  - `TestCollectDeps_SubstituteFromSkipsSecrets` — Secret ref does NOT produce edge
  - `TestCollectDeps_SubstituteFromIgnoresMalformedRefs` — unknown Kind / empty Name are dropped
- [x] `flate test ks` against `tholinka/home-ops` — **118 KS / 96 HR / 0 failed**
- [x] `flate test ks` against `JJGadgets/Biohazard` — **199 KS / 114 HR**, 9 pre-existing helm-schema failures unrelated to substituteFrom

🤖 Generated with [Claude Code](https://claude.com/claude-code)