### PR TITLE
refactor(source/git): split git.go into auth.go + tls.go

### DIFF
--- a/pkg/source/git/auth.go
+++ b/pkg/source/git/auth.go
@@ -1,0 +1,99 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// resolveAuth turns repo.SecretRef into a go-git AuthMethod. Returns
+// nil auth (anonymous) when no secret is configured, matching the
+// pre-auth behavior. For HTTPS URLs the secret may carry either
+// (username, password) or (bearerToken); for SSH URLs the secret
+// carries `identity` (PEM private key) and an optional `password`.
+func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMethod, error) {
+	if repo.SecretRef == nil {
+		return nil, nil
+	}
+	if f.Secrets == nil {
+		return nil, fmt.Errorf("GitRepository %s/%s references secretRef but no SecretGetter is wired",
+			repo.Namespace, repo.Name)
+	}
+	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s not found",
+			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+	}
+	if isSSHURL(repo.URL) {
+		identity := source.StringFromSecret(sec, "identity")
+		if identity == "" {
+			// Empty covers both missing-key and PLACEHOLDER-wiped values
+			// (the ExternalSecret case). Same sentinel so
+			// --allow-missing-secrets covers both shapes.
+			return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s missing 'identity' for SSH auth",
+				manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+		}
+		password := source.StringFromSecret(sec, "password")
+		user := sshUserFromURL(repo.URL)
+		auth, err := gitssh.NewPublicKeys(user, []byte(identity), password)
+		if err != nil {
+			return nil, fmt.Errorf("GitRepository %s/%s: parse SSH identity: %w",
+				repo.Namespace, repo.Name, err)
+		}
+		// Flate has no central known_hosts. If the secret carries one,
+		// enforce strict host-key checking; otherwise skip (offline
+		// renders against ephemeral worktrees are the norm). Users who
+		// need strict checks provide `known_hosts` in the Secret.
+		if kh := source.StringFromSecret(sec, "known_hosts"); kh != "" {
+			cb, herr := knownHostsCallback([]byte(kh))
+			if herr != nil {
+				return nil, fmt.Errorf("GitRepository %s/%s: parse known_hosts: %w",
+					repo.Namespace, repo.Name, herr)
+			}
+			auth.HostKeyCallback = cb
+		} else {
+			auth.HostKeyCallback = insecureIgnoreHostKey
+		}
+		return auth, nil
+	}
+	// HTTPS / HTTP: bearerToken takes precedence over basic auth, mirroring
+	// source-controller's docs.
+	if token := source.StringFromSecret(sec, "bearerToken"); token != "" {
+		return &githttp.TokenAuth{Token: token}, nil
+	}
+	username := source.StringFromSecret(sec, "username")
+	password := source.StringFromSecret(sec, "password")
+	if username == "" || password == "" {
+		// Empty covers both missing-key and PLACEHOLDER-wiped values
+		// (the ExternalSecret case). Same sentinel so
+		// --allow-missing-secrets covers both shapes.
+		return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s missing username/password (or bearerToken) for HTTPS auth",
+			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
+	}
+	return &githttp.BasicAuth{Username: username, Password: password}, nil
+}
+
+// isSSHURL detects a git SSH URL. Covers both `ssh://user@host/repo`
+// and the scp-like `user@host:repo` form Flux GitRepository specs
+// commonly use; rejects http(s):// URLs that happen to contain `@`
+// (e.g. embedded basic-auth credentials).
+func isSSHURL(url string) bool {
+	return strings.HasPrefix(url, "ssh://") ||
+		(strings.Contains(url, "@") && !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://"))
+}
+
+// sshUserFromURL extracts the SSH user from "user@host:repo" or
+// "ssh://user@host/repo" forms. Defaults to "git" when absent.
+func sshUserFromURL(url string) string {
+	u := strings.TrimPrefix(url, "ssh://")
+	if at := strings.Index(u, "@"); at > 0 {
+		return u[:at]
+	}
+	return "git"
+}

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -3,14 +3,12 @@ package git
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5"
@@ -18,7 +16,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
-	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
@@ -34,14 +31,8 @@ type Fetcher struct {
 	Secrets source.SecretGetter
 }
 
-// httpsTransportMu serializes the brief window where a per-CR HTTPS
-// client is installed as go-git's process-global transport. go-git v5
-// has no per-CloneOptions TLS hook, so custom-CA fetches must hold
-// this lock across InstallProtocol → clone → restore. The lock is
-// package-global because `client.InstallProtocol` is itself
-// process-global — a per-Fetcher mutex would race when two Fetchers
-// run concurrently and clobber each other's transport.
-var httpsTransportMu sync.Mutex
+// httpsTransportMu is declared in tls.go (with the only caller —
+// the TLS-customized InstallProtocol path in Fetch below).
 
 // Fetch implements source.Fetcher for *manifest.GitRepository.
 func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
@@ -86,125 +77,9 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	return f.fetch(ctx, repo, auth, proxy)
 }
 
