### PR TITLE
refactor(discovery): drop dead alreadyAliased skip-set + free knownSourceIDs

### DIFF
--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -60,7 +60,7 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 // trade-off inherited from the original `flux-system` path.
 func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 	aliased := d.aliasMissingKustomizationSources(repoRoot)
-	aliased = append(aliased, d.overrideSelfReferentialGitRepositories(repoRoot, aliased)...)
+	aliased = append(aliased, d.overrideSelfReferentialGitRepositories(repoRoot)...)
 	warnIfMultipleBootstrapAliases(aliased, repoRoot)
 }
 
@@ -68,10 +68,10 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 // Kustomization and, for any unique Git/OCIRepository sourceRef that no
 // in-tree CR satisfies, publishes a synthetic CR + working-tree
 // artifact. Without this, dependent Kustomizations would fail depwait
-// with `dependency not found`. Returns the IDs aliased so pass 2 can
-// skip them.
+// with `dependency not found`. Returns the IDs aliased so the multi-
+// source WARN sees them.
 func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifest.NamedResource {
-	existing := d.knownSourceIDs(manifest.KindGitRepository, manifest.KindOCIRepository)
+	existing := knownSourceIDs(d.cfg.Store, manifest.KindGitRepository, manifest.KindOCIRepository)
 	seen := make(map[manifest.NamedResource]struct{})
 	var aliased []manifest.NamedResource
 	for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
@@ -83,10 +83,10 @@ func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifes
 			continue
 		}
 		if !d.publishBootstrapAlias(id, repoRoot) {
-			// Unsupported kind (HelmRepository, Bucket, etc.) — these
-			// can't be aliased to a filesystem path, so we silently
-			// skip; the downstream depwait failure surfaces a clearer
-			// error than a misleading half-publish would.
+			// Unsupported kind for aliasing (anything outside
+			// newBootstrapAlias's switch) — silently skip; the
+			// downstream depwait failure surfaces a clearer error
+			// than a misleading half-publish would.
 			continue
 		}
 		seen[id] = struct{}{}
@@ -102,22 +102,19 @@ func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifes
 // offline so we substitute the local checkout. Returns the IDs
 // overridden so the multi-alias footgun check sees them.
 //
