### PR TITLE
refactor(helm): observability + semver guard + distinct ambiguous error

### DIFF
--- a/pkg/helm/oci_chart_test.go
+++ b/pkg/helm/oci_chart_test.go
@@ -149,6 +149,13 @@ func TestLocateOCIChart_PrefersSourceArtifactChartnameSubdir(t *testing.T) {
 		t.Fatal(err)
 	}
 	writeChartFiles(t, chartDir, "vector", "0.52.0")
+	// Real source/oci slots also contain `.flate-digest` (and possibly
+	// `.flate-layer.tar.gz` from a `copy` op). Drop one to verify the
+	// hidden-prefix filter in findChartSubdir doesn't mistake it for
+	// a Chart.yaml-less subdir.
+	if err := os.WriteFile(filepath.Join(slot, ".flate-digest"), []byte("sha256:abcd"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 
 	cli, hr := setupOCIChartTest(t, slot, "subdir")
 	// hr.Chart.Name purposely differs from the on-disk subdir name to
@@ -170,7 +177,9 @@ func TestLocateOCIChart_PrefersSourceArtifactChartnameSubdir(t *testing.T) {
 // TestLocateOCIChart_AmbiguousSubdirs covers the multi-subdir case:
 // when an OCI artifact unexpectedly contains MORE than one
 // Chart.yaml-bearing subdir, refuse to guess. Better a loud error
-// than silently rendering the wrong chart.
+// than silently rendering the wrong chart. The error must call out
+// the bundle-of-charts shape so the operator gets an actionable
+// hint, not just "Chart.yaml missing".
 func TestLocateOCIChart_AmbiguousSubdirs(t *testing.T) {
 	t.Parallel()
 
@@ -189,8 +198,50 @@ func TestLocateOCIChart_AmbiguousSubdirs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for ambiguous subdirs")
 	}
-	if !strings.Contains(err.Error(), "Chart.yaml") {
-		t.Errorf("error message should mention Chart.yaml; got: %v", err)
+	if !strings.Contains(err.Error(), "multiple") || !strings.Contains(err.Error(), "bundle-of-charts") {
+		t.Errorf("error message should distinguish ambiguous case (mention 'multiple' + 'bundle-of-charts'); got: %v", err)
+	}
+}
+
+// TestLocateOCIChart_FallbackSemverRefused covers the fallback's
+// semver guard: spec.ref.semver requires the source.oci.Fetcher
+// (which lists tags from the registry); the helm-side fallback has
+// no way to resolve it, so we error early with an explicit message
+// rather than letting helm's registry client return a cryptic
+// "invalid tag" deeper down.
+func TestLocateOCIChart_FallbackSemverRefused(t *testing.T) {
+	t.Parallel()
+
+	cli, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	st := store.New()
+	repo := &manifest.OCIRepository{
+		Name: "semver", Namespace: "flux-system",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       "oci://ghcr.io/test/chart",
+			Reference: &sourcev1.OCIRepositoryRef{SemVer: ">=1.0.0"},
+		},
+	}
+	st.AddObject(repo)
+	// No SetArtifact — forces the fallback.
+	cli.SetSourceResolver(NewStoreSourceResolver(st))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "chart", RepoName: "semver", RepoNamespace: "flux-system",
+			RepoKind: manifest.KindOCIRepository,
+		},
+	}
+
+	_, err = cli.locateOCIChart(t.Context(), hr)
+	if err == nil {
+		t.Fatal("expected error for semver in fallback mode")
+	}
+	if !strings.Contains(err.Error(), "semver") || !strings.Contains(err.Error(), "enable-oci") {
+		t.Errorf("error should name the cause (semver) and the resolution (enable-oci); got: %v", err)
 	}
 }
 

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -316,10 +317,30 @@ func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (
 		}
 		return path, nil
 	}
+	// Fallback path. The source.oci.Fetcher didn't produce an
+	// artifact for this OCIRepository — typically because the
+	// orchestrator is configured with EnableOCI=false (which wires
+	// source.ExistenceFetcher) or because the HR's source controller
+	// was never wired in this embedding. NONE of the OCIRepository
+	// spec.* features (verify / layerSelector / certSecretRef /
+	// proxySecretRef / insecure / ignore) apply on this path.
+	if r.Reference != nil && r.Reference.SemVer != "" {
+		// Semver resolution requires listing tags from the registry —
+		// that's part of source.oci.Fetcher, not helm's registry
+		// client. The helm-side fall-back would just pass the semver
+		// constraint to Pull and get a cryptic "invalid tag" error.
+		return "", fmt.Errorf(
+			"OCIRepository %s/%s uses spec.ref.semver but the source.oci.Fetcher is not active "+
+				"(likely --enable-oci=false); semver resolution requires the OCI fetcher",
+			r.Namespace, r.Name)
+	}
 	ver, err := r.Version()
 	if err != nil {
 		return "", err
 	}
+	slog.Debug("helm: OCIRepository SourceArtifact missing; falling back to helm registry client",
+		"ociRepository", r.Namespace+"/"+r.Name, "url", r.URL, "version", ver,
+		"note", "OCIRepository spec.verify/layerSelector/etc. NOT applied on this path")
 	return c.fetchOCIChart(ctx, r.URL, ver)
 }
 
