### PR TITLE
feat: support local gitrepository sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ flate diff ks --path ./kubernetes --path-orig ../baseline/kubernetes
 
 PLACEHOLDER-wiped values (the always-on wipe of cleartext Secret data) are treated as missing — auth fails with a clear "missing username/password" instead of attempting auth with the placeholder string. See [Behaviors](#behaviors) for `--allow-missing-secrets`, which soft-skips affected sources end-to-end.
 
+For CI against a checked-out GitOps repo, an in-repo `GitRepository` can be mapped to the local checkout instead of fetched with its deploy key:
+
+```bash
+flate test ks --path ./pull/k8s \
+  --local-git-source flux-system/gitops=./pull
+
+flate diff ks --path ./pull/k8s --path-orig ./default/k8s \
+  --local-git-source flux-system/gitops=./pull \
+  --local-git-source-orig flux-system/gitops=./default
+```
+
+Use the repository root on the right-hand side when Flux `spec.path` values are repo-root relative, e.g. `./k8s/apps/...`. The mapping is explicit and scoped to the named `GitRepository`; missing secrets on other sources still follow the normal `--allow-missing-secrets` behavior. Local overrides use the checkout as-is, so callers must check out the intended ref themselves; configured `spec.ref` is only logged. Local overrides refuse `spec.verify` rather than silently bypassing Git signature verification.
+
 ## Behaviors
 
 **SOPS** — `spec.decryption` is not implemented. Encrypted Secret values get wiped to `..PLACEHOLDER_<key>..`, same as cleartext values under the always-on wipe. Downstream `postBuild.substituteFrom` lookups resolve to the placeholder string rather than failing.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -53,6 +53,38 @@ data:
 	return k8s
 }
 
