### PR TITLE
refactor(source/oci): split out flatFallbackStorage + tighten test

### DIFF
--- a/pkg/source/oci/fallback.go
+++ b/pkg/source/oci/fallback.go
@@ -1,0 +1,54 @@
+package oci
+
+import (
+	"context"
+	"io"
+	"os"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// flatFallbackStorage is the content.Storage we wire into
+// orasfile.NewWithFallbackStorage so blobs lacking an
+// `org.opencontainers.image.title` annotation still land on disk.
+//
+// orasfile's default fallback is in-memory, so any unnamed blob — every
+// Flux `vnd.cncf.flux.content.v1.tar+gzip` content layer, its config,
+// and the image manifest itself — never appears in the slot directory.
+// applyLayerSelector then short-circuits on ErrNotExist when it tries
+// to read the manifest from disk (see layer.go), and the slot is left
+// holding only the `.flate-digest` sentinel. Downstream `kustomize
+// build` renders zero manifests rather than failing — silently.
+//
+// Every fallback blob lands at `slot/<hex>` because that's the layout
+// digestPath / readSlotManifest / cleanupBlobs already address. Fetch +
+// Exists read from the same path so oras can resume / dedup blobs it
+// already pulled within a single Copy.
+type flatFallbackStorage struct{ root string }
+
+func (s *flatFallbackStorage) Push(_ context.Context, desc ocispec.Descriptor, content io.Reader) error {
+	path := digestPath(s.root, desc.Digest)
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // path lives under fetcher-owned slot
+	if err != nil {
+		return err
+	}
+	// oras-go bounds the reader to desc.Size during Copy, so plain io.Copy
+	// is not unbounded here.
+	if _, err := io.Copy(out, content); err != nil { //nolint:gosec // size-bounded by oras's descriptor verification
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+func (s *flatFallbackStorage) Fetch(_ context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	return os.Open(digestPath(s.root, desc.Digest)) //nolint:gosec // path lives under fetcher-owned slot
+}
+
+func (s *flatFallbackStorage) Exists(_ context.Context, desc ocispec.Descriptor) (bool, error) {
+	_, err := os.Stat(digestPath(s.root, desc.Digest))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return err == nil, err
+}

--- a/pkg/source/oci/fallback_test.go
+++ b/pkg/source/oci/fallback_test.go
@@ -1,11 +1,11 @@
 package oci
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -16,6 +16,7 @@ import (
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -23,85 +24,27 @@ import (
 )
 
 // TestFetcher_ExtractsLayerWithoutTitleAnnotation regresses the silent
-// no-op that Zariel/home-ops hit on flux-manifests: orasfile's default
-// fallback storage is in-memory, so blobs without an
-// `org.opencontainers.image.title` annotation (the shape of every Flux
-// `vnd.cncf.flux.content.v1.tar+gzip` artifact, plus its config + the
-// image manifest itself) never landed on disk. applyLayerSelector then
-// silently returned because the manifest file wasn't present, leaving
-// the slot empty — `kustomize build` then rendered zero manifests
-// rather than failing. The fix wires a flat-layout fallback so the
-// manifest + config + layer blobs all land at `slot/<hex>`.
+// no-op that Zariel/home-ops hit on flux-manifests: every blob in a
+// Flux OCIRepository artifact lacks `org.opencontainers.image.title`,
+// orasfile's default in-memory fallback swallowed them, the slot was
+// left holding only `.flate-digest`, and `kustomize build` rendered
+// zero manifests rather than failing. The flat-layout fallback (see
+// fallback.go) writes the manifest + config + layer to `slot/<hex>`,
+// at which point applyLayerSelector finds them and extracts the
+// content layer.
 func TestFetcher_ExtractsLayerWithoutTitleAnnotation(t *testing.T) {
-	// Build a single-file gzipped tarball as the "content" layer.
-	// Reuses mustTarGz from layer_test.go.
+	t.Parallel()
+
 	layerBytes := mustTarGz(t, map[string]string{
 		"gotk-components.yaml": "kind: ConfigMap\n",
 	})
-	layerDigest := sha256Digest(layerBytes)
-
 	configBytes := []byte(`{"created":"2026-01-01T00:00:00Z"}`)
-	configDigest := sha256Digest(configBytes)
+	manifestBytes := mustManifestJSON(t, configBytes, layerBytes,
+		"application/vnd.cncf.flux.config.v1+json",
+		"application/vnd.cncf.flux.content.v1.tar+gzip",
+	)
 
-	manifestObj := ocispec.Manifest{
-		Versioned: ocispec.Manifest{}.Versioned,
-		MediaType: ocispec.MediaTypeImageManifest,
-		Config: ocispec.Descriptor{
-			MediaType: "application/vnd.cncf.flux.config.v1+json",
-			Digest:    digest.Digest(configDigest),
-			Size:      int64(len(configBytes)),
-		},
-		Layers: []ocispec.Descriptor{
-			{
-				MediaType: "application/vnd.cncf.flux.content.v1.tar+gzip",
-				Digest:    digest.Digest(layerDigest),
-				Size:      int64(len(layerBytes)),
-			},
-		},
-	}
-	manifestObj.SchemaVersion = 2
-	manifestBytes, err := json.Marshal(manifestObj)
-	if err != nil {
-		t.Fatal(err)
-	}
-	manifestDigest := sha256Digest(manifestBytes)
-
-	// Tiny OCI Distribution API server: responds to manifests by tag or
-	// digest, and to blobs by digest. Enough to satisfy oras.Copy.
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/v2/" || r.URL.Path == "/v2":
-			// Distribution v2 probe.
-			w.WriteHeader(http.StatusOK)
-		case strings.Contains(r.URL.Path, "/manifests/"):
-			w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
-			w.Header().Set("Docker-Content-Digest", manifestDigest)
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write(manifestBytes)
-		case strings.Contains(r.URL.Path, "/blobs/"):
-			parts := strings.Split(r.URL.Path, "/")
-			d := parts[len(parts)-1]
-			switch d {
-			case configDigest:
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(configBytes)
-			case layerDigest:
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write(layerBytes)
-			default:
-				w.WriteHeader(http.StatusNotFound)
-			}
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-	// TLS server: flate's spec.insecure maps to TLS InsecureSkipVerify
-	// (it doesn't downshift to PlainHTTP), so the test server has to
-	// speak TLS for the fetcher's standard credential path to apply.
-	srv := httptest.NewTLSServer(mux)
-	t.Cleanup(srv.Close)
-
+	srv := startFakeRegistry(t, manifestBytes, configBytes, layerBytes)
 	hostport := mustURL(t, srv.URL).Host
 
 	f := &Fetcher{Cache: source.NewCache(t.TempDir())}
@@ -109,17 +52,15 @@ func TestFetcher_ExtractsLayerWithoutTitleAnnotation(t *testing.T) {
 		Name:      "flux-manifests",
 		Namespace: "flux-system",
 		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:      fmt.Sprintf("oci://%s/fluxcd/flux-manifests", hostport),
-			// httptest.NewTLSServer issues a self-signed cert; spec.insecure
-			// maps to TLS InsecureSkipVerify.
-			Insecure: true,
-			Reference: &sourcev1.OCIRepositoryRef{
-				Tag: "v2.8.8",
-			},
+			URL: fmt.Sprintf("oci://%s/fluxcd/flux-manifests", hostport),
+			// httptest.NewTLSServer issues a self-signed cert; flate
+			// maps spec.insecure to TLS InsecureSkipVerify.
+			Insecure:  true,
+			Reference: &sourcev1.OCIRepositoryRef{Tag: "v2.8.8"},
 		},
 	}
 
-	art, err := f.Fetch(context.Background(), repo)
+	art, err := f.Fetch(t.Context(), repo)
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
@@ -127,24 +68,130 @@ func TestFetcher_ExtractsLayerWithoutTitleAnnotation(t *testing.T) {
 		t.Fatal("Fetch returned no artifact")
 	}
 
-	// Slot must contain the extracted tarball entries, not just the
-	// `.flate-digest` sentinel — that's exactly the regression: pre-fix
-	// the slot had only the sentinel because the blobs were dropped in
-	// memory.
-	extracted := filepath.Join(art.LocalPath, "gotk-components.yaml")
-	got, err := os.ReadFile(extracted) //nolint:gosec // inside t.TempDir-rooted slot
+	// The regression target: pre-fix the slot held only .flate-digest
+	// because the layer blob went to memory; the extracted file is the
+	// observable proof that fallback storage now writes to disk.
+	got, err := os.ReadFile(filepath.Join(art.LocalPath, "gotk-components.yaml")) //nolint:gosec // inside t.TempDir-rooted slot
 	if err != nil {
-		entries, _ := os.ReadDir(art.LocalPath)
-		names := make([]string, 0, len(entries))
-		for _, e := range entries {
-			names = append(names, e.Name())
-		}
-		t.Fatalf("expected extracted gotk-components.yaml under %s; slot contents: %v; err: %v",
-			art.LocalPath, names, err)
+		t.Fatalf("expected extracted gotk-components.yaml under %s: %v\nslot contents: %v",
+			art.LocalPath, err, slotEntries(t, art.LocalPath))
 	}
 	if want := "kind: ConfigMap\n"; string(got) != want {
 		t.Errorf("gotk-components.yaml = %q, want %q", got, want)
 	}
+}
+
+// TestFlatFallbackStorage exercises the storage contract directly so
+// regressions in Push / Fetch / Exists don't depend on the full
+// httptest-registry round-trip catching them.
+func TestFlatFallbackStorage(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	s := &flatFallbackStorage{root: root}
+	payload := []byte("hello flate")
+	desc := ocispec.Descriptor{
+		MediaType: "application/vnd.test",
+		Digest:    digest.Digest(sha256Digest(payload)),
+		Size:      int64(len(payload)),
+	}
+
+	// Exists is false before Push.
+	if ok, err := s.Exists(t.Context(), desc); err != nil || ok {
+		t.Fatalf("Exists before Push = (%v, %v), want (false, nil)", ok, err)
+	}
+
+	if err := s.Push(t.Context(), desc, strings.NewReader(string(payload))); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	// Push lands at <root>/<hex> — applyLayerSelector / cleanupBlobs
+	// both rely on this layout.
+	_, hexDigest, _ := strings.Cut(desc.Digest.String(), ":")
+	if _, err := os.Stat(filepath.Join(root, hexDigest)); err != nil {
+		t.Fatalf("blob not at <root>/<hex>: %v", err)
+	}
+
+	if ok, err := s.Exists(t.Context(), desc); err != nil || !ok {
+		t.Fatalf("Exists after Push = (%v, %v), want (true, nil)", ok, err)
+	}
+
+	rc, err := s.Fetch(t.Context(), desc)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("Fetch = %q, want %q", got, payload)
+	}
+}
+
+// startFakeRegistry serves the minimum subset of the OCI Distribution
+// API that oras.Copy needs: a /v2/ probe, manifests by tag, and blobs
+// by digest. httptest.NewTLSServer's self-signed cert pairs with the
+// caller's spec.insecure to bypass verification.
+func startFakeRegistry(t *testing.T, manifestBytes, configBytes, layerBytes []byte) *httptest.Server {
+	t.Helper()
+	configDigest := sha256Digest(configBytes)
+	layerDigest := sha256Digest(layerBytes)
+	manifestDigest := sha256Digest(manifestBytes)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/v2/"):
+			// Distribution v2 probe.
+			return
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+			w.Header().Set("Docker-Content-Digest", manifestDigest)
+			_, _ = w.Write(manifestBytes)
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			switch r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:] {
+			case configDigest:
+				_, _ = w.Write(configBytes)
+			case layerDigest:
+				_, _ = w.Write(layerBytes)
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// mustManifestJSON builds an OCI image manifest pointing at the given
+// config + single layer (no title annotations — that's the whole
+// point of the regression).
+func mustManifestJSON(t *testing.T, configBytes, layerBytes []byte, configMT, layerMT string) []byte {
+	t.Helper()
+	m := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config: ocispec.Descriptor{
+			MediaType: configMT,
+			Digest:    digest.Digest(sha256Digest(configBytes)),
+			Size:      int64(len(configBytes)),
+		},
+		Layers: []ocispec.Descriptor{{
+			MediaType: layerMT,
+			Digest:    digest.Digest(sha256Digest(layerBytes)),
+			Size:      int64(len(layerBytes)),
+		}},
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }
 
 func sha256Digest(b []byte) string {
@@ -160,3 +207,17 @@ func mustURL(t *testing.T, raw string) *url.URL {
 	}
 	return u
 }
+
+func slotEntries(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []string{"<unreadable: " + err.Error() + ">"}
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -19,42 +19,6 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-// flatFallbackStorage is the orasfile fallback we pass to
-// NewWithFallbackStorage so blobs lacking an
-// `org.opencontainers.image.title` annotation still land on disk
-// (orasfile's default fallback is an in-memory store). It writes each
-// blob as `<root>/<hex>` — the same layout applyLayerSelector,
-// readSlotManifest, and cleanupBlobs already address. The
-// non-title-annotated case covers every Flux OCIRepository payload
-// (vnd.cncf.flux.content.v1.tar+gzip), the artifact's config blob, and
-// the image manifest itself.
-type flatFallbackStorage struct{ root string }
-
-func (s *flatFallbackStorage) Push(_ context.Context, desc ocispec.Descriptor, content io.Reader) error {
-	path := digestPath(s.root, desc.Digest)
-	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // path lives under fetcher-owned slot
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, content); err != nil { //nolint:gosec // size-bounded by oras's descriptor verification
-		_ = out.Close()
-		return err
-	}
-	return out.Close()
-}
-
-func (s *flatFallbackStorage) Fetch(_ context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
-	return os.Open(digestPath(s.root, desc.Digest)) //nolint:gosec // path lives under fetcher-owned slot
-}
-
-func (s *flatFallbackStorage) Exists(_ context.Context, desc ocispec.Descriptor) (bool, error) {
-	_, err := os.Stat(digestPath(s.root, desc.Digest))
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return err == nil, err
-}
-
 // copiedLayerFilename is the deterministic name layers are stored
 // under when LayerSelector.Operation is "copy". Downstream consumers
 // (e.g. Kustomization spec.path on an OCIRepository whose artifact

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -262,17 +262,10 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		tag = "latest"
 	}
 
-	// orasfile.New's default fallback storage is an in-memory store, so
-	// any blob without an `org.opencontainers.image.title` annotation
-	// (the typical shape of Flux's `vnd.cncf.flux.content.v1.tar+gzip`
-	// content layer, plus most non-Helm OCI artifacts) is dropped into
-	// memory and never lands in the slot. applyLayerSelector then can't
-	// find the manifest on disk and silently no-ops — the slot is left
-	// empty except for `.flate-digest`, and downstream `kustomize build`
-	// renders zero manifests rather than failing. Wire a flat-layout
-	// fallback that writes each unnamed blob as `slot/<hex>`, the layout
-	// applyLayerSelector / readSlotManifest / cleanupBlobs already
-	// expect.
+	// Non-default fallback so blobs without an
+	// `org.opencontainers.image.title` annotation still land on disk
+	// rather than orasfile's in-memory default. See fallback.go for the
+	// why — every Flux OCIRepository payload hits this case.
 	dest, err := orasfile.NewWithFallbackStorage(slot, &flatFallbackStorage{root: slot})
 	if err != nil {
 		return nil, fmt.Errorf("oras file store: %w", err)


### PR DESCRIPTION
## Summary

Follow-up review of #265.

- **`flatFallbackStorage` → `fallback.go`** — `layer.go` is about tarball extraction; the type belongs with the orasfile destination wiring. Matches the codebase split-by-concern style (`auth.go`, `verify.go`, `cosign.go`).
- **Trim call-site comment in `oci.go`** — the WHY now lives next to the type, the call site just points back.
- **New `TestFlatFallbackStorage`** — exercises Push / Fetch / Exists directly so a regression in any one of them surfaces without needing the full httptest-registry round-trip to catch it. Verified both this test AND the integration test fail when Push is broken.
- **Tighten integration test** — extracted `startFakeRegistry` + `mustManifestJSON` helpers so the test body reads top-down. Switched `rc.Read(buf)` to `io.ReadAll(rc)` (Read doesn't guarantee a full buffer fill). Replaced the empty-struct-then-mutate `Versioned` init with `specs.Versioned{SchemaVersion: 2}`.

## Test plan

- [x] `go test ./...` green.
- [x] `go vet` + `golangci-lint run ./...` clean.
- [x] Zariel/home-ops full battery without `spec.layerSelector`: `test all` 191/0.
- [x] Both `TestFetcher_ExtractsLayerWithoutTitleAnnotation` and `TestFlatFallbackStorage` correctly fail when `flatFallbackStorage.Push` is sabotaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)