### PR TITLE
refactor: dedup RS render-doc identity key (resourceset.DedupKey)

### DIFF
--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -123,7 +123,7 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 			if _, raw := parsed.(*manifest.RawObject); !raw {
 				continue
 			}
-			key := dedupKeyForDoc(doc)
+			key := resourceset.DedupKey(doc)
 			if key == "" {
 				continue
 			}
@@ -135,21 +135,6 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		}
 	}
 	o.rsExtensions = out
-}
-
-// dedupKeyForDoc keys a rendered doc by (apiVersion, kind, namespace,
-// name). Empty string when any required component is missing —
-// signals "drop this doc" rather than collide with other emptys.
-func dedupKeyForDoc(doc map[string]any) string {
-	apiVersion, _ := doc["apiVersion"].(string)
-	kind, _ := doc["kind"].(string)
-	md, _ := doc["metadata"].(map[string]any)
-	name, _ := md["name"].(string)
-	ns, _ := md["namespace"].(string)
-	if kind == "" || name == "" {
-		return ""
-	}
-	return apiVersion + "|" + kind + "|" + ns + "|" + name
 }
 
 // resolveInputProvider mirrors discovery.resolveInputProvider but

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -2,7 +2,16 @@ package resourceset
 
 import fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 
-func dedupKey(doc map[string]any) string {
+// DedupKey identifies a rendered doc by (apiVersion, kind, namespace,
+// name) for cross-render deduplication. Returns "" when kind or name
+// are missing — signal to the caller to drop the doc rather than
+// merge with an "empty key" collision pile.
+//
+// Exported so the orchestrator's post-Run RS-extension pass can share
+// the same identity rule as the in-package RS render — without that,
+// a name-grouped RS that emits the same child from two namespace
+// variants could land both copies in the parent KS's extension list.
+func DedupKey(doc map[string]any) string {
 	apiVersion, _ := doc["apiVersion"].(string)
 	kind, _ := doc["kind"].(string)
 	md, _ := doc["metadata"].(map[string]any)

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -78,7 +78,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	var docs []map[string]any
 	seen := map[string]struct{}{}
 	appendUnique := func(doc map[string]any) {
-		key := dedupKey(doc)
+		key := DedupKey(doc)
 		if key == "" {
 			return
 		}


### PR DESCRIPTION
## Summary

`pkg/resourceset/output.go`'s `dedupKey` and `pkg/orchestrator/resourceset.go`'s `dedupKeyForDoc` were **byte-identical**:

- Both key a rendered doc by `(apiVersion, kind, namespace, name)`.
- Both return `""` when `kind` or `name` are missing — signal to drop, not collide on the empty key.

Export as **`resourceset.DedupKey`** so the orchestrator's post-Run RS-extension pass shares the same identity rule as the in-package RS render. Without sharing, a future change to either rule could silently let a doc that the RS render dropped sneak into the orchestrator's extension map (or vice versa).

Behavior unchanged. Full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)