### PR TITLE
refactor(store): encapsulate status reset inside Refire

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -345,28 +345,23 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	// emitRenderedChildren → keepEmitted) refires any source whose
 	// listener already short-circuited via PreGate before the
 	// consuming KS joined keep. Without this hook, the source stays
-	// Ready "unchanged" with no artifact and the KS's
+	// Ready/"unchanged" with no artifact and the KS's
 	// resolveSourceRoot surfaces "artifact not found" downstream.
-	// Issue #260.
+	// Issue #260. Refire owns the status reset that closes the
+	// depwait race — see Store.Refire.
 	//
-	// Reset the source's status to Pending BEFORE the Refire fires
-	// so a concurrent depwait — the KS consuming this source is
-	// reconciled on a sibling goroutine right after Filter.Add
-	// returns — sees Pending and blocks instead of reading the
-	// stale Ready/"unchanged" status from the initial PreGate skip.
-	// Without this, depwait races the re-fetch and may proceed with
-	// no artifact even though the fetch is queued. (Visible as
-	// intermittent CI flakes on the issue #260 regression test
-	// before this guard landed.)
+	// Kinds limited to the source-controller-managed set (those wired
+	// with a Fetcher in the constructor above). HelmChart resources
+	// are read directly by helm.storeResolver without a Fetcher, so
+	// Refire on a HelmChart id would write a Pending status that no
+	// controller transitions back to Ready.
 	f.OnAdd = func(id manifest.NamedResource) {
 		switch id.Kind {
 		case manifest.KindGitRepository,
 			manifest.KindOCIRepository,
 			manifest.KindHelmRepository,
 			manifest.KindBucket,
-			manifest.KindHelmChart,
 			manifest.KindExternalArtifact:
-			o.store.UpdateStatus(id, store.StatusPending, "re-fetching after keep-set extension")
 			o.store.Refire(id)
 		}
 	}

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -33,6 +33,12 @@ const (
 	SkippedPrefix = "skipped:"
 	MsgUnchanged  = "unchanged"
 	MsgSuspended  = "suspended"
+	// MsgRefetching is the Pending-message Refire writes before
+	// re-dispatching EventObjectAdded. Surfaced as a distinct sentinel
+	// (vs. the source controller's own "fetching" mid-reconcile) so log
+	// scraping can distinguish a Refire-triggered re-pull from a
+	// first-time fetch.
+	MsgRefetching = "re-fetching"
 )
 
 // IsSkipped reports whether info represents a soft-skip — i.e. a

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -89,12 +89,21 @@ func (s *Store) AddObject(obj manifest.BaseManifest) {
 	s.fire(EventObjectAdded, id, obj)
 }
 
-// Refire dispatches EventObjectAdded for the existing object at id
-// without altering state. Used to wake up listeners that
-// short-circuited the first time (e.g. source controllers that
-// PreGate-skipped a source whose consumer joined the change-filter
-// keep set only at runtime — see issue #260). No-op when id is not
-// in the store.
+// Refire resets the resource's Ready condition to Pending and then
+// dispatches EventObjectAdded for the existing object at id. Used to
+// wake up listeners that short-circuited the first time — e.g. source
+// controllers that PreGate-skipped a source whose consumer joined the
+// change-filter keep set only at runtime (issue #260).
+//
+// The status reset is load-bearing, not cosmetic. Without it, a
+// consumer's depwait may read the stale Ready/"unchanged" status the
+// initial PreGate skip wrote, return immediately, and race ahead of
+// the queued re-reconcile — producing an "artifact not found" failure
+// while the actual fetch is still in flight. UpdateStatus completes
+// before EventObjectAdded fires, so any depwait that reads status
+// between the two events still sees Pending.
+//
+// No-op when id is not in the store.
 func (s *Store) Refire(id manifest.NamedResource) {
 	s.mu.RLock()
 	obj, ok := s.objects[id]
@@ -102,6 +111,7 @@ func (s *Store) Refire(id manifest.NamedResource) {
 	if !ok {
 		return
 	}
+	s.UpdateStatus(id, StatusPending, MsgRefetching)
 	s.fire(EventObjectAdded, id, obj)
 }
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -83,6 +83,53 @@ func TestStore_AddListener_Flush(t *testing.T) {
 	}
 }
 
+// TestStore_Refire_ResetsStatusBeforeDispatch pins the contract that
+// makes the issue #260 fix race-free: by the time the EventObjectAdded
+// listener fires, the resource's recorded status MUST already be
+// Pending. A consumer's depwait observing status between the two events
+// must never see the stale Ready left by an initial PreGate skip.
+func TestStore_Refire_ResetsStatusBeforeDispatch(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "src"}
+	s.AddObject(&manifest.OCIRepository{Name: "src", Namespace: "flux-system"})
+	s.UpdateStatus(id, StatusReady, MsgUnchanged) // simulate PreGate skip
+
+	var observed StatusInfo
+	s.AddListener(EventObjectAdded, func(eventID manifest.NamedResource, _ any) {
+		if eventID != id {
+			return
+		}
+		info, _ := s.GetStatus(eventID)
+		observed = info
+	}, false)
+	s.Refire(id)
+
+	if observed.Status != StatusPending {
+		t.Errorf("listener saw status %+v on Refire; want Pending so depwaits block", observed)
+	}
+	if observed.Message != MsgRefetching {
+		t.Errorf("listener saw message %q; want %q", observed.Message, MsgRefetching)
+	}
+}
+
+// TestStore_Refire_NoopMissingID pins that Refire silently returns
+// when id isn't in the store — used by callers that may speculatively
+// refire ids that race a DeleteObject.
+func TestStore_Refire_NoopMissingID(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "ns", Name: "nope"}
+
+	fired := 0
+	s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) { fired++ }, false)
+	s.Refire(id) // must not panic, must not dispatch
+	if fired != 0 {
+		t.Errorf("Refire on missing id fired %d events; want 0", fired)
+	}
+	if _, ok := s.GetStatus(id); ok {
+		t.Errorf("Refire on missing id left status behind")
+	}
+}
+
 func TestStore_UpdateStatus_Idempotent(t *testing.T) {
 	s := New()
 	id := manifest.NamedResource{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"}


### PR DESCRIPTION
## Summary

Follow-up to #269's race fix. The agent review flagged the orchestrator's manual `UpdateStatus → Refire` sequencing as an encapsulation gap — every future caller has to remember it, and the (sole) call site duplicates logic that belongs with `Refire`.

- **`Store.Refire` now owns the status reset** — writes a canonical `MsgRefetching` Pending status before dispatching `EventObjectAdded`. Consumers observing status between the two events see `Pending` and block, never the stale `Ready/"unchanged"` the initial PreGate skip wrote.
- **`MsgRefetching` joins `MsgUnchanged` / `MsgSuspended`** as a sentinel constant so log scraping distinguishes Refire-triggered re-pulls from first-time fetches (the source controller's own `"fetching"` message).
- **Drops `KindHelmChart`** from the orchestrator's `OnAdd` switch — `HelmChart` resources are read directly by `helm.storeResolver` without a `Fetcher`, so a `Refire` on a `HelmChart` id would write a `Pending` status no controller transitions back to `Ready`. The set now matches the kinds registered with a `source.Fetcher` in `orchestrator.New`.

## Tests

- `TestStore_Refire_ResetsStatusBeforeDispatch` pins the contract that `EventObjectAdded` listeners observe `Pending` the moment they fire.
- `TestStore_Refire_NoopMissingID` pins the missing-id no-op.
- `TestIssue260` stress-passes 200× under `-race` (was a one-off CI flake before #269's spot fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)