@@ -350,27 +371,46 @@ func ociChartPathFromArtifact(slot string) (string, error) {
 	if _, err := os.Stat(tgz); err == nil {
 		return tgz, nil
 	}
-	if sub, ok := findChartSubdir(slot); ok {
+	switch sub, status := findChartSubdir(slot); status {
+	case chartSubdirFound:
 		return sub, nil
+	case chartSubdirAmbiguous:
+		// More than one Chart.yaml-bearing subdir — distinct failure
+		// from "no chart found", and the right hint is "this is a
+		// bundle-of-charts artifact, not a single chart".
+		return "", fmt.Errorf("OCIRepository artifact at %s contains multiple Chart.yaml-bearing subdirs; "+
+			"flate cannot disambiguate a bundle-of-charts artifact", slot)
 	}
-	return "", fmt.Errorf("OCIRepository artifact at %s has neither %s, %s, nor a <name>/Chart.yaml subdir — chart layer missing or layerSelector misconfigured",
+	return "", fmt.Errorf("OCIRepository artifact at %s has neither %s, %s, nor a <name>/Chart.yaml subdir — "+
+		"chart layer missing or layerSelector misconfigured",
 		slot, chartYamlFilename, copiedOCILayerFilename)
 }
 
+// chartSubdirStatus is the typed result of findChartSubdir. The
+// caller branches between "not found" and "ambiguous" to surface
+// distinct error messages — the operator hint is different.
+type chartSubdirStatus int
+
+const (
+	chartSubdirNotFound chartSubdirStatus = iota
+	chartSubdirFound
+	chartSubdirAmbiguous
+)
+
 // findChartSubdir scans the immediate children of slot for one that
 // contains a Chart.yaml — the shape produced by `helm package` when
-// extracted via operation=extract. Returns the matching subdir's full
-// path. Hidden entries (`.flate-digest`, `.flate-layer.tar.gz`) are
-// skipped because they're flate internals, not user content.
+// extracted via operation=extract. Hidden entries (anything starting
+// with `.`) are skipped: this safely covers the .flate-* sentinels and
+// any incidental dotfiles. Valid charts never use a dot-prefixed
+// top-level directory.
 //
-// Returns (path, false) when no subdir matches; (path, false) when
-// multiple subdirs match, because we can't safely pick one — that's
-// either a bundle-of-charts artifact (unsupported here, surfaces as
-// a clear error from the caller) or a polluted slot.
-func findChartSubdir(slot string) (string, bool) {
+// Returns ("", chartSubdirNotFound) when no subdir matches and
+// ("", chartSubdirAmbiguous) when multiple match, so the caller can
+// emit a specific error for each.
+func findChartSubdir(slot string) (string, chartSubdirStatus) {
 	entries, err := os.ReadDir(slot)
 	if err != nil {
-		return "", false
+		return "", chartSubdirNotFound
 	}
 	var match string
 	for _, e := range entries {
@@ -381,11 +421,14 @@ func findChartSubdir(slot string) (string, bool) {
 			continue
 		}
 		if match != "" {
-			return "", false // ambiguous
+			return "", chartSubdirAmbiguous
 		}
 		match = filepath.Join(slot, e.Name())
 	}
-	return match, match != ""
+	if match == "" {
+		return "", chartSubdirNotFound
+	}
+	return match, chartSubdirFound
 }
 
 // chartYamlFilename / copiedOCILayerFilename mirror, by string value,


### PR DESCRIPTION
## Summary

Three helm-OCI improvements from the agent review of #269.

### 1. Log when fallback fires

An operator debugging "why isn't my `spec.verify` gating my HelmRelease?" previously saw normal renders with no signal that flate had bypassed the OCIRepository spec entirely. Adds a Debug-level `slog` at the fallback site noting that `spec.verify` / `spec.layerSelector` / etc. do NOT apply on this path.

### 2. Refuse semver in the fallback

`spec.ref.semver` requires listing tags from the registry — that's part of `source.oci.Fetcher`, not helm's registry client. The previous code passed the semver string verbatim to `ociPullRef` → `registry.Pull`, which would fail with a cryptic "invalid tag" error from deep inside helm. Now: error early with an explicit `semver resolution requires the OCI fetcher` message naming `--enable-oci` as the cause.

### 3. Distinguish "ambiguous chart subdirs" from "chart missing"

A slot containing two `Chart.yaml`-bearing subdirs is a different failure shape from a slot with none — it's a bundle-of-charts artifact that flate can't disambiguate. `findChartSubdir` now returns a typed `chartSubdirStatus` (`NotFound` / `Found` / `Ambiguous`), and `ociChartPathFromArtifact` emits a specific error per case so the operator hint matches the actual problem.

## Tests

- **`TestLocateOCIChart_FallbackSemverRefused`** asserts the semver guard fires with both `semver` and `enable-oci` in the message.
- **`TestLocateOCIChart_AmbiguousSubdirs`** strengthened to require the bundle-of-charts wording.
- **`TestLocateOCIChart_PrefersSourceArtifactChartnameSubdir`** now drops a `.flate-digest` sentinel into the slot to actually exercise the hidden-prefix filter in `findChartSubdir` (the prior test didn't).

## Test plan

- [x] All 7 helm-OCI tests pass.
- [x] `go test ./...` green, `golangci-lint run ./...` clean.
- [x] Zariel/home-ops `test all`: 191 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)