### PR TITLE
fix(source/oci): write blobs without title annotation to slot

### DIFF
--- a/pkg/source/oci/fallback_test.go
+++ b/pkg/source/oci/fallback_test.go
@@ -1,0 +1,162 @@
+package oci
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// TestFetcher_ExtractsLayerWithoutTitleAnnotation regresses the silent
+// no-op that Zariel/home-ops hit on flux-manifests: orasfile's default
+// fallback storage is in-memory, so blobs without an
+// `org.opencontainers.image.title` annotation (the shape of every Flux
+// `vnd.cncf.flux.content.v1.tar+gzip` artifact, plus its config + the
+// image manifest itself) never landed on disk. applyLayerSelector then
+// silently returned because the manifest file wasn't present, leaving
+// the slot empty — `kustomize build` then rendered zero manifests
+// rather than failing. The fix wires a flat-layout fallback so the
+// manifest + config + layer blobs all land at `slot/<hex>`.
+func TestFetcher_ExtractsLayerWithoutTitleAnnotation(t *testing.T) {
+	// Build a single-file gzipped tarball as the "content" layer.
+	// Reuses mustTarGz from layer_test.go.
+	layerBytes := mustTarGz(t, map[string]string{
+		"gotk-components.yaml": "kind: ConfigMap\n",
+	})
+	layerDigest := sha256Digest(layerBytes)
+
+	configBytes := []byte(`{"created":"2026-01-01T00:00:00Z"}`)
+	configDigest := sha256Digest(configBytes)
+
+	manifestObj := ocispec.Manifest{
+		Versioned: ocispec.Manifest{}.Versioned,
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config: ocispec.Descriptor{
+			MediaType: "application/vnd.cncf.flux.config.v1+json",
+			Digest:    digest.Digest(configDigest),
+			Size:      int64(len(configBytes)),
+		},
+		Layers: []ocispec.Descriptor{
+			{
+				MediaType: "application/vnd.cncf.flux.content.v1.tar+gzip",
+				Digest:    digest.Digest(layerDigest),
+				Size:      int64(len(layerBytes)),
+			},
+		},
+	}
+	manifestObj.SchemaVersion = 2
+	manifestBytes, err := json.Marshal(manifestObj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest := sha256Digest(manifestBytes)
+
+	// Tiny OCI Distribution API server: responds to manifests by tag or
+	// digest, and to blobs by digest. Enough to satisfy oras.Copy.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/" || r.URL.Path == "/v2":
+			// Distribution v2 probe.
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+			w.Header().Set("Docker-Content-Digest", manifestDigest)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(manifestBytes)
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			parts := strings.Split(r.URL.Path, "/")
+			d := parts[len(parts)-1]
+			switch d {
+			case configDigest:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(configBytes)
+			case layerDigest:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(layerBytes)
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	// TLS server: flate's spec.insecure maps to TLS InsecureSkipVerify
+	// (it doesn't downshift to PlainHTTP), so the test server has to
+	// speak TLS for the fetcher's standard credential path to apply.
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	hostport := mustURL(t, srv.URL).Host
+
+	f := &Fetcher{Cache: source.NewCache(t.TempDir())}
+	repo := &manifest.OCIRepository{
+		Name:      "flux-manifests",
+		Namespace: "flux-system",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:      fmt.Sprintf("oci://%s/fluxcd/flux-manifests", hostport),
+			// httptest.NewTLSServer issues a self-signed cert; spec.insecure
+			// maps to TLS InsecureSkipVerify.
+			Insecure: true,
+			Reference: &sourcev1.OCIRepositoryRef{
+				Tag: "v2.8.8",
+			},
+		},
+	}
+
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if art == nil || art.LocalPath == "" {
+		t.Fatal("Fetch returned no artifact")
+	}
+
+	// Slot must contain the extracted tarball entries, not just the
+	// `.flate-digest` sentinel — that's exactly the regression: pre-fix
+	// the slot had only the sentinel because the blobs were dropped in
+	// memory.
+	extracted := filepath.Join(art.LocalPath, "gotk-components.yaml")
+	got, err := os.ReadFile(extracted) //nolint:gosec // inside t.TempDir-rooted slot
+	if err != nil {
+		entries, _ := os.ReadDir(art.LocalPath)
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected extracted gotk-components.yaml under %s; slot contents: %v; err: %v",
+			art.LocalPath, names, err)
+	}
+	if want := "kind: ConfigMap\n"; string(got) != want {
+		t.Errorf("gotk-components.yaml = %q, want %q", got, want)
+	}
+}
+
+func sha256Digest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return u
+}

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -19,6 +19,42 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// flatFallbackStorage is the orasfile fallback we pass to
+// NewWithFallbackStorage so blobs lacking an
+// `org.opencontainers.image.title` annotation still land on disk
+// (orasfile's default fallback is an in-memory store). It writes each
+// blob as `<root>/<hex>` — the same layout applyLayerSelector,
+// readSlotManifest, and cleanupBlobs already address. The
+// non-title-annotated case covers every Flux OCIRepository payload
+// (vnd.cncf.flux.content.v1.tar+gzip), the artifact's config blob, and
+// the image manifest itself.
+type flatFallbackStorage struct{ root string }
+
+func (s *flatFallbackStorage) Push(_ context.Context, desc ocispec.Descriptor, content io.Reader) error {
+	path := digestPath(s.root, desc.Digest)
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // path lives under fetcher-owned slot
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, content); err != nil { //nolint:gosec // size-bounded by oras's descriptor verification
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func (s *flatFallbackStorage) Fetch(_ context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	return os.Open(digestPath(s.root, desc.Digest)) //nolint:gosec // path lives under fetcher-owned slot
+}
+
+func (s *flatFallbackStorage) Exists(_ context.Context, desc ocispec.Descriptor) (bool, error) {
+	_, err := os.Stat(digestPath(s.root, desc.Digest))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 // copiedLayerFilename is the deterministic name layers are stored
 // under when LayerSelector.Operation is "copy". Downstream consumers
 // (e.g. Kustomization spec.path on an OCIRepository whose artifact

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -262,7 +262,18 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		tag = "latest"
 	}
 
-	dest, err := orasfile.New(slot)
+	// orasfile.New's default fallback storage is an in-memory store, so
+	// any blob without an `org.opencontainers.image.title` annotation
+	// (the typical shape of Flux's `vnd.cncf.flux.content.v1.tar+gzip`
+	// content layer, plus most non-Helm OCI artifacts) is dropped into
+	// memory and never lands in the slot. applyLayerSelector then can't
+	// find the manifest on disk and silently no-ops — the slot is left
+	// empty except for `.flate-digest`, and downstream `kustomize build`
+	// renders zero manifests rather than failing. Wire a flat-layout
+	// fallback that writes each unnamed blob as `slot/<hex>`, the layout
+	// applyLayerSelector / readSlotManifest / cleanupBlobs already
+	// expect.
+	dest, err := orasfile.NewWithFallbackStorage(slot, &flatFallbackStorage{root: slot})
 	if err != nil {
 		return nil, fmt.Errorf("oras file store: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `orasfile.New` uses an in-memory fallback storage, so any blob lacking an `org.opencontainers.image.title` annotation never lands on disk. For a Flux `OCIRepository` pointing at `oci://ghcr.io/fluxcd/flux-manifests` the layer, the config, and the image manifest itself all hit that path — leaving the cache slot empty except for `.flate-digest`.
- `applyLayerSelector` then silently no-ops because the manifest file isn't present, so the slot stays empty and `kustomize build` renders zero manifests for the `flux` Kustomization without surfacing an error. On CI runs where `oras.Copy` errors before the slot is created, the same condition presents as `source OCIRepository/... artifact not found`.
- Fix: pass a flat-layout `content.Storage` fallback to `orasfile.NewWithFallbackStorage` so unnamed blobs land at `slot/<hex>` — the layout `applyLayerSelector` / `readSlotManifest` / `cleanupBlobs` already expect.

## Reproduction (Zariel/home-ops)

Pre-fix, against [Zariel/home-ops@99d8147](https://github.com/Zariel/home-ops/commit/99d8147) (no `layerSelector` on the flux-manifests OCIRepository):

```
$ flate build ks flux --path ./k8s | wc -l
0    # silently empty — the Flux install manifests should be ~800 lines
$ ls /tmp/flate-cache/sources/v2.8.8/<slot>/
.flate-digest    # only the sentinel; no layer, no extracted yaml
```

Post-fix, same input:

```
$ flate build ks flux --path ./k8s | wc -l
822
$ ls /tmp/flate-cache/sources/v2.8.8/<slot>/
gotk-components.yaml    # tarball extracted as expected
```

This removes the need for the [`spec.layerSelector` workaround](https://github.com/Zariel/home-ops/commit/47f3c3522b3b241ab58c9c4552c2ce5b31462ac8) on every Flux OCIRepository.

## Test plan

- [x] New regression test `TestFetcher_ExtractsLayerWithoutTitleAnnotation` stands up an httptest registry that serves a manifest + config + tar+gzip layer with no title annotations. Pre-fix the test fails with `slot contents: [.flate-digest]`; post-fix it finds the extracted file.
- [x] Full `go test ./...` green.
- [x] `go vet` + `golangci-lint run` clean.
- [x] Full battery on Zariel/home-ops (no layerSelector): `test ks` 93/0, `test all` 191/0; `diff ks` for a non-flux change shows correctly scoped output.
- [x] Verified no regression on biohazard (381/10, pre-existing chart-side failures), m00nwtchr (468/3, pre-existing), buroa-k8s-gitops (166/0), morte-test (236/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)