### PR TITLE
feat(loader): DiscoveryOnly with lazy promotion (step 4/4)

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -49,7 +49,8 @@ type Controller struct {
 	//     the orchestrator's renderedSet.ParentOf, populated when the
 	//     parent KS's emitRenderedChildren fires.
 	// Nil means "no parent enforcement"; matches pre-#221 behavior.
-	parentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
+	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
+	resolveMissing func(manifest.NamedResource) bool
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -64,6 +65,12 @@ type Controller struct {
 type ReconcileOptions struct {
 	Filter   *change.Filter
 	ParentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
+	// ResolveMissing, when non-nil, is forwarded to every depwait
+	// Waiter built during reconcile. The orchestrator wires this
+	// against the loader's ExistenceIndex so file-indexed sources
+	// (HelmRepository, OCIRepository, HelmChart) can be lazy-loaded
+	// the moment the HR's chartRef gate needs them.
+	ResolveMissing func(manifest.NamedResource) bool
 }
 
 // New constructs a HelmRelease controller.
@@ -82,6 +89,7 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
+	c.resolveMissing = opts.ResolveMissing
 }
 
 // lookupParent reports the structural parent KS of id via the
@@ -141,9 +149,10 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
 			w := &depwait.Waiter{
-				Store:   c.Store,
-				Parent:  id,
-				Timeout: depwait.TimeoutFromSpec(hr.Timeout),
+				Store:          c.Store,
+				Parent:         id,
+				Timeout:        depwait.TimeoutFromSpec(hr.Timeout),
+				ResolveMissing: c.resolveMissing,
 			}
 			sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: parent}}))
 		})
@@ -169,9 +178,10 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
 			w := &depwait.Waiter{
-				Store:   c.Store,
-				Parent:  id,
-				Timeout: depwait.TimeoutFromSpec(hr.Timeout),
+				Store:          c.Store,
+				Parent:         id,
+				Timeout:        depwait.TimeoutFromSpec(hr.Timeout),
+				ResolveMissing: c.resolveMissing,
 			}
 			sum = depwait.WaitAll(w.Watch(ctx, deps))
 		})
@@ -218,9 +228,10 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	var sum depwait.Summary
 	c.Tasks.YieldSlot(func() {
 		w := &depwait.Waiter{
-			Store:   c.Store,
-			Parent:  id,
-			Timeout: depwait.TimeoutFromSpec(hr.Timeout),
+			Store:          c.Store,
+			Parent:         id,
+			Timeout:        depwait.TimeoutFromSpec(hr.Timeout),
+			ResolveMissing: c.resolveMissing,
 		}
 		sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
 	})

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -45,8 +45,9 @@ type Controller struct {
 	WipeSecrets bool
 
 	// Set via Configure() — see Options.
-	parentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
-	renderTracker RenderTracker
+	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
+	renderTracker  RenderTracker
+	resolveMissing func(manifest.NamedResource) bool
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -76,6 +77,12 @@ type Options struct {
 	Filter        *change.Filter
 	ParentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
 	RenderTracker RenderTracker
+	// ResolveMissing, when non-nil, is forwarded to every depwait
+	// Waiter built during reconcile. The orchestrator wires this
+	// against the loader's ExistenceIndex so a substituteFrom CM
+	// rendered by a sibling KS can be lazy-loaded on demand instead
+	// of failing the parent KS with "dependency not found."
+	ResolveMissing func(manifest.NamedResource) bool
 }
 
 // New constructs a Kustomization controller.
@@ -94,6 +101,7 @@ func (c *Controller) Configure(opts Options) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
 	c.renderTracker = opts.RenderTracker
+	c.resolveMissing = opts.ResolveMissing
 }
 
 // markRendered reports a parent→child render emission to the
