### PR TITLE
refactor: cmp.Or sweep — two more comparator cascades

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -34,10 +34,10 @@ func firstArg(args []string) string {
 // deterministic across runs.
 func sortRows(rows []map[string]string) {
 	slices.SortFunc(rows, func(a, b map[string]string) int {
-		if c := cmp.Compare(a["namespace"], b["namespace"]); c != 0 {
-			return c
-		}
-		return cmp.Compare(a["name"], b["name"])
+		return cmp.Or(
+			cmp.Compare(a["namespace"], b["namespace"]),
+			cmp.Compare(a["name"], b["name"]),
+		)
 	})
 }
 

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -47,13 +47,11 @@ func (n NamedResource) String() string {
 // Compare orders NamedResources by (kind, namespace, name) — returns
 // -1, 0, or +1 per cmp.Compare semantics.
 func (n NamedResource) Compare(other NamedResource) int {
-	if c := cmp.Compare(n.Kind, other.Kind); c != 0 {
-		return c
-	}
-	if c := cmp.Compare(n.Namespace, other.Namespace); c != 0 {
-		return c
-	}
-	return cmp.Compare(n.Name, other.Name)
+	return cmp.Or(
+		cmp.Compare(n.Kind, other.Kind),
+		cmp.Compare(n.Namespace, other.Namespace),
+		cmp.Compare(n.Name, other.Name),
+	)
 }
 
 // BaseManifest is the marker interface every domain object implements.


### PR DESCRIPTION
## Summary

Follow-up to the pkg/diff sort sweep (#284). Two more sites had the same nested `if c := cmp.Compare(...); c != 0 { return c }` cascade:

- **`pkg/manifest/types.go`** — `NamedResource.Compare` ordering by `(kind, namespace, name)`.
- **`internal/cli/helpers.go`** — `sortRows` table ordering by `(namespace, name)`.

Behavior unchanged; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)