### PR TITLE
refactor(source/oci): zip-bomb cap, cosign Warn, multi-layer ambiguity guard

### DIFF
--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -99,9 +99,13 @@ func (f *Fetcher) verifyCosignSignature(
 	}
 	if repo.Verify.SecretRef == nil {
 		// Keyless (OIDC) — flate can't reach Fulcio/Rekor offline and
-		// doesn't carry the sigstore trust roots. Log and proceed so the
-		// chart still renders for diff purposes.
-		slog.Debug("cosign keyless verification skipped; rendering unverified artifact",
+		// doesn't carry the sigstore trust roots. Log and proceed so
+		// the chart still renders for diff purposes. WARN (not Debug)
+		// so an operator who deliberately opted into spec.verify can
+		// SEE that flate skipped the verification — silent skip on a
+		// security-gating spec field is the worst-of-both-worlds
+		// outcome.
+		slog.Warn("cosign keyless verification skipped; rendering unverified artifact",
 			"ociRepository", repo.Namespace+"/"+repo.Name,
 			"digest", pulledDigest)
 		return nil

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -63,7 +63,7 @@ func effectiveLayerOperation(selector *manifest.OCILayerSelector) string {
 // Layout spec (see ociLayoutArtifacts). This function:
 //
 //   - Reads the manifest blob to find the layer matching
-//     selector.MediaType (or the first layer when MediaType is empty).
+//     selector.MediaType (or the single layer when no selector is set).
 //   - Stages the layer at slot/<stagedLayerFilename> so the layout
 //     wipe in the next step can't take open handles or user-tarball
 //     entries that collide with OCI well-known names down with it.
@@ -74,9 +74,10 @@ func effectiveLayerOperation(selector *manifest.OCILayerSelector) string {
 //     <copiedLayerFilename>.
 //   - Wipes the OCI Image Layout artifacts.
 //
-// When selector is nil the default extract behavior still applies —
-// matches source-controller's behavior when spec.layerSelector is
-// omitted but the artifact has exactly one tarball layer.
+// When the selector is nil and the artifact has multiple layers, the
+// function errors rather than silently picking layers[0] — matches
+// Flux source-controller's "ambiguous selection" behavior and avoids
+// rendering the wrong layer for multi-layer artifacts.
 func applyLayerSelector(
 	_ context.Context,
 	slot string,
@@ -91,6 +92,14 @@ func applyLayerSelector(
 			return nil
 		}
 		return err
+	}
+	if len(man.Layers) > 1 && (selector == nil || selector.MediaType == "") {
+		mts := make([]string, len(man.Layers))
+		for i, l := range man.Layers {
+			mts[i] = l.MediaType
+		}
+		return fmt.Errorf("OCI artifact has %d layers but no spec.layerSelector.mediaType to disambiguate (layer mediaTypes: %v)",
+			len(man.Layers), mts)
 	}
 	layer, ok := pickLayer(man.Layers, selector)
 	if !ok {
@@ -192,12 +201,24 @@ func cleanupOCILayout(slot string) error {
 	return nil
 }
 
+// maxExtractedBytes caps the total bytes extractTarGz writes to disk
+// per call. Defends against zip-bomb-style artifacts (small gzip,
+// huge tar) that would otherwise fill the cache slot until ENOSPC.
+// 1 GiB is generous enough for every helm chart and flux-manifests
+// shape seen in the wild — the largest known charts are ~50 MiB
+// extracted — while still bounding a malicious or buggy publisher.
+//
+// var (not const) so tests can lower it without writing real-size
+// tarballs. Production callers must NOT override it.
+var maxExtractedBytes int64 = 1 << 30
+
 // extractTarGz unpacks a gzipped tarball into dst. Rejects any entry
 // whose resolved path escapes dst — covers `../` traversal, absolute
 // paths in the tar header (e.g. `/etc/passwd`), and symlink-pivoting
 // hardlinks. Symlinks/hardlinks/devices are silently skipped rather
 // than honored; Flux's source-controller does the same and helm
-// charts never depend on them.
+// charts never depend on them. Output is capped at maxExtractedBytes
+// to bound zip-bomb-style artifacts.
 func extractTarGz(src, dst string) error {
 	f, err := os.Open(src) //nolint:gosec // src lives under the fetcher's cache slot
 	if err != nil {
@@ -210,6 +231,7 @@ func extractTarGz(src, dst string) error {
 	}
 	defer func() { _ = gz.Close() }()
 	tr := tar.NewReader(gz)
+	remaining := maxExtractedBytes
 	for {
 		hdr, err := tr.Next()
 		if errors.Is(err, io.EOF) {
@@ -235,10 +257,22 @@ func extractTarGz(src, dst string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(out, tr); err != nil { //nolint:gosec // tar.Reader is size-bounded by header
+			// LimitReader caps per-call output AND turns a header that
+			// over-claims size into a short read at the limit (rather
+			// than an unbounded write). Track remaining manually so a
+			// single oversized entry surfaces a clear "extract limit"
+			// error instead of a torso-shaped truncated file.
+			n, err := io.Copy(out, io.LimitReader(tr, remaining+1))
+			if err != nil {
 				_ = out.Close()
 				return err
 			}
+			if n > remaining {
+				_ = out.Close()
+				_ = os.Remove(target)
+				return fmt.Errorf("tar entry %q exceeds %d-byte extract limit", hdr.Name, maxExtractedBytes)
+			}
+			remaining -= n
 			if err := out.Close(); err != nil {
 				return err
 			}

--- a/pkg/source/oci/layer_test.go
+++ b/pkg/source/oci/layer_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/opencontainers/go-digest"
@@ -188,6 +189,99 @@ func TestSafeJoinTarPath(t *testing.T) {
 				t.Errorf("safeJoinTarPath(%q): %v", tc.entry, err)
 			}
 		})
+	}
+}
+
+// TestApplyLayerSelector_MultiLayerAmbiguous regresses the silent-
+// pick-first behavior: when a manifest carries multiple layers and
+// no spec.layerSelector.mediaType is set, flate must NOT silently
+// pick layers[0] (could be the wrong layer — chart vs. cosign
+// signature vs. provenance). Matches Flux source-controller behavior.
+func TestApplyLayerSelector_MultiLayerAmbiguous(t *testing.T) {
+	slot := t.TempDir()
+	layerA := mustTarGz(t, map[string]string{"a.yaml": "kind: A\n"})
+	layerB := mustTarGz(t, map[string]string{"b.yaml": "kind: B\n"})
+	digA := writeBlob(t, slot, layerA)
+	digB := writeBlob(t, slot, layerB)
+	_, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip", Digest: digA, Size: int64(len(layerA))},
+		{MediaType: "application/vnd.cncf.helm.chart.provenance.v1.prov", Digest: digB, Size: int64(len(layerB))},
+	})
+
+	err := applyLayerSelector(t.Context(), slot, manifestDigest.String(), nil)
+	if err == nil {
+		t.Fatal("expected ambiguous-layer error; got nil")
+	}
+	if !strings.Contains(err.Error(), "layerSelector") {
+		t.Errorf("error should mention layerSelector as the fix; got: %v", err)
+	}
+}
+
+// TestApplyLayerSelector_MultiLayerWithSelector confirms the
+// disambiguating path: when the selector names a mediaType, the
+// matching layer is picked regardless of count.
+func TestApplyLayerSelector_MultiLayerWithSelector(t *testing.T) {
+	slot := t.TempDir()
+	chart := mustTarGz(t, map[string]string{"Chart.yaml": "apiVersion: v2\nname: x\nversion: 0.1.0\n"})
+	prov := []byte("provenance not a tarball")
+	digChart := writeBlob(t, slot, chart)
+	digProv := writeBlob(t, slot, prov)
+	_, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{MediaType: "application/vnd.cncf.helm.chart.provenance.v1.prov", Digest: digProv, Size: int64(len(prov))},
+		{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip", Digest: digChart, Size: int64(len(chart))},
+	})
+	if err := applyLayerSelector(t.Context(), slot, manifestDigest.String(),
+		&manifest.OCILayerSelector{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"}); err != nil {
+		t.Fatalf("applyLayerSelector: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(slot, "Chart.yaml")); err != nil {
+		t.Errorf("expected Chart.yaml extracted from chart layer: %v", err)
+	}
+}
+
+// TestExtractTarGz_ZipBombRejected covers the maxExtractedBytes cap.
+// Lower the cap to 100 bytes for the test and write a 1 KiB entry —
+// extractTarGz's LimitReader catches the over-budget write and emits
+// the "extract limit" error.
+func TestExtractTarGz_ZipBombRejected(t *testing.T) {
+	orig := maxExtractedBytes
+	t.Cleanup(func() { maxExtractedBytes = orig })
+	maxExtractedBytes = 100
+
+	dir := t.TempDir()
+	tgz := filepath.Join(dir, "bomb.tar.gz")
+	f, err := os.Create(tgz) //nolint:gosec // inside t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	gw := gzip.NewWriter(f)
+	tw := tar.NewWriter(gw)
+	body := bytes.Repeat([]byte("A"), 1<<10) // 1 KiB > 100-byte cap
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "huge.bin", Typeflag: tar.TypeReg,
+		Size: int64(len(body)), Mode: 0o644,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+	_ = f.Close()
+
+	dst := t.TempDir()
+	err = extractTarGz(tgz, dst)
+	if err == nil {
+		t.Fatal("expected extract-limit error; got nil")
+	}
+	if !strings.Contains(err.Error(), "extract limit") {
+		t.Errorf("error should mention extract limit; got: %v", err)
+	}
+	// The over-budget partial file must be removed so a retry sees
+	// a clean slot.
+	if _, err := os.Stat(filepath.Join(dst, "huge.bin")); !os.IsNotExist(err) {
+		t.Errorf("partial extract not cleaned up (err=%v)", err)
 	}
 }
 

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -156,9 +156,8 @@ func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, f
 // digest is verified against the trusted public keys before returning.
 func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, registryConfig string, tlsCfg *tls.Config, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
 	cache := f.Cache
-	if repo == nil {
-		return nil, errors.New("oci repository is nil")
-	}
+	// Note: Fetch already type-asserts repo non-nil before calling
+	// fetch(), so no nil check needed here.
 	if repo.URL == "" {
 		return nil, fmt.Errorf("%w: OCIRepository %s missing url", manifest.ErrInput, repo.RepoName())
 	}
@@ -451,6 +450,16 @@ func loadCredentials(configPath string) (credentials.Store, error) {
 	s, err := credentials.NewStoreFromDocker(opts)
 	if err != nil {
 		// Missing docker config is not fatal — anonymous pulls work.
+		// Distinguish os.ErrNotExist (the common case: no docker login
+		// on this machine) from permission / corrupt-JSON errors so an
+		// operator running flate with a broken ~/.docker/config.json
+		// gets a breadcrumb instead of a silent "401 unauthorized"
+		// from the registry.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		slog.Debug("oci: docker credentials load failed; falling back to anonymous pulls",
+			"err", err)
 		return nil, nil
 	}
 	return s, nil


### PR DESCRIPTION
## Summary

Five OCI hardening items from the second agent review:

### 1. Zip-bomb defense in `extractTarGz` (MEDIUM/HIGH)

A tar header overstating `Size` could previously extract unbounded — the existing `nolint:gosec` comment overstated the protection. New `maxExtractedBytes` (1 GiB) caps total output per call via `io.LimitReader`; a single oversized entry now fails loudly with `tar entry %q exceeds %d-byte extract limit` and removes the partial file. 1 GiB is generous for every helm chart / Flux manifest shape seen in the wild (~50 MiB extracted max).

### 2. Cosign keyless skip: Debug → Warn (MEDIUM, security visibility)

`spec.verify` is a security-gating opt-in; an operator who configured it deserves to SEE that flate skipped verification (no Fulcio/Rekor offline, no sigstore trust roots bundled). The package doc already promised Warn — the code now matches.

### 3. Multi-layer ambiguity error (MEDIUM)

Pre-fix, an artifact with multiple layers and no `spec.layerSelector.mediaType` silently picked `layers[0]` — could be the cosign signature, the provenance, or the wrong chart variant. Now: error with the list of layer mediaTypes so the operator can pick one. Matches Flux source-controller behavior.

### 4. `loadCredentials` error distinction (MEDIUM)

Pre-fix, ANY credential-load failure became a silent anonymous-pull fallback — the user running flate with a broken `~/.docker/config.json` got "401 unauthorized" with no breadcrumb. Now: `os.ErrNotExist` stays silent (common case: no docker login), other errors log at Debug.

### 5. Dead nil check (LOW)

Drop the unreachable `if repo == nil` in `fetch()` — `Fetch()` already type-asserts non-nil before calling.

## Tests

- **`TestApplyLayerSelector_MultiLayerAmbiguous`** regresses the silent pick-first behavior.
- **`TestApplyLayerSelector_MultiLayerWithSelector`** confirms the disambiguation path still works.
- **`TestExtractTarGz_ZipBombRejected`** regresses the unbounded extract; uses a test-overridable cap (`maxExtractedBytes` is `var`, not `const`) to avoid writing a real >1 GiB tarball.

## Test plan

- [x] `go test ./...` green; `golangci-lint run ./...` clean.
- [x] Zariel/home-ops `test all`: 191 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)