### PR TITLE
docs(source)+style(kustomize): SecretGetter currency + dot-prefix idiom

### DIFF
--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -137,7 +138,7 @@ func (c *StagingCache) copyTree(src string) (string, error) {
 		if d.IsDir() {
 			// Skip anything that isn't user content: .git / node_modules
 			// and every dot-prefixed dir (which captures .flate-cache).
-			if base == "node_modules" || (len(base) > 0 && base[0] == '.') {
+			if base == "node_modules" || strings.HasPrefix(base, ".") {
 				return fs.SkipDir
 			}
 			return os.MkdirAll(filepath.Join(dst, rel), 0o750)

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -53,9 +53,10 @@ func (ExistenceFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*stor
 	return nil, nil
 }
 
-// SecretGetter resolves a Secret CR by namespace + name. Fetchers that
-// read authentication credentials (Bucket; future GitRepository
-// SecretRef; future OCIRepository SecretRef) accept one of these so
-// they don't need a back-reference to the Store. The orchestrator
-// wires it to Store.GetByName at construction time.
+// SecretGetter resolves a Secret CR by namespace + name. Fetchers
+// that read authentication, TLS, proxy, or cosign-verify material
+// from a Flux spec.*SecretRef accept one of these so they don't need
+// a back-reference to the Store. Today: GitRepository (auth + TLS),
+// OCIRepository (auth + TLS + cosign verify), Bucket (auth + TLS).
+// The orchestrator wires it to Store.GetByName at construction time.
 type SecretGetter func(namespace, name string) *manifest.Secret


### PR DESCRIPTION
## Summary

Two tiny cleanups noticed while loop-reviewing `pkg/source` and `pkg/kustomize`:

- **`pkg/source/source.go`**: `SecretGetter`'s doc listed `GitRepository SecretRef` and `OCIRepository SecretRef` as "future" — both have shipped for a while. Updated to enumerate the actual current consumers (Git auth/TLS, OCI auth/TLS/cosign verify, Bucket auth/TLS).
- **`pkg/kustomize/stage.go`**: replaced `(len(base) > 0 && base[0] == '.')` with `strings.HasPrefix(base, ".")` — same behavior, idiomatic.

No behavior change; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)