### PR TITLE
refactor: cmp.Or sweep #4 across manifest, oci, cli, errors

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -108,10 +108,7 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 	// its own mutex, and concurrent first-time clones of the same
 	// (url, ref) slot can race past the mkdir/Readdirnames check and
 	// step on each other.
-	cacheRoot := currentCfg.CacheDir
-	if cacheRoot == "" {
-		cacheRoot = filepath.Join(os.TempDir(), "flate-cache")
-	}
+	cacheRoot := cmp.Or(currentCfg.CacheDir, filepath.Join(os.TempDir(), "flate-cache"))
 	shared := source.NewCache(filepath.Join(cacheRoot, "sources"))
 	currentCfg.SourceCache = shared
 	origCfg.SourceCache = shared

--- a/pkg/manifest/errors.go
+++ b/pkg/manifest/errors.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"strings"
@@ -85,11 +86,7 @@ type ResourceFailedError struct {
 }
 
 func (e *ResourceFailedError) Error() string {
-	reason := e.Reason
-	if reason == "" {
-		reason = "unknown error"
-	}
-	return fmt.Sprintf("resource %s failed: %s", e.Resource, reason)
+	return fmt.Sprintf("resource %s failed: %s", e.Resource, cmp.Or(e.Reason, "unknown error"))
 }
 
 func (*ResourceFailedError) Unwrap() error { return ErrFlux }

--- a/pkg/manifest/helmchartsource.go
+++ b/pkg/manifest/helmchartsource.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"cmp"
+
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 )
 
@@ -38,22 +40,16 @@ func parseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
 	if cr.Name == "" {
 		return nil, inputf("HelmChart missing metadata.name")
 	}
-	ns := cr.Namespace
-	if ns == "" {
-		ns = DefaultNamespace
-	}
 	if cr.Spec.Chart == "" {
 		return nil, inputf("HelmChart missing spec.chart")
 	}
 	if cr.Spec.SourceRef.Name == "" {
 		return nil, inputf("HelmChart missing spec.sourceRef.name")
 	}
-	if cr.Spec.SourceRef.Kind == "" {
-		cr.Spec.SourceRef.Kind = KindHelmRepository
-	}
+	cr.Spec.SourceRef.Kind = cmp.Or(cr.Spec.SourceRef.Kind, KindHelmRepository)
 	return &HelmChartSource{
 		Name:          cr.Name,
-		Namespace:     ns,
+		Namespace:     cmp.Or(cr.Namespace, DefaultNamespace),
 		HelmChartSpec: cr.Spec,
 	}, nil
 }

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -53,13 +54,9 @@ func parseResourceSet(doc map[string]any) (*ResourceSet, error) {
 	if cr.Name == "" {
 		return nil, inputf("ResourceSet missing metadata.name")
 	}
-	ns := cr.Namespace
-	if ns == "" {
-		ns = DefaultNamespace
-	}
 	return &ResourceSet{
 		Name:            cr.Name,
-		Namespace:       ns,
+		Namespace:       cmp.Or(cr.Namespace, DefaultNamespace),
 		ResourceSetSpec: cr.Spec,
 		Labels:          cr.Labels,
 	}, nil
@@ -104,13 +101,9 @@ func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvide
 	if cr.Name == "" {
 		return nil, inputf("ResourceSetInputProvider missing metadata.name")
 	}
-	ns := cr.Namespace
-	if ns == "" {
-		ns = DefaultNamespace
-	}
 	return &ResourceSetInputProvider{
 		Name:                         cr.Name,
-		Namespace:                    ns,
+		Namespace:                    cmp.Or(cr.Namespace, DefaultNamespace),
 		ResourceSetInputProviderSpec: cr.Spec,
 		Labels:                       cr.Labels,
 	}, nil

--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -1,6 +1,7 @@
 package oci
 
 import (
+	"cmp"
 	"context"
 	"crypto"
 	"crypto/ecdsa"
@@ -89,10 +90,7 @@ func (f *Fetcher) verifyCosignSignature(
 	if repo.Verify == nil {
 		return nil
 	}
-	provider := repo.Verify.Provider
-	if provider == "" {
-		provider = "cosign"
-	}
+	provider := cmp.Or(repo.Verify.Provider, "cosign")
 	if provider != "cosign" {
 		return fmt.Errorf("OCIRepository %s/%s: verify provider %q is not implemented; flate currently supports only %q",
 			repo.Namespace, repo.Name, provider, "cosign")

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -4,6 +4,7 @@
 package oci
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -263,10 +264,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		}
 	}
 
-	tag := versionTag(ref)
-	if tag == "" {
-		tag = "latest"
-	}
+	tag := cmp.Or(versionTag(ref), "latest")
 
 	// OCI Image Layout content store: blobs land at
 	// `slot/blobs/<algo>/<hex>` regardless of title annotations, so we


### PR DESCRIPTION
## Summary
- Seven more \`if x == \"\" { x = fallback }\` patterns collapsed into \`cmp.Or\`, continuing the sweep from iters 17/19/20/21.
- Touched packages: \`pkg/manifest\` (resourceset, helmchartsource, errors), \`pkg/source/oci\` (oci, cosign), \`internal/cli\` (helpers).
- No behavior change — \`cmp.Or\` returns the first non-zero argument; identical semantics to the prior assignment guards.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)