### PR TITLE
refactor(helm): split repo.go into auth.go + oci_chart.go

### DIFF
--- a/pkg/helm/auth.go
+++ b/pkg/helm/auth.go
@@ -1,0 +1,126 @@
+package helm
+
+import (
+	"fmt"
+	"os"
+
+	"helm.sh/helm/v4/pkg/getter"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// helmRepoAuthOptions resolves SecretRef credentials for a HelmRepository
+// into helm getter options. Returns nil options when no SecretRef is
+// configured (anonymous). Username/password basic auth + optional
+// PassCredentials forwarding. Insecure flag is OCI-only per Flux's
+// schema so it is intentionally not surfaced here.
+func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Option, error) {
+	if r.SecretRef == nil {
+		return nil, nil
+	}
+	c.mu.RLock()
+	getSec := c.secrets
+	c.mu.RUnlock()
+	if getSec == nil {
+		// Use the same sentinel as the "secret not found" path so
+		// --allow-missing-secrets covers both shapes — from the
+		// caller's perspective the dependency is equally unresolved.
+		return nil, fmt.Errorf("%w: HelmRepository %s/%s references secretRef but no SecretGetter is wired",
+			manifest.ErrMissingSecret, r.Namespace, r.Name)
+	}
+	sec := getSec(r.Namespace, r.SecretRef.Name)
+	if sec == nil {
+		return nil, fmt.Errorf("%w: HelmRepository %s/%s: secret %s/%s not found",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
+	}
+	username := source.StringFromSecret(sec, "username")
+	password := source.StringFromSecret(sec, "password")
+	if username == "" || password == "" {
+		// Empty covers both missing-key and PLACEHOLDER-wiped values
+		// (the ExternalSecret case). Same sentinel so
+		// --allow-missing-secrets covers both shapes.
+		return nil, fmt.Errorf("%w: HelmRepository %s/%s: secret %s/%s missing username/password",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
+	}
+	opts := []getter.Option{getter.WithBasicAuth(username, password)}
+	if r.PassCredentials {
+		opts = append(opts, getter.WithPassCredentialsAll(true))
+	}
+	return opts, nil
+}
+
+// helmRepoTLSOptions resolves spec.certSecretRef into helm getter
+// options. The Secret should carry one or both of (tls.crt, tls.key)
+// for client cert auth, plus optional ca.crt for a custom server CA.
+// Each present file is materialized to a temp file (helm getter v4's
+// WithTLSClientConfig accepts paths, not bytes) and removed by the
+// returned cleanup func — always safe to call.
+func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option, func(), error) {
+	noCleanup := func() {}
+	if r.CertSecretRef == nil {
+		return nil, noCleanup, nil
+	}
+	c.mu.RLock()
+	getSec := c.secrets
+	c.mu.RUnlock()
+	if getSec == nil {
+		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
+			manifest.ErrMissingSecret, r.Namespace, r.Name)
+	}
+	sec := getSec(r.Namespace, r.CertSecretRef.Name)
+	if sec == nil {
+		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s: cert secret %s/%s not found",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+	}
+
+	var tmpFiles []string
+	writeKey := func(key string) (string, error) {
+		v := source.StringFromSecret(sec, key)
+		if v == "" {
+			return "", nil
+		}
+		tmp, err := os.CreateTemp(c.tmpDir, "helm-tls-*.pem")
+		if err != nil {
+			return "", fmt.Errorf("temp %s: %w", key, err)
+		}
+		if _, err := tmp.WriteString(v); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return "", fmt.Errorf("write %s: %w", key, err)
+		}
+		if err := tmp.Close(); err != nil {
+			_ = os.Remove(tmp.Name())
+			return "", fmt.Errorf("close %s: %w", key, err)
+		}
+		tmpFiles = append(tmpFiles, tmp.Name())
+		return tmp.Name(), nil
+	}
+	cleanup := func() {
+		for _, p := range tmpFiles {
+			_ = os.Remove(p)
+		}
+	}
+
+	certPath, err := writeKey("tls.crt")
+	if err != nil {
+		cleanup()
+		return nil, noCleanup, err
+	}
+	keyPath, err := writeKey("tls.key")
+	if err != nil {
+		cleanup()
+		return nil, noCleanup, err
+	}
+	caPath, err := writeKey("ca.crt")
+	if err != nil {
+		cleanup()
+		return nil, noCleanup, err
+	}
+	if certPath == "" && keyPath == "" && caPath == "" {
+		cleanup()
+		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+	}
+	return []getter.Option{getter.WithTLSClientConfig(certPath, keyPath, caPath)}, cleanup, nil
+}

