### PR TITLE
refactor(loader): collapse BuildParentIndex wrappers + drop one-line helper

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -101,7 +101,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	// includes Kind; downstream controllers look up by their own id
 	// and naturally filter to their own kind.
 	parentOf := mergeParents(
-		loader.BuildParentIndex(d.cfg.Store, d.sourceFiles),
+		loader.BuildParentIndexForKind(d.cfg.Store, d.sourceFiles, manifest.KindKustomization),
 		loader.BuildParentIndexForKind(d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease),
 	)
 	// Orphan promotion: every Existence entry whose file path is NOT

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -90,7 +90,7 @@ func collectGeneratorDataFiles(ctx context.Context, root string, ignore *ignoreS
 			}
 			return nil
 		}
-		if !isKustomizationFileName(d.Name()) {
+		if !slices.Contains(kustomizationFileNames, d.Name()) {
 			return nil
 		}
 		k := readKustomization(filepath.Dir(path))
@@ -174,8 +174,3 @@ func resolveDataPath(base, rel string) (string, bool) {
 	return abs, true
 }
 
-// isKustomizationFileName reports whether name matches one of the
-// three kustomize-recognized filenames.
-func isKustomizationFileName(name string) bool {
-	return slices.Contains(kustomizationFileNames, name)
-}

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -54,38 +54,31 @@ func LongestParent(prefixes []KSPathPrefix, file string, self manifest.NamedReso
 	return manifest.NamedResource{}, false
 }
 
-// BuildParentIndex maps each Flux Kustomization to its structural
-// parent — the Flux Kustomization whose spec.path is the deepest
-// strict ancestor of the child's source file. Excludes self-matches.
+// BuildParentIndexForKind maps each childKind resource to its
+// enclosing Flux Kustomization — the KS whose spec.path is the
+// deepest strict ancestor of the child's source file. Excludes
+// self-matches.
 //
 // Real Flux's reconcile chain enforces this naturally: a parent
-// Kustomization renders and applies its child Kustomizations, then
-// the kustomize-controller reconciles each child. flate's controllers
-// fire on AddObject and would otherwise race the parent's render —
-// the controller uses this index to wait for the parent's Ready
-// before reconciling, so any parent-render-time spec mutations
-// (e.g. `replacements:` injecting spec.targetNamespace) are visible
-// to the child's first reconcile.
+// Kustomization renders and applies its children, then the
+// downstream controller reconciles each. flate's controllers fire
+// on AddObject and would otherwise race the parent's render — the
+// child controllers use this index to gate reconcile on the
+// parent's Ready, so any parent-render-time spec mutations
+// (`replacements:` injecting spec.targetNamespace, `patches:`
+// rewriting HelmRelease driftDetection) are visible to the child's
+// first reconcile. Without the gate the file-loaded child renders
+// once with stale spec, the parent re-emits a mutated copy, and the
+// child renders again — twice the helm template / kustomize build
+// work for one logical resource.
 //
 // sourceFiles is the orchestrator's NamedResource → repo-relative
 // source-file map; entries without a recorded file are skipped.
-func BuildParentIndex(s *store.Store, sourceFiles map[manifest.NamedResource]string) map[manifest.NamedResource]manifest.NamedResource {
-	return buildParentIndexForKind(s, sourceFiles, manifest.KindKustomization)
-}
-
-// BuildParentIndexForKind extends BuildParentIndex to map any kind to
-// its enclosing Flux Kustomization. The HR controller uses this to
-// gate reconcile on the parent KS — without that gate, the file-
-// loaded HR renders once with stale spec, the parent KS applies
-// `replacements:` / `patches:` and re-emits a mutated HR, the HR
-// controller renders again with the canonical spec, and helm runs
-// twice for one logical resource. Same parent-prefix logic as
-// BuildParentIndex, just iterating the requested child kind.
+//
+// childKind=KindKustomization for the KS→KS parent map; pass
+// KindHelmRelease for the HR→KS map. The orchestrator builds both
+// (see discovery.Run → mergeParents).
 func BuildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResource]string, childKind string) map[manifest.NamedResource]manifest.NamedResource {
-	return buildParentIndexForKind(s, sourceFiles, childKind)
-}
-
-func buildParentIndexForKind(s *store.Store, sourceFiles map[manifest.NamedResource]string, childKind string) map[manifest.NamedResource]manifest.NamedResource {
 	prefixes := KSPathPrefixes(s)
 	out := map[manifest.NamedResource]manifest.NamedResource{}
 	for _, obj := range s.ListObjects(childKind) {

--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -37,7 +37,7 @@ func TestBuildParentIndex_CrossTreeBasePattern(t *testing.T) {
 		clusterApps.Named(): "kubernetes/clusters/main/apps.yaml",
 		karma.Named():       "kubernetes/apps/main/observability/karma.yaml",
 	}
-	parents := BuildParentIndex(s, sourceFiles)
+	parents := BuildParentIndexForKind(s, sourceFiles, manifest.KindKustomization)
 
 	if got, want := parents[karma.Named()], clusterApps.Named(); got != want {
 		t.Errorf("karma.parent = %+v; want %+v", got, want)
@@ -76,7 +76,7 @@ func TestBuildParentIndex_DeepestPrefixWins(t *testing.T) {
 		inner.Named():      "apps/media/kustomization.yaml",
 		grandchild.Named(): "apps/media/plex/ks.yaml",
 	}
-	parents := BuildParentIndex(s, sourceFiles)
+	parents := BuildParentIndexForKind(s, sourceFiles, manifest.KindKustomization)
 
 	if got, want := parents[grandchild.Named()], inner.Named(); got != want {
 		t.Errorf("grandchild.parent = %+v; want %+v (deepest prefix)", got, want)
@@ -99,7 +99,7 @@ func TestBuildParentIndex_NoSelfMatch(t *testing.T) {
 	sourceFiles := map[manifest.NamedResource]string{
 		ks.Named(): "apps/self/ks.yaml",
 	}
-	parents := BuildParentIndex(s, sourceFiles)
+	parents := BuildParentIndexForKind(s, sourceFiles, manifest.KindKustomization)
 	if _, ok := parents[ks.Named()]; ok {
 		t.Errorf("KS must not be its own parent: %v", parents)
 	}
@@ -126,7 +126,7 @@ func TestBuildParentIndex_NoSourceFileSkipped(t *testing.T) {
 		parent.Named(): "clusters/main/apps.yaml",
 		// orphan deliberately absent.
 	}
-	parents := BuildParentIndex(s, sourceFiles)
+	parents := BuildParentIndexForKind(s, sourceFiles, manifest.KindKustomization)
 	if _, ok := parents[orphan.Named()]; ok {
 		t.Errorf("KS without source file must not appear in parent index: %v", parents)
 	}


### PR DESCRIPTION
## Summary

Two small cleanups in `pkg/loader`:

1. **Wrapper collapse.** `BuildParentIndex` / `BuildParentIndexForKind` / `buildParentIndexForKind` was a three-layer chain: `BuildParentIndex`'s only purpose was to default `childKind=Kustomization`, and the unexported helper added no logic beyond what its exported caller did. Drop `BuildParentIndex` and the unexported helper. Callers now spell the kind explicitly:

   ```go
   loader.BuildParentIndexForKind(s, files, manifest.KindKustomization)
   loader.BuildParentIndexForKind(s, files, manifest.KindHelmRelease)
   ```

   Symmetric, no special-case wrapper. Single call site (`discovery.go`) and four `parent_test.go` tests updated.

2. **`isKustomizationFileName`** was a single-use one-liner wrapping `slices.Contains`. Inlined at its sole caller; the wrapper added indirection without abstraction.

Behavior unchanged. Full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)