### PR TITLE
feat(cli): add `flate diff all` for combined KS + HR diff

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -386,6 +386,9 @@ func TestBindHelmFlags_OnHRSubcommandOnly(t *testing.T) {
 		{argv: []string{"build", "ks"}, wantHelmFlag: false},
 		{argv: []string{"build", "hr"}, wantHelmFlag: true},
 		{argv: []string{"build", "all"}, wantHelmFlag: true},
+		{argv: []string{"diff", "ks"}, wantHelmFlag: false},
+		{argv: []string{"diff", "hr"}, wantHelmFlag: true},
+		{argv: []string{"diff", "all"}, wantHelmFlag: true},
 	}
 	for _, tc := range cases {
 		sub, _, err := cmd.Find(tc.argv)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -16,6 +16,8 @@ func newDiffCmd() *cobra.Command {
 		Short: "Diff rendered output against a previous revision",
 	}
 	cmd.AddCommand(
+		diffCmd("all", nil,
+			"Diff every Kustomization and HelmRelease against another path", ""),
 		diffCmd("ks [name]", []string{"kustomization", "kustomizations"},
 			"Diff Kustomizations against another path", manifest.KindKustomization),
 		diffCmd("hr [name]", []string{"helmrelease", "helmreleases"},
@@ -48,17 +50,26 @@ func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
 	d := &diffFlags{}
+	// `diff all` has no name filter — it's the catch-all combined
+	// view, accepts no positional args. Per-kind variants accept an
+	// optional single name positional to scope the diff.
+	maxArgs := 1
+	if kind == "" {
+		maxArgs = 0
+	}
 	cmd := &cobra.Command{
 		Use:     use,
 		Aliases: aliases,
 		Short:   short,
-		Args:    cobra.MaximumNArgs(1),
+		Args:    cobra.MaximumNArgs(maxArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDiff(cmd, c, h, d, kind, firstArg(args))
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	if rendersHelm([]string{kind}) {
+	// `diff all` renders HRs as part of its scope, so always bind
+	// helm flags (matches `build all` / `test all` / `get all`).
+	if kind == "" || rendersHelm([]string{kind}) {
 		bindHelmFlags(cmd.Flags(), h)
 	}
 	bindDiffFlags(cmd, d)
@@ -141,8 +152,8 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 	if orig.O == nil || current.O == nil {
 		return runErr
 	}
-	origDocs := gatherArtifacts(orig.O, orig.Res, kind, name, c)
-	currentDocs := gatherArtifacts(current.O, current.Res, kind, name, c)
+	origDocs := gatherAllArtifacts(orig.O, orig.Res, kind, name, c)
+	currentDocs := gatherAllArtifacts(current.O, current.Res, kind, name, c)
 
 	outFormat := c.output
 	if outFormat == "table" {

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -174,6 +174,19 @@ func joinRunErrors(orig, curr error) error {
 // Reads res.Manifests for the rendered docs; falls back to the Store
 // only to recover the producing object's spec.path (the diff header
 // shows it for KS parents).
+// gatherAllArtifacts is gatherArtifacts with a kind="" shortcut for
+// the `diff all` command: when kind is empty, collect both
+// Kustomization- and HelmRelease-rendered manifests in one pass.
+// Each kind's docs are gathered separately so the diff header
+// attribution (parent KS vs parent HR) stays accurate.
+func gatherAllArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
+	if kind != "" {
+		return gatherArtifacts(o, res, kind, name, c)
+	}
+	out := gatherArtifacts(o, res, manifest.KindKustomization, name, c)
+	return append(out, gatherArtifacts(o, res, manifest.KindHelmRelease, name, c)...)
+}
+
 func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
 	var out []diff.Doc
 	// Defensive re-drop of --skip-secrets / --skip-crds / --skip-kinds.


### PR DESCRIPTION
## Summary

\`test\`, \`build\`, and \`get\` all expose an \`all\` subcommand; \`diff\` didn't. PR-review workflow naturally wants "show me everything that changed" — without \`diff all\`, users had to run \`diff ks\` and \`diff hr\` separately and reconcile two outputs.

\`diff all\` aggregates both Kustomization- and HelmRelease-rendered manifests in one diff session. Helm flags are bound on \`diff all\` since its scope includes HRs — matches the existing \`build all\` / \`test all\` shape. \`diff all\` accepts no positional args (no name filter); the per-kind variants keep their existing single-name positional.

## Implementation

- \`internal/cli/diff.go\`: register \`diffCmd("all", nil, ..., "")\` with empty kind.
- \`internal/cli/helpers.go\`: new \`gatherAllArtifacts\` short-circuits on \`kind == ""\` by calling the existing per-kind gatherer twice. Header attribution (\`Kustomization: ns/name\` vs \`HelmRelease: ns/name\`) stays accurate because each call passes the real kind through.
- \`bindHelmFlags\` now fires for any kind in {"", KindHelmRelease} so \`diff all\` carries \`--kube-version\` / \`--api-versions\` / \`--show-only\` like \`build all\`.

## Verified

On Zariel/home-ops: a single-line patch to the top-level cluster Kustomization's \`retries\` value propagates via render-driven discovery to **138 attribution headers** in one \`diff all\` invocation (covering both KSes and the 45 HRs whose specs get the parent's injected \`upgrade.remediation.retries\`).

- [x] \`go test -count=1 ./...\` — full suite green (TestBindHelmFlags extended with diff variants)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against \`Zariel/home-ops\` — **93/0** (unchanged)
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118/0** (unchanged)
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199/0** (unchanged)
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287/2** (unchanged)
- [x] \`flate test ks --path .\` against \`buroa/k8s-gitops\` — **73/0** (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)