--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -1,0 +1,233 @@
+package helm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// locateOCIChart resolves a chart whose source is an OCIRepository.
+//
+// Preferred path: the source.oci.Fetcher has already pulled the
+// artifact (applying spec.verify cosign verification, spec.layerSelector,
+// spec.certSecretRef, spec.proxySecretRef, spec.insecure, spec.ignore,
+// semver tag resolution) into a slot under the shared source cache —
+// the HR depwait blocks render until that source is Ready, so by the
+// time this runs the artifact is on disk. Reading it from the store
+// keeps every Flux OCIRepository feature working uniformly for both
+// Kustomization and HelmRelease consumers.
+//
+// Fallback path: when no SourceArtifact is present (typically
+// --enable-oci=false, which wires source.ExistenceFetcher for
+// OCIRepository so HR depwait still unblocks but no artifact is
+// written), pull via helm's registry client. This preserves the
+// pre-unification behavior for embedders that don't wire the OCI
+// fetcher — but in that mode none of the OCIRepository spec.*
+// features apply, exactly as before.
+func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
+	r := c.resolveOCIRepo(hr)
+	if r == nil {
+		return "", fmt.Errorf("%w: OCIRepository %s not registered", manifest.ErrObjectNotFound, hr.Chart.RepoFullName())
+	}
+	if art := c.resolveLocalSource(hr); art != nil && art.LocalPath != "" {
+		path, err := ociChartPathFromArtifact(art.LocalPath)
+		if err != nil {
+			return "", fmt.Errorf("OCIRepository %s/%s: %w", r.Namespace, r.Name, err)
+		}
+		return path, nil
+	}
+	// Fallback path. The source.oci.Fetcher didn't produce an
+	// artifact for this OCIRepository — typically because the
+	// orchestrator is configured with EnableOCI=false (which wires
+	// source.ExistenceFetcher) or because the HR's source controller
+	// was never wired in this embedding. NONE of the OCIRepository
+	// spec.* features (verify / layerSelector / certSecretRef /
+	// proxySecretRef / insecure / ignore) apply on this path.
+	if r.Reference != nil && r.Reference.SemVer != "" {
+		// Semver resolution requires listing tags from the registry —
+		// that's part of source.oci.Fetcher, not helm's registry
+		// client. The helm-side fall-back would just pass the semver
+		// constraint to Pull and get a cryptic "invalid tag" error.
+		return "", fmt.Errorf(
+			"OCIRepository %s/%s uses spec.ref.semver but the source.oci.Fetcher is not active "+
+				"(likely --enable-oci=false); semver resolution requires the OCI fetcher",
+			r.Namespace, r.Name)
+	}
+	ver, err := r.Version()
+	if err != nil {
+		return "", err
+	}
+	slog.Debug("helm: OCIRepository SourceArtifact missing; falling back to helm registry client",
+		"ociRepository", r.Namespace+"/"+r.Name, "url", r.URL, "version", ver,
+		"note", "OCIRepository spec.verify/layerSelector/etc. NOT applied on this path")
+	return c.fetchOCIChart(ctx, r.URL, ver)
+}
+
+// ociChartPathFromArtifact picks the right chart path under an
+// OCIRepository SourceArtifact's slot. The source/oci fetcher's
+// applyLayerSelector produces one of three observable layouts:
+//
+//  1. Chart.yaml at slot root — the rare shape where a chart-as-OCI
+//     artifact is published WITHOUT helm's standard `<chartname>/`
+//     wrapper directory. Slot itself is the chart root.
+//  2. layer.tar.gz at slot root — operation=copy on the OCIRepository's
+//     layerSelector. Slot contains the packaged chart tgz; helm's
+//     loader.Load handles it via FileLoader.
+//  3. <slot>/<chartname>/Chart.yaml — the common shape: `helm package`
+//     emits tarballs with a single top-level directory named after
+//     the chart, and operation=extract (Flux's default) preserves
+//     that layout when unpacking. The chart name in the dir comes
+//     from the artifact, NOT hr.Chart.Name (those can differ), so we
+//     scan for the single subdir that contains a Chart.yaml.
+//
+// Probing the filesystem keeps this hr.Chart.Name-independent and
+// works uniformly across vendor packaging styles.
+func ociChartPathFromArtifact(slot string) (string, error) {
+	if _, err := os.Stat(filepath.Join(slot, chartYamlFilename)); err == nil {
+		return slot, nil
+	}
+	tgz := filepath.Join(slot, copiedOCILayerFilename)
+	if _, err := os.Stat(tgz); err == nil {
+		return tgz, nil
+	}
+	switch sub, status := findChartSubdir(slot); status {
+	case chartSubdirFound:
+		return sub, nil
+	case chartSubdirAmbiguous:
+		// More than one Chart.yaml-bearing subdir — distinct failure
+		// from "no chart found", and the right hint is "this is a
+		// bundle-of-charts artifact, not a single chart".
+		return "", fmt.Errorf("OCIRepository artifact at %s contains multiple Chart.yaml-bearing subdirs; "+
+			"flate cannot disambiguate a bundle-of-charts artifact", slot)
+	}
+	return "", fmt.Errorf("OCIRepository artifact at %s has neither %s, %s, nor a <name>/Chart.yaml subdir — "+
+		"chart layer missing or layerSelector misconfigured",
+		slot, chartYamlFilename, copiedOCILayerFilename)
+}
+
+// chartSubdirStatus is the typed result of findChartSubdir. The
+// caller branches between "not found" and "ambiguous" to surface
+// distinct error messages — the operator hint is different.
+type chartSubdirStatus int
+
+const (
+	chartSubdirNotFound chartSubdirStatus = iota
+	chartSubdirFound
+	chartSubdirAmbiguous
+)
+
+// findChartSubdir scans the immediate children of slot for one that
+// contains a Chart.yaml — the shape produced by `helm package` when
+// extracted via operation=extract. Hidden entries (anything starting
+// with `.`) are skipped: this safely covers the .flate-* sentinels and
+// any incidental dotfiles. Valid charts never use a dot-prefixed
+// top-level directory.
+//
+// Returns ("", chartSubdirNotFound) when no subdir matches and
+// ("", chartSubdirAmbiguous) when multiple match, so the caller can
+// emit a specific error for each.
+func findChartSubdir(slot string) (string, chartSubdirStatus) {
+	entries, err := os.ReadDir(slot)
+	if err != nil {
+		return "", chartSubdirNotFound
+	}
+	var match string
+	for _, e := range entries {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(slot, e.Name(), chartYamlFilename)); err != nil {
+			continue
+		}
+		if match != "" {
+			return "", chartSubdirAmbiguous
+		}
+		match = filepath.Join(slot, e.Name())
+	}
+	if match == "" {
+		return "", chartSubdirNotFound
+	}
+	return match, chartSubdirFound
+}
+
+// chartYamlFilename / copiedOCILayerFilename mirror, by string value,
+// the on-disk names produced by source/oci.applyLayerSelector. Kept
+// as constants here (and not imported across packages) to avoid a
+// pkg/helm → pkg/source/oci dependency for two static strings.
+const (
+	chartYamlFilename      = "Chart.yaml"
+	copiedOCILayerFilename = "layer.tar.gz"
+)
+
+// ociPullRef joins an OCI repo URL and an optional ref into the form
+// the helm registry client expects. A digest ref (`sha256:<hex>` and
+// friends) joins with `@`; a tag joins with `:`. Per OCI tag spec a
+// tag can never contain `:`, so its presence in `version` is an
+// unambiguous digest signal — without this branch, the helm client
+// rejects `repo:sha256:<hex>` as an invalid tag.
+func ociPullRef(ref, version string) string {
+	if version == "" {
+		return ref
+	}
+	sep := ":"
+	if strings.Contains(version, ":") {
+		sep = "@"
+	}
+	return ref + sep + version
+}
+
+// fetchOCIChart pulls an OCI chart via the helm registry client.
+// Used only as the EnableOCI=false fallback path of locateOCIChart;
+// when EnableOCI=true the source.oci.Fetcher's slot is consumed
+// directly via ociChartPathFromArtifact.
+func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string, error) {
+	if c.registry == nil {
+		return "", errors.New("helm registry client not initialized")
+	}
+	target := filepath.Join(c.cacheDir, safeName(filepath.Base(ref))+"-"+version+".tgz")
+
+	release, err := chartCacheLocks.Acquire(ctx, target)
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
+	if _, err := os.Stat(target); err == nil {
+		return target, nil
+	}
+
+	pullRef := ociPullRef(ref, version)
+	_ = ctx // reserved for future per-pull cancellation when helm supports it
+	result, err := c.registry.Pull(pullRef)
+	if err != nil {
+		return "", fmt.Errorf("oci pull %s: %w", pullRef, err)
+	}
+	if result == nil || result.Chart == nil {
+		return "", fmt.Errorf("oci pull %s: empty result", pullRef)
+	}
+	if err := writeAtomic(target, result.Chart.Data); err != nil {
+		return "", err
+	}
+	return target, nil
+}
+
+// safeName sanitizes an OCI ref's base name into a filesystem-safe
+// token for the on-disk cache target.
+func safeName(s string) string {
+	out := strings.Builder{}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-' || r == '_' || r == '.':
+			out.WriteRune(r)
+		default:
+			out.WriteRune('-')
+		}
+	}
+	return out.String()
+}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -2,9 +2,7 @@ package helm
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -16,7 +14,6 @@ import (
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/source"
 )
 
 // chartCacheLocks serializes concurrent fetches of the same cached
