### PR TITLE
chore(diff): default-strip checksum/secret annotation

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -29,10 +29,16 @@ func newDiffCmd() *cobra.Command {
 
 // defaultStripAttrs is the default `--strip-attr` list — annotations
 // and labels that Helm + kustomize rotate on every chart bump and
-// which contribute pure noise to PR-time diff review.
+// which contribute pure noise to PR-time diff review. checksum/*
+// annotations are templated as `sha256sum (include "secret.yaml")`
+// in many charts; the rendered Secret values flate sees are
+// wiped-to-PLACEHOLDER but the chart's helper pipeline still emits
+// non-stable bytes across runs (e.g. random suffix from sprig
+// randAlphaNum), producing churn-only diffs.
 var defaultStripAttrs = []string{
 	"helm.sh/chart",
 	"checksum/config",
+	"checksum/secret",
 	"app.kubernetes.io/version",
 	"chart",
 }


### PR DESCRIPTION
## Summary

Helm charts commonly emit a \`checksum/secret\` annotation on Deployments templated as \`sha256sum (include "secret.yaml" .)\`. The include re-renders the Secret template each time — and when chart values pipe through sprig \`randAlphaNum\` / \`genCertCA\` / similar non-deterministic helpers, the rendered Secret bytes (and therefore the sha256sum) differ across runs even when nothing meaningful changed.

flate already strips \`checksum/config\`; \`checksum/secret\` is the same class of helm-template noise and surfaces as a per-run diff for every chart that uses it.

## Verified

Zariel/home-ops with a single \`replicas\` bump on cert-manager:
- Before: diff included three HelmRelease blocks (\`cert-manager\`, \`netbox\`, \`grafana\` — the latter two from spurious checksum/secret rotation).
- After: only \`cert-manager\` (the actual change).

caBundle non-determinism in victoria-metrics-operator remains — that's a chart-side issue (\`genCertCA\` generates a fresh certificate each render) living in \`.webhooks[].clientConfig.caBundle\`, not in metadata.annotations, so the existing \`--strip-attr\` mechanism doesn't cover it.

## Test plan

- [x] \`go test -count=1 ./...\` — full suite green
- [x] All 6 test repos pass with identical numbers: **93/118/199/287/73/105**
- [x] Zariel/home-ops diff on a single replicas bump → diff scoped to one HelmRelease (was 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)