### PR TITLE
fix(discovery): alias in-tree GitRepository whose URL matches working tree

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -462,6 +462,48 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 			"id", id.String(), "localPath", repoRoot)
 		aliased = append(aliased, id)
 	}
+
+	// Second pass: a GitRepository CR may be file-loaded AND point
+	// at the same remote that flate is being run against (the
+	// Zariel/home-ops pattern — the in-tree GitRepository URL is
+	// the cluster's own deploy-key SSH URL). Real Flux fetches that
+	// URL with a SOPS-decrypted key; flate runs offline, so the
+	// fetch either round-trips slowly over the network or fails on
+	// the wiped-to-placeholder key. URL-match those against the
+	// working tree's git remotes and override the artifact to use
+	// the working tree directly. Single explicit warn when this
+	// fires so misattributed in-tree GitRepositories (a coincidental
+	// URL match on a real shared-infra repo) are spottable in logs.
+	remotes := readWorkingTreeRemotes(repoRoot)
+	debugLogRemotes(remotes)
+	if len(remotes) > 0 {
+		for _, obj := range d.cfg.Store.ListObjects(manifest.KindGitRepository) {
+			repo, ok := obj.(*manifest.GitRepository)
+			if !ok {
+				continue
+			}
+			id := repo.Named()
+			if _, alreadyAliased := seen[id]; alreadyAliased {
+				continue
+			}
+			normalized := normalizeGitURL(repo.URL)
+			if normalized == "" {
+				continue
+			}
+			if _, match := remotes[normalized]; !match {
+				continue
+			}
+			seen[id] = struct{}{}
+			d.cfg.Store.SetArtifact(id, &store.SourceArtifact{
+				Kind: manifest.KindGitRepository,
+				URL:  "file://" + repoRoot, LocalPath: repoRoot,
+			})
+			d.cfg.Store.UpdateStatus(id, store.StatusReady, "bootstrap alias (URL matches working tree)")
+			slog.Info("discovery: aliased in-tree GitRepository to working tree (URL matches working-tree remote)",
+				"id", id.String(), "url", repo.URL, "localPath", repoRoot)
+			aliased = append(aliased, id)
+		}
+	}
 	// Multiple unresolved GitRepositories is the cross-repo footgun:
 	// each gets aliased to the SAME working tree, so a real upstream
 	// shared-infra GitRepository would render against the wrong files

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -1,0 +1,107 @@
+package discovery
+
+import (
+	"log/slog"
+	"strings"
+
+	gogit "github.com/go-git/go-git/v5"
+)
+
+// readWorkingTreeRemotes returns the set of remote URLs configured on
+// the git repository at repoRoot, normalized for comparison against
+// Flux GitRepository.spec.url. Returns nil if repoRoot is not a git
+// repo or no remotes are configured.
+//
+// Consumed by aliasBootstrapSources to recognize a file-loaded
+// GitRepository whose URL points at the SAME repo the user is
+// running flate against — in those cases the SSH/HTTPS fetch would
+// either round-trip to a real host (slow, offline-unfriendly) or
+// fail due to SOPS-wiped credentials. Aliasing the GitRepository to
+// the working tree avoids both pitfalls.
+func readWorkingTreeRemotes(repoRoot string) map[string]struct{} {
+	repo, err := gogit.PlainOpen(repoRoot)
+	if err != nil {
+		return nil
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil
+	}
+	out := map[string]struct{}{}
+	for _, remote := range cfg.Remotes {
+		for _, url := range remote.URLs {
+			if n := normalizeGitURL(url); n != "" {
+				out[n] = struct{}{}
+			}
+		}
+	}
+	return out
+}
+
+// normalizeGitURL reduces git URL variants to a canonical
+// host/owner/repo key suitable for cross-syntax equality. Strips
+// scheme, leading user@, port, trailing .git, and lowercases the
+// result (GitHub/GitLab paths are case-insensitive in practice).
+//
+// Examples normalize to "github.com/owner/repo":
+//
+//	ssh://git@github.com/Owner/Repo.git
+//	git@github.com:owner/repo.git
+//	https://github.com/owner/repo
+//	https://user:pass@github.com/owner/repo.git
+//
+// Returns "" for inputs that don't look like a remote URL (e.g.
+// file:// or local paths) — those shouldn't participate in
+// bootstrap-alias matching.
+func normalizeGitURL(url string) string {
+	u := strings.TrimSpace(url)
+	if u == "" {
+		return ""
+	}
+	// scp-style: git@host:owner/repo — convert to a uniform shape
+	// before stripping scheme.
+	if !strings.Contains(u, "://") {
+		if at := strings.Index(u, "@"); at >= 0 {
+			if colon := strings.Index(u[at+1:], ":"); colon >= 0 {
+				u = u[at+1:colon+at+1] + "/" + u[at+1+colon+1:]
+			}
+		} else {
+			// Local path or other non-remote shape — skip.
+			return ""
+		}
+	} else {
+		u = u[strings.Index(u, "://")+3:]
+		// Strip optional userinfo (user[:pass]@).
+		if at := strings.Index(u, "@"); at >= 0 && at < strings.IndexByte(u+"/", '/') {
+			u = u[at+1:]
+		}
+		// Strip port (host:1234/...).
+		if slash := strings.IndexByte(u, '/'); slash > 0 {
+			host := u[:slash]
+			if colon := strings.Index(host, ":"); colon >= 0 {
+				u = host[:colon] + u[slash:]
+			}
+		}
+	}
+	// Discard file:// and other non-remote schemes that may have
+	// slipped past the scheme check.
+	if strings.HasPrefix(u, "/") {
+		return ""
+	}
+	u = strings.TrimSuffix(u, "/")
+	u = strings.TrimSuffix(u, ".git")
+	return strings.ToLower(u)
+}
+
+// debugLogRemotes is a small helper to keep the discovery flow log
+// readable when working-tree remote inspection is requested.
+func debugLogRemotes(remotes map[string]struct{}) {
+	if len(remotes) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(remotes))
+	for k := range remotes {
+		keys = append(keys, k)
+	}
+	slog.Debug("discovery: working tree remotes", "count", len(keys), "remotes", keys)
+}