@@ -142,120 +139,8 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	return target, nil
 }
 
-// helmRepoAuthOptions resolves SecretRef credentials for a HelmRepository
-// into helm getter options. Returns nil options when no SecretRef is
-// configured (anonymous). Username/password basic auth + optional
-// PassCredentials forwarding. Insecure flag is OCI-only per Flux's
-// schema so it is intentionally not surfaced here.
-func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Option, error) {
-	if r.SecretRef == nil {
-		return nil, nil
-	}
-	c.mu.RLock()
-	getSec := c.secrets
-	c.mu.RUnlock()
-	if getSec == nil {
-		// Use the same sentinel as the "secret not found" path so
-		// --allow-missing-secrets covers both shapes — from the
-		// caller's perspective the dependency is equally unresolved.
-		return nil, fmt.Errorf("%w: HelmRepository %s/%s references secretRef but no SecretGetter is wired",
-			manifest.ErrMissingSecret, r.Namespace, r.Name)
-	}
-	sec := getSec(r.Namespace, r.SecretRef.Name)
-	if sec == nil {
-		return nil, fmt.Errorf("%w: HelmRepository %s/%s: secret %s/%s not found",
-			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
-	}
-	username := source.StringFromSecret(sec, "username")
-	password := source.StringFromSecret(sec, "password")
-	if username == "" || password == "" {
-		// Empty covers both missing-key and PLACEHOLDER-wiped values
-		// (the ExternalSecret case). Same sentinel so
-		// --allow-missing-secrets covers both shapes.
-		return nil, fmt.Errorf("%w: HelmRepository %s/%s: secret %s/%s missing username/password",
-			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.SecretRef.Name)
-	}
-	opts := []getter.Option{getter.WithBasicAuth(username, password)}
-	if r.PassCredentials {
-		opts = append(opts, getter.WithPassCredentialsAll(true))
-	}
-	return opts, nil
-}
-
-// helmRepoTLSOptions resolves spec.certSecretRef into helm getter
-// options. The Secret should carry one or both of (tls.crt, tls.key)
-// for client cert auth, plus optional ca.crt for a custom server CA.
-// Each present file is materialized to a temp file (helm getter v4's
-// WithTLSClientConfig accepts paths, not bytes) and removed by the
-// returned cleanup func — always safe to call.
-func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option, func(), error) {
-	noCleanup := func() {}
-	if r.CertSecretRef == nil {
-		return nil, noCleanup, nil
-	}
-	c.mu.RLock()
-	getSec := c.secrets
-	c.mu.RUnlock()
-	if getSec == nil {
-		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
-			manifest.ErrMissingSecret, r.Namespace, r.Name)
-	}
-	sec := getSec(r.Namespace, r.CertSecretRef.Name)
-	if sec == nil {
-		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s: cert secret %s/%s not found",
-			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
-	}
-
-	var tmpFiles []string
-	writeKey := func(key string) (string, error) {
-		v := source.StringFromSecret(sec, key)
-		if v == "" {
-			return "", nil
-		}
-		tmp, err := os.CreateTemp(c.tmpDir, "helm-tls-*.pem")
-		if err != nil {
-			return "", fmt.Errorf("temp %s: %w", key, err)
-		}
-		if _, err := tmp.WriteString(v); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
-			return "", fmt.Errorf("write %s: %w", key, err)
-		}
-		if err := tmp.Close(); err != nil {
-			_ = os.Remove(tmp.Name())
-			return "", fmt.Errorf("close %s: %w", key, err)
-		}
-		tmpFiles = append(tmpFiles, tmp.Name())
-		return tmp.Name(), nil
-	}
-	cleanup := func() {
-		for _, p := range tmpFiles {
-			_ = os.Remove(p)
-		}
-	}
-
-	certPath, err := writeKey("tls.crt")
-	if err != nil {
-		cleanup()
-		return nil, noCleanup, err
-	}
-	keyPath, err := writeKey("tls.key")
-	if err != nil {
-		cleanup()
-		return nil, noCleanup, err
-	}
-	caPath, err := writeKey("ca.crt")
-	if err != nil {
-		cleanup()
-		return nil, noCleanup, err
-	}
-	if certPath == "" && keyPath == "" && caPath == "" {
-		cleanup()
-		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
-			manifest.ErrMissingSecret, r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
-	}
-	return []getter.Option{getter.WithTLSClientConfig(certPath, keyPath, caPath)}, cleanup, nil
-}
+// helmRepoAuthOptions / helmRepoTLSOptions live in auth.go (paired
+// with auth_test.go).
 
 // fetchIndex downloads and parses a HelmRepository index.yaml.
 func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexFile, error) {
@@ -287,208 +172,13 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 	return idx, nil
 }
 
