### PR TITLE
fix(change): Filter.Add walks transitiveDeps + refires source listeners (#260)

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -24,6 +24,21 @@ type Filter struct {
 	sourceFiles map[manifest.NamedResource]string
 	repoRoot    string
 
+	// objs is captured from NewFilter so runtime Add() can walk
+	// transitiveDeps without the caller re-supplying it. Set once
+	// at construction; never mutated.
+	objs ObjectLister
+
+	// OnAdd, when non-nil, fires for every id newly added to the
+	// keep set by Add (including transitive-dep recursion). The
+	// orchestrator wires this to refire EventObjectAdded for source-
+	// kind ids whose listener already short-circuited via PreGate
+	// before the consuming KS joined keep. Issue #260.
+	//
+	// Set BEFORE controllers start. The Filter calls OnAdd outside
+	// its internal lock so callbacks are free to take other locks.
+	OnAdd func(manifest.NamedResource)
+
 	// mu guards keep + keepByName for runtime Add(); resolve() runs
 	// once during construction before the controllers start, so it
 	// doesn't need to hold the lock.
@@ -59,6 +74,7 @@ func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repo
 		changes:     changes,
 		sourceFiles: sourceFiles,
 		repoRoot:    repoRoot,
+		objs:        objs,
 	}
 	if changes == nil {
 		return f
@@ -109,6 +125,19 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 // changed-only diffs: the leaf KS isn't keep-set'd, never reconciles,
 // and its render output is missing from the diff. Issue #204.
 //
+// Add ALSO walks transitiveDeps recursively so a Kustomization /
+// HelmRelease added at runtime carries its sourceRef and chartRef
+// into the keep set with it. Without this, a leaf KS emitted via a
+// parent's render lands in keep, runs reconcile, asks for its
+// sourceRef's artifact, and finds nothing — the source controller
+// PreGate-skipped that source at startup because nothing in keep
+// referenced it yet. Issue #260.
+//
+// Newly-added ids are passed to OnAdd (when configured) so the
+// orchestrator can refire dependent listeners (e.g. retrigger the
+// source controller's fetch for a source whose PreGate-skip happened
+// before its consumer joined keep).
+//
 // Ordering contract for embedders: call Add(child) BEFORE the
 // emitting Store.AddObject(child). Store events fire synchronously
 // on the calling goroutine, so the controller's listener invokes
@@ -121,15 +150,54 @@ func (f *Filter) Add(id manifest.NamedResource) {
 	if !f.Enabled() {
 		return
 	}
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if _, ok := f.keep[id]; ok {
+	added := f.addRecursive(id)
+	if f.OnAdd == nil || len(added) == 0 {
 		return
 	}
-	f.keep[id] = struct{}{}
-	if id.Namespace == "" {
-		f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+	// Call OnAdd outside the lock — callbacks may take other locks
+	// (e.g. the Store's mu via Refire) and we don't want to invert
+	// lock order with concurrent ShouldReconcile readers.
+	for _, newID := range added {
+		f.OnAdd(newID)
 	}
+}
+
+// addRecursive adds id (and transitive deps) to keep, returning the
+// list of ids that were newly added (so the caller can dispatch
+// OnAdd notifications outside the lock). Holds mu for the full
+// graph walk so the recursion sees a coherent keep snapshot.
+func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResource {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var added []manifest.NamedResource
+	stack := []manifest.NamedResource{id}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, ok := f.keep[cur]; ok {
+			continue
+		}
+		f.keep[cur] = struct{}{}
+		if cur.Namespace == "" {
+			f.keepByName[nameKey{cur.Kind, cur.Name}] = struct{}{}
+		}
+		added = append(added, cur)
+		// Transitive walk: a runtime-added KS / HR pulls its
+		// sourceRef / chartRef / valuesFrom into keep with it.
+		// objs may be nil for tests that construct a Filter without
+		// an ObjectLister; in that case the walk is a no-op (the
+		// resolve() pre-build covered the initial graph already).
+		if f.objs == nil {
+			continue
+		}
+		for _, dep := range transitiveDeps(f.objs, cur) {
+			if _, ok := f.keep[dep]; !ok {
+				stack = append(stack, dep)
+			}
+		}
+	}
+	return added
 }
 
 func (f *Filter) resolve(objs ObjectLister) {

--- a/pkg/change/issue260_test.go
+++ b/pkg/change/issue260_test.go
@@ -1,0 +1,179 @@
+package change_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/orchestrator"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// fakeOCIFetcher always returns a populated SourceArtifact so we can
+// exercise the change-filter / source-controller interplay without
+// hitting the network. The LocalPath points back at the working tree
+// so kustomize render against the OCI artifact resolves to local
+// files (the test fixture has an empty kustomization.yaml under the
+// path; kustomize accepts an empty resources list).
+type fakeOCIFetcher struct{ localPath string }
+
+func (f fakeOCIFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*store.SourceArtifact, error) {
+	return &store.SourceArtifact{
+		Kind:      manifest.KindOCIRepository,
+		URL:       "oci://example.test/homepage-config",
+		LocalPath: f.localPath,
+		Revision:  "test",
+	}, nil
+}
+
+// TestIssue260_OCIRepoFetchedWhenConsumerJoinsKeepSetAtRuntime
+// reproduces https://github.com/home-operations/flate/issues/260.
+//
+// Setup:
+//
+//	cluster-apps Kustomization (spec.path: ./kubernetes/apps,
+//	                            targetNamespace: default)
+//	  ↓ renders + emits
+//	homepage-config Kustomization (sourceRef = OCIRepository)
+//	  ↑ sourceRef
+//	OCIRepository (file-loaded under homepage tree)
+//
+// Diff-mode change: only an UNRELATED file changed. The keep set
+// resolves at construction with neither homepage-config nor the
+// OCIRepository in scope — both files sit under homepage's spec.path
+// and homepage isn't directly affected by the change.
+//
+// At runtime, cluster-apps renders ./kubernetes/apps and emits
+// homepage-config. The KS controller's keepEmitted calls
+// Filter.Add(homepage-config) and AddObject(homepage-config). The
+// child KS reconciles — and its sourceRef points at the OCIRepository
+// that was PreGate-skipped at startup with no artifact.
+//
+// Bug: Filter.Add was a one-shot add — it didn't walk transitiveDeps,
+// so the OCIRepository never entered the keep set, the source
+// controller never re-fetched it, and homepage-config's
+// resolveSourceRoot surfaced "source ... artifact not found".
+//
+// Fix: Filter.Add now walks transitiveDeps recursively AND the
+// orchestrator wires Filter.OnAdd to Store.Refire so source kinds
+// that newly join keep at runtime get their listener re-fired with
+// the updated filter state.
+func TestIssue260_OCIRepoFetchedWhenConsumerJoinsKeepSetAtRuntime(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "kubernetes/flux/cluster/ks.yaml"), clusterKS)
+	mustWrite(t, filepath.Join(dir, "kubernetes/apps/default/homepage/ks.yaml"), homepageKS)
+	mustWrite(t, filepath.Join(dir, "kubernetes/apps/default/homepage/repos/ocirepository.yaml"), ociRepo)
+	mustWrite(t, filepath.Join(dir, "kubernetes/apps/default/homepage/config/kustomization.yaml"), "resources: []\n")
+	mustWrite(t, filepath.Join(dir, "kubernetes/apps/default/homepage/app/kustomization.yaml"), "resources: []\n")
+	mustWrite(t, filepath.Join(dir, "kubernetes/apps/networking/echo.yaml"), echoCM)
+
+	o, err := orchestrator.New(orchestrator.Config{
+		Path:        dir,
+		WipeSecrets: true,
+		EnableOCI:   true,
+		ExternalChanges: change.NewSet([]string{
+			"kubernetes/apps/networking/echo.yaml",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("orchestrator.New: %v", err)
+	}
+	o.WithFetcher(manifest.KindOCIRepository, fakeOCIFetcher{localPath: dir})
+
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Logf("Render returned err: %v", err)
+	}
+	for id, info := range res.Failed {
+		if strings.Contains(info.Message, "artifact not found") {
+			t.Errorf("issue #260 regressed: %s reports %s", id, info.Message)
+		}
+	}
+}
+
+const clusterKS = `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+`
+
+const homepageKS = `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homepage-config
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/default/homepage/config
+  prune: true
+  sourceRef:
+    kind: OCIRepository
+    name: homepage-config
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: homepage
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/default/homepage
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`
+
+const ociRepo = `---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: homepage-config
+spec:
+  interval: 10m
+  url: oci://example.test/homepage-config
+  ref:
+    tag: v1.0.0
+`
+
+const echoCM = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: echo
+data:
+  msg: hello
+`
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -340,7 +340,26 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	if changes == nil {
 		return nil
 	}
-	o.attachFilter(change.NewFilter(changes, o.sourceFiles, repoRoot, o.store))
+	f := change.NewFilter(changes, o.sourceFiles, repoRoot, o.store)
+	// Wire OnAdd so a runtime keep-set extension (KS controller's
+	// emitRenderedChildren → keepEmitted) refires any source whose
+	// listener already short-circuited via PreGate before the
+	// consuming KS joined keep. Without this hook, the source stays
+	// Ready "unchanged" with no artifact and the KS's
+	// resolveSourceRoot surfaces "artifact not found" downstream.
+	// Issue #260.
+	f.OnAdd = func(id manifest.NamedResource) {
+		switch id.Kind {
+		case manifest.KindGitRepository,
+			manifest.KindOCIRepository,
+			manifest.KindHelmRepository,
+			manifest.KindBucket,
+			manifest.KindHelmChart,
+			manifest.KindExternalArtifact:
+			o.store.Refire(id)
+		}
+	}
+	o.attachFilter(f)
 	slog.Debug("changed-only keep set", "size", o.filter.Size(), "items", o.filter.KeepNames())
 	return nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -89,6 +89,22 @@ func (s *Store) AddObject(obj manifest.BaseManifest) {
 	s.fire(EventObjectAdded, id, obj)
 }
 
+// Refire dispatches EventObjectAdded for the existing object at id
+// without altering state. Used to wake up listeners that
+// short-circuited the first time (e.g. source controllers that
+// PreGate-skipped a source whose consumer joined the change-filter
+// keep set only at runtime — see issue #260). No-op when id is not
+// in the store.
+func (s *Store) Refire(id manifest.NamedResource) {
+	s.mu.RLock()
+	obj, ok := s.objects[id]
+	s.mu.RUnlock()
+	if !ok {
+		return
+	}
+	s.fire(EventObjectAdded, id, obj)
+}
+
 // Cloneable is satisfied by manifest types that can be shallowly
 // duplicated for safe mutation under the Store's immutability
 // contract. Kustomization, HelmRelease implement this; new types that


### PR DESCRIPTION
## Summary

Fixes #260. \`flate diff\` in changed-only mode intermittently fails with \`source <OCIRepository> artifact not found\` when the consuming Kustomization isn't part of the changed files. \`flate test\` is unaffected because it runs without a change filter.

## Root cause

\`Filter.Add\` was a one-shot add. When a parent KS rendered at runtime and emitted a child Kustomization (\`cluster-apps\` render → \`emitRenderedChildren\` → \`keepEmitted\` → \`Filter.Add\`), the child landed in the keep set but its \`sourceRef\` was **not** walked. The source CR's listener had already fired at controller-start, found itself absent from the keep set, and \`PreGate\`-skipped to Ready+"unchanged" without fetching. By the time the child KS reconciled and asked for its sourceRef's artifact via \`resolveSourceRoot\`, the source was Ready but artifact-less — surfacing as \`source X artifact not found\`.

## Fix (two-part — neither piece is sufficient alone)

### 1. \`pkg/change/filter.go\` — Filter.Add walks transitiveDeps recursively
A runtime-added Kustomization pulls its sourceRef into keep; a runtime-added HelmRelease pulls chartRef + valuesFrom. Walks inside the existing \`mu\` lock so the recursion sees a coherent keep snapshot.

### 2. \`pkg/store\` + \`pkg/orchestrator\` — \`Store.Refire\` + \`Filter.OnAdd\`
\`Store.Refire(id)\` dispatches \`EventObjectAdded\` without state change. Filter gains an \`OnAdd func(id)\` hook; orchestrator wires it so source-kind ids newly entering keep at runtime get their listener refired. The source controller's PreGate then sees the updated filter, accepts, and fetches.

Why both: (1) alone fixes the keep-set membership but the source controller already short-circuited via PreGate at startup. (2) alone has nothing to fire on (no transitive walk → no \`OnAdd\` event). The combination resolves both the membership gap and the already-listener-fired ordering issue.

## Repro test

\`pkg/change/issue260_test.go\` reproduces the user's exact pattern:
- \`cluster-apps\` Kustomization with \`targetNamespace: default\` renders \`./kubernetes/apps\`
- \`homepage-config\` Kustomization at \`apps/default/homepage/ks.yaml\` with \`sourceRef\` → OCIRepository
- OCIRepository at \`apps/default/homepage/repos/ocirepository.yaml\` (under homepage's tree)
- Change set restricted to an unrelated \`apps/networking/echo.yaml\`

Pre-fix surfaces \`OCIRepository/default/homepage-config artifact not found\`. Post-fix passes cleanly.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] new repro test passes
- [x] \`flate test ks --path .\` against all 5 test repos — **118 / 199 / 287 / 73 / 93** (identical to pre-fix)
- [x] \`flate diff ks\` against \`buroa/k8s-gitops\` with an unrelated change — clean, no spurious failures

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)