### PR TITLE
feat(helm): route OCI chart pulls through source.oci.Fetcher

### DIFF
--- a/pkg/helm/oci_chart_test.go
+++ b/pkg/helm/oci_chart_test.go
@@ -1,0 +1,296 @@
+package helm
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestLocateOCIChart_PrefersSourceArtifactExtract is the headline of
+// the unification: when the source.oci.Fetcher has materialized an
+// OCIRepository to an EXTRACTED slot (Flux's default
+// layerSelector.operation), locateOCIChart returns that slot directly
+// instead of issuing a duplicate pull via helm's registry client.
+//
+// This is also what makes spec.verify (cosign), spec.layerSelector,
+// spec.certSecretRef, etc. apply to Helm chart pulls — they all fire
+// during the source.Fetcher.Fetch call, and now Helm consumes the
+// already-verified, already-selected artifact instead of re-pulling
+// over a separate code path.
+func TestLocateOCIChart_PrefersSourceArtifactExtract(t *testing.T) {
+	t.Parallel()
+
+	slot := t.TempDir()
+	writeChartFiles(t, slot, "mychart", "0.1.0")
+
+	cli, hr := setupOCIChartTest(t, slot, "extracted")
+
+	path, err := cli.locateOCIChart(t.Context(), hr)
+	if err != nil {
+		t.Fatalf("locateOCIChart: %v", err)
+	}
+	if path != slot {
+		t.Errorf("path = %q, want extracted slot %q", path, slot)
+	}
+	// loader.Load(dir) should succeed on the extracted layout.
+	if _, err := cli.LoadChart(t.Context(), hr); err != nil {
+		t.Errorf("LoadChart on extracted slot: %v", err)
+	}
+}
+
+// TestLocateOCIChart_PrefersSourceArtifactCopy covers
+// layerSelector.operation=copy: the slot holds layer.tar.gz rather
+// than an extracted chart tree. locateOCIChart should return the tgz
+// path so helm's FileLoader handles it.
+func TestLocateOCIChart_PrefersSourceArtifactCopy(t *testing.T) {
+	t.Parallel()
+
+	slot := t.TempDir()
+	chartTGZ := buildChartTarGz(t, "mychart", "0.1.0")
+	tgzPath := filepath.Join(slot, copiedOCILayerFilename)
+	if err := os.WriteFile(tgzPath, chartTGZ, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cli, hr := setupOCIChartTest(t, slot, "copied")
+
+	path, err := cli.locateOCIChart(t.Context(), hr)
+	if err != nil {
+		t.Fatalf("locateOCIChart: %v", err)
+	}
+	if path != tgzPath {
+		t.Errorf("path = %q, want copied tgz %q", path, tgzPath)
+	}
+	if _, err := cli.LoadChart(t.Context(), hr); err != nil {
+		t.Errorf("LoadChart on copied layer.tar.gz: %v", err)
+	}
+}
+
+// TestLocateOCIChart_FallsBackWhenNoArtifact covers the
+// --enable-oci=false shape: source.ExistenceFetcher leaves the
+// OCIRepository Ready with no SourceArtifact, so locateOCIChart must
+// fall through to helm's registry client. We don't have a real
+// registry here, but the fallback's first action is to try the
+// helm-side cache file; we pre-populate it so the fallback returns
+// success without a network roundtrip. The point of the test is that
+// when no artifact is present, the fallback path runs (and does NOT
+// error out with the artifact-missing message).
+func TestLocateOCIChart_FallsBackWhenNoArtifact(t *testing.T) {
+	t.Parallel()
+
+	cli, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	st := store.New()
+	const repoURL = "oci://ghcr.io/test/chart"
+	repo := &manifest.OCIRepository{
+		Name: "chart", Namespace: "flux-system",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       repoURL,
+			Reference: &sourcev1.OCIRepositoryRef{Tag: "0.1.0"},
+		},
+	}
+	st.AddObject(repo)
+	// Intentionally NO SetArtifact — this is the --enable-oci=false shape.
+	cli.SetSourceResolver(NewStoreSourceResolver(st))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "chart",
+			RepoName:      "chart",
+			RepoNamespace: "flux-system",
+			RepoKind:      manifest.KindOCIRepository,
+			Version:       "0.1.0",
+		},
+	}
+
+	// Pre-populate the helm cache target so fetchOCIChart's cache-hit
+	// branch returns without network. The target naming comes from
+	// fetchOCIChart's `safeName(filepath.Base(ref))+"-"+version+".tgz"`.
+	cacheTarget := filepath.Join(cli.cacheDir, "chart-0.1.0.tgz")
+	if err := os.WriteFile(cacheTarget, buildChartTarGz(t, "chart", "0.1.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path, err := cli.locateOCIChart(t.Context(), hr)
+	if err != nil {
+		t.Fatalf("locateOCIChart fallback: %v", err)
+	}
+	if path != cacheTarget {
+		t.Errorf("path = %q, want fallback cache %q", path, cacheTarget)
+	}
+}
+
+// TestLocateOCIChart_PrefersSourceArtifactChartnameSubdir covers the
+// most common chart-as-OCI shape: `helm package` emits a tarball with
+// a single top-level `<chartname>/` directory, and operation=extract
+// (Flux's default) preserves that — so the chart files end up under
+// `<slot>/<chartname>/` rather than at the slot root. The hr.Chart.Name
+// can differ from the on-disk dir name (publishers may rename), so the
+// resolver scans for the single Chart.yaml-bearing subdir.
+func TestLocateOCIChart_PrefersSourceArtifactChartnameSubdir(t *testing.T) {
+	t.Parallel()
+
+	slot := t.TempDir()
+	chartDir := filepath.Join(slot, "vector") // dir name matches the publisher's chart, not hr.Chart.Name
+	if err := os.MkdirAll(filepath.Join(chartDir, "templates"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeChartFiles(t, chartDir, "vector", "0.52.0")
+
+	cli, hr := setupOCIChartTest(t, slot, "subdir")
+	// hr.Chart.Name purposely differs from the on-disk subdir name to
+	// pin that the resolver doesn't rely on a name match.
+	hr.Chart.Name = "vector-aggregator"
+
+	path, err := cli.locateOCIChart(t.Context(), hr)
+	if err != nil {
+		t.Fatalf("locateOCIChart: %v", err)
+	}
+	if path != chartDir {
+		t.Errorf("path = %q, want chart subdir %q", path, chartDir)
+	}
+	if _, err := cli.LoadChart(t.Context(), hr); err != nil {
+		t.Errorf("LoadChart on chartname subdir: %v", err)
+	}
+}
+
+// TestLocateOCIChart_AmbiguousSubdirs covers the multi-subdir case:
+// when an OCI artifact unexpectedly contains MORE than one
+// Chart.yaml-bearing subdir, refuse to guess. Better a loud error
+// than silently rendering the wrong chart.
+func TestLocateOCIChart_AmbiguousSubdirs(t *testing.T) {
+	t.Parallel()
+
+	slot := t.TempDir()
+	for _, name := range []string{"chart-a", "chart-b"} {
+		dir := filepath.Join(slot, name)
+		if err := os.MkdirAll(filepath.Join(dir, "templates"), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		writeChartFiles(t, dir, name, "0.1.0")
+	}
+
+	cli, hr := setupOCIChartTest(t, slot, "ambiguous")
+
+	_, err := cli.locateOCIChart(t.Context(), hr)
+	if err == nil {
+		t.Fatal("expected error for ambiguous subdirs")
+	}
+	if !strings.Contains(err.Error(), "Chart.yaml") {
+		t.Errorf("error message should mention Chart.yaml; got: %v", err)
+	}
+}
+
+// TestOCIChartPathFromArtifact_MissingLayer verifies the explicit
+// error when the source fetcher landed a slot that's missing all
+// expected shapes — points the operator at the obvious fix
+// (layerSelector misconfiguration) instead of failing later inside
+// helm's loader with a less-clear message.
+func TestOCIChartPathFromArtifact_MissingLayer(t *testing.T) {
+	t.Parallel()
+	slot := t.TempDir()
+	_, err := ociChartPathFromArtifact(slot)
+	if err == nil {
+		t.Fatal("expected error for empty slot")
+	}
+	if !strings.Contains(err.Error(), "Chart.yaml") || !strings.Contains(err.Error(), "layerSelector") {
+		t.Errorf("error message should name the missing shapes and hint at layerSelector; got: %v", err)
+	}
+}
+
+// setupOCIChartTest builds the common helm.Client + store + HR for
+// the source-artifact-preferred path. The slot is registered as the
+// OCIRepository's SourceArtifact, matching what source.oci.Fetcher
+// would have produced.
+func setupOCIChartTest(t *testing.T, slot, label string) (*Client, *manifest.HelmRelease) {
+	t.Helper()
+	cli, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	st := store.New()
+	repo := &manifest.OCIRepository{
+		Name: "chart-" + label, Namespace: "flux-system",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL: "oci://ghcr.io/test/chart-" + label,
+		},
+	}
+	st.AddObject(repo)
+	st.SetArtifact(repo.Named(), &store.SourceArtifact{
+		Kind:      manifest.KindOCIRepository,
+		URL:       repo.URL,
+		LocalPath: slot,
+	})
+	cli.SetSourceResolver(NewStoreSourceResolver(st))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "mychart",
+			RepoName:      repo.Name,
+			RepoNamespace: repo.Namespace,
+			RepoKind:      manifest.KindOCIRepository,
+		},
+	}
+	return cli, hr
+}
+
+// writeChartFiles drops a minimal helm chart at root/<name-from-Chart.yaml-dir>
+// — used for the "extract" layout test where source.oci leaves chart
+// files at slot root.
+func writeChartFiles(t *testing.T, root, name, version string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, "Chart.yaml"),
+		[]byte("apiVersion: v2\nname: "+name+"\nversion: "+version+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "templates"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "templates", "_helpers.tpl"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// buildChartTarGz returns a gzipped tarball of a minimal helm chart
+// — used for the "copy" layout test where source.oci leaves the
+// chart at slot/layer.tar.gz.
+func buildChartTarGz(t *testing.T, name, version string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	files := map[string]string{
+		name + "/Chart.yaml":              "apiVersion: v2\nname: " + name + "\nversion: " + version + "\n",
+		name + "/templates/_helpers.tpl": "",
+	}
+	for path, body := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     path,
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(body)),
+			Mode:     0o644,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(tw, body); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+	return buf.Bytes()
+}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -287,13 +287,34 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 }
 
 // locateOCIChart resolves a chart whose source is an OCIRepository.
