### PR TITLE
refactor(orchestrator): cacheRoot + RS sourceFile lookup → cmp.Or

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -160,10 +160,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("orchestrator: path is required")
 	}
 
-	cacheRoot := cfg.CacheDir
-	if cacheRoot == "" {
-		cacheRoot = filepath.Join(os.TempDir(), "flate-cache")
-	}
+	cacheRoot := cmp.Or(cfg.CacheDir, filepath.Join(os.TempDir(), "flate-cache"))
 	helmClient, err := helm.NewClient(
 		filepath.Join(cacheRoot, "helm-tmp"),
 		filepath.Join(cacheRoot, "helm-cache"),

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -96,10 +96,7 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		if parent, ok := o.rendered.ParentOf(rs.Named()); ok {
 			parentKS, matched = parent, true
 		} else {
-			file := o.sourceFiles[rs.Named()]
-			if file == "" {
-				file = sourceByName[rs.Name]
-			}
+			file := cmp.Or(o.sourceFiles[rs.Named()], sourceByName[rs.Name])
 			if file == "" {
 				continue
 			}


### PR DESCRIPTION
## Summary

Two more fallback-to-default sites caught by the `cmp.Or` sweep:

- **`orchestrator.go New()`** — `cacheRoot` default to `os.TempDir()/flate-cache` when `CacheDir` is unset.
- **`resourceset.go expandResourceSetsPostRun`** — `file` lookup falls back from `o.sourceFiles[rs.Named()]` to `sourceByName[rs.Name]` for KS-controller-emitted RS variants whose namespace shifted at emit time but share a name with a file-loaded sibling.

Behavior unchanged; full suite + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)