--- a/pkg/discovery/remotes_test.go
+++ b/pkg/discovery/remotes_test.go
@@ -1,0 +1,57 @@
+package discovery
+
+import "testing"
+
+// TestNormalizeGitURL_CanonicalForms exercises every URL shape the
+// bootstrap-alias URL-match heuristic needs to recognize as the same
+// remote. All four inputs below describe the same GitHub repository
+// in different syntaxes; they must collapse to one key so a file-
+// loaded GitRepository.spec.url written in any of them matches the
+// working tree's `.git/config` regardless of style.
+func TestNormalizeGitURL_CanonicalForms(t *testing.T) {
+	want := "github.com/owner/repo"
+	cases := []string{
+		"ssh://git@github.com/Owner/Repo.git",
+		"git@github.com:owner/repo.git",
+		"https://github.com/owner/repo",
+		"https://user:pass@github.com/owner/repo.git",
+		"https://github.com:443/owner/repo",
+	}
+	for _, in := range cases {
+		if got := normalizeGitURL(in); got != want {
+			t.Errorf("normalizeGitURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestNormalizeGitURL_RejectsNonRemoteShapes locks the negative
+// contract: file:// URLs and local paths are not remote sources and
+// must not participate in URL-match aliasing — otherwise a working
+// tree containing its own file://-aliased GitRepository would alias
+// against itself recursively.
+func TestNormalizeGitURL_RejectsNonRemoteShapes(t *testing.T) {
+	cases := []string{
+		"",
+		"file:///tmp/repo",
+		"/tmp/repo",
+		"./repo",
+	}
+	for _, in := range cases {
+		if got := normalizeGitURL(in); got != "" {
+			t.Errorf("normalizeGitURL(%q) should be rejected; got %q", in, got)
+		}
+	}
+}
+
+// TestNormalizeGitURL_TrailingSlashAndDotGit_NormalizeIdentically
+// guards the cosmetic-differences vector. A GitRepository.spec.url
+// might be written with or without trailing `.git` or `/`; the local
+// `.git/config` typically omits the trailing slash but keeps `.git`.
+// Both must reduce to the same key.
+func TestNormalizeGitURL_TrailingSlashAndDotGit(t *testing.T) {
+	a := normalizeGitURL("https://github.com/owner/repo.git/")
+	b := normalizeGitURL("https://github.com/owner/repo")
+	if a != b {
+		t.Errorf("trailing .git/slash should normalize identically: %q vs %q", a, b)
+	}
+}

--- a/pkg/orchestrator/rendered.go
+++ b/pkg/orchestrator/rendered.go
@@ -39,7 +39,19 @@ func newRenderedSet() *renderedSet {
 // linkage replaces the previous file-path prefix-match used by
 // loader.BuildParentIndexForKind — render-emitted children have no
 // source file, but they DO have a known parent.
+//
+// Self-edges are dropped: a KS whose spec.path covers its own
+// definition file (the Zariel/home-ops pattern — cluster KS at
+// ./k8s/flux/config/cluster.yaml with spec.path ./k8s/flux/) emits
+// itself during render. Without this guard, ParentOf(cluster) would
+// return cluster, the parent-gate would depwait on the KS itself,
+// and reconcile would time out. The file-loaded path-prefix index
+// already excludes self in loader.LongestParent; renderedSet mirrors
+// that contract.
 func (r *renderedSet) MarkRendered(parent, child manifest.NamedResource) {
+	if parent == child {
+		return
+	}
 	r.mu.Lock()
 	r.parents[child] = parent
 	r.mu.Unlock()


### PR DESCRIPTION
## Summary

Two fixes for the Zariel/home-ops pattern surfaced when testing real-world repos:

### 1. URL-match bootstrap alias

\`pkg/discovery/{remotes,discovery}.go\`: \`aliasBootstrapSources\` now also overrides **file-loaded** GitRepositories whose \`spec.url\` normalizes to the same remote as the working tree's \`.git/config\`. Real Flux uses these to deliver the cluster's own repo via SSH with a SOPS-decrypted deploy key; flate runs offline and can't materialize the SSH key, so the fetch fails on the wiped-to-placeholder credential and the failure cascades to every dependent KS.

URL-match aliasing routes the source straight to the working tree like the existing \`flux bootstrap\` pattern. Logs an INFO when this fires so a coincidental URL match (e.g. a shared-infra GitRepository that genuinely needs network fetch) is spottable.

\`normalizeGitURL\` handles every common remote URL shape — \`ssh://\`, scp-style \`git@host:owner/repo\`, \`https://\` with optional userinfo+port, trailing \`.git\`/slash — all collapse to one key.

### 2. MarkRendered drops self-edges

\`pkg/orchestrator/rendered.go\`: a KS whose \`spec.path\` covers its own definition file (the \`cluster\` KS at \`./k8s/flux/config/cluster.yaml\` with \`spec.path: ./k8s/flux/\`) emits itself during render. Without this guard, \`ParentOf(cluster)\` returned cluster, the parent-gate depwait'd on the KS itself, and reconcile timed out. The file-loaded path-prefix index already excludes self in \`loader.LongestParent\`; renderedSet now mirrors that contract.

## Test plan

- [x] Zariel/home-ops             — **93/0 ks**, **45/0 hr**, 107 images
- [x] tholinka/home-ops           — 118/0 (unchanged)
- [x] JJGadgets/Biohazard         — 199/0 (unchanged)
- [x] m00nwtchr/homelab-cluster   — 287/2 (unchanged, same upstream 404)
- [x] buroa/k8s-gitops            — 73/0 (unchanged)
- [x] \`go test -count=1 ./...\` — full suite green (3 new unit tests in remotes_test.go)
- [x] \`golangci-lint run ./...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)