### PR TITLE
refactor: dedup kustomize-builder filename list to manifest.KustomizeBuilderFilenames

### DIFF
--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -70,7 +70,7 @@ func buildOwnership(objs ObjectLister, repoRoot string) ownershipIndex {
 // readKustomizeComponents returns the top-level `components:` field
 // of the kustomization file at base (resolved relative to repoRoot).
 func readKustomizeComponents(repoRoot, base string) []string {
-	for _, name := range []string{"kustomization.yaml", "kustomization.yml", "Kustomization"} {
+	for _, name := range manifest.KustomizeBuilderFilenames {
 		data, err := os.ReadFile(filepath.Join(repoRoot, base, name)) //nolint:gosec // path composed from known cluster layout
 		if err != nil {
 			continue

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -261,9 +261,12 @@ func restoreKustomizationFile(sourceRoot, stagedSub, subPath string) error {
 	return nil
 }
 
-// kustomizationFilenames is the canonical set kustomize looks for at
-// any directory it builds.
-var kustomizationFilenames = []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}
+// kustomizationFilenames is the canonical set kustomize looks for
+// at any directory it builds. Aliased here so the restoreKustomizationFile
+// loop reads as a local; the canonical declaration is in
+// manifest.KustomizeBuilderFilenames so other packages don't
+// duplicate the list.
+var kustomizationFilenames = manifest.KustomizeBuilderFilenames
 
 // validatePath returns a clean ErrInput when p is missing or isn't a
 // directory.

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -10,10 +10,13 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
 	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/home-operations/flate/pkg/manifest"
 )
 
 // remoteFetchTimeout caps each pre-flight HTTP GET. Kustomize's
@@ -64,8 +67,7 @@ func preflightRemoteResources(ctx context.Context, cache *StagingCache, root str
 		if d.IsDir() {
 			return nil
 		}
-		name := d.Name()
-		if name != "kustomization.yaml" && name != "kustomization.yml" && name != "Kustomization" {
+		if !slices.Contains(manifest.KustomizeBuilderFilenames, d.Name()) {
 			return nil
 		}
 		return rewriteURLResources(ctx, cache, path)

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -168,7 +168,7 @@ func indexKustomizeNamespaces(sourceFiles map[manifest.NamedResource]string, rep
 // a kustomization.yaml in dir (resolved relative to repoRoot), or ""
 // if no kustomize file exists or the namespace key is absent.
 func readKustomizeNamespace(repoRoot, dir string) string {
-	for _, name := range []string{"kustomization.yaml", "kustomization.yml", "Kustomization"} {
+	for _, name := range manifest.KustomizeBuilderFilenames {
 		path := filepath.Join(repoRoot, dir, name)
 		data, err := os.ReadFile(path) //nolint:gosec // path composed from known cluster layout
 		if err != nil {

--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -59,3 +59,19 @@ const ValuePlaceholderTemplate = "..PLACEHOLDER_%s.."
 // rather than hard-coding the prefix.
 const ValuePlaceholderPrefix = "..PLACEHOLDER_"
 
+// KustomizeBuilderFilenames is the canonical list the kustomize tool
+// recognizes at any directory it builds — ordered by priority, first
+// match wins. Distinct from pkg/loader's `kustomizationFileNames`
+// (which includes .json for flate's generic YAML/JSON load path):
+// these three are specifically what `kustomize build` looks for at
+// runtime, and what flate's components/parent walks must agree on.
+//
+// Multiple packages need this list (kustomize render, change-filter
+// ownership, namespace inheritance) — keeping it here avoids cross-
+// package coupling on a 3-element string slice.
+var KustomizeBuilderFilenames = []string{
+	"kustomization.yaml",
+	"kustomization.yml",
+	"Kustomization",
+}
+


### PR DESCRIPTION
## Summary

Four places independently declared the `{"kustomization.yaml", "kustomization.yml", "Kustomization"}` list — the file set kustomize recognizes at any directory it builds:

- `pkg/change/ownership.go` — components walk for changed-file owners
- `pkg/loader/inherit.go` — top-level namespace inheritance
- `pkg/kustomize/preflight.go` — URL-resource rewrite scan
- `pkg/kustomize/flux.go` — stage restore + cleanup loop

Hoist to **`manifest.KustomizeBuilderFilenames`** with a doc that calls out the distinction from `pkg/loader`'s `kustomizationFileNames` (which includes `.json` for flate's generic YAML/JSON load path — these three are specifically what `kustomize build` looks for at runtime).

`flux.go`'s local `kustomizationFilenames` is now an alias of the exported var so the local restore/cleanup loop still reads as a local. Behavior unchanged; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)