-// The OCIRepository.url already points at the chart artifact (Flux's
-// "chart-as-OCI-artifact" model) so we use it verbatim — the chart's
-// short name from the HelmRelease is metadata, not part of the URL.
+//
+// Preferred path: the source.oci.Fetcher has already pulled the
+// artifact (applying spec.verify cosign verification, spec.layerSelector,
+// spec.certSecretRef, spec.proxySecretRef, spec.insecure, spec.ignore,
+// semver tag resolution) into a slot under the shared source cache —
+// the HR depwait blocks render until that source is Ready, so by the
+// time this runs the artifact is on disk. Reading it from the store
+// keeps every Flux OCIRepository feature working uniformly for both
+// Kustomization and HelmRelease consumers.
+//
+// Fallback path: when no SourceArtifact is present (typically
+// --enable-oci=false, which wires source.ExistenceFetcher for
+// OCIRepository so HR depwait still unblocks but no artifact is
+// written), pull via helm's registry client. This preserves the
+// pre-unification behavior for embedders that don't wire the OCI
+// fetcher — but in that mode none of the OCIRepository spec.*
+// features apply, exactly as before.
 func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
 	r := c.resolveOCIRepo(hr)
 	if r == nil {
 		return "", fmt.Errorf("%w: OCIRepository %s not registered", manifest.ErrObjectNotFound, hr.Chart.RepoFullName())
+	}
+	if art := c.resolveLocalSource(hr); art != nil && art.LocalPath != "" {
+		path, err := ociChartPathFromArtifact(art.LocalPath)
+		if err != nil {
+			return "", fmt.Errorf("OCIRepository %s/%s: %w", r.Namespace, r.Name, err)
+		}
+		return path, nil
 	}
 	ver, err := r.Version()
 	if err != nil {
@@ -301,6 +322,80 @@ func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (
 	}
 	return c.fetchOCIChart(ctx, r.URL, ver)
 }