-// resolveTLS builds a *tls.Config from spec.secretRef for HTTPS GitRepositories
-// using a custom CA. Returns nil when no CA material is present (anonymous /
-// system-CA path). Matches Flux source-controller key conventions:
-// "ca.crt" (preferred) or "caFile" (legacy alias).
-//
-// SSH repositories ignore this — TLS doesn't apply to that transport.
-func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) {
-	if repo.SecretRef == nil {
-		return nil, nil
-	}
-	if isSSHURL(repo.URL) {
-		return nil, nil
-	}
-	if f.Secrets == nil {
-		// resolveAuth already errored if SecretRef && !Secrets, but
-		// guard anyway so this method is safe to call standalone.
-		return nil, nil
-	}
-	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
-	if sec == nil {
-		// resolveAuth reports the missing-secret error first.
-		return nil, nil
-	}
-	ca := source.StringFromSecret(sec, "ca.crt")
-	if ca == "" {
-		ca = source.StringFromSecret(sec, "caFile")
-	}
-	if ca == "" {
-		return nil, nil
-	}
-	cfg, err := source.BuildTLSConfig("", "", ca)
-	if err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: secretRef %s/%s: %w",
-			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name, err)
-	}
-	return cfg, nil
-}
-
-// resolveAuth turns repo.SecretRef into a go-git AuthMethod. Returns
-// nil auth (anonymous) when no secret is configured, matching the
-// pre-auth behavior. For HTTPS URLs the secret may carry either
-// (username, password) or (bearerToken); for SSH URLs the secret
-// carries `identity` (PEM private key) and an optional `password`.
-func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMethod, error) {
-	if repo.SecretRef == nil {
-		return nil, nil
-	}
-	if f.Secrets == nil {
-		return nil, fmt.Errorf("GitRepository %s/%s references secretRef but no SecretGetter is wired",
-			repo.Namespace, repo.Name)
-	}
-	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
-	if sec == nil {
-		return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s not found",
-			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
-	}
-	if isSSHURL(repo.URL) {
-		identity := source.StringFromSecret(sec, "identity")
-		if identity == "" {
-			// Empty covers both missing-key and PLACEHOLDER-wiped values
-			// (the ExternalSecret case). Same sentinel so
-			// --allow-missing-secrets covers both shapes.
-			return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s missing 'identity' for SSH auth",
-				manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
-		}
-		password := source.StringFromSecret(sec, "password")
-		user := sshUserFromURL(repo.URL)
-		auth, err := gitssh.NewPublicKeys(user, []byte(identity), password)
-		if err != nil {
-			return nil, fmt.Errorf("GitRepository %s/%s: parse SSH identity: %w",
-				repo.Namespace, repo.Name, err)
-		}
-		// Flate has no central known_hosts. If the secret carries one,
-		// enforce strict host-key checking; otherwise skip (offline
-		// renders against ephemeral worktrees are the norm). Users who
-		// need strict checks provide `known_hosts` in the Secret.
-		if kh := source.StringFromSecret(sec, "known_hosts"); kh != "" {
-			cb, herr := knownHostsCallback([]byte(kh))
-			if herr != nil {
-				return nil, fmt.Errorf("GitRepository %s/%s: parse known_hosts: %w",
-					repo.Namespace, repo.Name, herr)
-			}
-			auth.HostKeyCallback = cb
-		} else {
-			auth.HostKeyCallback = insecureIgnoreHostKey
-		}
-		return auth, nil
-	}
-	// HTTPS / HTTP: bearerToken takes precedence over basic auth, mirroring
-	// source-controller's docs.
-	if token := source.StringFromSecret(sec, "bearerToken"); token != "" {
-		return &githttp.TokenAuth{Token: token}, nil
-	}
-	username := source.StringFromSecret(sec, "username")
-	password := source.StringFromSecret(sec, "password")
-	if username == "" || password == "" {
-		// Empty covers both missing-key and PLACEHOLDER-wiped values
-		// (the ExternalSecret case). Same sentinel so
-		// --allow-missing-secrets covers both shapes.
-		return nil, fmt.Errorf("%w: GitRepository %s/%s: secret %s/%s missing username/password (or bearerToken) for HTTPS auth",
-			manifest.ErrMissingSecret, repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name)
-	}
-	return &githttp.BasicAuth{Username: username, Password: password}, nil
-}
-
-func isSSHURL(url string) bool {
-	return strings.HasPrefix(url, "ssh://") ||
-		(strings.Contains(url, "@") && !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://"))
-}
-
-// sshUserFromURL extracts the SSH user from "user@host:repo" or
-// "ssh://user@host/repo" forms. Defaults to "git" when absent.
-func sshUserFromURL(url string) string {
-	u := strings.TrimPrefix(url, "ssh://")
-	if at := strings.Index(u, "@"); at > 0 {
-		return u[:at]
-	}
-	return "git"
-}
+// resolveTLS / resolveAuth / isSSHURL / sshUserFromURL split into
+// tls.go and auth.go (mirroring the existing tls_test.go and
+// auth_test.go layouts).
 
 // fetch clones the GitRepository, then runs verification, ignore, and
 // the cache-marker write — ALL inside the per-slot critical section.

--- a/pkg/source/git/tls.go
+++ b/pkg/source/git/tls.go
@@ -1,0 +1,58 @@
+package git
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sync"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// httpsTransportMu serializes the brief window where a per-CR HTTPS
+// client is installed as go-git's process-global transport. go-git v5
+// has no per-CloneOptions TLS hook, so custom-CA fetches must hold
+// this lock across InstallProtocol → clone → restore. Package-global
+// because `client.InstallProtocol` is itself process-global — a
+// per-Fetcher mutex would race when two Fetchers run concurrently
+// and clobber each other's transport.
+var httpsTransportMu sync.Mutex
+
+// resolveTLS builds a *tls.Config from spec.secretRef for HTTPS
+// GitRepositories using a custom CA. Returns nil when no CA material
+// is present (anonymous / system-CA path). Matches Flux
+// source-controller key conventions: "ca.crt" (preferred) or
+// "caFile" (legacy alias).
+//
+// SSH repositories ignore this — TLS doesn't apply to that transport.
+func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) {
+	if repo.SecretRef == nil {
+		return nil, nil
+	}
+	if isSSHURL(repo.URL) {
+		return nil, nil
+	}
+	if f.Secrets == nil {
+		// resolveAuth already errored if SecretRef && !Secrets, but
+		// guard anyway so this method is safe to call standalone.
+		return nil, nil
+	}
+	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
+	if sec == nil {
+		// resolveAuth reports the missing-secret error first.
+		return nil, nil
+	}
+	ca := source.StringFromSecret(sec, "ca.crt")
+	if ca == "" {
+		ca = source.StringFromSecret(sec, "caFile")
+	}
+	if ca == "" {
+		return nil, nil
+	}
+	cfg, err := source.BuildTLSConfig("", "", ca)
+	if err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: secretRef %s/%s: %w",
+			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name, err)
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
## Summary

Pure code reorg. Mirrors the existing test layout (`auth_test.go`, `tls_test.go`) which already named what their production-side targets should be — but the implementations lived in `git.go` alongside the Fetch entry point and the cache/checkout helpers.

- **`auth.go`** (new, 99 lines): `resolveAuth` + `isSSHURL` + `sshUserFromURL`. Covered by `auth_test.go`'s existing 8 tests.
- **`tls.go`** (new, 58 lines): `resolveTLS` + `httpsTransportMu`. Covered by `tls_test.go`'s existing 6 tests.
- **`git.go`** (456 → 331 lines): `Fetcher` type + `Fetch` + `fetch` + `finalize` + cache/checkout helpers — the actual Git operation surface.

## Test plan

- [x] `go test ./...` green, `golangci-lint run ./...` clean.
- [x] All `pkg/source/git` tests still pass against the new file layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)