-// locateOCIChart resolves a chart whose source is an OCIRepository.
-//
-// Preferred path: the source.oci.Fetcher has already pulled the
-// artifact (applying spec.verify cosign verification, spec.layerSelector,
-// spec.certSecretRef, spec.proxySecretRef, spec.insecure, spec.ignore,
-// semver tag resolution) into a slot under the shared source cache —
-// the HR depwait blocks render until that source is Ready, so by the
-// time this runs the artifact is on disk. Reading it from the store
-// keeps every Flux OCIRepository feature working uniformly for both
-// Kustomization and HelmRelease consumers.
-//
-// Fallback path: when no SourceArtifact is present (typically
-// --enable-oci=false, which wires source.ExistenceFetcher for
-// OCIRepository so HR depwait still unblocks but no artifact is
-// written), pull via helm's registry client. This preserves the
-// pre-unification behavior for embedders that don't wire the OCI
-// fetcher — but in that mode none of the OCIRepository spec.*
-// features apply, exactly as before.
-func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (string, error) {
-	r := c.resolveOCIRepo(hr)
-	if r == nil {
-		return "", fmt.Errorf("%w: OCIRepository %s not registered", manifest.ErrObjectNotFound, hr.Chart.RepoFullName())
-	}
-	if art := c.resolveLocalSource(hr); art != nil && art.LocalPath != "" {
-		path, err := ociChartPathFromArtifact(art.LocalPath)
-		if err != nil {
-			return "", fmt.Errorf("OCIRepository %s/%s: %w", r.Namespace, r.Name, err)
-		}
-		return path, nil
-	}
-	// Fallback path. The source.oci.Fetcher didn't produce an
-	// artifact for this OCIRepository — typically because the
-	// orchestrator is configured with EnableOCI=false (which wires
-	// source.ExistenceFetcher) or because the HR's source controller
-	// was never wired in this embedding. NONE of the OCIRepository
-	// spec.* features (verify / layerSelector / certSecretRef /
-	// proxySecretRef / insecure / ignore) apply on this path.
-	if r.Reference != nil && r.Reference.SemVer != "" {
-		// Semver resolution requires listing tags from the registry —
-		// that's part of source.oci.Fetcher, not helm's registry
-		// client. The helm-side fall-back would just pass the semver
-		// constraint to Pull and get a cryptic "invalid tag" error.
-		return "", fmt.Errorf(
-			"OCIRepository %s/%s uses spec.ref.semver but the source.oci.Fetcher is not active "+
-				"(likely --enable-oci=false); semver resolution requires the OCI fetcher",
-			r.Namespace, r.Name)
-	}
-	ver, err := r.Version()
-	if err != nil {
-		return "", err
-	}
-	slog.Debug("helm: OCIRepository SourceArtifact missing; falling back to helm registry client",
-		"ociRepository", r.Namespace+"/"+r.Name, "url", r.URL, "version", ver,
-		"note", "OCIRepository spec.verify/layerSelector/etc. NOT applied on this path")
-	return c.fetchOCIChart(ctx, r.URL, ver)
-}
+// locateOCIChart + ociChartPathFromArtifact + findChartSubdir +
+// ociPullRef + fetchOCIChart + safeName live in oci_chart.go (paired
+// with oci_chart_test.go).
 