+
+// ociChartPathFromArtifact picks the right chart path under an
+// OCIRepository SourceArtifact's slot. The source/oci fetcher's
+// applyLayerSelector produces one of three observable layouts:
+//
+//  1. Chart.yaml at slot root — the rare shape where a chart-as-OCI
+//     artifact is published WITHOUT helm's standard `<chartname>/`
+//     wrapper directory. Slot itself is the chart root.
+//  2. layer.tar.gz at slot root — operation=copy on the OCIRepository's
+//     layerSelector. Slot contains the packaged chart tgz; helm's
+//     loader.Load handles it via FileLoader.
+//  3. <slot>/<chartname>/Chart.yaml — the common shape: `helm package`
+//     emits tarballs with a single top-level directory named after
+//     the chart, and operation=extract (Flux's default) preserves
+//     that layout when unpacking. The chart name in the dir comes
+//     from the artifact, NOT hr.Chart.Name (those can differ), so we
+//     scan for the single subdir that contains a Chart.yaml.
+//
+// Probing the filesystem keeps this hr.Chart.Name-independent and
+// works uniformly across vendor packaging styles.
+func ociChartPathFromArtifact(slot string) (string, error) {
+	if _, err := os.Stat(filepath.Join(slot, chartYamlFilename)); err == nil {
+		return slot, nil
+	}
+	tgz := filepath.Join(slot, copiedOCILayerFilename)
+	if _, err := os.Stat(tgz); err == nil {
+		return tgz, nil
+	}
+	if sub, ok := findChartSubdir(slot); ok {
+		return sub, nil
+	}
+	return "", fmt.Errorf("OCIRepository artifact at %s has neither %s, %s, nor a <name>/Chart.yaml subdir — chart layer missing or layerSelector misconfigured",
+		slot, chartYamlFilename, copiedOCILayerFilename)
+}
+
+// findChartSubdir scans the immediate children of slot for one that
+// contains a Chart.yaml — the shape produced by `helm package` when
+// extracted via operation=extract. Returns the matching subdir's full
+// path. Hidden entries (`.flate-digest`, `.flate-layer.tar.gz`) are
+// skipped because they're flate internals, not user content.
+//
+// Returns (path, false) when no subdir matches; (path, false) when
+// multiple subdirs match, because we can't safely pick one — that's
+// either a bundle-of-charts artifact (unsupported here, surfaces as
+// a clear error from the caller) or a polluted slot.
+func findChartSubdir(slot string) (string, bool) {
+	entries, err := os.ReadDir(slot)
+	if err != nil {
+		return "", false
+	}
+	var match string
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(slot, e.Name(), chartYamlFilename)); err != nil {
+			continue
+		}
+		if match != "" {
+			return "", false // ambiguous
+		}
+		match = filepath.Join(slot, e.Name())
+	}
+	return match, match != ""
+}
+
+// chartYamlFilename / copiedOCILayerFilename mirror, by string value,
+// the on-disk names produced by source/oci.applyLayerSelector. Kept
+// as constants here (and not imported across packages) to avoid a
+// pkg/helm → pkg/source/oci dependency for two static strings.
+const (
+	chartYamlFilename      = "Chart.yaml"
+	copiedOCILayerFilename = "layer.tar.gz"
+)
 
 // ociPullRef joins an OCI repo URL and an optional ref into the form
 // the helm registry client expects. A digest ref (`sha256:<hex>` and

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -348,6 +348,16 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	// Ready "unchanged" with no artifact and the KS's
 	// resolveSourceRoot surfaces "artifact not found" downstream.
 	// Issue #260.
