### PR TITLE
fix(store): close AddListener double-fire race + harden Refire/Snapshot

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -92,7 +92,16 @@ func compileReadyExpr(expr string) (cel.Program, error) {
 // rely on these being populated. The full spec is not yet projected;
 // CEL expressions touching spec.* read undefined (documented gap).
 func projectObject(s *store.Store, id manifest.NamedResource) map[string]any {
-	conds := s.GetConditions(id)
+	// Snapshot the object AND its conditions atomically. Independent
+	// GetObject + GetConditions calls would each take their own
+	// s.mu.RLock; between them a writer can land an AddObject and/or
+	// SetCondition, mixing the freshly-projected object with stale
+	// conditions (or vice versa). For correlation-style CEL like
+	//   dep.metadata.labels['component'] == 'cache' &&
+	//   dep.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')
+	// the mixed snapshot can render a false positive/negative until
+	// the next event triggers re-evaluation.
+	obj, conds := s.Snapshot(id)
 	condsAny := make([]any, 0, len(conds))
 	for _, c := range conds {
 		condsAny = append(condsAny, conditionToMap(c))
@@ -109,7 +118,7 @@ func projectObject(s *store.Store, id manifest.NamedResource) map[string]any {
 		// — a common Flux readiness idiom — never spuriously fail.
 		"generation": int64(1),
 	}
-	if labels, annotations := labelsAndAnnotations(s.GetObject(id)); labels != nil || annotations != nil {
+	if labels, annotations := labelsAndAnnotations(obj); labels != nil || annotations != nil {
 		if labels != nil {
 			meta["labels"] = labels
 		}

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -96,8 +96,9 @@ func (s *Store) SetArtifact(id manifest.NamedResource, artifact Artifact) {
 		return
 	}
 	s.artifacts[id] = artifact
+	dispatch := s.fireUnderLock(EventArtifactUpdated, id, artifact)
 	s.mu.Unlock()
-	s.fire(EventArtifactUpdated, id, artifact)
+	dispatch()
 }
 
 // GetArtifact returns the artifact for id, or nil if none was set.

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"log/slog"
-	"maps"
 	"slices"
 	"sync"
 
@@ -73,65 +72,99 @@ func (s *Store) OnArtifact(fn func(manifest.NamedResource, Artifact), replay boo
 // order must sort what they receive. Listener panics during replay
 // are recovered, same as live dispatch. The returned Unsubscribe
 // removes the listener.
+//
+// The flush=true path holds s.mu across the (register + capture
+// replay snapshot) pair. Without that serialization, a concurrent
+// writer (AddObject / SetCondition / SetArtifact) could update its
+// map, release s.mu, snapshot listeners (now including this fresh
+// listener because set.add already ran), and dispatch the live event
+// to fn — while THIS goroutine separately replays the same object
+// from the post-update map snapshot. The result is a double-fire.
+// Holding s.mu while we both register AND capture the replay state
+// means writers either see the listener-registered state before
+// dispatch (replay returns nothing new, live event fires once) or
+// see the pre-registered state (live event misses this listener,
+// replay fires once). Exactly-one delivery either way.
 func (s *Store) AddListener(event EventKind, fn Listener, flush bool) Unsubscribe {
 	set, ok := s.listeners[event]
 	if !ok {
 		panic("store: unknown event kind")
 	}
+	if !flush {
+		handle := set.add(fn)
+		return func() { set.remove(handle) }
+	}
+	s.mu.Lock()
 	handle := set.add(fn)
-
-	if flush {
-		s.replayInto(event, fn)
+	pairs := s.snapshotForReplay(event)
+	s.mu.Unlock()
+	for _, p := range pairs {
+		safeInvoke(fn, p.id, p.payload)
 	}
 	return func() { set.remove(handle) }
 }
 
-// replayInto delivers existing state to a fresh listener so it can catch
-// up. Called under no lock; takes its own RLock. Listener panics are
-// recovered via safeInvoke — replay must NOT crash the controller that
-// just attached the listener (parity with live `fire` dispatch).
-func (s *Store) replayInto(event EventKind, fn Listener) {
-	switch event {
-	case EventObjectAdded:
-		s.mu.RLock()
-		snap := make(map[manifest.NamedResource]manifest.BaseManifest, len(s.objects))
-		maps.Copy(snap, s.objects)
-		s.mu.RUnlock()
-		for id, obj := range snap {
-			safeInvoke(fn, id, obj)
-		}
-	case EventStatusUpdated:
-		s.mu.RLock()
-		snap := make(map[manifest.NamedResource]StatusInfo, len(s.conditions))
-		for id, conds := range s.conditions {
-			if info, ok := statusInfoFromConditions(conds); ok {
-				snap[id] = info
-			}
-		}
-		s.mu.RUnlock()
-		for id, info := range snap {
-			safeInvoke(fn, id, info)
-		}
-	case EventArtifactUpdated:
-		s.mu.RLock()
-		snap := make(map[manifest.NamedResource]Artifact, len(s.artifacts))
-		maps.Copy(snap, s.artifacts)
-		s.mu.RUnlock()
-		for id, art := range snap {
-			safeInvoke(fn, id, art)
-		}
-	}
+// idPayload is the replay tuple snapshotForReplay returns.
+type idPayload struct {
+	id      manifest.NamedResource
+	payload any
 }
 
-// fire dispatches an event to every registered listener. Listeners run
-// synchronously on the calling goroutine. A panic in any listener is
-// recovered to prevent one bad listener from breaking the dispatch.
-func (s *Store) fire(event EventKind, id manifest.NamedResource, payload any) {
+// snapshotForReplay captures the existing-state replay for event.
+// Caller MUST hold s.mu (write lock) — the snapshot read must be
+// atomic with respect to writers' map updates so the listener-snapshot
+// they capture is consistent with the replay set returned here.
+func (s *Store) snapshotForReplay(event EventKind) []idPayload {
+	switch event {
+	case EventObjectAdded:
+		out := make([]idPayload, 0, len(s.objects))
+		for id, obj := range s.objects {
+			out = append(out, idPayload{id, obj})
+		}
+		return out
+	case EventStatusUpdated:
+		out := make([]idPayload, 0, len(s.conditions))
+		for id, conds := range s.conditions {
+			if info, ok := statusInfoFromConditions(conds); ok {
+				out = append(out, idPayload{id, info})
+			}
+		}
+		return out
+	case EventArtifactUpdated:
+		out := make([]idPayload, 0, len(s.artifacts))
+		for id, art := range s.artifacts {
+			out = append(out, idPayload{id, art})
+		}
+		return out
+	}
+	return nil
+}
+
+// fireUnderLock is the race-safe dispatcher writers MUST use: it
+// captures the listener snapshot under the caller's already-held
+// s.mu and returns a closure the caller invokes AFTER releasing the
+// lock. The pattern is:
+//
+//	s.mu.Lock()
+//	... mutate ...
+//	dispatch := s.fireUnderLock(EventX, id, payload)
+//	s.mu.Unlock()
+//	dispatch()
+//
+// Holding s.mu while snapshotting listeners closes the
+// AddListener-vs-writer race documented on AddListener.
+func (s *Store) fireUnderLock(event EventKind, id manifest.NamedResource, payload any) func() {
 	set := s.listeners[event]
 	if set == nil {
-		return
+		return func() {}
 	}
-	for _, fn := range set.snapshot() {
+	listeners := set.snapshot()
+	return func() { dispatch(listeners, id, payload) }
+}
+
+// dispatch invokes each listener with the payload, recovering panics.
+func dispatch(listeners []Listener, id manifest.NamedResource, payload any) {
+	for _, fn := range listeners {
 		safeInvoke(fn, id, payload)
 	}
 }

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -180,16 +180,30 @@ func (s *Store) UpdateStatus(id manifest.NamedResource, status Status, message s
 // An identical re-write of the same condition is a no-op (no event).
 func (s *Store) SetCondition(id manifest.NamedResource, cond Condition) {
 	s.mu.Lock()
-	prev := s.conditions[id]
+	updated, changed := s.setConditionLocked(id, cond)
+	if !changed {
+		s.mu.Unlock()
+		return
+	}
+	newInfo, _ := statusInfoFromConditions(updated)
+	dispatch := s.fireUnderLock(EventStatusUpdated, id, newInfo)
+	s.mu.Unlock()
+	dispatch()
+}
 
-	updated := make([]Condition, 0, len(prev)+1)
+// setConditionLocked upserts cond into id's condition list and
+// returns the updated list plus whether it actually changed (an
+// identical re-write is a no-op). Caller MUST hold s.mu — used both
+// by SetCondition (which takes the lock itself) and by Refire (which
+// already holds the lock for an atomic check-and-act).
+func (s *Store) setConditionLocked(id manifest.NamedResource, cond Condition) (updated []Condition, changed bool) {
+	prev := s.conditions[id]
+	updated = make([]Condition, 0, len(prev)+1)
 	replaced := false
 	for _, c := range prev {
 		if c.Type == cond.Type {
 			if conditionEqual(c, cond) {
-				// Identical condition — nothing to do, including no event.
-				s.mu.Unlock()
-				return
+				return prev, false
 			}
 			updated = append(updated, cond)
 			replaced = true
@@ -201,10 +215,7 @@ func (s *Store) SetCondition(id manifest.NamedResource, cond Condition) {
 		updated = append(updated, cond)
 	}
 	s.conditions[id] = updated
-	newInfo, _ := statusInfoFromConditions(updated)
-	s.mu.Unlock()
-
-	s.fire(EventStatusUpdated, id, newInfo)
+	return updated, true
 }
 
 // GetStatus returns the Ready-derived StatusInfo for id and whether

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -85,8 +85,9 @@ func (s *Store) AddObject(obj manifest.BaseManifest) {
 		s.byName[id.Kind] = inner
 	}
 	inner[nameKey(id.Namespace, id.Name)] = obj
+	dispatch := s.fireUnderLock(EventObjectAdded, id, obj)
 	s.mu.Unlock()
-	s.fire(EventObjectAdded, id, obj)
+	dispatch()
 }
 
 // Refire resets the resource's Ready condition to Pending and then
@@ -103,16 +104,30 @@ func (s *Store) AddObject(obj manifest.BaseManifest) {
 // before EventObjectAdded fires, so any depwait that reads status
 // between the two events still sees Pending.
 //
-// No-op when id is not in the store.
+// No-op when id is not in the store. The object existence check, the
+// status reset, and the event capture all run under one s.mu
+// acquisition so a concurrent DeleteObject can't slip in and leave
+// the listener dispatching against a stale object or the status map
+// resurrected with a phantom Pending entry.
 func (s *Store) Refire(id manifest.NamedResource) {
-	s.mu.RLock()
+	s.mu.Lock()
 	obj, ok := s.objects[id]
-	s.mu.RUnlock()
 	if !ok {
+		s.mu.Unlock()
 		return
 	}
-	s.UpdateStatus(id, StatusPending, MsgRefetching)
-	s.fire(EventObjectAdded, id, obj)
+	updated, changed := s.setConditionLocked(id, readyCondition(StatusPending, MsgRefetching))
+	dispatchObj := s.fireUnderLock(EventObjectAdded, id, obj)
+	var dispatchStatus func()
+	if changed {
+		info, _ := statusInfoFromConditions(updated)
+		dispatchStatus = s.fireUnderLock(EventStatusUpdated, id, info)
+	}
+	s.mu.Unlock()
+	if dispatchStatus != nil {
+		dispatchStatus()
+	}
+	dispatchObj()
 }
 
 // Cloneable is satisfied by manifest types that can be shallowly
@@ -172,6 +187,26 @@ func (s *Store) GetObject(id manifest.NamedResource) manifest.BaseManifest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.objects[id]
+}
+
+// Snapshot returns the manifest and conditions for id captured under
+// a single RLock acquisition. Use this when a caller needs a
+// consistent view of both — e.g. depwait's CEL projection reads
+// status.conditions AND metadata.labels in one expression, and
+// independent GetObject / GetConditions calls can mix a fresh object
+// snapshot with stale conditions (or vice versa) if a writer
+// interleaves. Returns nil object and nil conditions for unknown ids.
+func (s *Store) Snapshot(id manifest.NamedResource) (manifest.BaseManifest, []Condition) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	obj := s.objects[id]
+	conds := s.conditions[id]
+	if len(conds) == 0 {
+		return obj, nil
+	}
+	out := make([]Condition, len(conds))
+	copy(out, conds)
+	return obj, out
 }
 
 // DeleteObject removes the object stored under id. Returns whether

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -3,7 +3,9 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -556,4 +558,57 @@ func TestStore_Concurrency(_ *testing.T) {
 		}
 	}()
 	wg.Wait()
+}
+
+// TestStore_AddListener_FlushNoDoubleFire stresses the
+// AddObject-vs-AddListener race that the fireUnderLock pattern closes.
+// Without the fix, a flush=true listener registering while a sibling
+// goroutine ran AddObject for the same id could observe the object
+// TWICE: once via the live event (listener was added before the
+// writer's listener-snapshot ran) and again via the replay snapshot
+// (which captured the same object). The Coalescer hid this in
+// production by deduping per-id reconciles, but a test counter
+// surfaces it.
+func TestStore_AddListener_FlushNoDoubleFire(t *testing.T) {
+	const iterations = 200
+	for range iterations {
+		s := New()
+		// Seed enough objects that the replay snapshot is non-trivial
+		// and the race window is reachable.
+		const seed = 8
+		for i := range seed {
+			s.AddObject(newCM(fmt.Sprintf("seed-%d", i), "ns"))
+		}
+
+		var (
+			counts   sync.Map // id → atomic count
+			racerID  = manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "racer"}
+			racerObj = newCM("racer", "ns")
+		)
+
+		var startGate, done sync.WaitGroup
+		startGate.Add(1)
+		done.Add(2)
+
+		go func() {
+			defer done.Done()
+			startGate.Wait()
+			s.AddObject(racerObj)
+		}()
+		go func() {
+			defer done.Done()
+			startGate.Wait()
+			s.AddListener(EventObjectAdded, func(id manifest.NamedResource, _ any) {
+				v, _ := counts.LoadOrStore(id, new(atomic.Int64))
+				v.(*atomic.Int64).Add(1)
+			}, true)
+		}()
+		startGate.Done()
+		done.Wait()
+
+		v, _ := counts.LoadOrStore(racerID, new(atomic.Int64))
+		if got := v.(*atomic.Int64).Load(); got != 1 {
+			t.Fatalf("racer fired %d times on iteration; want exactly 1", got)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Three correctness fixes the second agent review found in the `pkg/store` + `pkg/depwait` race surface.

### 1. AddListener flush=true double-fire (HIGH — real bug)

Pre-fix: `AddListener` called `set.add(fn)` then released no lock, then `replayInto` took its own RLock. A concurrent `AddObject` sequence (`Lock → mutate → Unlock → fire → snapshot listeners → invoke`) could land between `set.add(fn)` and the replay snapshot, with the result that `fn` was invoked **TWICE** for the same id:
- Once from the live event (listener set already included `fn`).
- Once from the replay snapshot (map already included the new object).

Controllers masked this in production via the per-id Coalescer, but the double-fire was real waste and a hidden footgun for any non-coalesced listener.

**Fix**: new `fireUnderLock` — writers snapshot their listener set INSIDE the same `s.mu` acquisition that performed the underlying mutation, then dispatch after `Unlock`. `AddListener`'s `flush=true` path holds `s.mu` across `(register + replay snapshot)`. Either ordering yields exactly-one delivery.

**Regression test**: `TestStore_AddListener_FlushNoDoubleFire` iterates 200×; verified to fail pre-fix with `racer fired 2 times; want exactly 1`.

### 2. Refire vs DeleteObject TOCTOU (MEDIUM — latent invariant)

Pre-fix: `Refire` RUnlocked between the existence check and `UpdateStatus + fire`. A concurrent `DeleteObject` between them would leave a phantom `Pending` condition for an id whose object map entry was just dropped (and whose conditions `DeleteObject` had cleared). No caller does this concurrently today, but the invariant was fragile.

**Fix**: hold a single `s.mu.Lock` across the existence check, the conditional status reset (new `setConditionLocked` helper), and both event captures via `fireUnderLock`.

### 3. depwait CEL split-snapshot read (MEDIUM — near-real bug)

`projectObject` called `GetConditions` then `GetObject` — two independent `RLock` acquisitions. A writer landing between them could mix a fresh object snapshot with stale conditions, producing wrong CEL verdicts for correlation expressions like:

```cel
dep.metadata.labels['component'] == 'cache' &&
dep.status.conditions.exists(c, c.type == 'Ready' && c.status == 'True')
```

**Fix**: new `Store.Snapshot(id) → (obj, conds)` returning both under one `RLock`. `projectObject` uses it.

## Test plan

- [x] `go test ./... -race` green.
- [x] `golangci-lint run ./...` clean.
- [x] New `TestStore_AddListener_FlushNoDoubleFire` (200×, verified fails pre-fix).
- [x] Zariel/home-ops `test all`: 191 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)