### PR TITLE
fix(orchestrator): assert WithFetcher pre-Bootstrap + warn on ignored OCI features

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -130,6 +130,11 @@ type Orchestrator struct {
 	// into Result.Manifests at Render time so `flate build` surfaces
 	// what the RS would create in-cluster.
 	rsExtensions map[manifest.NamedResource][]map[string]any
+
+	// bootstrapped flips true once Bootstrap returns. Read by
+	// WithFetcher to refuse late fetcher swaps that would silently
+	// miss any source CR discovery already reconciled.
+	bootstrapped bool
 }
 
 // Result is the structured output of Orchestrator.Render: the rendered
@@ -226,7 +231,17 @@ func (o *Orchestrator) Store() *store.Store { return o.store }
 //
 // Passing a nil fetcher unregisters the kind — useful for stripping a
 // default registration in tests.
+//
+// Panics if called after Bootstrap: by then discovery has already run
+// and any source CR discovered between New() and Bootstrap was
+// reconciled by whichever fetcher was registered at that moment. A
+// later swap silently misses those reconciles and the embedder gets
+// inconsistent behavior across source CRs of the same kind. Bootstrap
+// is the natural commit point for the controller wiring.
 func (o *Orchestrator) WithFetcher(kind string, f source.Fetcher) *Orchestrator {
+	if o.bootstrapped {
+		panic("orchestrator: WithFetcher called after Bootstrap; install fetchers BEFORE Bootstrap")
+	}
 	if f == nil {
 		delete(o.src.Fetchers, kind)
 		return o
@@ -255,7 +270,41 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 
 	o.validateDependsOn()
 	o.breakDependsOnCycles()
-	return o.buildChangeFilter(res.RepoRoot)
+	o.warnOnDisabledOCIFeatures()
+	if err := o.buildChangeFilter(res.RepoRoot); err != nil {
+		return err
+	}
+	o.bootstrapped = true
+	return nil
+}
+
+// warnOnDisabledOCIFeatures surfaces the EnableOCI=false footgun: with
+// the source.ExistenceFetcher wired for OCIRepository, spec.verify,
+// spec.layerSelector, spec.certSecretRef, spec.proxySecretRef,
+// spec.insecure, and spec.ignore are all parsed from the manifests but
+// silently discarded — the source is marked Ready without a real
+// fetch. A user who configured spec.verify deserves to SEE that
+// flate skipped verification rather than discover it via "passed in
+// flate, failed in cluster".
+func (o *Orchestrator) warnOnDisabledOCIFeatures() {
+	if o.cfg.EnableOCI {
+		return
+	}
+	for _, repo := range store.ListAs[*manifest.OCIRepository](o.store, manifest.KindOCIRepository) {
+		if repo.Verify == nil && repo.LayerSelector == nil {
+			continue
+		}
+		fields := []string{}
+		if repo.Verify != nil {
+			fields = append(fields, "spec.verify")
+		}
+		if repo.LayerSelector != nil {
+			fields = append(fields, "spec.layerSelector")
+		}
+		slog.Warn("OCIRepository spec fields ignored — EnableOCI=false wires ExistenceFetcher",
+			"ociRepository", repo.Namespace+"/"+repo.Name,
+			"ignoredFields", fields)
+	}
 }
 
 // validateDependsOn drops dangling dependsOn references on both

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -105,6 +106,47 @@ func TestDetectOrphans_NonReconcilableKindsIgnored(t *testing.T) {
 	if len(orphans) != 0 {
 		t.Errorf("orphan detection should skip non-reconcilable kinds; got %+v", orphans)
 	}
+}
+
+// TestOrchestrator_WithFetcherAfterBootstrapPanics pins the
+// contract that WithFetcher MUST be called before Bootstrap. A
+// late swap would silently miss any source CR discovery already
+// reconciled, so we fail fast instead of pretending success.
+func TestOrchestrator_WithFetcherAfterBootstrapPanics(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources: []\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when WithFetcher is called after Bootstrap")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "BEFORE Bootstrap") {
+			t.Errorf("panic message should name the ordering contract; got: %v", r)
+		}
+	}()
+	o.WithFetcher(manifest.KindOCIRepository, nil)
 }
 
 func TestOrchestrator_SimpleCluster(t *testing.T) {


### PR DESCRIPTION
## Summary

Two orchestrator footguns the agent review flagged at the embedder seam.

### 1. `WithFetcher` must precede `Bootstrap` — now enforced (MEDIUM)

Pre-fix: the doc said "Call BEFORE Bootstrap" but nothing checked it. A late swap silently misses any source CR discovery already reconciled, so the embedder gets inconsistent behavior across source CRs of the same kind. Now: `Bootstrap` flips a `bootstrapped` flag; `WithFetcher` panics on late calls with a clear `install fetchers BEFORE Bootstrap` message.

Regression test: **`TestOrchestrator_WithFetcherAfterBootstrapPanics`**.

### 2. `EnableOCI=false` silently ignored `spec.verify` / `spec.layerSelector` (MEDIUM, security visibility)

Pre-fix: with `source.ExistenceFetcher` wired, every OCIRepository's security-gating fields were parsed from manifests and discarded. An operator who configured `spec.verify` on their HelmRelease's OCIRepository and then ran with `--enable-oci=false` (a common "speed up local runs" toggle) would discover the gating was off only when cluster reconcile failed.

Now: new `warnOnDisabledOCIFeatures` sweeps the store post-discovery and emits one `WARN` per affected OCIRepository listing the ignored fields.

## Verification

Zariel/home-ops with `--enable-oci=false` now emits warnings for ~12 OCIRepositories that ship `spec.layerSelector` workarounds for flate compatibility:

```
WARN msg="OCIRepository spec fields ignored — EnableOCI=false wires ExistenceFetcher" ociRepository=network/external-dns ignoredFields=[spec.layerSelector]
```

Default-settings `test all` stays 191 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)