### PR TITLE
refactor(store): typed Get[T] + ListAs[T] generic helpers

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // firstArg returns the first positional arg, or "" when none was given.
@@ -210,7 +211,7 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 			continue
 		}
 		parent := diff.Parent{Kind: id.Kind, Namespace: id.Namespace, Name: id.Name}
-		if ks, ok := o.Store().GetObject(id).(*manifest.Kustomization); ok {
+		if ks, ok := store.Get[*manifest.Kustomization](o.Store(), id); ok {
 			parent.Path = strings.TrimPrefix(ks.Path, "./")
 		}
 		for _, m := range manifest.DropKinds(docs, skip) {

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		// with a patched copy; re-read so the rest of reconcile uses
 		// the canonical spec instead of the pre-patch snapshot we
 		// were dispatched with.
-		if obj, ok := c.Store.GetObject(id).(*manifest.HelmRelease); ok {
+		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
 			hr = obj
 		}
 	}
@@ -201,7 +201,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		// keeps the pre-mutation snapshot through chart
 		// resolution. Mirrors the KS controller's single
 		// refresh after its combined dep wait.
-		if obj, ok := c.Store.GetObject(id).(*manifest.HelmRelease); ok {
+		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
 			hr = obj
 		}
 	}

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -169,7 +169,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// re-read the first render would use the stale-spec snapshot
 		// captured by RunWithStatus, producing duplicate renders that
 		// linger in the store with the wrong namespace. See #102.
-		if fresh, ok := c.Store.GetObject(id).(*manifest.Kustomization); ok {
+		if fresh, ok := store.Get[*manifest.Kustomization](c.Store, id); ok {
 			ks = fresh
 		}
 	}

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -57,9 +57,8 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 	}
 	seen := make(map[manifest.NamedResource]struct{})
 	var aliased []manifest.NamedResource
-	for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.SourceKind != manifest.KindGitRepository {
+	for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
+		if ks.SourceKind != manifest.KindGitRepository {
 			continue
 		}
 		id := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: ks.SourceNamespace, Name: ks.SourceName}
