### PR TITLE
refactor(diff): collapse 6-level sort cascade with cmp.Or

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -192,22 +192,14 @@ func pair(left, right []Doc) []pairedResource {
 		out = append(out, *p)
 	}
 	slices.SortFunc(out, func(a, b pairedResource) int {
-		if c := cmp.Compare(a.parent.Kind, b.parent.Kind); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.parent.Namespace, b.parent.Namespace); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.parent.Name, b.parent.Name); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.kind, b.kind); c != 0 {
-			return c
-		}
-		if c := cmp.Compare(a.namespace, b.namespace); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.name, b.name)
+		return cmp.Or(
+			cmp.Compare(a.parent.Kind, b.parent.Kind),
+			cmp.Compare(a.parent.Namespace, b.parent.Namespace),
+			cmp.Compare(a.parent.Name, b.parent.Name),
+			cmp.Compare(a.kind, b.kind),
+			cmp.Compare(a.namespace, b.namespace),
+			cmp.Compare(a.name, b.name),
+		)
 	})
 	return out
 }


### PR DESCRIPTION
## Summary

`pkg/diff/diff.go`'s pair-sort comparator stacked six `if c := cmp.Compare(...); c != 0 { return c }` blocks for the `(parent.Kind, parent.Namespace, parent.Name, kind, namespace, name)` tie-break chain. **`cmp.Or`** is the canonical short-circuit for exactly this pattern.

```go
slices.SortFunc(out, func(a, b pairedResource) int {
    return cmp.Or(
        cmp.Compare(a.parent.Kind, b.parent.Kind),
        cmp.Compare(a.parent.Namespace, b.parent.Namespace),
        cmp.Compare(a.parent.Name, b.parent.Name),
        cmp.Compare(a.kind, b.kind),
        cmp.Compare(a.namespace, b.namespace),
        cmp.Compare(a.name, b.name),
    )
})
```

Reads as the sort key list it actually is. Behavior unchanged; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)