### PR TITLE
chore: round-2 correctness pass (sentinel wrapping + honest failures)

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -103,10 +103,12 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	}
 	cv, err := idx.Get(hr.Chart.Name, hr.Chart.Version)
 	if err != nil {
-		return "", fmt.Errorf("chart %s@%s not found in %s: %w", hr.Chart.Name, hr.Chart.Version, r.URL, err)
+		return "", fmt.Errorf("%w: chart %s@%s not found in %s: %v",
+			manifest.ErrObjectNotFound, hr.Chart.Name, hr.Chart.Version, r.URL, err)
 	}
 	if len(cv.URLs) == 0 {
-		return "", fmt.Errorf("chart %s@%s in %s has no URLs", hr.Chart.Name, hr.Chart.Version, r.URL)
+		return "", fmt.Errorf("%w: chart %s@%s in %s has no URLs",
+			manifest.ErrObjectNotFound, hr.Chart.Name, hr.Chart.Version, r.URL)
 	}
 	chartURL, err := absChartURL(r.URL, cv.URLs[0])
 	if err != nil {
@@ -152,8 +154,11 @@ func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Optio
 	getSec := c.secrets
 	c.mu.RUnlock()
 	if getSec == nil {
-		return nil, fmt.Errorf("HelmRepository %s/%s references secretRef but no SecretGetter is wired",
-			r.Namespace, r.Name)
+		// Use the same sentinel as the "secret not found" path so
+		// --allow-missing-secrets covers both shapes — from the
+		// caller's perspective the dependency is equally unresolved.
+		return nil, fmt.Errorf("%w: HelmRepository %s/%s references secretRef but no SecretGetter is wired",
+			manifest.ErrMissingSecret, r.Namespace, r.Name)
 	}
 	sec := getSec(r.Namespace, r.SecretRef.Name)
 	if sec == nil {
@@ -191,13 +196,13 @@ func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option
 	getSec := c.secrets
 	c.mu.RUnlock()
 	if getSec == nil {
-		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
-			r.Namespace, r.Name)
+		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
+			manifest.ErrMissingSecret, r.Namespace, r.Name)
 	}
 	sec := getSec(r.Namespace, r.CertSecretRef.Name)
 	if sec == nil {
-		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s: cert secret %s/%s not found",
-			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s: cert secret %s/%s not found",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
 	}
 
 	var tmpFiles []string
@@ -245,8 +250,8 @@ func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option
 	}
 	if certPath == "" && keyPath == "" && caPath == "" {
 		cleanup()
-		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
-			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
 	}
 	return []getter.Option{getter.WithTLSClientConfig(certPath, keyPath, caPath)}, cleanup, nil
 }

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"log/slog"
 	"maps"
 	"slices"
 	"sync"
@@ -136,7 +137,16 @@ func (s *Store) fire(event EventKind, id manifest.NamedResource, payload any) {
 }
 
 func safeInvoke(fn Listener, id manifest.NamedResource, payload any) {
-	defer func() { _ = recover() }()
+	defer func() {
+		if r := recover(); r != nil {
+			// A panicking listener silently swallowed the event in
+			// the past — the orchestrator would see a missing
+			// status update with no diagnostic. Log at Error so
+			// a CI run surfaces the panic instead of buried
+			// "FAILED (no status reported)" downstream.
+			slog.Error("store: listener panicked", "id", id.String(), "panic", r)
+		}
+	}()
 	fn(id, payload)
 }
 

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -101,9 +101,16 @@ func DeepMerge(base, override map[string]any) map[string]any {
 // merges them with hr.Values (inline values take precedence per Helm
 // semantics), and writes the result back to hr.Values.
 //
-// Per-reference resolution failures are logged and skipped, matching
-// upstream behavior. Hard errors (kind unknown, missing key in present
-// resource) bubble up.
+// Honors ValuesReference.Optional: missing references on Optional=true
+// refs are skipped silently; missing references on Optional=false (the
+// default) return ErrObjectNotFound so the orchestrator can surface a
+// real failure or honor --allow-missing-secrets. Matches Flux's helm-
+// controller, which fails the reconcile on a missing non-optional
+// valuesFrom but tolerates a missing optional one.
+//
+// Hard errors from the lookup itself — unsupported kind, missing key
+// in a present resource, malformed binaryData — always bubble up; they
+// are unrelated to whether the ref is optional.
 func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 	if hr == nil || len(hr.ValuesFrom) == 0 {
 		return nil
@@ -112,11 +119,17 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 	for _, ref := range hr.ValuesFrom {
 		found, err := lookupValueRef(ref, hr.Namespace, provider)
 		if err != nil {
-			slog.Debug("values: skipped ValuesReference",
-				"id", hr.Named().String(), "ref", ref.Name, "err", err)
-			continue
+			return fmt.Errorf("building HelmRelease %s: %w", hr.NamespacedName(), err)
 		}
 		if found == "" {
+			// Resource missing. lookupValueRef only returns "" when
+			// the underlying CM/Secret was absent AND no TargetPath
+			// short-circuit produced a placeholder; that's the only
+			// case where Optional applies.
+			if !ref.Optional {
+				return fmt.Errorf("%w: HelmRelease %s: valuesFrom %s %s/%s not found",
+					manifest.ErrObjectNotFound, hr.NamespacedName(), ref.Kind, hr.Namespace, ref.Name)
+			}
 			continue
 		}
 		merged, err := updateHelmReleaseValues(ref, found, values)


### PR DESCRIPTION
## Summary

Three targeted fixes surfaced by a multi-agent audit of code **outside** the recent render-driven migration footprint. All low-LOC correctness wins.

### 1. \`pkg/store/events.go\`: log listener panics
\`safeInvoke\` now logs \`slog.Error\` when a listener panics. Previously the \`recover\` swallowed silently, so a buggy listener produced a missing status update and "FAILED (no status reported)" downstream with no diagnostic trail.

### 2. \`pkg/helm/repo.go\`: sentinel wrapping
Every missing-secret and missing-chart error path now wraps the canonical sentinel (\`manifest.ErrMissingSecret\` / \`manifest.ErrObjectNotFound\`) so \`errors.Is\` checks at the orchestrator level catch them. Without this, \`--allow-missing-secrets\` skipped some auth-Secret-missing shapes but not others, and chart-not-found was indistinguishable from a transient network failure to downstream callers.

### 3. \`pkg/values/values.go\`: ExpandValueReferences honors Optional
Previously, **all** missing \`valuesFrom\` references were silently skipped at Debug log level — a typo in a required ref produced an incomplete HR render with no diagnostic. Now non-Optional missing refs return \`ErrObjectNotFound\`; Optional refs continue to silently skip per upstream semantics. Matches the "honest failure" principle from #235.

## Audit findings that were false alarms

- **Filter.Add nil-map crash** (agent A finding #1): \`Add\` short-circuits on \`!Enabled()\` before touching the maps, and \`resolve()\` initializes both when changes != nil. Path is unreachable.
- **OCI temp credential leak on write error** (agent B finding #2): The error paths already inline-remove the temp file (lines 138-145). Not a leak.
- **DeepCopyMap unexport** (agent D finding #6): \`pkg/diff/diff.go:225\` uses it. Keeping exported.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118 passed / 0 failed**
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199 passed / 0 failed**
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287 passed / 2 failed** (same pre-existing upstream HTTP 404)
- [x] \`flate test ks --path .\` against \`buroa/k8s-gitops\` — **73 passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)