### PR TITLE
chore: round-4 hardening — version stamp + HTTP cap + path-traversal guard

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,10 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w
+      # -X main.version stamps the tag into cmd/flate's `version` var
+      # so `flate --version` reports the release tag instead of
+      # debug.ReadBuildInfo's "(devel)" fallback.
+      - -s -w -X main.version={{ .Version }}
     goos:
       - linux
       - windows

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -21,6 +21,13 @@ import (
 // in seconds, not minutes.
 const remoteFetchTimeout = 5 * time.Second
 
+// remoteFetchMaxBytes caps each pre-flight response body. A
+// kustomization resource is almost always under a megabyte of YAML;
+// 64 MiB is several orders of magnitude of headroom that still
+// bounds the OOM blast radius from a malicious or accidentally-huge
+// URL endpoint.
+const remoteFetchMaxBytes = 64 << 20 // 64 MiB
+
 // remoteFetchClient is the package-level client used by the
 // pre-flight pass. Distinct from the helm/oci clients so resource-
 // fetch latency stays observable.
@@ -158,7 +165,18 @@ func httpGetURL(ctx context.Context, urlStr string) ([]byte, error) {
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
-	return io.ReadAll(resp.Body)
+	// Cap with LimitReader +1 so we can detect overflow precisely:
+	// read up to remoteFetchMaxBytes+1, and if we actually got
+	// MaxBytes+1 bytes the body is larger than the cap and we fail
+	// fast instead of OOMing on an attacker-controlled endpoint.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, remoteFetchMaxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > remoteFetchMaxBytes {
+		return nil, fmt.Errorf("response body exceeds %d-byte cap", remoteFetchMaxBytes)
+	}
+	return body, nil
 }
 
 func urlHash(s string) string {

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -235,3 +235,43 @@ func newPreflightCache(t *testing.T) *StagingCache {
 	t.Cleanup(func() { _ = c.Close() })
 	return c
 }
+
+// TestHttpGetURL_RejectsOversizedBody pins the round-4 OOM
+// guard: a malicious or accidentally-huge endpoint returning more
+// than remoteFetchMaxBytes must fail fast rather than reading the
+// whole body into memory. Reads MaxBytes+1 via LimitReader and
+// errors on overflow.
+func TestHttpGetURL_RejectsOversizedBody(t *testing.T) {
+	huge := strings.Repeat("a", remoteFetchMaxBytes+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(huge))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := httpGetURL(context.Background(), srv.URL+"/big.yaml")
+	if err == nil {
+		t.Fatalf("expected oversized-body error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected 'exceeds ... cap' error, got %q", err.Error())
+	}
+}
+
+// TestHttpGetURL_AcceptsBodyAtCap is the boundary check: a body
+// exactly at the cap must succeed. Guards against off-by-one in the
+// LimitReader+overflow-detection pattern.
+func TestHttpGetURL_AcceptsBodyAtCap(t *testing.T) {
+	atCap := strings.Repeat("b", remoteFetchMaxBytes)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(atCap))
+	}))
+	t.Cleanup(srv.Close)
+
+	body, err := httpGetURL(context.Background(), srv.URL+"/atcap.yaml")
+	if err != nil {
+		t.Fatalf("body exactly at cap should succeed, got: %v", err)
+	}
+	if len(body) != remoteFetchMaxBytes {
+		t.Errorf("expected %d bytes, got %d", remoteFetchMaxBytes, len(body))
+	}
+}

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -154,7 +154,11 @@ func stripFileEntryKey(s string) string {
 // resolveDataPath joins rel against base and cleans the result. An
 // empty rel is rejected (kustomize would reject it too). Absolute
 // paths pass through verbatim — kustomize doesn't forbid them and
-// some generated manifests use them.
+// some generated manifests use them. Relative paths that escape
+// base via `..` are rejected: the resolved key is only consulted
+// against tree-walk paths today (no escape can match a walked path
+// rooted at --path), but a future caller that opens the path would
+// otherwise hit a TOCTOU + path-traversal surface for free.
 func resolveDataPath(base, rel string) (string, bool) {
 	if rel == "" {
 		return "", false
@@ -162,7 +166,12 @@ func resolveDataPath(base, rel string) (string, bool) {
 	if filepath.IsAbs(rel) {
 		return filepath.Clean(rel), true
 	}
-	return filepath.Clean(filepath.Join(base, rel)), true
+	abs := filepath.Clean(filepath.Join(base, rel))
+	cleanBase := filepath.Clean(base) + string(filepath.Separator)
+	if abs != filepath.Clean(base) && !strings.HasPrefix(abs+string(filepath.Separator), cleanBase) {
+		return "", false
+	}
+	return abs, true
 }
 
 // isKustomizationFileName reports whether name matches one of the

--- a/pkg/loader/kustomization_test.go
+++ b/pkg/loader/kustomization_test.go
@@ -1,0 +1,60 @@
+package loader
+
+import "testing"
+
+// TestResolveDataPath_RelativeUnderBase covers the happy path: a
+// generator file path that stays under the kustomization directory
+// resolves to its absolute equivalent.
+func TestResolveDataPath_RelativeUnderBase(t *testing.T) {
+	abs, ok := resolveDataPath("/tmp/cluster/apps/foo", "data/values.yaml")
+	if !ok {
+		t.Fatalf("expected resolve to succeed for in-tree relative path")
+	}
+	if abs != "/tmp/cluster/apps/foo/data/values.yaml" {
+		t.Errorf("unexpected resolution: %s", abs)
+	}
+}
+
+// TestResolveDataPath_RejectsTraversal locks the defense-in-depth
+// guard added after the round-4 audit: a kustomization.yaml that
+// declares `files: ["../../../etc/passwd"]` must NOT escape the
+// kustomization directory. The resolved key is consulted against
+// tree-walk paths today (no escape can match a walked path rooted
+// at --path), but a future caller that opens the path would hit a
+// path-traversal surface for free without this guard.
+func TestResolveDataPath_RejectsTraversal(t *testing.T) {
+	cases := []string{
+		"../escape.yaml",
+		"../../etc/passwd",
+		"sub/../../escape",
+	}
+	for _, rel := range cases {
+		if _, ok := resolveDataPath("/tmp/cluster/apps/foo", rel); ok {
+			t.Errorf("rel %q should have been rejected as escaping base", rel)
+		}
+	}
+}
+
+// TestResolveDataPath_AbsolutePathPassesThrough confirms the
+// documented exception: kustomize accepts absolute paths for
+// generator files, so we pass them verbatim (after Clean). The
+// loader's downstream "is this under --path?" check still applies
+// at walk time; resolveDataPath isn't responsible for absolute-path
+// containment.
+func TestResolveDataPath_AbsolutePathPassesThrough(t *testing.T) {
+	abs, ok := resolveDataPath("/tmp/cluster/apps", "/etc/values.yaml")
+	if !ok {
+		t.Fatalf("expected absolute path to resolve")
+	}
+	if abs != "/etc/values.yaml" {
+		t.Errorf("absolute path should pass through verbatim; got %s", abs)
+	}
+}
+
+// TestResolveDataPath_EmptyRejected guards the explicit empty-rel
+// check — kustomize would reject an empty entry too.
+func TestResolveDataPath_EmptyRejected(t *testing.T) {
+	if _, ok := resolveDataPath("/tmp/cluster/apps", ""); ok {
+		t.Errorf("empty rel should be rejected")
+	}
+}


### PR DESCRIPTION
## Summary

Fourth multi-agent review pass. Three targeted hardening fixes — two correctness wins (one user-visible), one defense-in-depth.

### 1. \`.goreleaser.yaml\`: stamp version into release ldflags
\`cmd/flate/main.go\` has had a \`var version = "dev"\` placeholder waiting for goreleaser to set it via \`-ldflags -X main.version=...\`. Without that flag, \`flate --version\` on a release binary fell through to \`debug.ReadBuildInfo\`'s \`(devel)\` fallback. \`-trimpath\` strips VCS info that would otherwise stand in. **User-visible: \`flate --version\` will now report the actual release tag.**

### 2. \`pkg/kustomize/preflight.go\`: cap remote-resource HTTP bodies
The pre-flight pass fetches user-declared kustomize URLs via Go HTTP to avoid the SDK's git binary fallback. A malicious or accidentally-huge endpoint returning gigabytes would OOM the renderer. Now wrapped with \`io.LimitReader(body, 64MiB+1)\` so we detect overflow precisely and surface a clear \`"exceeds N-byte cap"\` error.

### 3. \`pkg/loader/kustomization.go\`: resolveDataPath traversal guard
\`resolveDataPath\` now rejects relative paths that escape the kustomization directory via \`..\`. The resolved key is consulted against tree-walk paths today (no escape can match a walked path rooted at \`--path\`), so this is defense-in-depth — future callers that open the path get path-traversal containment for free.

## Audit findings that were non-issues

- **depwait goroutine leak** (concurrency agent): Verified — \`out\` is buffered to \`len(deps)\`, every goroutine sends exactly once via \`safeWatchOne\` (which catches panics via named return), \`defer wg.Done()\` runs in all cases, closer waits for \`wg.Wait()\` before closing. No leak path.
- **keylock release-loss starvation** (concurrency agent): Generic mutex-API critique, not an actual bug. All 4 callers use canonical \`defer release()\` pattern. \`Acquire\` already honors ctx via select.
- **Listener replay race** (concurrency agent CRITICAL): \`AddListener\` snapshot is built under RLock; dispatch happens within the same RLock window. Verified safe.
- **Empty kustomize ResMap silent drop** (earlier pass): Matches upstream Flux semantics — an empty render is a valid render.
- **Lint config gaps** (CI agent): Subjective; deferred — \`errorlint\`/\`ineffassign\`/\`shadow\` would add noise without catching active bugs.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green (incl. 5 new tests: 4 \`resolveDataPath\` + 2 \`httpGetURL\` body-cap)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118/0**
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199/0**
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287/2** (same pre-existing upstream HTTP 404)
- [x] \`flate test ks --path .\` against \`buroa/k8s-gitops\` — **73/0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)