### PR TITLE
refactor: cmp.Or sweep round 3 — 7 more zero-fallback sites

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -4,6 +4,7 @@
 package depwait
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -305,11 +306,7 @@ func classify(dep manifest.NamedResource, err error, fallback string) Event {
 	}
 	var rfe *manifest.ResourceFailedError
 	if errors.As(err, &rfe) {
-		reason := rfe.Reason
-		if reason == "" {
-			reason = fallback
-		}
-		return Event{Dep: dep, Status: DepFailed, Reason: reason}
+		return Event{Dep: dep, Status: DepFailed, Reason: cmp.Or(rfe.Reason, fallback)}
 	}
 	if err != nil {
 		return Event{Dep: dep, Status: DepFailed, Reason: err.Error()}

--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"cmp"
+
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
@@ -49,9 +51,7 @@ func parseBucket(doc map[string]any) (*Bucket, error) {
 	if cr.Spec.Endpoint == "" {
 		return nil, inputf("Bucket %s/%s missing spec.endpoint", cr.Namespace, cr.Name)
 	}
-	if cr.Spec.Provider == "" {
-		cr.Spec.Provider = sourcev1.BucketProviderGeneric
-	}
+	cr.Spec.Provider = cmp.Or(cr.Spec.Provider, sourcev1.BucketProviderGeneric)
 	owner := cr.Namespace + "/" + cr.Name
 	if r := cr.Spec.SecretRef; r != nil {
 		if err := validateSecretRefName("Bucket", owner, "spec.secretRef", r.Name); err != nil {

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -290,12 +290,8 @@ func parseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 		if dep.Name == "" {
 			return nil, inputf("HelmRelease missing dependsOn.name")
 		}
-		depNS := dep.Namespace
-		if depNS == "" {
-			depNS = cr.Namespace
-		}
 		dependsOn = append(dependsOn, DependencyRef{
-			NamedResource: NamedResource{Kind: KindHelmRelease, Namespace: depNS, Name: dep.Name},
+			NamedResource: NamedResource{Kind: KindHelmRelease, Namespace: cmp.Or(dep.Namespace, cr.Namespace), Name: dep.Name},
 			ReadyExpr:     dep.ReadyExpr,
 		})
 	}

--- a/pkg/manifest/helmrepository.go
+++ b/pkg/manifest/helmrepository.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"cmp"
+
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
@@ -38,9 +40,7 @@ func parseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("HelmRepository missing spec.url")
 	}
-	if cr.Spec.Type == "" {
-		cr.Spec.Type = RepoTypeDefault
-	}
+	cr.Spec.Type = cmp.Or(cr.Spec.Type, RepoTypeDefault)
 	owner := cr.Namespace + "/" + cr.Name
 	if r := cr.Spec.SecretRef; r != nil {
 		if err := validateSecretRefName("HelmRepository", owner, "spec.secretRef", r.Name); err != nil {

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"cmp"
 	"log/slog"
 	"maps"
 	"slices"
@@ -195,10 +196,7 @@ func parseKustomization(doc map[string]any) (*Kustomization, error) {
 	// namespace is optional — a parent Kustomization's
 	// spec.targetNamespace may fill it in at apply time.
 	ns := cr.Namespace
-	srcNamespace := cr.Spec.SourceRef.Namespace
-	if srcNamespace == "" {
-		srcNamespace = ns
-	}
+	srcNamespace := cmp.Or(cr.Spec.SourceRef.Namespace, ns)
 
 	var substituteFrom []SubstituteReference
 	var subst map[string]any
@@ -217,12 +215,8 @@ func parseKustomization(doc map[string]any) (*Kustomization, error) {
 		if dep.Name == "" {
 			return nil, inputf("Kustomization missing dependsOn.name")
 		}
-		depNS := dep.Namespace
-		if depNS == "" {
-			depNS = ns
-		}
 		dependsOn = append(dependsOn, DependencyRef{
-			NamedResource: NamedResource{Kind: KindKustomization, Namespace: depNS, Name: dep.Name},
+			NamedResource: NamedResource{Kind: KindKustomization, Namespace: cmp.Or(dep.Namespace, ns), Name: dep.Name},
 			ReadyExpr:     dep.ReadyExpr,
 		})
 	}

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"cmp"
+
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
@@ -91,9 +93,7 @@ func parseGitRepository(doc map[string]any) (*GitRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("GitRepository missing spec.url")
 	}
-	if cr.Spec.Provider == "" {
-		cr.Spec.Provider = sourcev1.GitProviderGeneric
-	}
+	cr.Spec.Provider = cmp.Or(cr.Spec.Provider, sourcev1.GitProviderGeneric)
 	cr.Spec.URL = ResolveEnvsubstDefaults(cr.Spec.URL)
 	if r := cr.Spec.Reference; r != nil {
 		r.Branch = ResolveEnvsubstDefaults(r.Branch)
@@ -209,9 +209,7 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 	if cr.Spec.URL == "" {
 		return nil, inputf("OCIRepository missing spec.url")
 	}
-	if cr.Spec.Provider == "" {
-		cr.Spec.Provider = sourcev1.GenericOCIProvider
-	}
+	cr.Spec.Provider = cmp.Or(cr.Spec.Provider, sourcev1.GenericOCIProvider)
 	// Pre-resolve envsubst defaults on ref fields so a chart pin like
 	// `tag: "${FLUXCD_VERSION:=v2.8.5}"` becomes "v2.8.5" before the
 	// fetcher tries to resolve it. Bare ${VAR} (no default) is left


### PR DESCRIPTION
## Summary

Continuation of the `cmp.Or` sweeps (#284, #285). Seven more `if x == "" { x = fallback }` → `cmp.Or(x, fallback)` sites:

- **`pkg/depwait/depwait.go`** `classify()` — `rfe.Reason ?? fallback`.
- **`pkg/manifest/helmrepository.go`** — `spec.type ?? RepoTypeDefault`.
- **`pkg/manifest/bucket.go`** — `spec.provider ?? BucketProviderGeneric`.
- **`pkg/manifest/source.go`** — `parseGitRepository` and `ParseOCIRepository` provider defaults.
- **`pkg/manifest/kustomization.go`** — `SourceRef.Namespace ?? cr.Namespace` + dependsOn-namespace inlined into the `DependencyRef` construction.
- **`pkg/manifest/helmrelease.go`** — dependsOn-namespace inlined into the `DependencyRef` construction (same shape).

Behavior unchanged; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)