@@ -99,11 +98,7 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 	remotes := readWorkingTreeRemotes(repoRoot)
 	debugLogRemotes(remotes)
 	if len(remotes) > 0 {
-		for _, obj := range d.cfg.Store.ListObjects(manifest.KindGitRepository) {
-			repo, ok := obj.(*manifest.GitRepository)
-			if !ok {
-				continue
-			}
+		for _, repo := range store.ListAs[*manifest.GitRepository](d.cfg.Store, manifest.KindGitRepository) {
 			id := repo.Named()
 			if _, alreadyAliased := seen[id]; alreadyAliased {
 				continue

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -191,11 +191,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	ksExpanded := map[manifest.NamedResource]struct{}{}
 	for {
 		added := 0
-		for _, obj := range d.cfg.Store.ListObjects(manifest.KindKustomization) {
-			ks, ok := obj.(*manifest.Kustomization)
-			if !ok {
-				continue
-			}
+		for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
 			id := ks.Named()
 			if _, seen := ksExpanded[id]; seen {
 				continue
@@ -217,11 +213,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			}
 			added++
 		}
-		for _, obj := range d.cfg.Store.ListObjects(manifest.KindResourceSet) {
-			rs, ok := obj.(*manifest.ResourceSet)
-			if !ok {
-				continue
-			}
+		for _, rs := range store.ListAs[*manifest.ResourceSet](d.cfg.Store, manifest.KindResourceSet) {
 			n, err := d.renderResourceSet(rs)
 			if err != nil {
 				return err

--- a/pkg/discovery/rsexpand.go
+++ b/pkg/discovery/rsexpand.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // renderResourceSet evaluates rs.Spec across its inputs and AddObjects
@@ -64,8 +65,8 @@ func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, n
 			Namespace: namespace,
 			Name:      ref.Name,
 		}
-		obj, _ := d.cfg.Store.GetObject(id).(*manifest.ResourceSetInputProvider)
-		if obj == nil {
+		obj, ok := store.Get[*manifest.ResourceSetInputProvider](d.cfg.Store, id)
+		if !ok {
 			return nil, nil
 		}
 		return []*manifest.ResourceSetInputProvider{obj}, nil
@@ -74,9 +75,8 @@ func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, n
 		return nil, nil
 	}
 	var out []*manifest.ResourceSetInputProvider
-	for _, obj := range d.cfg.Store.ListObjects(manifest.KindResourceSetInputProvider) {
-		p, ok := obj.(*manifest.ResourceSetInputProvider)
-		if !ok || p.Namespace != namespace {
+	for _, p := range store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider) {
+		if p.Namespace != namespace {
 			continue
 		}
 		match, err := resourceset.MatchSelector(ref.Selector, p.Labels)

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -118,9 +118,8 @@ func resolveNamespace(file string, flux, kust []pathEntry) string {
 // stay unsorted.
 func indexFluxByPath(s *store.Store, sourceFiles map[manifest.NamedResource]string, kust []pathEntry) []pathEntry {
 	var out []pathEntry
-	for _, obj := range s.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		if ks.Path == "" {
 			continue
 		}
 		ns := ks.TargetNamespace

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -25,9 +25,8 @@ type KSPathPrefix struct {
 // O(K²) to O(K · depth) in the typical case.
 func KSPathPrefixes(s *store.Store) []KSPathPrefix {
 	var out []KSPathPrefix
-	for _, obj := range s.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		if ks.Path == "" {
 			continue
 		}
 		out = append(out, KSPathPrefix{ID: ks.Named(), Prefix: normalizePrefix(ks.Path)})

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -61,22 +61,14 @@ func (o *Orchestrator) breakDependsOnCycles() {
 			}
 		}
 	}
-	for _, ks := range o.store.ListObjects(manifest.KindKustomization) {
-		k, ok := ks.(*manifest.Kustomization)
-		if !ok {
-			continue
-		}
+	for _, k := range store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization) {
 		if _, member := inCycle[manifest.KindKustomization][k.Named()]; !member {
 			continue
 		}
 		stripped := stripCycleDeps(k.DependsOn, inCycle[manifest.KindKustomization])
 		store.Mutate(o.store, k.Named(), func(x *manifest.Kustomization) { x.DependsOn = stripped })
 	}
-	for _, hr := range o.store.ListObjects(manifest.KindHelmRelease) {
-		h, ok := hr.(*manifest.HelmRelease)
-		if !ok {
-			continue
-		}
+	for _, h := range store.ListAs[*manifest.HelmRelease](o.store, manifest.KindHelmRelease) {
 		if _, member := inCycle[manifest.KindHelmRelease][h.Named()]; !member {
 			continue
 		}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -175,8 +175,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	ts := task.NewBounded(cfg.Concurrency)
 	cache := cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources")))
 	secretGet := func(ns, name string) *manifest.Secret {
-		obj := st.GetByName(manifest.KindSecret, ns, name)
-		s, _ := obj.(*manifest.Secret)
+		s, _ := store.GetByName[*manifest.Secret](st, manifest.KindSecret, ns, name)
 		return s
 	}
 	helmClient.SetSecretGetter(secretGet)
@@ -267,36 +266,24 @@ func (o *Orchestrator) validateDependsOn() {
 		manifest.KindKustomization: {},
 		manifest.KindHelmRelease:   {},
 	}
-	ksList := o.store.ListObjects(manifest.KindKustomization)
-	for _, obj := range ksList {
-		if ks, ok := obj.(*manifest.Kustomization); ok {
-			known[manifest.KindKustomization][ks.NamespacedName()] = struct{}{}
-		}
+	ksList := store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization)
+	for _, ks := range ksList {
+		known[manifest.KindKustomization][ks.NamespacedName()] = struct{}{}
 	}
-	hrList := o.store.ListObjects(manifest.KindHelmRelease)
-	for _, obj := range hrList {
-		if hr, ok := obj.(*manifest.HelmRelease); ok {
-			known[manifest.KindHelmRelease][hr.NamespacedName()] = struct{}{}
-		}
+	hrList := store.ListAs[*manifest.HelmRelease](o.store, manifest.KindHelmRelease)
+	for _, hr := range hrList {
+		known[manifest.KindHelmRelease][hr.NamespacedName()] = struct{}{}
 	}
 	// Mutate via the Store helper — encodes the clone-then-AddObject
 	// contract so callers don't have to remember it.
-	for _, obj := range ksList {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok {
-			continue
-		}
+	for _, ks := range ksList {
 		kept, dropped := manifest.FilterDependsOn(ks.DependsOn, known[manifest.KindKustomization])
 		if dropped == 0 {
 			continue
 		}
 		store.Mutate(o.store, ks.Named(), func(k *manifest.Kustomization) { k.DependsOn = kept })
 	}
-	for _, obj := range hrList {
-		hr, ok := obj.(*manifest.HelmRelease)
-		if !ok {
-			continue
-		}
+	for _, hr := range hrList {
 		kept, dropped := manifest.FilterDependsOn(hr.DependsOn, known[manifest.KindHelmRelease])
 		if dropped == 0 {
 			continue

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // expandResourceSetsPostRun re-renders every ResourceSet using the
@@ -26,7 +27,7 @@ import (
 // is the canonical seeding point for Flux-kind RS children; this pass
 // only handles the visibility gap for non-Flux output.
 func (o *Orchestrator) expandResourceSetsPostRun() {
-	rsList := o.store.ListObjects(manifest.KindResourceSet)
+	rsList := store.ListAs[*manifest.ResourceSet](o.store, manifest.KindResourceSet)
 	if len(rsList) == 0 {
 		return
 	}
@@ -38,9 +39,8 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		id     manifest.NamedResource
 	}
 	var owners []owner
-	for _, obj := range o.store.ListObjects(manifest.KindKustomization) {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
+	for _, ks := range store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization) {
+		if ks.Path == "" {
 			continue
 		}
 		p := filepath.ToSlash(ks.Path)
@@ -76,11 +76,7 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 	// emit it under the parent KS.
 	seen := map[string]struct{}{}
 	out := map[manifest.NamedResource][]map[string]any{}
-	for _, obj := range rsList {
-		rs, ok := obj.(*manifest.ResourceSet)
-		if !ok {
-			continue
-		}
+	for _, rs := range rsList {
 		docs, err := resourceset.Render(rs, o.resolveInputProvider)
 		if err != nil || len(docs) == 0 {
 			continue
@@ -168,8 +164,8 @@ func (o *Orchestrator) resolveInputProvider(ref fluxopv1.InputProviderReference,
 			Namespace: namespace,
 			Name:      ref.Name,
 		}
-		obj, _ := o.store.GetObject(id).(*manifest.ResourceSetInputProvider)
-		if obj == nil {
+		obj, ok := store.Get[*manifest.ResourceSetInputProvider](o.store, id)
+		if !ok {
 			return nil, nil
 		}
 		return []*manifest.ResourceSetInputProvider{obj}, nil
@@ -178,9 +174,8 @@ func (o *Orchestrator) resolveInputProvider(ref fluxopv1.InputProviderReference,
 		return nil, nil
 	}
 	var out []*manifest.ResourceSetInputProvider
-	for _, obj := range o.store.ListObjects(manifest.KindResourceSetInputProvider) {
-		p, ok := obj.(*manifest.ResourceSetInputProvider)
-		if !ok || p.Namespace != namespace {
+	for _, p := range store.ListAs[*manifest.ResourceSetInputProvider](o.store, manifest.KindResourceSetInputProvider) {
+		if p.Namespace != namespace {
 			continue
 		}
 		match, err := resourceset.MatchSelector(ref.Selector, p.Labels)

--- a/pkg/store/typed.go
+++ b/pkg/store/typed.go
@@ -1,0 +1,76 @@
+package store
+
+import "github.com/home-operations/flate/pkg/manifest"
+
+// Get fetches the object at id and asserts it to T in one step.
+// Returns (zero, false) when the object is absent or stored under a
+// different type. Eliminates the two-line GetObject + type-assert
+// pattern that otherwise repeats across controllers, discovery, and
+// the orchestrator:
+//
+//	// before
+//	ks, ok := s.GetObject(id).(*manifest.Kustomization)
+//
+//	// after
+//	ks, ok := store.Get[*manifest.Kustomization](s, id)
+//
+// The constraint on T is the same shape Mutate already uses, so
+// callers see a uniform interface for the two type-safe Store APIs.
+func Get[T manifest.BaseManifest](s *Store, id manifest.NamedResource) (T, bool) {
+	if s == nil {
+		var zero T
+		return zero, false
+	}
+	obj, ok := s.GetObject(id).(T)
+	return obj, ok
+}
+
+// GetByName is the (kind, namespace, name) sibling of Get — performs
+// the same store lookup as Store.GetByName and asserts the result to
+// T. Returns (zero, false) on miss or type mismatch.
+//
+// Useful when the caller has the human-readable triple (e.g. from a
+// SecretRef or valuesFrom) rather than a NamedResource.
+func GetByName[T manifest.BaseManifest](s *Store, kind, namespace, name string) (T, bool) {
+	if s == nil {
+		var zero T
+		return zero, false
+	}
+	obj, ok := s.GetByName(kind, namespace, name).(T)
+	return obj, ok
+}
+
+// ListAs lists every stored object of kind and returns those that
+// type-assert to T. Mirrors ListObjects(kind) but returns the
+// concrete-typed slice the caller almost always needs:
+//
+//	// before
+//	for _, obj := range s.ListObjects(manifest.KindKustomization) {
+//	    ks, ok := obj.(*manifest.Kustomization)
+//	    if !ok { continue }
+//	    // use ks
+//	}
+//
+//	// after
+//	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+//	    // use ks
+//	}
+//
+// The store invariant guarantees that ListObjects(K) returns only
+// objects whose Named().Kind == K, so the inner type-assert is a
+// defensive net rather than a real filter — but keeping it cheap
+// means a future invariant relaxation degrades safely rather than
+// panicking.
+func ListAs[T manifest.BaseManifest](s *Store, kind string) []T {
+	if s == nil {
+		return nil
+	}
+	raw := s.ListObjects(kind)
+	out := make([]T, 0, len(raw))
+	for _, obj := range raw {
+		if typed, ok := obj.(T); ok {
+			out = append(out, typed)
+		}
+	}
+	return out
+}

--- a/pkg/store/typed_test.go
+++ b/pkg/store/typed_test.go
@@ -1,0 +1,137 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestGet_ReturnsTypedObject locks the happy path: an object stored
+// under id returns successfully as its concrete pointer type.
+func TestGet_ReturnsTypedObject(t *testing.T) {
+	s := store.New()
+	ks := &manifest.Kustomization{Name: "apps", Namespace: "flux-system"}
+	s.AddObject(ks)
+
+	got, ok := store.Get[*manifest.Kustomization](s, ks.Named())
+	if !ok {
+		t.Fatalf("expected hit; got miss")
+	}
+	if got != ks {
+		t.Errorf("Get returned a different pointer; want %p got %p", ks, got)
+	}
+}
+
+// TestGet_MissReturnsZeroFalse covers the absent case: nothing stored
+// at id yields (zero, false) without panic.
+func TestGet_MissReturnsZeroFalse(t *testing.T) {
+	s := store.New()
+	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "ghost"}
+
+	got, ok := store.Get[*manifest.Kustomization](s, id)
+	if ok {
+		t.Fatalf("expected miss; got hit")
+	}
+	if got != nil {
+		t.Errorf("missed Get should return nil pointer; got %v", got)
+	}
+}
+
+// TestGet_WrongTypeReturnsZeroFalse covers the type-mismatch case:
+// id exists but stored as a different concrete type. Returns
+// (zero, false) rather than panicking, matching the comma-ok shape
+// of a raw type assertion.
+func TestGet_WrongTypeReturnsZeroFalse(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "demo", Namespace: "default"}
+	s.AddObject(hr)
+
+	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "demo"}
+	got, ok := store.Get[*manifest.Kustomization](s, id)
+	if ok {
+		t.Errorf("Get with wrong type should miss; got hit %v", got)
+	}
+}
+
+// TestGet_NilStoreSafe is the defensive guard — embedder constructed
+// a struct holding a *Store that was never initialized. Returns
+// (zero, false) without panic.
+func TestGet_NilStoreSafe(t *testing.T) {
+	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "x"}
+	if got, ok := store.Get[*manifest.Kustomization](nil, id); ok || got != nil {
+		t.Errorf("nil store: want (nil, false); got (%v, %v)", got, ok)
+	}
+}
+
+// TestGetByName_ReturnsTypedObject covers the (kind, namespace,
+// name) lookup path: GetByName resolves the store's secondary index
+// and asserts to T in one step.
+func TestGetByName_ReturnsTypedObject(t *testing.T) {
+	s := store.New()
+	sec := &manifest.Secret{Name: "creds", Namespace: "flux-system"}
+	s.AddObject(sec)
+
+	got, ok := store.GetByName[*manifest.Secret](s, manifest.KindSecret, "flux-system", "creds")
+	if !ok {
+		t.Fatalf("expected hit; got miss")
+	}
+	if got != sec {
+		t.Errorf("GetByName returned a different pointer; want %p got %p", sec, got)
+	}
+}
+
+// TestGetByName_NilStoreSafe mirrors Get's defensive nil guard.
+func TestGetByName_NilStoreSafe(t *testing.T) {
+	if got, ok := store.GetByName[*manifest.Secret](nil, manifest.KindSecret, "ns", "name"); ok || got != nil {
+		t.Errorf("nil store: want (nil, false); got (%v, %v)", got, ok)
+	}
+}
+
+// TestListAs_TypedSlice locks the typed-iteration contract: every
+// object stored under the requested kind comes back as the typed
+// pointer slice, in store-iteration order (unsorted, but we just
+// verify membership).
+func TestListAs_TypedSlice(t *testing.T) {
+	s := store.New()
+	for _, name := range []string{"a", "b", "c"} {
+		s.AddObject(&manifest.Kustomization{Name: name, Namespace: "flux-system"})
+	}
+	// Add a HelmRelease to confirm kind filtering excludes other kinds.
+	s.AddObject(&manifest.HelmRelease{Name: "noisy", Namespace: "flux-system"})
+
+	got := store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 KSes; got %d", len(got))
+	}
+	seen := map[string]bool{}
+	for _, ks := range got {
+		seen[ks.Name] = true
+	}
+	for _, n := range []string{"a", "b", "c"} {
+		if !seen[n] {
+			t.Errorf("missing KS %q", n)
+		}
+	}
+}
+
+// TestListAs_NilStoreReturnsNil mirrors Get's nil-store guard.
+func TestListAs_NilStoreReturnsNil(t *testing.T) {
+	if got := store.ListAs[*manifest.Kustomization](nil, manifest.KindKustomization); got != nil {
+		t.Errorf("nil store: want nil slice; got %v", got)
+	}
+}
+
+// TestListAs_EmptyKindReturnsEmpty covers a kind with no entries.
+// Should return a non-nil but length-0 slice, suitable for direct
+// iteration without nil-check.
+func TestListAs_EmptyKindReturnsEmpty(t *testing.T) {
+	s := store.New()
+	got := store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization)
+	if got == nil {
+		t.Errorf("want empty slice, not nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("want length 0; got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

Add two generic helpers on \`*Store\` that collapse the repeating \`GetObject\` + type-assert pattern spread across discovery, orchestrator, controllers, loader, and internal/cli.

\`\`\`go
// before
obj := s.GetObject(id)
ks, ok := obj.(*manifest.Kustomization)

// after
ks, ok := store.Get[*manifest.Kustomization](s, id)
\`\`\`

\`\`\`go
// before
for _, obj := range s.ListObjects(manifest.KindKustomization) {
    ks, ok := obj.(*manifest.Kustomization)
    if !ok { continue }
    ...
}

// after
for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
    ...
}
\`\`\`

T is constrained to \`manifest.BaseManifest\`, matching the existing \`Mutate[T]\` helper. The Kind string is still required to filter at the Store level; the inner type assertion in \`ListAs\` is a defensive net since the Store invariant guarantees \`ListObjects(K)\` yields only objects whose \`Named().Kind == K\`.

## Converted (12+ sites)

- \`pkg/discovery/{discovery,bootstrap,rsexpand}.go\`
- \`pkg/orchestrator/{orchestrator,cycles,resourceset}.go\`
- \`pkg/controllers/{kustomization,helmrelease}/controller.go\`
- \`pkg/loader/{parent,inherit}.go\`
- \`internal/cli/helpers.go\`

## NOT converted (deliberate)

- \`pkg/change/{filter,ownership}.go\` — uses the slim consumer-defined \`ObjectLister\` interface, not \`*Store\`. Forcing it to take \`*Store\` would over-couple for marginal gain.
- \`pkg/orchestrator/{orchestrator,cycles}.go\` \`ListObjects(kind)\` calls where \`kind\` is parameterized at runtime — can't bind the type parameter from a string.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green (6 new unit tests for typed helpers: happy path, miss, wrong type, nil store, kind filter, empty kind)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`flate test ks --path .\` against all 5 test repos — identical numbers (118/199/287/73/93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)