+	//
+	// Reset the source's status to Pending BEFORE the Refire fires
+	// so a concurrent depwait — the KS consuming this source is
+	// reconciled on a sibling goroutine right after Filter.Add
+	// returns — sees Pending and blocks instead of reading the
+	// stale Ready/"unchanged" status from the initial PreGate skip.
+	// Without this, depwait races the re-fetch and may proceed with
+	// no artifact even though the fetch is queued. (Visible as
+	// intermittent CI flakes on the issue #260 regression test
+	// before this guard landed.)
 	f.OnAdd = func(id manifest.NamedResource) {
 		switch id.Kind {
 		case manifest.KindGitRepository,
@@ -356,6 +366,7 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 			manifest.KindBucket,
 			manifest.KindHelmChart,
 			manifest.KindExternalArtifact:
+			o.store.UpdateStatus(id, store.StatusPending, "re-fetching after keep-set extension")
 			o.store.Refire(id)
 		}
 	}

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -47,6 +47,18 @@ var ociLayoutArtifacts = []string{
 	ocispec.ImageIndexFile,  // "index.json"
 }
 
+// effectiveLayerOperation returns the operation applyLayerSelector
+// will run for a given selector — Extract by default, honoring an
+// explicit override otherwise. Exposed so callers (the OCI fetcher)
+// can branch behavior such as source-ignore application that only
+// makes sense for the extracted-contents shape.
+func effectiveLayerOperation(selector *manifest.OCILayerSelector) string {
+	if selector == nil || selector.Operation == "" {
+		return manifest.OCILayerOperationExtract
+	}
+	return selector.Operation
+}
+
 // applyLayerSelector post-processes an OCI artifact written into slot
 // by oras.Copy. After Copy, the slot is laid out per the OCI Image
 // Layout spec (see ociLayoutArtifacts). This function:

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -293,9 +293,17 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		resetOnErr()
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
-	if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
-		resetOnErr()
-		return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+	// Source-controller's default ignore set includes `*.tar.gz`. For
+	// operation=copy the artifact IS the .tar.gz file we just produced
+	// at slot/<copiedLayerFilename>, so running ApplyIgnore would
+	// delete it. Skip the ignore pass in that case; for operation=
+	// extract the slot holds the extracted directory tree and the
+	// ignore semantics apply as Flux ships them.
+	if effectiveLayerOperation(repo.LayerSelector) == manifest.OCILayerOperationExtract {
+		if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
+			resetOnErr()
+			return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+		}
 	}
 	// Persist the resolved digest so a subsequent cache hit can
 	// re-verify against the exact bytes we wrote, even when the spec


