### PR TITLE
refactor: cmp.Or sweep #5 — chartRef version, dep error, git TLS

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"cmp"
 	"io"
 	"maps"
 	"slices"
@@ -99,15 +100,7 @@ func resolveChartRefVersion(orch *orchestrator.Orchestrator, hr *manifest.HelmRe
 	switch s := obj.(type) {
 	case *manifest.OCIRepository:
 		if s.Reference != nil {
-			if s.Reference.Tag != "" {
-				return s.Reference.Tag
-			}
-			if s.Reference.SemVer != "" {
-				return s.Reference.SemVer
-			}
-			if s.Reference.Digest != "" {
-				return s.Reference.Digest
-			}
+			return cmp.Or(s.Reference.Tag, s.Reference.SemVer, s.Reference.Digest)
 		}
 	case *manifest.HelmChartSource:
 		return s.Version

--- a/pkg/manifest/errors.go
+++ b/pkg/manifest/errors.go
@@ -108,11 +108,7 @@ func (e *DependencyFailedError) Error() string {
 	}
 	parts := make([]string, 0, len(e.Failed))
 	for _, f := range e.Failed {
-		reason := e.Reasons[f]
-		if reason == "" {
-			reason = "unknown error"
-		}
-		parts = append(parts, f.String()+": "+reason)
+		parts = append(parts, f.String()+": "+cmp.Or(e.Reasons[f], "unknown error"))
 	}
 	return "dependencies failed: " + strings.Join(parts, "; ")
 }

--- a/pkg/source/git/tls.go
+++ b/pkg/source/git/tls.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"cmp"
 	"crypto/tls"
 	"fmt"
 	"sync"
@@ -42,10 +43,7 @@ func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) 
 		// resolveAuth reports the missing-secret error first.
 		return nil, nil
 	}
-	ca := source.StringFromSecret(sec, "ca.crt")
-	if ca == "" {
-		ca = source.StringFromSecret(sec, "caFile")
-	}
+	ca := cmp.Or(source.StringFromSecret(sec, "ca.crt"), source.StringFromSecret(sec, "caFile"))
 	if ca == "" {
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary
- Three more zero-fallback patterns collapsed into \`cmp.Or\`:
  - \`resolveChartRefVersion\` for OCIRepository (Tag → SemVer → Digest chain).
  - \`DependencyFailedError.Error\` per-dep \`reason\` fallback now inlined into the loop body.
  - \`pkg/source/git/tls.go\` \`ca.crt\` → \`caFile\` secret-key fallback now expressed in a single line.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)