@@ -142,9 +150,10 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
 			w := &depwait.Waiter{
-				Store:   c.Store,
-				Parent:  id,
-				Timeout: depwait.TimeoutFromSpec(ks.Timeout),
+				Store:          c.Store,
+				Parent:         id,
+				Timeout:        depwait.TimeoutFromSpec(ks.Timeout),
+				ResolveMissing: c.resolveMissing,
 			}
 			sum = depwait.WaitAll(w.Watch(ctx, deps))
 		})

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -89,6 +89,19 @@ type Waiter struct {
 	// true. When true, the dep must satisfy both the built-in
 	// Ready check AND the ReadyExpr (additive mode).
 	AdditiveReadyExpr bool
+
+	// ResolveMissing, when non-nil, is consulted after the
+	// missing-dep grace window elapses and the dep is still absent
+	// from the Store. A true return means the resolver has (or can)
+	// promote the dep into the Store — the wait then continues
+	// instead of failing. Used by the orchestrator to lazy-load
+	// file-indexed objects (CMs/Secrets/HRs the DiscoveryOnly
+	// loader kept in Existence) the moment a depwait edge needs
+	// them. Without this hook, the render-driven loader breaks the
+	// bjw-s parent-patches pattern where a KS's substituteFrom CM
+	// lives inside that KS's own spec.path: the dep would never
+	// clear because the producing render hasn't run yet.
+	ResolveMissing func(manifest.NamedResource) bool
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -169,7 +182,14 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 		_, err := w.Store.WatchExists(graceCtx, id)
 		graceCancel()
 		if err != nil && !w.depExists(id) {
-			return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+			// Final fallback: ask the resolver to materialize the
+			// dep from the file-indexed Existence map. A true
+			// return means the dep is now in the Store and the
+			// wait can continue against built-in status / exists
+			// semantics below; false confirms it really is missing.
+			if w.ResolveMissing == nil || !w.ResolveMissing(id) {
+				return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+			}
 		}
 	}
 

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -98,6 +98,58 @@ func TestWaiter_MissingDepFailsFast(t *testing.T) {
 	}
 }
 
+// TestWaiter_ResolveMissingLazyPromotes covers the step-4 fallback:
+// when the missing-grace expires and the dep is still absent, the
+// Waiter consults ResolveMissing. A true return (closure has
+// promoted the object into the Store) means the wait continues
+// against built-in existence semantics instead of failing.
+// Mirrors the orchestrator's wiring where ResolveMissing closes
+// over the loader.ExistenceIndex's Promote.
+func TestWaiter_ResolveMissingLazyPromotes(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "settings"}
+
+	resolveCalled := false
+	resolve := func(id manifest.NamedResource) bool {
+		resolveCalled = true
+		if id != dep {
+			t.Errorf("resolver called with %+v, want %+v", id, dep)
+			return false
+		}
+		// Simulate lazy promotion: object lands in the Store as a
+		// side effect, which is how loader.Promote works.
+		s.AddObject(&manifest.ConfigMap{Name: dep.Name, Namespace: dep.Namespace})
+		return true
+	}
+
+	w := &Waiter{Store: s, Timeout: 5 * time.Second, ResolveMissing: resolve}
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+
+	if !resolveCalled {
+		t.Errorf("ResolveMissing was never invoked")
+	}
+	if !sum.AllReady() {
+		t.Errorf("expected dep to clear after lazy promotion: %+v", sum)
+	}
+}
+
+// TestWaiter_ResolveMissingFalseStillFails locks the symmetric
+// contract: a false return from ResolveMissing means the dep
+// genuinely doesn't exist (no Existence index entry) and the wait
+// surfaces the same "dependency not found" failure as if no
+// resolver were configured.
+func TestWaiter_ResolveMissingFalseStillFails(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "ghost"}
+	resolve := func(manifest.NamedResource) bool { return false }
+	w := &Waiter{Store: s, Timeout: 5 * time.Second, ResolveMissing: resolve}
+
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	if !sum.AnyFailed() {
+		t.Errorf("ResolveMissing=false should still fail: %+v", sum)
+	}
+}
+
 func TestWaiter_NoDeps(t *testing.T) {
 	w := &Waiter{Store: store.New()}
 	sum := WaitAll(w.Watch(context.Background(), nil))

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -51,6 +51,17 @@ type Result struct {
 	// file-loaded copy. Keyed by NamedResource so KS and HR entries
 	// never collide. Empty when no parent enforcement applies.
 	ParentOf map[manifest.NamedResource]manifest.NamedResource
+	// Existence holds every file-loaded object the DiscoveryOnly
+	// loader kept out of the Store: HRs, sources, CMs, Secrets, and
+	// raw manifests. depwait's missing-dep fallback consults it to
+	// resolve sibling-rendered substituteFrom CMs without
+	// deadlocking the parent KS. The orchestrator passes a closure
+	// over this index into the controllers' Waiter wiring.
+	Existence *loader.ExistenceIndex
+	// WipeSecrets reflects the loader's WipeSecrets setting. The
+	// orchestrator forwards it to lazy-promotion so SOPS Secrets
+	// stay wiped on demand the same way they were at file-load.
+	WipeSecrets bool
 }
 
 // Config is the input contract for Run. Store is mandatory.
@@ -69,6 +80,14 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}
 	l := loader.New(cfg.Store)
 	l.Options.WipeSecrets = cfg.WipeSecrets
