### PR TITLE
chore: round-3 polish — complete Clone helpers + coverage gaps

### DIFF
--- a/pkg/loader/existence_test.go
+++ b/pkg/loader/existence_test.go
@@ -118,6 +118,114 @@ data:
 	}
 }
 
+// TestExistenceIndex_PromoteNilReceiverSafe confirms the defensive
+// nil-receiver guard: a nil index promoted against any id should be
+// a no-op false return, not a panic. The orchestrator's
+// resolveMissing closure relies on this when DiscoveryOnly is off
+// and Existence was never initialized.
+func TestExistenceIndex_PromoteNilReceiverSafe(t *testing.T) {
+	var idx *ExistenceIndex
+	id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "x"}
+	if got := idx.Promote(store.New(), id, true); got {
+		t.Errorf("nil index Promote should return false, got true")
+	}
+}
+
+// TestExistenceIndex_PromoteUnknownIDReturnsFalse covers the path
+// where depwait's missing-dep fallback asks for a CM that never
+// reached file-load: existence index has no entry, so Promote bails
+// out cleanly and the depwait surfaces "dependency not found" as
+// intended.
+func TestExistenceIndex_PromoteUnknownIDReturnsFalse(t *testing.T) {
+	idx := NewExistenceIndex()
+	id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "ghost"}
+	if got := idx.Promote(store.New(), id, true); got {
+		t.Errorf("Promote on unknown id should return false, got true")
+	}
+}
+
+// TestExistenceIndex_PromoteFileRemovedBetweenRecordAndPromote
+// exercises the race where the indexed file was deleted (or
+// permission-stripped) between the file walk and the lazy lookup.
+// Promote should fail gracefully (return false), not panic, so the
+// depwait surfaces "dependency not found" instead of crashing the
+// orchestrator.
+func TestExistenceIndex_PromoteFileRemovedBetweenRecordAndPromote(t *testing.T) {
+	dir := t.TempDir()
+	writeExistenceFile(t, dir, "cm.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ephemeral
+  namespace: default
+data:
+  KEY: value
+`)
+	st := store.New()
+	l := New(st)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Remove the file behind the index.
+	if err := os.Remove(filepath.Join(dir, "cm.yaml")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "ephemeral"}
+	if got := l.Existence.Promote(st, id, true); got {
+		t.Errorf("Promote on a removed file should return false, got true")
+	}
+	if st.GetObject(id) != nil {
+		t.Errorf("removed file should not have produced a Store entry")
+	}
+}
+
+// TestExistenceIndex_PromoteMultiDocLoadsSiblings pins the
+// "whole-file parse" contract documented on Promote: a YAML file
+// packing CM + Secret + HR together promotes ALL three when ANY one
+// is requested. This is what allows depwait to avoid re-opening the
+// same file once per dep in the common multi-doc fixture pattern.
+func TestExistenceIndex_PromoteMultiDocLoadsSiblings(t *testing.T) {
+	dir := t.TempDir()
+	writeExistenceFile(t, dir, "bundle.yaml", `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+  namespace: default
+data:
+  KEY: value
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secret
+  namespace: default
+type: Opaque
+data:
+  TOKEN: dG9rZW4=
+`)
+	st := store.New()
+	l := New(st)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "app-config"}
+	secretID := manifest.NamedResource{Kind: manifest.KindSecret, Namespace: "default", Name: "app-secret"}
+	if !l.Existence.Promote(st, cmID, true) {
+		t.Fatalf("Promote(cm) should succeed")
+	}
+	if st.GetObject(cmID) == nil {
+		t.Errorf("CM not in store after Promote")
+	}
+	if st.GetObject(secretID) == nil {
+		t.Errorf("sibling Secret should have been promoted alongside the CM (whole-file parse contract)")
+	}
+}
+
 // TestDiscoveryOnly_SourcesStayFileLoaded pins the regression fix
 // found on JJGadgets/Biohazard: sources (GitRepository,
 // OCIRepository, HelmRepository) must remain in the Store under

--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -131,3 +131,97 @@ func TestBuildParentIndex_NoSourceFileSkipped(t *testing.T) {
 		t.Errorf("KS without source file must not appear in parent index: %v", parents)
 	}
 }
+
+// TestKSPathPrefixes_SortsLongestFirst pins the contract documented
+// on KSPathPrefixes: prefixes come back sorted by length descending
+// so the first HasPrefix match on a given file is the deepest
+// (most-specific) structural parent. Both BuildParentIndex and the
+// orchestrator's detectOrphans rely on this for correctness.
+func TestKSPathPrefixes_SortsLongestFirst(t *testing.T) {
+	s := store.New()
+	root := &manifest.Kustomization{
+		Name: "root", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	mid := &manifest.Kustomization{
+		Name: "mid", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/team-a"},
+	}
+	leaf := &manifest.Kustomization{
+		Name: "leaf", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/team-a/web"},
+	}
+	s.AddObject(root)
+	s.AddObject(mid)
+	s.AddObject(leaf)
+
+	prefixes := KSPathPrefixes(s)
+	if len(prefixes) != 3 {
+		t.Fatalf("expected 3 prefixes, got %d", len(prefixes))
+	}
+	// Longest first: leaf > mid > root.
+	if got := []string{prefixes[0].ID.Name, prefixes[1].ID.Name, prefixes[2].ID.Name}; got[0] != "leaf" || got[1] != "mid" || got[2] != "root" {
+		t.Errorf("expected leaf/mid/root by descending prefix length, got %v", got)
+	}
+}
+
+// TestKSPathPrefixes_SkipsEmptyPath confirms the "ks.Path == ''"
+// guard: a Kustomization without a spec.path (chart-of-charts style,
+// or chained-via-sourceRef-only) doesn't contribute a prefix that
+// would silently swallow files at the repo root.
+func TestKSPathPrefixes_SkipsEmptyPath(t *testing.T) {
+	s := store.New()
+	with := &manifest.Kustomization{
+		Name: "with", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	without := &manifest.Kustomization{Name: "without", Namespace: "flux-system"}
+	s.AddObject(with)
+	s.AddObject(without)
+
+	prefixes := KSPathPrefixes(s)
+	if len(prefixes) != 1 || prefixes[0].ID.Name != "with" {
+		t.Errorf("expected only 'with' in prefixes; got %+v", prefixes)
+	}
+}
+
+// TestLongestParent_SkipsSelf locks the self-exclusion contract:
+// a KS sitting on its own spec.path (rare but possible — a KS whose
+// definition file lives at the same prefix it renders) must not be
+// returned as its own parent.
+func TestLongestParent_SkipsSelf(t *testing.T) {
+	prefixes := []KSPathPrefix{
+		{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "self"}, Prefix: "apps/team-a/"},
+	}
+	self := prefixes[0].ID
+	if _, ok := LongestParent(prefixes, "apps/team-a/ks.yaml", self); ok {
+		t.Errorf("LongestParent must skip self matches")
+	}
+}
+
+// TestLongestParent_DeepestMatchWins exercises the typical case:
+// a file under apps/team-a/web/ should attribute to the deepest
+// covering KS, not the shallower one — which is what
+// KSPathPrefixes's descending-length sort enables. Pins the
+// integration of the two helpers.
+func TestLongestParent_DeepestMatchWins(t *testing.T) {
+	s := store.New()
+	root := &manifest.Kustomization{
+		Name: "root", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	leaf := &manifest.Kustomization{
+		Name: "leaf", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/team-a/web"},
+	}
+	s.AddObject(root)
+	s.AddObject(leaf)
+	prefixes := KSPathPrefixes(s)
+	got, ok := LongestParent(prefixes, "apps/team-a/web/deploy.yaml", manifest.NamedResource{})
+	if !ok {
+		t.Fatalf("expected a parent match")
+	}
+	if got.Name != "leaf" {
+		t.Errorf("expected deepest parent 'leaf', got %q", got.Name)
+	}
+}

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -166,14 +167,19 @@ func (h *HelmRelease) Named() NamedResource {
 }
 
 // Clone returns a copy of h safe for in-place mutation during a single
-// reconcile pass. Deep-copies the maps and slices reconcile writes to
-// (Values, ChartValuesFiles, DependsOn) so the canonical store-owned
-// object is never observed mid-mutation by other goroutines.
+// reconcile pass. Deep-copies every mutable reference field —
+// reconcile bodies, prepare passes, and orchestrator stamping all
+// observe the same canonical store-owned object across goroutines,
+// so a partial clone is a footgun the moment any of those grow a
+// new mutation. Cheap: typical HR has <10 labels/annotations and
+// short DependsOn / ChartValuesFiles.
 func (h *HelmRelease) Clone() *HelmRelease {
 	out := *h
 	out.Values = DeepCopyMap(h.Values)
 	out.ChartValuesFiles = slices.Clone(h.ChartValuesFiles)
 	out.DependsOn = slices.Clone(h.DependsOn)
+	out.Labels = maps.Clone(h.Labels)
+	out.Annotations = maps.Clone(h.Annotations)
 	return &out
 }
 

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -80,13 +80,20 @@ func (k *Kustomization) Named() NamedResource {
 }
 
 // Clone returns a copy of k safe for in-place mutation during a single
-// reconcile pass. Deep-copies the maps reconcile writes to (Contents,
-// PostBuildSubstitute) so the canonical store-owned object is never
-// observed mid-mutation by other goroutines.
+// reconcile pass. Deep-copies every mutable reference field —
+// reconcile bodies, prepare passes, and orchestrator stamping all
+// observe the same canonical store-owned object across goroutines,
+// so a partial clone is a footgun the moment any of those grow a
+// new mutation. Cheap: typical KS has <10 labels/annotations and
+// short DependsOn / PostBuildSubstituteFrom.
 func (k *Kustomization) Clone() *Kustomization {
 	out := *k
 	out.Contents = DeepCopyMap(k.Contents)
 	out.PostBuildSubstitute = maps.Clone(k.PostBuildSubstitute)
+	out.PostBuildSubstituteFrom = slices.Clone(k.PostBuildSubstituteFrom)
+	out.DependsOn = slices.Clone(k.DependsOn)
+	out.Labels = maps.Clone(k.Labels)
+	out.Annotations = maps.Clone(k.Annotations)
 	return &out
 }
 


### PR DESCRIPTION
## Summary

Third multi-agent review pass. Two targeted polish items, both defense-in-depth + test-coverage. No behavior change in normal operation.

### 1. Complete \`Clone()\` helpers

\`pkg/manifest/{helmrelease,kustomization}.go\`: \`Clone()\` now deep-copies **every** mutable reference field — Labels, Annotations, and any previously-missed slice/map field. The store immutability contract documented in \`doc.go\` requires Clone() to produce an independently-mutable copy; previously only the fields a current controller body mutates were deep-copied, leaving Labels/Annotations as a footgun the moment a future change starts stamping them. No active mutation site exists today (verified via grep), so this is defense-in-depth. Cost is negligible: typical HR/KS carries <10 labels/annotations.

### 2. Coverage gaps in render-driven discovery code

\`pkg/loader/{existence,parent}_test.go\` backfills the gaps the audit flagged:

- \`ExistenceIndex.Promote\` on nil receiver (defensive guard path)
- \`Promote\` on an unknown id (depwait surfaces "dependency not found")
- \`Promote\` when the indexed file was deleted between Record and lookup (graceful failure, not a panic)
- \`Promote\` pulls in sibling docs from a multi-doc file (the whole-file-parse contract documented on \`Promote\`)
- \`KSPathPrefixes\` direct: longest-first sort, empty-path skip
- \`LongestParent\`: self-exclusion + deepest-match-wins

## Audit findings that were non-issues

- **SOPS-Secret valuesFrom wipe** (kustomize/helm agent): The CLI hardcodes \`WipeSecrets=true\` (\`internal/cli/common.go:179\`) and \`updateHelmReleaseValues\` already detects wiped placeholders (\`pkg/values/values.go:245-247\`). Library embedders who explicitly set \`WipeSecrets=false\` are signaling they own the consequences.
- **HTTP redirect error opacity in preflight** (kustomize agent): Go's \`http.Client\` follows redirects transparently; the final 4xx/5xx is what surfaces. Not an actual silent failure.
- **Empty kustomize ResMap silent drop** (kustomize agent): Real Flux behavior is the same — an empty render is a valid render. Matching upstream.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118/0**
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199/0**
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287/2** (same pre-existing upstream HTTP 404)
- [x] \`flate test ks --path .\` against \`buroa/k8s-gitops\` — **73/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)