### PR DESCRIPTION
## Summary

Unifies the helm OCI chart fetch path with `pkg/source/oci.Fetcher`. A `HelmRelease.spec.chart.spec.sourceRef.kind: OCIRepository` (or `spec.chartRef.kind: OCIRepository`) now pulls through the SAME code path that handles standalone OCIRepository Kustomization sources — so `spec.verify` (cosign), `spec.layerSelector`, `spec.certSecretRef`, `spec.proxySecretRef`, `spec.insecure`, `spec.ignore`, and semver tag resolution ALL apply to Helm chart pulls. They didn't before; the helm path bypassed the source controller entirely via `helm.sh/helm/v3/pkg/registry`.

**Concretely**: someone landing `spec.verify` on a Flux HR's OCIRepository now gets cosign verification on the chart pull, matching what real Flux ships.

## What changed

- **`helm.Client.locateOCIChart`** now reads the OCIRepository's `SourceArtifact` from the store (already fetched by the source controller under the HR's depwait gate) and resolves the chart path from the slot layout.
- **`ociChartPathFromArtifact`** handles all three observable layouts:
  - `Chart.yaml` at slot root — direct extract.
  - `layer.tar.gz` at slot root — `operation: copy`.
  - `<slot>/<chartname>/Chart.yaml` — `helm package` wrapper (the common shape). A scan picks the single chart subdir without depending on `hr.Chart.Name` matching the on-disk dir name (publishers may rename). Ambiguous multi-chart slots fail loudly rather than guessing.
- **Fallback retained** for `--enable-oci=false`: source registers `ExistenceFetcher`, no artifact, helm's registry client handles the pull as before. That mode was already feature-blind; nothing regresses.

## Bug fix uncovered en route

`source/oci.fetch` unconditionally ran `source.ApplyIgnore` after `applyLayerSelector`. The default Flux ignore set includes `*.tar.gz`, which **deletes the artifact** produced by `operation: copy`. The bug never surfaced before because the helm path bypassed the slot entirely; with the unified path it broke cert-manager-style HRs. Fix: skip `ApplyIgnore` when `operation: copy` — the file IS the artifact, not content to filter.

## Test plan

- [x] 6 new tests in `pkg/helm/oci_chart_test.go` covering:
  - Source artifact preferred — `extract` layout, `copy` layout, chartname-subdir layout.
  - Ambiguous-subdir fails cleanly.
  - Missing-layer error message names the layerSelector hint.
  - `--enable-oci=false` fallback path.
- [x] `go test ./...` green; `golangci-lint run ./...` clean.
- [x] **Zariel/home-ops `test all`: 191 / 0** without `spec.layerSelector` workarounds.
- [x] Cross-repo: buroa-k8s-gitops 166/0, morte-test 236/0; biohazard / m00nwtchr pre-existing chart-side failures unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)