+	// Step 4 of the render-driven migration: only Kustomizations (plus
+	// the discovery-meta ResourceSet/RSIP pair) reach the Store from
+	// the file walker. HRs, sources, CMs, Secrets, and raw manifests
+	// flow through Existence — picked up later by KS render via
+	// emitRenderedChildren, the orchestrator's orphan-promotion
+	// sweep, or depwait's lazy-promotion fallback.
+	l.Options.DiscoveryOnly = true
+	l.Existence = loader.NewExistenceIndex()
 	d := &discoverer{
 		cfg:         cfg,
 		loader:      l,
@@ -91,10 +110,19 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 		loader.BuildParentIndex(d.cfg.Store, d.sourceFiles),
 		loader.BuildParentIndexForKind(d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease),
 	)
+	// Orphan promotion: every Existence entry whose file path is NOT
+	// under any KS spec.path will never reach the Store through KS
+	// render emission. Promote it now so standalone CRs (loose HR
+	// at repo root, sources next to flux-system/kustomization.yaml,
+	// etc.) keep working in DiscoveryOnly mode.
+	d.promoteOrphans(repoRoot)
+
 	return &Result{
 		RepoRoot:    repoRoot,
 		SourceFiles: d.sourceFiles,
 		ParentOf:    parentOf,
+		Existence:   l.Existence,
+		WipeSecrets: cfg.WipeSecrets,
 	}, nil
 }
 
@@ -339,6 +367,71 @@ func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, n
 		}
 	}
 	return out, nil
