### PR TITLE
chore: cleanup pass after render-driven discovery migration

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -102,6 +103,20 @@ func (c *Controller) lookupParent(id manifest.NamedResource) (manifest.NamedReso
 	return c.parentOf(id)
 }
 
+// newWaiter constructs a depwait.Waiter pre-wired with the
+// controller's Store and lazy-promotion fallback, parented to id and
+// budgeted from timeout (typically hr.Timeout). Centralizes the
+// boilerplate so the parent-KS gate, dependsOn wait, and chart-
+// source wait don't drift apart.
+func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
+	return &depwait.Waiter{
+		Store:          c.Store,
+		Parent:         id,
+		Timeout:        depwait.TimeoutFromSpec(timeout),
+		ResolveMissing: c.resolveMissing,
+	}
+}
+
 // Start registers the listeners. The controller runs until Close.
 // The HR controller only listens for HelmRelease and HelmChartSource
 // (the chart-ref index) — source-kind events (HelmRepository,
@@ -148,13 +163,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		c.Store.UpdateStatus(id, store.StatusPending, "waiting for parent KS")
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
-			w := &depwait.Waiter{
-				Store:          c.Store,
-				Parent:         id,
-				Timeout:        depwait.TimeoutFromSpec(hr.Timeout),
-				ResolveMissing: c.resolveMissing,
-			}
-			sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: parent}}))
+			sum = depwait.WaitAll(c.newWaiter(id, hr.Timeout).Watch(ctx, []manifest.DependencyRef{{NamedResource: parent}}))
 		})
 		if sum.AnyFailed() {
 			return fmt.Errorf("%w: parent Kustomization %s not ready: %s",
@@ -177,13 +186,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
-			w := &depwait.Waiter{
-				Store:          c.Store,
-				Parent:         id,
-				Timeout:        depwait.TimeoutFromSpec(hr.Timeout),
-				ResolveMissing: c.resolveMissing,
-			}
-			sum = depwait.WaitAll(w.Watch(ctx, deps))
+			sum = depwait.WaitAll(c.newWaiter(id, hr.Timeout).Watch(ctx, deps))
 		})
 		if sum.AnyFailed() {
 			return &manifest.DependencyFailedError{
@@ -227,13 +230,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	}
 	var sum depwait.Summary
 	c.Tasks.YieldSlot(func() {
-		w := &depwait.Waiter{
-			Store:          c.Store,
-			Parent:         id,
-			Timeout:        depwait.TimeoutFromSpec(hr.Timeout),
-			ResolveMissing: c.resolveMissing,
-		}
-		sum = depwait.WaitAll(w.Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
+		sum = depwait.WaitAll(c.newWaiter(id, hr.Timeout).Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
 	})
 	if sum.AnyFailed() {
 		return fmt.Errorf("%w: chart source %s not ready: %s",

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -17,6 +17,7 @@ import (
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	yaml "go.yaml.in/yaml/v4"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -54,12 +55,10 @@ type Controller struct {
 // "this child id was emitted by THIS parent KS's render" to the
 // orchestrator. Nil is OK — the controller no-ops.
 //
-// The parent linkage is consumed by detectOrphans and (in later
-// steps of the render-driven discovery migration) by the parent
-// index, change filter, and ResourceSet extension attribution —
-// every place that today relies on `sourceFiles[id]` for
-// file-loaded resources gains the ability to query parent
-// provenance for render-emitted ones.
+// The parent linkage is consumed by detectOrphans, the parent
+// resolver (combined with the file-loaded path-prefix index), and
+// ResourceSet extension attribution — every place that needs to
+// query parent provenance for render-emitted resources.
 type RenderTracker interface {
 	MarkRendered(parent, child manifest.NamedResource)
 }
@@ -113,6 +112,18 @@ func (c *Controller) markRendered(parent, child manifest.NamedResource) {
 	}
 }
 
+// newWaiter constructs a depwait.Waiter pre-wired with the
+// controller's Store and lazy-promotion fallback, parented to id and
+// budgeted from timeout (typically ks.Timeout).
+func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
+	return &depwait.Waiter{
+		Store:          c.Store,
+		Parent:         id,
+		Timeout:        depwait.TimeoutFromSpec(timeout),
+		ResolveMissing: c.resolveMissing,
+	}
+}
+
 // Start registers the listener that drives reconciliation.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("kustomization")
@@ -149,13 +160,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// slots while waiting for children that need a slot to run.
 		var sum depwait.Summary
 		c.Tasks.YieldSlot(func() {
-			w := &depwait.Waiter{
-				Store:          c.Store,
-				Parent:         id,
-				Timeout:        depwait.TimeoutFromSpec(ks.Timeout),
-				ResolveMissing: c.resolveMissing,
-			}
-			sum = depwait.WaitAll(w.Watch(ctx, deps))
+			sum = depwait.WaitAll(c.newWaiter(id, ks.Timeout).Watch(ctx, deps))
 		})
 		if sum.AnyFailed() {
 			return &manifest.DependencyFailedError{

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -41,12 +41,11 @@ func TestCollectDeps_NoParentNoExtraDep(t *testing.T) {
 	}
 }
 
-// TestCollectDeps_AppendsSubstituteFromConfigMap is step 3 of the
-// render-driven migration: every non-Optional postBuild.substituteFrom
-// ConfigMap becomes a real depwait edge. Without this, KS-A would
-// race the CM that KS-B's render emits, and Prepare would silently
-// expand with empty values for any var that should have come from
-// KS-B's CM.
+// TestCollectDeps_AppendsSubstituteFromConfigMap locks the
+// substituteFrom→ConfigMap depwait edge: every non-Optional ref
+// becomes a real dependency. Without this, KS-A would race the CM
+// that KS-B's render emits, and Prepare would silently expand with
+// empty values for any var that should have come from KS-B's CM.
 func TestCollectDeps_AppendsSubstituteFromConfigMap(t *testing.T) {
 	ks := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -80,10 +80,10 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}
 	l := loader.New(cfg.Store)
 	l.Options.WipeSecrets = cfg.WipeSecrets
-	// Step 4 of the render-driven migration: only Kustomizations (plus
-	// the discovery-meta ResourceSet/RSIP pair) reach the Store from
-	// the file walker. HRs, sources, CMs, Secrets, and raw manifests
-	// flow through Existence — picked up later by KS render via
+	// Render-driven discovery: only Kustomizations and the discovery-
+	// meta pair (ResourceSet, RSIP) reach the Store from the file
+	// walker. HRs, sources, CMs, Secrets, and raw manifests flow
+	// through Existence — picked up later by KS render via
 	// emitRenderedChildren, the orchestrator's orphan-promotion
 	// sweep, or depwait's lazy-promotion fallback.
 	l.Options.DiscoveryOnly = true
@@ -115,7 +115,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	// render emission. Promote it now so standalone CRs (loose HR
 	// at repo root, sources next to flux-system/kustomization.yaml,
 	// etc.) keep working in DiscoveryOnly mode.
-	d.promoteOrphans(repoRoot)
+	d.promoteOrphans()
 
 	return &Result{
 		RepoRoot:    repoRoot,
@@ -371,9 +371,8 @@ func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, n
 
 // promoteOrphans materializes Existence entries that no Kustomization
 // will ever render. An "orphan" here is a file-indexed object whose
-// absolute file path is not under any loaded KS's spec.path — render-
-// driven discovery would leave it stranded otherwise. Common shapes
-// promoted here:
+// source file is not under any loaded KS's spec.path — render-driven
+// discovery would leave it stranded otherwise. Common shapes:
 //
 //   - A loose HelmRelease/source at repo root that `flate build`
 //     should still render even with no enclosing KS.
@@ -384,54 +383,32 @@ func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, n
 // they'll be emitted by that KS's render via emitRenderedChildren
 // (or resolved on-demand by depwait's lazy-promotion fallback when a
 // substituteFrom edge fires before the producing KS reconciles).
-func (d *discoverer) promoteOrphans(repoRoot string) {
+//
+// Shares the parent-path-prefix predicate with the orchestrator's
+// detectOrphans via loader.KSPathPrefixes — the two run in
+// complementary phases (pre-reconcile materialization here,
+// post-reconcile failure demotion there) and must agree on the
+// same "under a KS path" predicate so an object can't be classified
+// orphan by one and parented by the other.
+func (d *discoverer) promoteOrphans() {
 	if d.loader.Existence == nil {
 		return
 	}
-	covered := d.coveredPathPrefixes(repoRoot)
-	for id, path := range d.loader.Existence.All() {
+	prefixes := loader.KSPathPrefixes(d.cfg.Store)
+	for id := range d.loader.Existence.All() {
 		if d.cfg.Store.GetObject(id) != nil {
 			continue
 		}
-		if pathUnderAny(path, covered) {
-			continue
+		file, hasFile := d.sourceFiles[id]
+		if hasFile {
+			if _, covered := loader.LongestParent(prefixes, file, id); covered {
+				continue
+			}
 		}
-		if !loader.Promote(d.loader.Existence, d.cfg.Store, id, d.cfg.WipeSecrets) {
-			slog.Debug("discovery: orphan promotion failed", "id", id.String(), "path", path)
-		}
-	}
-}
-
-// coveredPathPrefixes returns the absolute directory prefixes covered
-// by every loaded Kustomization's spec.path (each terminated with a
-// path separator so pathUnderAny matches a directory boundary instead
-// of a name-prefix collision like `/apps/foo` vs `/apps-foo`).
-func (d *discoverer) coveredPathPrefixes(repoRoot string) []string {
-	var out []string
-	for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
-			continue
-		}
-		abs := filepath.Join(repoRoot, filepath.FromSlash(stripDotSlash(ks.Path)))
-		out = append(out, filepath.Clean(abs)+string(filepath.Separator))
-	}
-	return out
-}
-
-// pathUnderAny reports whether path sits under one of prefixes
-// (which must already end with a path separator).
-func pathUnderAny(path string, prefixes []string) bool {
-	clean := filepath.Clean(path)
-	for _, prefix := range prefixes {
-		if len(clean) >= len(prefix)-1 && clean+string(filepath.Separator) == prefix {
-			return true
-		}
-		if len(clean) > len(prefix) && clean[:len(prefix)] == prefix {
-			return true
+		if !d.loader.Existence.Promote(d.cfg.Store, id, d.cfg.WipeSecrets) {
+			slog.Debug("discovery: orphan promotion failed", "id", id.String())
 		}
 	}
-	return false
 }
 
 // aliasBootstrapSources seeds a working-tree SourceArtifact for every

--- a/pkg/loader/existence_test.go
+++ b/pkg/loader/existence_test.go
@@ -110,7 +110,7 @@ data:
 	if st.GetObject(id) != nil {
 		t.Fatalf("precondition: CM should not be in store yet")
 	}
-	if !Promote(l.Existence, st, id, true) {
+	if !l.Existence.Promote(st, id, true) {
 		t.Fatalf("Promote should return true on a known id")
 	}
 	if st.GetObject(id) == nil {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -3,10 +3,8 @@ package loader
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -153,53 +151,25 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 }
 
 func (l *Loader) loadFile(path string) (int, error) {
-	f, err := os.Open(path) //nolint:gosec // path is a tree-walk result under the cluster scan root
+	objs, err := parseFile(path, manifest.ParseDocOptions{WipeSecrets: l.Options.WipeSecrets})
 	if err != nil {
 		return 0, err
 	}
-	defer func() { _ = f.Close() }()
-	docs, err := manifest.DecodeDocs(f)
-	if err != nil {
-		return 0, fmt.Errorf("decode %s: %w", path, err)
-	}
-	opts := manifest.ParseDocOptions{WipeSecrets: l.Options.WipeSecrets}
 	count := 0
-	for _, doc := range docs {
-		obj, err := manifest.ParseDoc(doc, opts)
-		if err != nil {
-			// Don't break on a single bad doc; flux-local skips and logs.
-			slog.Debug("loader: doc skipped", "path", path, "err", err)
-			continue
-		}
-		if _, ok := obj.(*manifest.RawObject); ok {
-			// We only persist objects we explicitly understand.
-			continue
-		}
+	for _, obj := range objs {
 		id := obj.Named()
-		// Skip resources whose name or namespace contains a literal
-		// `${VAR}` reference — those are templates the user expects a
-		// parent Kustomization's postBuild.substitute(From) to resolve
-		// at render time. Real Flux never sees them as in-cluster CRs
-		// (the K8s API would reject `$` in metadata.name) and flate
-		// shouldn't try to reconcile them either; the substituted copy
-		// emitted by the parent KS's render is the reconcilable one.
-		if manifest.HasEnvsubstReference(id.Name) || manifest.HasEnvsubstReference(id.Namespace) {
-			slog.Debug("loader: skipped template file (unresolved envsubst in name/namespace)",
-				"path", path, "id", id.String())
-			continue
-		}
 		if l.PreferExisting && l.Store.GetObject(id) != nil {
 			continue
 		}
 		if l.Options.DiscoveryOnly && !isDiscoveryKind(obj) {
-			// Step 4 of the render-driven migration: HRs, sources,
-			// ConfigMaps, Secrets and other reconcilable kinds stay
-			// out of the Store at file-load time. They appear later
-			// via KS render emission (emitRenderedChildren) or via
-			// orphan promotion. The existence index records the
-			// {id, path} pair so depwait's missing-dep fallback can
-			// resolve sibling-rendered substituteFrom CMs without
-			// deadlocking the parent KS.
+			// Under render-driven discovery, HRs / ConfigMaps /
+			// Secrets / raw manifests stay out of the Store at file-
+			// load time. They reach the Store via KS render
+			// emission (emitRenderedChildren), depwait's lazy-
+			// promotion fallback, or the orchestrator's orphan
+			// sweep. The Existence index records the {id, path}
+			// pair so the depwait fallback can re-parse the file
+			// on demand without deadlocking the producing KS.
 			l.Existence.Record(id, path)
 			l.recordSource(id, path)
 			continue

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -10,6 +10,51 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// KSPathPrefix pairs a Kustomization id with its slash-terminated,
+// repo-relative spec.path prefix. Returned by KSPathPrefixes for use
+// in parent-index construction and orphan classification.
+type KSPathPrefix struct {
+	ID     manifest.NamedResource
+	Prefix string
+}
+
+// KSPathPrefixes returns one entry per loaded Kustomization with a
+// non-empty spec.path, sorted by prefix length descending so the
+// first HasPrefix match on a given file is the most-specific
+// structural parent. The descending sort drops parent lookup from
+// O(K²) to O(K · depth) in the typical case.
+func KSPathPrefixes(s *store.Store) []KSPathPrefix {
+	var out []KSPathPrefix
+	for _, obj := range s.ListObjects(manifest.KindKustomization) {
+		ks, ok := obj.(*manifest.Kustomization)
+		if !ok || ks.Path == "" {
+			continue
+		}
+		out = append(out, KSPathPrefix{ID: ks.Named(), Prefix: normalizePrefix(ks.Path)})
+	}
+	slices.SortFunc(out, func(a, b KSPathPrefix) int {
+		return cmp.Compare(len(b.Prefix), len(a.Prefix))
+	})
+	return out
+}
+
+// LongestParent returns the deepest KS whose spec.path covers file
+// (slash-normalized repo-relative path), excluding self. The second
+// return reports whether a parent was found. prefixes is expected to
+// be the sorted output of KSPathPrefixes.
+func LongestParent(prefixes []KSPathPrefix, file string, self manifest.NamedResource) (manifest.NamedResource, bool) {
+	slashFile := filepath.ToSlash(file)
+	for _, p := range prefixes {
+		if p.ID == self {
+			continue
+		}
+		if strings.HasPrefix(slashFile, p.Prefix) {
+			return p.ID, true
+		}
+	}
+	return manifest.NamedResource{}, false
+}
+
 // BuildParentIndex maps each Flux Kustomization to its structural
 // parent — the Flux Kustomization whose spec.path is the deepest
 // strict ancestor of the child's source file. Excludes self-matches.
@@ -42,25 +87,7 @@ func BuildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResou
 }
 
 func buildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResource]string, childKind string) map[manifest.NamedResource]manifest.NamedResource {
-	type owner struct {
-		prefix string
-		id     manifest.NamedResource
-	}
-	var owners []owner
-	for _, obj := range s.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
-			continue
-		}
-		owners = append(owners, owner{prefix: normalizePrefix(ks.Path), id: ks.Named()})
-	}
-	// Sort by prefix length descending so the longest-prefix parent
-	// (the most specific structural owner) is the first match in the
-	// inner loop; we can short-circuit on first hit. Drops the worst
-	// case from O(K²) to O(K · depth) and the typical case to O(K).
-	slices.SortFunc(owners, func(a, b owner) int {
-		return cmp.Compare(len(b.prefix), len(a.prefix))
-	})
+	prefixes := KSPathPrefixes(s)
 	out := map[manifest.NamedResource]manifest.NamedResource{}
 	for _, obj := range s.ListObjects(childKind) {
 		id := obj.Named()
@@ -68,15 +95,8 @@ func buildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResou
 		if !ok {
 			continue
 		}
-		slashFile := filepath.ToSlash(file)
-		for _, o := range owners {
-			if o.id == id {
-				continue
-			}
-			if strings.HasPrefix(slashFile, o.prefix) {
-				out[id] = o.id
-				break
-			}
+		if parent, ok := LongestParent(prefixes, file, id); ok {
+			out[id] = parent
 		}
 	}
 	return out

--- a/pkg/loader/parse.go
+++ b/pkg/loader/parse.go
@@ -1,0 +1,59 @@
+package loader
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// parseFile opens path, decodes every YAML/JSON doc, and returns the
+// recognized Flux CRs in document order. Filters that match both the
+// initial file-walk load and the lazy promotion path live here so
+// "what counts as a loadable Flux doc" has one canonical definition:
+//
+//   - manifest.ParseDoc per-doc errors are swallowed at Debug log
+//     level (matches flux-local — a malformed sibling doc in a
+//     multi-doc file shouldn't poison the rest of the file).
+//   - manifest.RawObject results are dropped — flate only persists
+//     kinds it explicitly understands.
+//   - Objects whose name/namespace contain `${VAR}` are dropped as
+//     templates: a parent KS's postBuild.substitute(From) is supposed
+//     to resolve them at render time; Kubernetes itself rejects `$`
+//     in metadata.name, so the unsubstituted file copy would never
+//     reach the API server in real Flux either.
+//
+// Per-doc parse errors include path in their log fields so the caller
+// doesn't need to wrap them. File-level errors (open, decode) surface
+// to the caller with the path baked into the wrap.
+func parseFile(path string, opts manifest.ParseDocOptions) ([]manifest.BaseManifest, error) {
+	f, err := os.Open(path) //nolint:gosec // path came from a tree-walk under the scan root or the ExistenceIndex
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	docs, err := manifest.DecodeDocs(f)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	out := make([]manifest.BaseManifest, 0, len(docs))
+	for _, doc := range docs {
+		obj, err := manifest.ParseDoc(doc, opts)
+		if err != nil {
+			slog.Debug("loader: doc skipped", "path", path, "err", err)
+			continue
+		}
+		if _, ok := obj.(*manifest.RawObject); ok {
+			continue
+		}
+		id := obj.Named()
+		if manifest.HasEnvsubstReference(id.Name) || manifest.HasEnvsubstReference(id.Namespace) {
+			slog.Debug("loader: skipped template doc (unresolved envsubst in name/namespace)",
+				"path", path, "id", id.String())
+			continue
+		}
+		out = append(out, obj)
+	}
+	return out, nil
+}

--- a/pkg/loader/promote.go
+++ b/pkg/loader/promote.go
@@ -1,9 +1,7 @@
 package loader
 
 import (
-	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -20,70 +18,33 @@ import (
 // and AddObject'ing every doc avoids re-opening the same file
 // repeatedly when several lazy lookups land on it.
 //
-// PreferExisting semantics are honored: if an id already lives in the
-// store (already promoted, or render-emitted by a KS), the existing
-// object stays put. wipeSecrets matches the loader's: callers should
-// pass through whatever DiscoveryOnly used at file-load time so SOPS
-// Secrets stay wiped on promotion the same way they were skipped at
-// load.
-func Promote(idx *ExistenceIndex, st *store.Store, id manifest.NamedResource, wipeSecrets bool) bool {
-	if idx == nil || st == nil {
+// PreferExisting semantics are honored: if an id already lives in
+// the store (already promoted, or render-emitted by a KS), the
+// existing object stays put. wipeSecrets matches the loader's:
+// callers should pass through whatever DiscoveryOnly used at file-
+// load time so SOPS Secrets stay wiped on promotion the same way
+// they were skipped at load.
+func (i *ExistenceIndex) Promote(st *store.Store, id manifest.NamedResource, wipeSecrets bool) bool {
+	if i == nil || st == nil {
 		return false
 	}
-	path, ok := idx.Get(id)
+	path, ok := i.Get(id)
 	if !ok {
 		return false
 	}
-	if obj := st.GetObject(id); obj != nil {
+	if st.GetObject(id) != nil {
 		return true
 	}
-	objs, err := parseFileObjects(path, wipeSecrets)
+	objs, err := parseFile(path, manifest.ParseDocOptions{WipeSecrets: wipeSecrets})
 	if err != nil {
 		slog.Debug("loader: promote re-parse failed", "id", id.String(), "path", path, "err", err)
 		return false
 	}
 	for _, obj := range objs {
-		if obj == nil {
-			continue
-		}
-		if existing := st.GetObject(obj.Named()); existing != nil {
+		if st.GetObject(obj.Named()) != nil {
 			continue
 		}
 		st.AddObject(obj)
 	}
 	return st.GetObject(id) != nil
-}
-
-// parseFileObjects re-reads path and returns the recognized Flux CRs
-// in document order. Errors at the file level surface; per-doc parse
-// failures are swallowed at Debug log level (consistent with
-// Loader.loadFile, which also skips bad docs in mixed files).
-func parseFileObjects(path string, wipeSecrets bool) ([]manifest.BaseManifest, error) {
-	f, err := os.Open(path) //nolint:gosec // path came from ExistenceIndex, populated by tree walk
-	if err != nil {
-		return nil, fmt.Errorf("open %s: %w", path, err)
-	}
-	defer func() { _ = f.Close() }()
-	docs, err := manifest.DecodeDocs(f)
-	if err != nil {
-		return nil, fmt.Errorf("decode %s: %w", path, err)
-	}
-	opts := manifest.ParseDocOptions{WipeSecrets: wipeSecrets}
-	out := make([]manifest.BaseManifest, 0, len(docs))
-	for _, doc := range docs {
-		obj, err := manifest.ParseDoc(doc, opts)
-		if err != nil {
-			slog.Debug("loader: promote doc skipped", "path", path, "err", err)
-			continue
-		}
-		if _, ok := obj.(*manifest.RawObject); ok {
-			continue
-		}
-		id := obj.Named()
-		if manifest.HasEnvsubstReference(id.Name) || manifest.HasEnvsubstReference(id.Namespace) {
-			continue
-		}
-		out = append(out, obj)
-	}
-	return out, nil
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -318,23 +318,7 @@ func (o *Orchestrator) validateDependsOn() {
 // warning rather than gating the test on stale local files.
 func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.StatusInfo) map[manifest.NamedResource]struct{} {
 	out := make(map[manifest.NamedResource]struct{})
-	// Collect every loaded Kustomization's spec.path so we can ask
-	// "does any parent's path cover this file?" cheaply.
-	type parentPath struct {
-		id   manifest.NamedResource
-		path string
-	}
-	var parents []parentPath
-	for _, obj := range o.store.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
-			continue
-		}
-		parents = append(parents, parentPath{
-			id:   ks.Named(),
-			path: filepath.ToSlash(strings.TrimPrefix(strings.TrimSuffix(ks.Path, "/"), "./")) + "/",
-		})
-	}
+	prefixes := loader.KSPathPrefixes(o.store)
 	for id := range failed {
 		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
 			continue
@@ -348,18 +332,7 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 		if !ok {
 			continue
 		}
-		slashFile := filepath.ToSlash(file)
-		var covered bool
-		for _, p := range parents {
-			if p.id == id {
-				continue
-			}
-			if strings.HasPrefix(slashFile, p.path) {
-				covered = true
-				break
-			}
-		}
-		if covered {
+		if _, ok := loader.LongestParent(prefixes, file, id); ok {
 			out[id] = struct{}{}
 		}
 	}
@@ -434,14 +407,11 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		Filter:             o.filter,
 		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
 	})
-	// parentResolver unifies the two sources of structural-parent info:
-	// (1) the pre-built file-path prefix index for file-loaded
-	// resources (o.parentOf), and (2) the renderedSet's parent-of
-	// linkage for resources that arrive via a KS render's
-	// emitRenderedChildren (populated at Run-time, not at Bootstrap).
-	// Controllers query through this single seam; later migration
-	// steps swap (1) for the full render-driven version without
-	// touching controller code.
+	// parentResolver unifies the two sources of structural-parent
+	// info: (1) the pre-built file-path prefix index for file-loaded
+	// resources, and (2) the renderedSet for resources that arrive
+	// via a KS render's emitRenderedChildren (populated at Run-time,
+	// not at Bootstrap). Controllers query through this single seam.
 	parentResolver := func(id manifest.NamedResource) (manifest.NamedResource, bool) {
 		if parent, ok := o.parentOf[id]; ok {
 			return parent, true
@@ -458,7 +428,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	// asks instead of waiting for the producing render that can't
 	// run until the depwait clears.
 	resolveMissing := func(id manifest.NamedResource) bool {
-		return loader.Promote(o.existence, o.store, id, o.cfg.WipeSecrets)
+		return o.existence.Promote(o.store, id, o.cfg.WipeSecrets)
 	}
 	o.ksc.Configure(kustomization.Options{
 		Filter:         o.filter,
@@ -726,15 +696,13 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		// Resolve parent KS in priority order:
 		//
 		//   1. renderedSet.ParentOf — most direct; set when the RS
-		//      arrived via emitRenderedChildren (the render-driven
-		//      path that increasingly dominates as the migration
-		//      progresses). No prefix matching needed.
-		//   2. sourceFiles + path-prefix match — covers file-loaded
-		//      RSes (today's typical case).
-		//   3. Name-keyed sourceFile fallback — covers the
-		//      KS-substituted variant whose namespace shifted at
-		//      emit time, identified by sharing a name with a
-		//      file-loaded sibling.
+		//      arrived via emitRenderedChildren. No prefix matching
+		//      needed.
+		//   2. sourceFiles + path-prefix match — file-loaded RSes.
+		//   3. Name-keyed sourceFile fallback — covers a KS-
+		//      substituted variant whose namespace shifted at emit
+		//      time, identified by sharing a name with a file-loaded
+		//      sibling.
 		var parentKS manifest.NamedResource
 		var matched bool
 		if parent, ok := o.rendered.ParentOf(rs.Named()); ok {


### PR DESCRIPTION
## Summary

Fresh-eyes review of the render-driven discovery migration code (#238, #239, #240, #242). Five targeted dedups + comment cleanup. **Net −103 lines** across 9 files. No behavior change.

## Changes

### 1. Extract \`pkg/loader/parse.go\`
\`parseFile\` consolidates the YAML decode + \`ParseDoc\` + RawObject skip + envsubst-template skip pipeline shared by \`Loader.loadFile\` and what was \`promote.parseFileObjects\`. One canonical definition of "what counts as a loadable Flux doc."

### 2. \`Promote\` becomes a method on \`ExistenceIndex\`
\`idx.Promote(store, id, wipe)\` reads cleaner than the free function \`loader.Promote(idx, store, id, wipe)\` and puts the responsibility on the type that owns the index.

### 3. \`newWaiter\` helper on both controllers
Four near-identical \`depwait.Waiter\` constructions (3 in HR, 1 in KS) collapse into \`c.newWaiter(id, timeout)\`. Centralizes the Store/Parent/Timeout/ResolveMissing wiring.

### 4. Unify orphan path-prefix predicate
\`loader.KSPathPrefixes\` + \`loader.LongestParent\` replace both \`orchestrator.detectOrphans\`'s inline parent-list construction AND \`discovery.promoteOrphans\`'s bespoke \`coveredPathPrefixes\`/\`pathUnderAny\`. The two phases (pre-reconcile orphan **promotion** in discovery, post-reconcile orphan **demotion** in orchestrator) now share one predicate so an object can't be classified differently by each. \`promoteOrphans\` switches from absolute-path matching to relative-path matching via \`sourceFiles\`, aligning with \`BuildParentIndex\`.

### 5. Condense migration "step N" comment noise
References to "step 4 of the migration" and "in later migration steps" updated to describe current behavior without the historical landmarks. Git log retains the migration narrative.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118 passed / 0 failed**
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199 passed / 0 failed**
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287 passed / 2 failed** (same pre-existing upstream HTTP 404 as before)
- [x] \`flate test ks --path .\` against \`buroa/k8s-gitops\` — **73 passed / 0 failed**, perf at parity (~0.72s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)