+func writeGitDiff(t *testing.T, value string) string {
+	t.Helper()
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, ".git", "config"), "")
+	mustWrite(t, filepath.Join(root, "k8s", "flux", "cluster.yaml"), `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: gitops, namespace: flux-system}
+spec:
+  url: ssh://git@example.invalid/example/gitops.git
+  secretRef: {name: deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  interval: 10m
+  path: ./k8s/apps
+  sourceRef: {kind: GitRepository, name: gitops, namespace: flux-system}
+`)
+	mustWrite(t, filepath.Join(root, "k8s", "apps", "kustomization.yaml"),
+		"resources:\n- cm.yaml\n")
+	mustWrite(t, filepath.Join(root, "k8s", "apps", "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: rendered, namespace: default}
+data:
+  value: `+value+`
+`)
+	return root
+}
+
 func mustWrite(t *testing.T, p, body string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
@@ -337,6 +369,27 @@ func TestRun_DiffImages_NameDefault(t *testing.T) {
 	}
 }
 
+func TestRun_DiffLocalGit(t *testing.T) {
+	current := writeGitDiff(t, "new")
+	orig := writeGitDiff(t, "old")
+	stdout, stderr, code := runCLI(t,
+		"diff", "ks",
+		"--allow-missing-secrets",
+		"--path", filepath.Join(current, "k8s"),
+		"--path-orig", filepath.Join(orig, "k8s"),
+		"--local-git-source", "flux-system/gitops="+current,
+		"--local-git-source-orig", "flux-system/gitops="+orig,
+	)
+	if code != 0 {
+		t.Fatalf("diff local git exited %d: %s", code, stderr)
+	}
+	for _, want := range []string{"old", "new"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("diff output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
 func copyTree(t *testing.T, src, dst string) {
 	t.Helper()
 	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
@@ -446,10 +499,10 @@ func TestCompareDocs_OrdersByKindNamespaceName(t *testing.T) {
 		a, b map[string]any
 		want int
 	}{
-		{mkDoc("ConfigMap", "a", "x"), mkDoc("Secret", "a", "x"), -1},     // kind wins
-		{mkDoc("CM", "a", "x"), mkDoc("CM", "b", "x"), -1},                // ns wins after kind tie
-		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "y"), -1},                // name wins last
-		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "x"), 0},                 // identical
+		{mkDoc("ConfigMap", "a", "x"), mkDoc("Secret", "a", "x"), -1}, // kind wins
+		{mkDoc("CM", "a", "x"), mkDoc("CM", "b", "x"), -1},            // ns wins after kind tie
+		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "y"), -1},            // name wins last
+		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "x"), 0},             // identical
 	}
 	for _, tc := range cases {
 		got := compareDocs(tc.a, tc.b)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -13,22 +13,25 @@ import (
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 )
 
 type commonFlags struct {
-	path               string
-	pathOrig           string
-	namespace          string
-	labels             map[string]string
-	skipCRDs           bool
-	skipSecrets        bool
+	path                string
+	pathOrig            string
+	namespace           string
+	labels              map[string]string
+	skipCRDs            bool
+	skipSecrets         bool
 	allowMissingSecrets bool
-	skipKinds          []string
-	output             string
-	enableOCI          bool
-	registryConfig     string
-	concurrency        int
+	localGitSources     []string
+	localGitSourcesOrig []string
+	skipKinds           []string
+	output              string
+	enableOCI           bool
+	registryConfig      string
+	concurrency         int
 }
 
 func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
@@ -43,12 +46,62 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 		"soft-skip sources whose auth Secret is missing or whose values are placeholders "+
 			"(typical when the live cluster materializes auth via ExternalSecret); dependent "+
 			"Kustomizations/HelmReleases propagate the skip. Verify/cert/proxy secretRefs still fail loud.")
+	fs.StringArrayVar(&f.localGitSources, "local-git-source", nil,
+		"map a GitRepository to a local checkout root as namespace/name=path (repeatable)")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")
 	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, yaml, json, name")
 	fs.BoolVar(&f.enableOCI, "enable-oci", true, "reconcile OCIRepository objects")
 	fs.StringVar(&f.registryConfig, "registry-config", "", "docker config.json for OCI authentication")
 	fs.IntVar(&f.concurrency, "concurrency", runtime.NumCPU()*4,
 		"max parallel reconcile bodies (0 = unbounded)")
+}
+
+func bindOrigLocal(fs *pflag.FlagSet, f *commonFlags) {
+	fs.StringArrayVar(&f.localGitSourcesOrig, "local-git-source-orig", nil,
+		"map a baseline GitRepository to a local checkout root as namespace/name=path (repeatable)")
+}
+
+func parseLocalSources(flag string, values []string) (map[manifest.NamedResource]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make(map[manifest.NamedResource]string, len(values))
+	for _, value := range values {
+		left, right, ok := strings.Cut(value, "=")
+		if !ok || strings.TrimSpace(left) == "" || strings.TrimSpace(right) == "" {
+			return nil, fmt.Errorf("%s %q must be namespace/name=path", flag, value)
+		}
+		id, err := parseGitID(strings.TrimSpace(left))
+		if err != nil {
+			return nil, fmt.Errorf("%s %q: %w", flag, value, err)
+		}
+		if _, exists := out[id]; exists {
+			return nil, fmt.Errorf("%s %q duplicates %s", flag, value, id.String())
+		}
+		out[id] = strings.TrimSpace(right)
+	}
+	return out, nil
+}
+
+func parseGitID(raw string) (manifest.NamedResource, error) {
+	parts := strings.Split(raw, "/")
+	switch len(parts) {
+	case 2:
+		if parts[0] == "" || parts[1] == "" {
+			return manifest.NamedResource{}, fmt.Errorf("want namespace/name")
+		}
+		return manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: parts[0], Name: parts[1]}, nil
+	case 3:
+		if parts[0] != manifest.KindGitRepository {
+			return manifest.NamedResource{}, fmt.Errorf("kind must be %s", manifest.KindGitRepository)
+		}
+		if parts[1] == "" || parts[2] == "" {
+			return manifest.NamedResource{}, fmt.Errorf("want GitRepository/namespace/name")
+		}
+		return manifest.NamedResource{Kind: parts[0], Namespace: parts[1], Name: parts[2]}, nil
+	default:
+		return manifest.NamedResource{}, fmt.Errorf("want namespace/name or GitRepository/namespace/name")
+	}
 }
 
 // skipResourceKinds delegates to helm.Options.SkipResourceKinds so
@@ -171,17 +224,22 @@ func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 	}
 }
 
-func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
-	return orchestrator.Config{
-		Path:               c.path,
-		PathOrig:           c.pathOrig,
-		HelmOptions:        c.helmOptions(h),
-		WipeSecrets:        true,
-		EnableOCI:          c.enableOCI,
-		RegistryConfig:     c.registryConfig,
-		Concurrency:        c.concurrency,
-		AllowMissingSecrets: c.allowMissingSecrets,
+func buildOrchCfg(c commonFlags, h helmFlags) (orchestrator.Config, error) {
+	localGitSources, err := parseLocalSources("--local-git-source", c.localGitSources)
+	if err != nil {
+		return orchestrator.Config{}, err
 	}
+	return orchestrator.Config{
+		Path:                c.path,
+		PathOrig:            c.pathOrig,
+		HelmOptions:         c.helmOptions(h),
+		WipeSecrets:         true,
+		EnableOCI:           c.enableOCI,
+		RegistryConfig:      c.registryConfig,
+		Concurrency:         c.concurrency,
+		AllowMissingSecrets: c.allowMissingSecrets,
+		LocalGitSources:     localGitSources,
+	}, nil
 }
 
 func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, *orchestrator.Result, error) {
@@ -191,7 +249,11 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 	if _, err := format.ParseOutput(c.output); err != nil {
 		return nil, nil, err
 	}
-	return runOrchestratorCfg(ctx, buildOrchCfg(c, h))
+	cfg, err := buildOrchCfg(c, h)
+	if err != nil {
+		return nil, nil, err
+	}
+	return runOrchestratorCfg(ctx, cfg)
 }
 
 // outputOrDefault returns the user's -o choice, or fallback when -o

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -58,6 +58,7 @@ func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
+	bindOrigLocal(cmd.Flags(), c)
 	if rendersHelm([]string{kind}) {
 		bindHelmFlags(cmd.Flags(), h)
 	}
@@ -77,6 +78,7 @@ func newDiffImagesCmd() *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
+	bindOrigLocal(cmd.Flags(), c)
 	bindHelmFlags(cmd.Flags(), h)
 	cmd.Flags().BoolVar(&includeRemoved, "include-removed", false,
 		"also emit images present only in --path-orig (default: only newly added images)")

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -98,9 +98,17 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 	if c.pathOrig == "" {
 		return diffSide{}, diffSide{}, errors.New("diff requires --path-orig")
 	}
-	currentCfg := buildOrchCfg(*c, *h)
+	currentCfg, err := buildOrchCfg(*c, *h)
+	if err != nil {
+		return diffSide{}, diffSide{}, err
+	}
 	origCfg := currentCfg
 	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path
+	localGitSourcesOrig, err := parseLocalSources("--local-git-source-orig", c.localGitSourcesOrig)
+	if err != nil {
+		return diffSide{}, diffSide{}, err
+	}
+	origCfg.LocalGitSources = localGitSourcesOrig
 
 	// One source.Cache shared across both orchestrators. They write into
 	// the same on-disk cache root; without a shared *Cache each side has

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -55,9 +55,10 @@ type Result struct {
 
 // Config is the input contract for Run. Store is mandatory.
 type Config struct {
-	Path        string
-	Store       *store.Store
-	WipeSecrets bool
+	Path            string
+	Store           *store.Store
+	WipeSecrets     bool
+	LocalGitSources map[manifest.NamedResource]string
 }
 
 // Run performs the full discovery phase against cfg and writes results
@@ -83,6 +84,9 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}
 	d.aliasBootstrapSources(repoRoot)
 	loader.ApplyNamespaceInheritance(d.cfg.Store, d.sourceFiles, repoRoot)
+	if err := d.applyLocalSources(); err != nil {
+		return nil, err
+	}
 	// Unified parent index over every reconcilable kind that uses a
 	// parent gate. KS and HR keys never collide because NamedResource
 	// includes Kind; downstream controllers look up by their own id
@@ -131,6 +135,11 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 		return "", err
 	}
 	root := FindRepoRoot(abs)
+	if localRoot, ok, err := d.scanLocalRoot(abs); err != nil {
+		return "", err
+	} else if ok {
+		root = localRoot
+	}
 
 	repo := &manifest.GitRepository{
 		Name: manifest.BootstrapSourceID.Name, Namespace: manifest.BootstrapSourceID.Namespace,
@@ -377,6 +386,11 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 		if _, dup := seen[id]; dup {
 			continue
 		}
+		if len(d.cfg.LocalGitSources) > 0 {
+			if _, mapped := d.cfg.LocalGitSources[id]; !mapped {
+				continue
+			}
+		}
 		seen[id] = struct{}{}
 		alias := &manifest.GitRepository{
 			Name: id.Name, Namespace: id.Namespace,
@@ -406,6 +420,82 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 		slog.Warn("discovery: aliased multiple GitRepositories to the working tree; cross-repo refs render against the wrong tree",
 			"count", len(aliased), "ids", names, "localPath", repoRoot)
 	}
+}
+
+func (d *discoverer) scanLocalRoot(scanRoot string) (string, bool, error) {
+	var best string
+	for id, raw := range d.cfg.LocalGitSources {
+		if id.Kind != manifest.KindGitRepository {
+			continue
+		}
+		root, err := resolveLocalRoot(raw)
+		if err != nil {
+			return "", false, fmt.Errorf("local Git source %s: %w", id.String(), err)
+		}
+		if !pathUnderRoot(scanRoot, root) {
+			continue
+		}
+		if len(root) > len(best) {
+			best = root
+		}
+	}
+	if best == "" {
+		return "", false, nil
+	}
+	return best, true, nil
+}
+
+func (d *discoverer) applyLocalSources() error {
+	for id, raw := range d.cfg.LocalGitSources {
+		if id.Kind != manifest.KindGitRepository {
+			return fmt.Errorf("local Git source %s: only GitRepository mappings are supported", id.String())
+		}
+		root, err := resolveLocalRoot(raw)
+		if err != nil {
+			return fmt.Errorf("local Git source %s: %w", id.String(), err)
+		}
+		repo, ok := d.cfg.Store.GetObject(id).(*manifest.GitRepository)
+		if !ok {
+			return fmt.Errorf("local Git source %s: GitRepository was not discovered or referenced by a Kustomization", id.String())
+		}
+		if repo.Verification != nil {
+			return fmt.Errorf("local Git source %s: refusing to bypass spec.verify; remove the local override or add explicit verification support", id.String())
+		}
+		if repo.Reference != nil {
+			if ref := manifest.GitRefString(*repo.Reference); ref != "" {
+				slog.Warn("discovery: local GitRepository override uses checkout as-is; spec.ref is not checked",
+					"id", id.String(), "ref", ref, "localPath", root)
+			}
+		}
+		d.cfg.Store.SetArtifact(id, &store.SourceArtifact{
+			Kind:      manifest.KindGitRepository,
+			URL:       "file://" + root,
+			LocalPath: root,
+			Revision:  "local",
+		})
+		d.cfg.Store.UpdateStatus(id, store.StatusReady, "local override")
+		slog.Debug("discovery: mapped GitRepository to local checkout",
+			"id", id.String(), "localPath", root)
+	}
+	return nil
+}
+
+func resolveLocalRoot(raw string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("path is empty")
+	}
+	root, err := ResolveScanPath(raw)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%q is not a directory", raw)
+	}
+	return root, nil
 }
 
 // ResolveScanPath normalizes a user-supplied --path / --path-orig:

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -135,6 +135,45 @@ spec:
 	}
 }
 
+func TestRun_LocalGitNoAlias(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	mustWrite(t, filepath.Join(dir, "flux", "cluster.yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: home, namespace: flux-system}
+spec:
+  path: ./apps/home
+  sourceRef: {kind: GitRepository, name: gitops, namespace: flux-system}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: shared, namespace: flux-system}
+spec:
+  path: ./apps/shared
+  sourceRef: {kind: GitRepository, name: shared, namespace: flux-system}
+`)
+	mustWrite(t, filepath.Join(dir, "apps", "home", "kustomization.yaml"), "resources: []\n")
+	mustWrite(t, filepath.Join(dir, "apps", "shared", "kustomization.yaml"), "resources: []\n")
+
+	homeID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "gitops"}
+	sharedID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "shared"}
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+		LocalGitSources: map[manifest.NamedResource]string{homeID: dir},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if st.GetObject(homeID) == nil || st.GetArtifact(homeID) == nil {
+		t.Fatalf("mapped GitRepository should be aliased with an artifact")
+	}
+	if st.GetObject(sharedID) != nil || st.GetArtifact(sharedID) != nil {
+		t.Fatalf("unmapped GitRepository should not be aliased")
+	}
+}
+
 // TestRun_ResourceSetReExpandsForLateRSIPs pins a discovery-loop
 // fix: a ResourceSet whose RSIP providers only become visible in a
 // later iteration (because they live behind a Kustomization path

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -55,6 +55,11 @@ type Config struct {
 	// consumers propagate the skip so the dependency chain doesn't
 	// surface as a cascade of failures in `flate test`.
 	AllowMissingSecrets bool
+	// LocalGitSources maps specific GitRepository resources to local
+	// checkout roots. This is an explicit CI escape hatch for in-repo
+	// GitRepositories whose auth Secret is unavailable offline; all
+	// other GitRepositories continue through the normal source fetcher.
+	LocalGitSources map[manifest.NamedResource]string
 
 	// RegistryConfig is the docker config.json used for OCI auth.
 	RegistryConfig string
@@ -208,8 +213,8 @@ func New(cfg Config) (*Orchestrator, error) {
 		ksc:      kustomization.New(st, ts, staging, cfg.WipeSecrets),
 		hrc:      helmrelease.New(st, ts, helmClient, cfg.HelmOptions, cfg.WipeSecrets),
 		rendered: newRenderedSet(),
-		helm:    helmClient,
-		staging: staging,
+		helm:     helmClient,
+		staging:  staging,
 	}
 	return o, nil
 }