+}
+
+// promoteOrphans materializes Existence entries that no Kustomization
+// will ever render. An "orphan" here is a file-indexed object whose
+// absolute file path is not under any loaded KS's spec.path — render-
+// driven discovery would leave it stranded otherwise. Common shapes
+// promoted here:
+//
+//   - A loose HelmRelease/source at repo root that `flate build`
+//     should still render even with no enclosing KS.
+//   - flux-system bootstrap CRs that exist beside the bootstrap KS
+//     itself but aren't inside its spec.path tree.
+//
+// Entries whose path IS under a KS's spec.path stay in Existence —
+// they'll be emitted by that KS's render via emitRenderedChildren
+// (or resolved on-demand by depwait's lazy-promotion fallback when a
+// substituteFrom edge fires before the producing KS reconciles).
+func (d *discoverer) promoteOrphans(repoRoot string) {
+	if d.loader.Existence == nil {
+		return
+	}
+	covered := d.coveredPathPrefixes(repoRoot)
+	for id, path := range d.loader.Existence.All() {
+		if d.cfg.Store.GetObject(id) != nil {
+			continue
+		}
+		if pathUnderAny(path, covered) {
+			continue
+		}
+		if !loader.Promote(d.loader.Existence, d.cfg.Store, id, d.cfg.WipeSecrets) {
+			slog.Debug("discovery: orphan promotion failed", "id", id.String(), "path", path)
+		}
+	}
+}
+
+// coveredPathPrefixes returns the absolute directory prefixes covered
+// by every loaded Kustomization's spec.path (each terminated with a
+// path separator so pathUnderAny matches a directory boundary instead
+// of a name-prefix collision like `/apps/foo` vs `/apps-foo`).
+func (d *discoverer) coveredPathPrefixes(repoRoot string) []string {
+	var out []string
+	for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok || ks.Path == "" {
+			continue
+		}
+		abs := filepath.Join(repoRoot, filepath.FromSlash(stripDotSlash(ks.Path)))
+		out = append(out, filepath.Clean(abs)+string(filepath.Separator))
+	}
+	return out
+}
+
+// pathUnderAny reports whether path sits under one of prefixes
+// (which must already end with a path separator).
+func pathUnderAny(path string, prefixes []string) bool {
+	clean := filepath.Clean(path)
+	for _, prefix := range prefixes {
+		if len(clean) >= len(prefix)-1 && clean+string(filepath.Separator) == prefix {
+			return true
+		}
+		if len(clean) > len(prefix) && clean[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
 }
 
 // aliasBootstrapSources seeds a working-tree SourceArtifact for every

--- a/pkg/loader/existence.go
+++ b/pkg/loader/existence.go
@@ -1,0 +1,89 @@
+package loader
+
+import (
+	"sync"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// ExistenceIndex records "object with this id was parsed from this
+// file" without committing it to the store. Populated by the loader
+// under DiscoveryOnly: HelmReleases, sources, ConfigMaps, Secrets,
+// and other reconcilable kinds skip AddObject and land here instead.
+//
+// Three consumers:
+//
+//   - depwait's missing-dep fallback. A KS that names a CM via
+//     substituteFrom blocks on existence; if the CM lives in a sibling
+//     KS's spec.path the file is in the index even though the store
+//     doesn't have it yet. Lazy-loading from the indexed path unblocks
+//     the depwait without forcing the rendered version to materialize
+//     first — which is impossible for self-rendering patterns like
+//     bjw-s where the parent KS's substituteFrom CM is rendered by
+//     that same parent KS.
+//
+//   - orchestrator orphan promotion. After discovery, any index entry
+//     whose file path is not under any KS's spec.path is promoted to
+//     the store via AddObject. Standalone CRs (e.g. a loose HR file
+//     at repo root with no enclosing KS) keep working through
+//     `flate build`.
+//
+//   - change.Detect sees the file path through the loader's
+//     SourceFiles map regardless of whether the object reached the
+//     store. The index doesn't duplicate that bookkeeping.
+//
+// Thread-safe: the loader walks files concurrently from one goroutine
+// today, but lazy-promotion from depwait can be invoked from
+// reconcile-worker goroutines. Cheap RW mutex keeps the contract
+// clear if either side grows concurrency later.
+type ExistenceIndex struct {
+	mu      sync.RWMutex
+	entries map[manifest.NamedResource]string
+}
+
+// NewExistenceIndex returns an empty index ready for Record / Get.
+func NewExistenceIndex() *ExistenceIndex {
+	return &ExistenceIndex{entries: map[manifest.NamedResource]string{}}
+}
+
+// Record associates id with the absolute file path it was parsed
+// from. Subsequent Record calls for the same id overwrite — the
+// loader's PreferExisting branch handles ordering across multiple
+// scan roots before reaching here.
+func (i *ExistenceIndex) Record(id manifest.NamedResource, absPath string) {
+	if i == nil {
+		return
+	}
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.entries[id] = absPath
+}
+
+// Get returns the indexed file path for id and whether the index
+// has an entry. The returned path is absolute (whatever Record was
+// called with).
+func (i *ExistenceIndex) Get(id manifest.NamedResource) (string, bool) {
+	if i == nil {
+		return "", false
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	path, ok := i.entries[id]
+	return path, ok
+}
+
+// All yields a snapshot of every recorded {id, path}. The returned
+// map is a fresh copy so callers can iterate without holding the
+// lock or worrying about concurrent Record.
+func (i *ExistenceIndex) All() map[manifest.NamedResource]string {
+	if i == nil {
+		return nil
+	}
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	out := make(map[manifest.NamedResource]string, len(i.entries))
+	for k, v := range i.entries {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/loader/existence_test.go
+++ b/pkg/loader/existence_test.go
@@ -1,0 +1,180 @@
+package loader
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestDiscoveryOnly_SkipsNonDiscoveryKinds locks the step-4 contract:
+// under DiscoveryOnly, the file walker AddObjects only KS + RS + RSIP
+// + source kinds. HRs, CMs, Secrets, and raw manifests stay out of
+// the Store and land in Existence instead.
+func TestDiscoveryOnly_SkipsNonDiscoveryKinds(t *testing.T) {
+	dir := t.TempDir()
+	writeExistenceFile(t, dir, "ks.yaml", `
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: podinfo
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+        namespace: default
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  FOO: bar
+`)
+
+	st := store.New()
+	l := New(st)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	if st.GetObject(ksID) == nil {
+		t.Errorf("Kustomization should be in Store under DiscoveryOnly")
+	}
+
+	hrID := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "podinfo"}
+	if st.GetObject(hrID) != nil {
+		t.Errorf("HelmRelease should NOT be in Store under DiscoveryOnly; should be in Existence")
+	}
+	if _, ok := l.Existence.Get(hrID); !ok {
+		t.Errorf("HelmRelease must be recorded in Existence index")
+	}
+
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings"}
+	if st.GetObject(cmID) != nil {
+		t.Errorf("ConfigMap should NOT be in Store under DiscoveryOnly; should be in Existence")
+	}
+	if _, ok := l.Existence.Get(cmID); !ok {
+		t.Errorf("ConfigMap must be recorded in Existence index")
+	}
+}
+
+// TestDiscoveryOnly_PromoteMaterializesFromIndex covers the
+// lazy-promotion contract: when depwait hits a missing dep that the
+// Existence index knows about, Promote re-parses the file and
+// AddObjects it into the Store so the wait can clear.
+func TestDiscoveryOnly_PromoteMaterializesFromIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeExistenceFile(t, dir, "cm.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+  namespace: default
+data:
+  KEY: value
+`)
+
+	st := store.New()
+	l := New(st)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "my-cm"}
+	if st.GetObject(id) != nil {
+		t.Fatalf("precondition: CM should not be in store yet")
+	}
+	if !Promote(l.Existence, st, id, true) {
+		t.Fatalf("Promote should return true on a known id")
+	}
+	if st.GetObject(id) == nil {
+		t.Errorf("Promote did not materialize CM into Store")
+	}
+}
+
+// TestDiscoveryOnly_SourcesStayFileLoaded pins the regression fix
+// found on JJGadgets/Biohazard: sources (GitRepository,
+// OCIRepository, HelmRepository) must remain in the Store under
+// DiscoveryOnly, otherwise aliasBootstrapSources can't recognize
+// them and aliases every source URL to the working tree (silently
+// redirecting every KS render to the wrong source root).
+func TestDiscoveryOnly_SourcesStayFileLoaded(t *testing.T) {
+	dir := t.TempDir()
+	writeExistenceFile(t, dir, "src.yaml", `
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: upstream
+  namespace: flux-system
+spec:
+  url: https://example.test/upstream.git
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: charts
+  namespace: flux-system
+spec:
+  url: oci://example.test/charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: podinfo
+  namespace: default
+spec:
+  url: https://example.test/charts
+`)
+
+	st := store.New()
+	l := New(st)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	for _, want := range []manifest.NamedResource{
+		{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "upstream"},
+		{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "charts"},
+		{Kind: manifest.KindHelmRepository, Namespace: "default", Name: "podinfo"},
+	} {
+		if st.GetObject(want) == nil {
+			t.Errorf("source %s must stay in Store under DiscoveryOnly; got nil", want.String())
+		}
+	}
+}
+
+func writeExistenceFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -18,6 +18,24 @@ import (
 type Options struct {
 	// WipeSecrets controls Secret cleartext replacement. Default true.
 	WipeSecrets bool
+
+	// DiscoveryOnly restricts file-loaded kinds that reach the Store
+	// to the discovery-meta set: Kustomization, ResourceSet, and
+	// ResourceSetInputProvider. Every other Flux CR (HelmRelease,
+	// sources, ConfigMap, Secret) is recorded in Existence instead of
+	// AddObject'd, matching real Flux's render-driven discovery
+	// model where only the bootstrap KS is static and the rest of
+	// the cluster materializes through KS reconciles. depwait
+	// consults the existence index on missing deps; orchestrator
+	// orphan-promotes any index entry not under a KS's spec.path
+	// before reconcile starts.
+	//
+	// Why RS + RSIP stay in-scope: the discovery loop renders
+	// ResourceSets to discover further KSes (RSIPs feed selectors,
+	// RSes produce KSes/RSIPs). There is no ResourceSet controller
+	// yet, so render-emitted RSes would never be processed; keeping
+	// them file-loaded preserves the meta-discovery fixed point.
+	DiscoveryOnly bool
 }
 
 // Loader walks a directory tree and adds Flux objects to a Store.
@@ -41,6 +59,11 @@ type Loader struct {
 	// --path scan's data wins over downstream paths that may point
 	// into a different tree.
 	PreferExisting bool
+
+	// Existence captures every file-loaded object that DiscoveryOnly
+	// keeps out of the Store. Nil disables the bookkeeping (the
+	// default for non-DiscoveryOnly callers).
+	Existence *ExistenceIndex
 }
 
 // New returns a Loader configured to wipe secrets.
@@ -168,6 +191,19 @@ func (l *Loader) loadFile(path string) (int, error) {
 		if l.PreferExisting && l.Store.GetObject(id) != nil {
 			continue
 		}
+		if l.Options.DiscoveryOnly && !isDiscoveryKind(obj) {
+			// Step 4 of the render-driven migration: HRs, sources,
+			// ConfigMaps, Secrets and other reconcilable kinds stay
+			// out of the Store at file-load time. They appear later
+			// via KS render emission (emitRenderedChildren) or via
+			// orphan promotion. The existence index records the
+			// {id, path} pair so depwait's missing-dep fallback can
+			// resolve sibling-rendered substituteFrom CMs without
+			// deadlocking the parent KS.
+			l.Existence.Record(id, path)
+			l.recordSource(id, path)
+			continue
+		}
 		l.Store.AddObject(obj)
 		l.recordSource(id, path)
 		count++
@@ -189,6 +225,40 @@ func (l *Loader) recordSource(id manifest.NamedResource, absPath string) {
 		}
 	}
 	l.SourceFiles[id] = filepath.ToSlash(rel)
+}
+
+// isDiscoveryKind reports whether obj belongs to the discovery-meta
+// kind set the loader keeps in the Store under DiscoveryOnly:
+//
+//   - Kustomization, ResourceSet, ResourceSetInputProvider — the
+//     reconcile driver and its meta-discovery hooks (RS renders to
+//     more KSes; RSIPs feed RS selectors).
+//   - Sources (GitRepository, OCIRepository, HelmRepository,
+//     HelmChartSource, Bucket, ExternalArtifact) — sources are
+//     rarely patched at render time and need to be visible at
+//     discovery for the bootstrap-alias pass to recognize them as
+//     already-known (otherwise every GitRepository gets aliased to
+//     the working tree, which silently redirects every KS's render
+//     to the wrong source root).
+//
+// HelmReleases, ConfigMaps, Secrets, and other reconcilables flow
+// from KS render output via emitRenderedChildren — or, when no KS
+// would render them, through the orchestrator's post-discovery
+// orphan-promotion sweep.
+func isDiscoveryKind(obj manifest.BaseManifest) bool {
+	switch obj.(type) {
+	case *manifest.Kustomization,
+		*manifest.ResourceSet,
+		*manifest.ResourceSetInputProvider,
+		*manifest.GitRepository,
+		*manifest.OCIRepository,
+		*manifest.HelmRepository,
+		*manifest.HelmChartSource,
+		*manifest.Bucket,
+		*manifest.ExternalArtifact:
+		return true
+	}
+	return false
 }
 
 var manifestExtensions = map[string]struct{}{

--- a/pkg/loader/promote.go
+++ b/pkg/loader/promote.go
@@ -1,0 +1,89 @@
+package loader
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// Promote materializes id into st by re-parsing the file the
+// ExistenceIndex recorded for it and AddObject'ing every Flux CR in
+// the file. Returns true on success; false if the id is unknown to
+// the index or its file can no longer be parsed.
+//
+// The whole file is parsed (not just id) because YAML multi-doc files
+// often pack a CM + its Secret + a HelmRelease together — promoting
+// one frequently means callers will need a sibling next. Parsing once
+// and AddObject'ing every doc avoids re-opening the same file
+// repeatedly when several lazy lookups land on it.
+//
+// PreferExisting semantics are honored: if an id already lives in the
+// store (already promoted, or render-emitted by a KS), the existing
+// object stays put. wipeSecrets matches the loader's: callers should
+// pass through whatever DiscoveryOnly used at file-load time so SOPS
+// Secrets stay wiped on promotion the same way they were skipped at
+// load.
+func Promote(idx *ExistenceIndex, st *store.Store, id manifest.NamedResource, wipeSecrets bool) bool {
+	if idx == nil || st == nil {
+		return false
+	}
+	path, ok := idx.Get(id)
+	if !ok {
+		return false
+	}
+	if obj := st.GetObject(id); obj != nil {
+		return true
+	}
+	objs, err := parseFileObjects(path, wipeSecrets)
+	if err != nil {
+		slog.Debug("loader: promote re-parse failed", "id", id.String(), "path", path, "err", err)
+		return false
+	}
+	for _, obj := range objs {
+		if obj == nil {
+			continue
+		}
+		if existing := st.GetObject(obj.Named()); existing != nil {
+			continue
+		}
+		st.AddObject(obj)
+	}
+	return st.GetObject(id) != nil
+}
+
+// parseFileObjects re-reads path and returns the recognized Flux CRs
+// in document order. Errors at the file level surface; per-doc parse
+// failures are swallowed at Debug log level (consistent with
+// Loader.loadFile, which also skips bad docs in mixed files).
+func parseFileObjects(path string, wipeSecrets bool) ([]manifest.BaseManifest, error) {
+	f, err := os.Open(path) //nolint:gosec // path came from ExistenceIndex, populated by tree walk
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	docs, err := manifest.DecodeDocs(f)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	opts := manifest.ParseDocOptions{WipeSecrets: wipeSecrets}
+	out := make([]manifest.BaseManifest, 0, len(docs))
+	for _, doc := range docs {
+		obj, err := manifest.ParseDoc(doc, opts)
+		if err != nil {
+			slog.Debug("loader: promote doc skipped", "path", path, "err", err)
+			continue
+		}
+		if _, ok := obj.(*manifest.RawObject); ok {
+			continue
+		}
+		id := obj.Named()
+		if manifest.HasEnvsubstReference(id.Name) || manifest.HasEnvsubstReference(id.Namespace) {
+			continue
+		}
+		out = append(out, obj)
+	}
+	return out, nil
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/home-operations/flate/pkg/discovery"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/kustomize"
+	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
 	"github.com/home-operations/flate/pkg/source"
@@ -114,6 +115,12 @@ type Orchestrator struct {
 	// failing the run. Lives here, not on Store — iter-15 carved this
 	// orchestrator-internal bookkeeping out of the data substrate.
 	rendered *renderedSet
+
+	// existence is the file-indexed bookkeeping the DiscoveryOnly
+	// loader populated. Consumed by the depwait ResolveMissing
+	// closure to lazy-promote substituteFrom CMs/Secrets and any
+	// other file-indexed dep on demand.
+	existence *loader.ExistenceIndex
 
 	// orphans records resources Run demoted from Failed → Ready because
 	// they aren't referenced by any parent KS. Populated during Run,
@@ -250,6 +257,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	}
 	o.sourceFiles = res.SourceFiles
 	o.parentOf = res.ParentOf
+	o.existence = res.Existence
 
 	o.validateDependsOn()
 	o.breakDependsOnCycles()
@@ -440,12 +448,29 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		}
 		return o.rendered.ParentOf(id)
 	}
+	// resolveMissing closes over the file-indexed Existence map the
+	// DiscoveryOnly loader populated. When a depwait grace window
+	// elapses on a missing dep, the closure lazy-promotes the dep
+	// from its indexed file into the Store. This is the seam that
+	// keeps the bjw-s parent-patches pattern (KS substituting from
+	// a CM rendered by its own spec.path) from deadlocking — the CM
+	// file is on disk, so we materialize it the moment the depwait
+	// asks instead of waiting for the producing render that can't
+	// run until the depwait clears.
+	resolveMissing := func(id manifest.NamedResource) bool {
+		return loader.Promote(o.existence, o.store, id, o.cfg.WipeSecrets)
+	}
 	o.ksc.Configure(kustomization.Options{
-		Filter:        o.filter,
-		ParentOf:      parentResolver,
-		RenderTracker: o.rendered,
+		Filter:         o.filter,
+		ParentOf:       parentResolver,
+		RenderTracker:  o.rendered,
+		ResolveMissing: resolveMissing,
 	})
-	o.hrc.Configure(helmrelease.ReconcileOptions{Filter: o.filter, ParentOf: parentResolver})
+	o.hrc.Configure(helmrelease.ReconcileOptions{
+		Filter:         o.filter,
+		ParentOf:       parentResolver,
+		ResolveMissing: resolveMissing,
+	})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
 	o.hrc.Start(ctx)


### PR DESCRIPTION
## Summary

Step 4 of the render-driven discovery migration. Flips the file walker into render-driven mode: only Kustomizations, ResourceSets, ResourceSetInputProviders, and source kinds reach the Store at file-load time. HelmReleases, ConfigMaps, Secrets, and raw manifests are recorded in a new \`ExistenceIndex\` and flow into the Store via three paths:

1. **KS render emission** (\`emitRenderedChildren\`) — the canonical path; post-patch versions arrive once the parent KS reconciles.
2. **depwait lazy promotion** — when a missing dep grace window expires, the Waiter's new \`ResolveMissing\` fallback re-parses the indexed file and \`AddObject\`s it into the Store. **Fixes the bjw-s parent-patches deadlock**: a KS's \`substituteFrom\` CM that lives inside the parent KS's own \`spec.path\` materializes on demand instead of waiting for the producing render that can't run until the depwait clears.
3. **Orphan promotion** — every \`ExistenceIndex\` entry whose file path is not under any KS \`spec.path\` is materialized at end of \`Bootstrap\`, so standalone CRs (loose HR at repo root, sources beside \`flux-system/kustomization.yaml\`) keep working.

## Why sources stay file-loaded

\`aliasBootstrapSources\` needs to recognize sources as already-known; otherwise every GitRepository gets aliased to the working tree, silently redirecting every KS render to the wrong source root. Regression caught on JJGadgets/Biohazard during step-4 testing.

## Why RS / RSIP stay file-loaded

The discovery loop renders ResourceSets to discover further KSes — there is no RS controller yet, so render-emitted RSes would be unprocessed.

## Migration status

- ✅ Step 1 (#238): \`RenderTracker\` parent provenance
- ✅ Step 2 (#239): \`ParentOf\` resolver func
- ✅ Step 3 (#240): \`postBuild.substituteFrom\` CM as depwait edge
- 🟢 Step 4 (**this PR**): Loader flip + ExistenceIndex + lazy promotion

## Test plan

- [x] \`go test ./...\` — full suite green (full e2e + unit suite, no regressions)
- [x] New unit tests:
  - \`loader.TestDiscoveryOnly_SkipsNonDiscoveryKinds\` — HRs/CMs/Secrets go to Existence, not Store
  - \`loader.TestDiscoveryOnly_PromoteMaterializesFromIndex\` — \`Promote\` lazy-loads on demand
  - \`loader.TestDiscoveryOnly_SourcesStayFileLoaded\` — guards the Biohazard regression
  - \`depwait.TestWaiter_ResolveMissingLazyPromotes\` — fallback triggers + clears
  - \`depwait.TestWaiter_ResolveMissingFalseStillFails\` — false return still surfaces "not found"
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118 passed / 0 failed**
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199 passed / 0 failed**
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287 passed / 2 failed** (same upstream HTTP 404 on \`stunner-crd.yaml\` as on step 3 — not a regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)