### PR TITLE
fix(controllers/helmrelease): refresh HR after dependsOn wait

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -195,6 +195,19 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 				Reasons: sum.Messages,
 			}
 		}
+		// Re-read the HR after the dependsOn wait: while we were
+		// yielding our slot, the parent KS could have re-rendered
+		// (e.g. its own dependsOn cleared in the meantime, freeing
+		// up parent-render-time substitutions that mutate our
+		// spec). Without this refresh, an HR with explicit
+		// spec.dependsOn but no structural parent — or one whose
+		// parent re-emitted us after the parent-gate cleared —
+		// keeps the pre-mutation snapshot through chart
+		// resolution. Mirrors the KS controller's single
+		// refresh after its combined dep wait.
+		if obj, ok := c.Store.GetObject(id).(*manifest.HelmRelease); ok {
+			hr = obj
+		}
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")


### PR DESCRIPTION
## Summary

A top-down architectural review compared controller symmetry across KS, HR, and source. The Kustomization controller folds parent gate + dependsOn into a single combined wait and refreshes once at the end (\`kustomization/controller.go:178\`). The HR controller splits them into a parent gate followed by an explicit dependsOn wait, but only refreshes the \`hr\` variable after the parent gate — leaving the rest of reconcile (chart resolution, values expansion, helm render) running against a stale snapshot if the parent KS re-emitted us during the dependsOn wait.

## The race

While an HR is \`YieldSlot\`'d waiting on an HR-to-HR dependency:
1. Parent KS's own dependencies can clear
2. Parent re-renders with newly-available substitutions or replacements
3. Parent re-\`AddObject\`s us with mutated spec
4. Our local \`hr\` variable still points at the pre-render snapshot we were dispatched with
5. Chart resolution + values expansion + helm render run against stale spec

## Fix

Symmetric to the KS controller: re-read the object from the Store after the dependsOn wait clears. Mirrors the existing refresh that already runs after the parent gate; matches the established Store immutability contract.

## Architectural review outcome

The full top-down review (4 parallel agents across package boundaries, big-file split candidates, controller symmetry, interface debt) produced **exactly one** actionable finding — this HR refresh fix. Other candidates that surfaced and were verified-and-rejected:

- **Unify \`ObjectLister\`** — agent claimed redundancy, but \`values.ObjectLister\` and \`change.ObjectLister\` have different method sets (\`GetByName\` vs \`GetObject + ListObjects\`) tailored to each consumer per Go convention.
- **Delete \`Artifact\` marker** — used as parameter/return type in \`Store.SetArtifact\` / \`GetArtifact\`; removing weakens compile-time type discipline.
- **Replace \`Suspendable\`** — 4 implementations (Bucket, GitRepository, OCIRepository, ExternalArtifact), real polymorphism.
- **Source fetcher registry** — marginal architectural improvement; orchestrator IS the legitimate wiring layer.
- **\`Options\` renaming consistency** — package qualifier disambiguates; rename risks SDK consumer breakage for no real win.
- **\`ExistenceIndex\` to discovery** — moderate refactor cost (callback or exported parseFile) for marginal semantic improvement.
- **God-file splits** — 8 of 9 big files (orchestrator 815 LOC, discovery 576 LOC, etc.) are coherent at current size; the cosmetic split candidates (KS/HR controller fingerprint extraction) are pure stylistic moves.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against \`Zariel/home-ops\` — **93/0**
- [x] \`flate test ks --path .\` against \`tholinka/home-ops\` — **118/0**
- [x] \`flate test ks --path .\` against \`JJGadgets/Biohazard\` — **199/0**
- [x] \`flate test ks --path .\` against \`m00nwtchr/homelab-cluster\` — **287/2** (pre-existing upstream 404)
- [x] \`flate test ks --path .\` against \`buroa/k8s-gitops\` — **73/0**

No repo today exhibits the race (parent KSes typically run before HR dependsOn clears), so no test-repo numbers shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)