-// Skips IDs in alreadyAliased (defensive — pass 1 publishes synthetic
-// URLs that don't match real remotes, but staying explicit prevents
-// double-status writes).
-func (d *discoverer) overrideSelfReferentialGitRepositories(repoRoot string, alreadyAliased []manifest.NamedResource) []manifest.NamedResource {
+// No alreadyAliased skip-set needed: pass 1 publishes synthetic URLs
+// (file:// or oci://flate-bootstrap-alias/...) that normalizeGitURL
+// always rejects. A pass-1 alias can never URL-match a working-tree
+// remote, so the URL-match filter below is the natural guard.
+func (d *discoverer) overrideSelfReferentialGitRepositories(repoRoot string) []manifest.NamedResource {
 	remotes := readWorkingTreeRemotes(repoRoot)
 	debugLogRemotes(remotes)
 	if len(remotes) == 0 {
 		return nil
 	}
-	skip := namedResourceSet(alreadyAliased)
 	var overridden []manifest.NamedResource
 	for _, repo := range store.ListAs[*manifest.GitRepository](d.cfg.Store, manifest.KindGitRepository) {
 		id := repo.Named()
-		if _, ok := skip[id]; ok {
-			continue
-		}
 		normalized := normalizeGitURL(repo.URL)
 		if normalized == "" {
 			continue
@@ -181,25 +178,15 @@ func newBootstrapAlias(id manifest.NamedResource, repoRoot string) (manifest.Bas
 	return nil, "", false
 }
 
-// knownSourceIDs returns a set of the IDs of every object currently in
-// the store for the given kinds. Used by pass 1 to skip sourceRefs
-// that already have a real CR.
-func (d *discoverer) knownSourceIDs(kinds ...string) map[manifest.NamedResource]struct{} {
+// knownSourceIDs returns the IDs of every object currently in s for
+// the given kinds. Used by aliasing pass 1 to skip sourceRefs that
+// already have a real CR.
+func knownSourceIDs(s *store.Store, kinds ...string) map[manifest.NamedResource]struct{} {
 	out := make(map[manifest.NamedResource]struct{})
 	for _, kind := range kinds {
-		for _, obj := range d.cfg.Store.ListObjects(kind) {
+		for _, obj := range s.ListObjects(kind) {
 			out[obj.Named()] = struct{}{}
 		}
-	}
-	return out
-}
-
-// namedResourceSet builds a set lookup from a slice of NamedResource
-// IDs.
-func namedResourceSet(ids []manifest.NamedResource) map[manifest.NamedResource]struct{} {
-	out := make(map[manifest.NamedResource]struct{}, len(ids))
-	for _, id := range ids {
-		out[id] = struct{}{}
 	}
 	return out
 }
@@ -217,6 +204,6 @@ func warnIfMultipleBootstrapAliases(aliased []manifest.NamedResource, repoRoot s
 	for i, id := range aliased {
 		names[i] = id.String()
 	}
-	slog.Warn("discovery: aliased multiple GitRepositories to the working tree; cross-repo refs render against the wrong tree",
+	slog.Warn("discovery: aliased multiple bootstrap sources to the working tree; cross-repo refs render against the wrong tree",
 		"count", len(aliased), "ids", names, "localPath", repoRoot)
 }

--- a/pkg/discovery/bootstrap_internal_test.go
+++ b/pkg/discovery/bootstrap_internal_test.go
@@ -1,0 +1,96 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestNewBootstrapAlias covers the per-kind branches that aliasing
+// supports plus the unsupported-kind branch that lets
+// publishBootstrapAlias silently skip non-aliasable sourceRefs.
+func TestNewBootstrapAlias(t *testing.T) {
+	t.Parallel()
+	const repoRoot = "/tmp/repo"
+	cases := []struct {
+		name    string
+		id      manifest.NamedResource
+		wantOK  bool
+		wantURL string
+		wantNS  string
+	}{
+		{
+			name:    "GitRepository → file:// alias",
+			id:      manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "flux-system"},
+			wantOK:  true,
+			wantURL: "file:///tmp/repo",
+			wantNS:  "flux-system",
+		},
+		{
+			name:    "OCIRepository → synthetic oci:// alias",
+			id:      manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "flux-manifests"},
+			wantOK:  true,
+			wantURL: "oci://flate-bootstrap-alias/flux-manifests",
+			wantNS:  "flux-system",
+		},
+		{
+			name:   "HelmRepository → unsupported (caller should skip)",
+			id:     manifest.NamedResource{Kind: manifest.KindHelmRepository, Namespace: "flux-system", Name: "repo"},
+			wantOK: false,
+		},
+		{
+			name:   "Bucket → unsupported (caller should skip)",
+			id:     manifest.NamedResource{Kind: manifest.KindBucket, Namespace: "flux-system", Name: "bucket"},
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			obj, url, ok := newBootstrapAlias(tc.id, repoRoot)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				if obj != nil || url != "" {
+					t.Errorf("unsupported kind returned obj=%v url=%q; want zero values", obj, url)
+				}
+				return
+			}
+			if url != tc.wantURL {
+				t.Errorf("url = %q, want %q", url, tc.wantURL)
+			}
+			named := obj.Named()
+			if named != tc.id {
+				t.Errorf("obj.Named() = %v, want %v", named, tc.id)
+			}
+		})
+	}
+}
+
+// TestKnownSourceIDs covers the helper's multi-kind union behavior.
+func TestKnownSourceIDs(t *testing.T) {
+	t.Parallel()
+	s := store.New()
+	gr := &manifest.GitRepository{Name: "g1", Namespace: "ns"}
+	oc := &manifest.OCIRepository{Name: "o1", Namespace: "ns"}
+	hr := &manifest.HelmRepository{Name: "h1", Namespace: "ns"}
+	s.AddObject(gr)
+	s.AddObject(oc)
+	s.AddObject(hr)
+
+	got := knownSourceIDs(s, manifest.KindGitRepository, manifest.KindOCIRepository)
+	if _, ok := got[gr.Named()]; !ok {
+		t.Errorf("missing GitRepository entry")
+	}
+	if _, ok := got[oc.Named()]; !ok {
+		t.Errorf("missing OCIRepository entry")
+	}
+	if _, ok := got[hr.Named()]; ok {
+		t.Errorf("HelmRepository should not appear — not in the requested kinds")
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2; got = %v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up agent review of #268 caught three items:

- **Dead skip-set**: `alreadyAliased` on `overrideSelfReferentialGitRepositories` was a defensive guard against pass-1 aliases re-entering pass 2. But pass 1 publishes synthetic URLs (`file://...` or `oci://flate-bootstrap-alias/...`) that `normalizeGitURL` always rejects, so the URL-match filter is already the natural guard. The skip-set, the `alreadyAliased` parameter, and the `namedResourceSet` helper that only existed to build it are all dead — removed.
- **`knownSourceIDs` was a method without state**: lifted to a free function (`pkg/discovery/bootstrap.go:175`) for consistency with the other helpers in this file (and across the package — `readWorkingTreeRemotes`, `KSPathPrefixes`).
- **WARN message was inaccurate**: `warnIfMultipleBootstrapAliases` logged "aliased multiple GitRepositories" but the count includes OCIRepositories from pass 1. Rephrased to "aliased multiple bootstrap sources".

## Tests

- `TestNewBootstrapAlias` (table test) covers the per-kind branches plus the unsupported-kind branch (`HelmRepository`, `Bucket`) that lets `publishBootstrapAlias` silently skip non-aliasable sourceRefs.
- `TestKnownSourceIDs` covers the multi-kind union behavior.
- Existing `TestRun_Aliases*` integration tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)