-// ociChartPathFromArtifact picks the right chart path under an
-// OCIRepository SourceArtifact's slot. The source/oci fetcher's
-// applyLayerSelector produces one of three observable layouts:
-//
-//  1. Chart.yaml at slot root — the rare shape where a chart-as-OCI
-//     artifact is published WITHOUT helm's standard `<chartname>/`
-//     wrapper directory. Slot itself is the chart root.
-//  2. layer.tar.gz at slot root — operation=copy on the OCIRepository's
-//     layerSelector. Slot contains the packaged chart tgz; helm's
-//     loader.Load handles it via FileLoader.
-//  3. <slot>/<chartname>/Chart.yaml — the common shape: `helm package`
-//     emits tarballs with a single top-level directory named after
-//     the chart, and operation=extract (Flux's default) preserves
-//     that layout when unpacking. The chart name in the dir comes
-//     from the artifact, NOT hr.Chart.Name (those can differ), so we
-//     scan for the single subdir that contains a Chart.yaml.
-//
-// Probing the filesystem keeps this hr.Chart.Name-independent and
-// works uniformly across vendor packaging styles.
-func ociChartPathFromArtifact(slot string) (string, error) {
-	if _, err := os.Stat(filepath.Join(slot, chartYamlFilename)); err == nil {
-		return slot, nil
-	}
-	tgz := filepath.Join(slot, copiedOCILayerFilename)
-	if _, err := os.Stat(tgz); err == nil {
-		return tgz, nil
-	}
-	switch sub, status := findChartSubdir(slot); status {
-	case chartSubdirFound:
-		return sub, nil
-	case chartSubdirAmbiguous:
-		// More than one Chart.yaml-bearing subdir — distinct failure
-		// from "no chart found", and the right hint is "this is a
-		// bundle-of-charts artifact, not a single chart".
-		return "", fmt.Errorf("OCIRepository artifact at %s contains multiple Chart.yaml-bearing subdirs; "+
-			"flate cannot disambiguate a bundle-of-charts artifact", slot)
-	}
-	return "", fmt.Errorf("OCIRepository artifact at %s has neither %s, %s, nor a <name>/Chart.yaml subdir — "+
-		"chart layer missing or layerSelector misconfigured",
-		slot, chartYamlFilename, copiedOCILayerFilename)
-}
-
-// chartSubdirStatus is the typed result of findChartSubdir. The
-// caller branches between "not found" and "ambiguous" to surface
-// distinct error messages — the operator hint is different.
-type chartSubdirStatus int
-
-const (
-	chartSubdirNotFound chartSubdirStatus = iota
-	chartSubdirFound
-	chartSubdirAmbiguous
-)
-
-// findChartSubdir scans the immediate children of slot for one that
-// contains a Chart.yaml — the shape produced by `helm package` when
-// extracted via operation=extract. Hidden entries (anything starting
-// with `.`) are skipped: this safely covers the .flate-* sentinels and
-// any incidental dotfiles. Valid charts never use a dot-prefixed
-// top-level directory.
-//
-// Returns ("", chartSubdirNotFound) when no subdir matches and
-// ("", chartSubdirAmbiguous) when multiple match, so the caller can
-// emit a specific error for each.
-func findChartSubdir(slot string) (string, chartSubdirStatus) {
-	entries, err := os.ReadDir(slot)
-	if err != nil {
-		return "", chartSubdirNotFound
-	}
-	var match string
-	for _, e := range entries {
-		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(slot, e.Name(), chartYamlFilename)); err != nil {
-			continue
-		}
-		if match != "" {
-			return "", chartSubdirAmbiguous
-		}
-		match = filepath.Join(slot, e.Name())
-	}
-	if match == "" {
-		return "", chartSubdirNotFound
-	}
-	return match, chartSubdirFound
-}
-
-// chartYamlFilename / copiedOCILayerFilename mirror, by string value,
-// the on-disk names produced by source/oci.applyLayerSelector. Kept
-// as constants here (and not imported across packages) to avoid a
-// pkg/helm → pkg/source/oci dependency for two static strings.
-const (
-	chartYamlFilename      = "Chart.yaml"
-	copiedOCILayerFilename = "layer.tar.gz"
-)
-
-// ociPullRef joins an OCI repo URL and an optional ref into the form
-// the helm registry client expects. A digest ref (`sha256:<hex>` and
-// friends) joins with `@`; a tag joins with `:`. Per OCI tag spec a
-// tag can never contain `:`, so its presence in `version` is an
-// unambiguous digest signal — without this branch, the helm client
-// rejects `repo:sha256:<hex>` as an invalid tag.
-func ociPullRef(ref, version string) string {
-	if version == "" {
-		return ref
-	}
-	sep := ":"
-	if strings.Contains(version, ":") {
-		sep = "@"
-	}
-	return ref + sep + version
-}
-
-// fetchOCIChart pulls an OCI chart via the helm registry client.
-func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string, error) {
-	if c.registry == nil {
-		return "", errors.New("helm registry client not initialized")
-	}
-	target := filepath.Join(c.cacheDir, safeName(filepath.Base(ref))+"-"+version+".tgz")
-
-	release, err := chartCacheLocks.Acquire(ctx, target)
-	if err != nil {
-		return "", err
-	}
-	defer release()
-
-	if _, err := os.Stat(target); err == nil {
-		return target, nil
-	}
-
-	pullRef := ociPullRef(ref, version)
-	_ = ctx // reserved for future per-pull cancellation when helm supports it
-	result, err := c.registry.Pull(pullRef)
-	if err != nil {
-		return "", fmt.Errorf("oci pull %s: %w", pullRef, err)
-	}
-	if result == nil || result.Chart == nil {
-		return "", fmt.Errorf("oci pull %s: empty result", pullRef)
-	}
-	if err := writeAtomic(target, result.Chart.Data); err != nil {
-		return "", err
-	}
-	return target, nil
-}
-
+// absChartURL resolves urlStr against base — HelmRepository index
+// entries often carry relative URLs which need to be joined against
+// the repo's spec.url to produce something fetchable.
 func absChartURL(base, urlStr string) (string, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
@@ -502,17 +192,4 @@ func absChartURL(base, urlStr string) (string, error) {
 		return "", err
 	}
 	return baseURL.ResolveReference(u).String(), nil
-}
-
-func safeName(s string) string {
-	out := strings.Builder{}
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-' || r == '_' || r == '.':
-			out.WriteRune(r)
-		default:
-			out.WriteRune('-')
-		}
-	}
-	return out.String()
 }


### PR DESCRIPTION
## Summary

Same code-org symmetry as the git (#277) and bucket (#279) splits. `auth_test.go` and `oci_chart_test.go` already existed without production-side counterparts; the implementations lived in `repo.go` alongside the HelmRepository index-fetch path.

- **`auth.go`** (new, 126 lines): `helmRepoAuthOptions` + `helmRepoTLSOptions`. Covered by `auth_test.go`'s 10 tests.
- **`oci_chart.go`** (new, 233 lines): `locateOCIChart` + `ociChartPathFromArtifact` + `chartSubdirStatus` enum + `findChartSubdir` + the `chartYamlFilename` / `copiedOCILayerFilename` constants + `ociPullRef` + `fetchOCIChart` + `safeName`. Covered by `oci_chart_test.go`'s 7 tests.
- **`repo.go`** (518 → 195 lines): the HelmRepository index-fetch path — `writeAtomic` + `ChartLoadResult` + `locateLocalChart` + `locateHelmRepoChart` + `fetchIndex` + `absChartURL`.

Editing the OCI-chart-resolution surface no longer pulls the HelmRepository index code into the editor scope. Behavior unchanged; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)