@@ -244,6 +249,7 @@ func (o *Orchestrator) Filter() *change.Filter { return o.filter }
 func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	res, err := discovery.Run(ctx, discovery.Config{
 		Path: o.cfg.Path, Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
+		LocalGitSources: o.cfg.LocalGitSources,
 	})
 	if err != nil {
 		return err
@@ -423,7 +429,7 @@ func (o *Orchestrator) attachFilter(f *change.Filter) {
 // start → drain → finalize sequence.
 func (o *Orchestrator) Run(ctx context.Context) error {
 	o.src.Configure(sourcectrl.FetchOptions{
-		Filter:             o.filter,
+		Filter:              o.filter,
 		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
 	})
 	o.ksc.Configure(kustomization.Options{
@@ -536,7 +542,6 @@ func (o *Orchestrator) aggregateFailures(failed map[manifest.NamedResource]store
 	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",
 		len(msgs), strings.Join(msgs, "\n  "))
 }
-
 
 // Render is the structured embed-friendly entry point: Bootstrap +
 // Run + collect everything an external caller needs to consume the
@@ -789,4 +794,3 @@ func (o *Orchestrator) Stop() {
 		_ = o.staging.Close()
 	}
 }
-

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -2,6 +2,8 @@ package orchestrator
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -484,6 +486,242 @@ spec:
 			"If status is Failed with a registry-pull error, the pre-check is missing and "+
 			"helm tried an anonymous pull — exactly the silent-downgrade the pre-check exists to prevent.",
 			hrInfo)
+	}
+}
+
+func TestLocalGitSource(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteFile(t, root, ".git/config", "")
+	testutil.WriteFile(t, root, "k8s/flux/kustomization.yaml", "namespace: flux-system\n")
+	testutil.WriteFile(t, root, "k8s/flux/cluster.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: gitops}
+spec:
+  url: ssh://git@example.invalid/example/gitops.git
+  secretRef: {name: deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  path: ./k8s/apps
+  sourceRef:
+    kind: GitRepository
+    name: gitops
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, root, "k8s/apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, root, "k8s/apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: rendered, namespace: default}
+data: {value: current}
+`)
+
+	gitID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "gitops"}
+	o, err := New(Config{
+		Path:                filepath.Join(root, "k8s"),
+		WipeSecrets:         true,
+		AllowMissingSecrets: true,
+		LocalGitSources:     map[manifest.NamedResource]string{gitID: root},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("unexpected failures: %v", res.Failed)
+	}
+	if art, ok := o.Store().GetArtifact(gitID).(*store.SourceArtifact); !ok || art.LocalPath != root {
+		t.Fatalf("GitRepository artifact = %#v, want LocalPath %q", art, root)
+	}
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	if len(res.Manifests[ksID]) == 0 {
+		t.Fatalf("expected rendered manifests for %s", ksID)
+	}
+	info, ok := o.Store().GetStatus(ksID)
+	if !ok || store.IsSkipped(info) {
+		t.Fatalf("Kustomization should render, got status %+v", info)
+	}
+}
+
+func TestLocalGitMissing(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteFile(t, root, ".git/config", "")
+	testutil.WriteFile(t, root, "k8s/flux/cluster.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: gitops, namespace: flux-system}
+spec:
+  url: ssh://git@example.invalid/example/gitops.git
+  secretRef: {name: deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  path: ./k8s/apps
+  sourceRef:
+    kind: GitRepository
+    name: gitops
+    namespace: flux-system
+`)
+
+	o, err := New(Config{
+		Path:                filepath.Join(root, "k8s"),
+		WipeSecrets:         true,
+		AllowMissingSecrets: true,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("unexpected failures: %v", res.Failed)
+	}
+	gitID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "gitops"}
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	for _, id := range []manifest.NamedResource{gitID, ksID} {
+		info, ok := o.Store().GetStatus(id)
+		if !ok || !store.IsSkipped(info) {
+			t.Fatalf("%s should be skipped, got %+v", id, info)
+		}
+	}
+}
+
+func TestLocalGitScoped(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteFile(t, root, ".git/config", "")
+	testutil.WriteFile(t, root, "k8s/flux/cluster.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: gitops, namespace: flux-system}
+spec:
+  url: ssh://git@example.invalid/example/gitops.git
+  secretRef: {name: deploy-key}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: shared, namespace: flux-system}
+spec:
+  url: ssh://git@example.invalid/example/shared.git
+  secretRef: {name: shared-deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: good, namespace: flux-system}
+spec:
+  path: ./k8s/apps/good
+  sourceRef: {kind: GitRepository, name: gitops, namespace: flux-system}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: bad, namespace: flux-system}
+spec:
+  path: ./k8s/apps/bad
+  sourceRef: {kind: GitRepository, name: shared, namespace: flux-system}
+`)
+	testutil.WriteFile(t, root, "k8s/apps/good/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, root, "k8s/apps/good/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: good, namespace: default}
+data: {value: ok}
+`)
+	testutil.WriteFile(t, root, "k8s/apps/bad/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, root, "k8s/apps/bad/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: bad, namespace: default}
+data: {value: skipped}
+`)
+
+	homeID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "gitops"}
+	sharedID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "shared"}
+	o, err := New(Config{
+		Path:                filepath.Join(root, "k8s"),
+		WipeSecrets:         true,
+		AllowMissingSecrets: true,
+		LocalGitSources:     map[manifest.NamedResource]string{homeID: root},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("unexpected failures: %v", res.Failed)
+	}
+	goodID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "good"}
+	badID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "bad"}
+	if len(res.Manifests[goodID]) == 0 {
+		t.Fatalf("mapped Kustomization did not render")
+	}
+	if art := o.Store().GetArtifact(sharedID); art != nil {
+		t.Fatalf("unmapped GitRepository got artifact %#v", art)
+	}
+	info, ok := o.Store().GetStatus(badID)
+	if !ok || !store.IsSkipped(info) {
+		t.Fatalf("unmapped Kustomization should skip, got %+v", info)
+	}
+}
+
+func TestLocalGitVerify(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteFile(t, root, ".git/config", "")
+	testutil.WriteFile(t, root, "k8s/flux/cluster.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: gitops, namespace: flux-system}
+spec:
+  url: ssh://git@example.invalid/example/gitops.git
+  secretRef: {name: deploy-key}
+  verify:
+    mode: HEAD
+    secretRef: {name: pgp-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  path: ./k8s/apps
+  sourceRef: {kind: GitRepository, name: gitops, namespace: flux-system}
+`)
+	testutil.WriteFile(t, root, "k8s/apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, root, "k8s/apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: rendered, namespace: default}
+data: {value: verify}
+`)
+	gitID := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "gitops"}
+	o, err := New(Config{
+		Path:            filepath.Join(root, "k8s"),
+		WipeSecrets:     true,
+		LocalGitSources: map[manifest.NamedResource]string{gitID: root},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = o.Render(context.Background())
+	if err == nil {
+		t.Fatal("expected spec.verify local override to fail")
+	}
+	if !strings.Contains(err.Error(), "refusing to bypass spec.verify") {
+		t.Fatalf("expected spec.verify refusal, got %v", err)
 	}
 }
 


### PR DESCRIPTION
CI diff and test runs need to render GitOps repositories whose root GitRepository is declared in the repo but authenticates with deploy-key secrets that are unavailable offline. Add explicit local source mappings so callers can bind a named GitRepository to each checked-out worktree instead of relying on unsafe missing-secret inference. Keep the behavior opt-in, side-aware for diff, and refuse verified GitRepositories rather than silently bypassing signature checks.
