### PR TITLE
refactor: simplify OCIRepository.Version() — drop unused error, use cmp.Or

### DIFF
--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -59,10 +59,7 @@ func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (
 				"(likely --enable-oci=false); semver resolution requires the OCI fetcher",
 			r.Namespace, r.Name)
 	}
-	ver, err := r.Version()
-	if err != nil {
-		return "", err
-	}
+	ver := r.Version()
 	slog.Debug("helm: OCIRepository SourceArtifact missing; falling back to helm registry client",
 		"ociRepository", r.Namespace+"/"+r.Name, "url", r.URL, "version", ver,
 		"note", "OCIRepository spec.verify/layerSelector/etc. NOT applied on this path")

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -178,20 +178,11 @@ func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }
 // Version returns the digest, tag, or semver expression in that order.
 // A semver expression is returned verbatim — callers wanting a concrete
 // tag must resolve it against remote tag listing (pkg/source).
-func (o *OCIRepository) Version() (string, error) {
-	r := o.Reference
-	if r == nil {
-		return "", nil
+func (o *OCIRepository) Version() string {
+	if o.Reference == nil {
+		return ""
 	}
-	switch {
-	case r.Digest != "":
-		return r.Digest, nil
-	case r.Tag != "":
-		return r.Tag, nil
-	case r.SemVer != "":
-		return r.SemVer, nil
-	}
-	return "", nil
+	return cmp.Or(o.Reference.Digest, o.Reference.Tag, o.Reference.SemVer)
 }
 
 // ParseOCIRepository decodes an OCIRepository CR.


### PR DESCRIPTION
## Summary
- \`OCIRepository.Version()\` returned \`(string, error)\` but never actually produced an error — all branches returned \`nil\`. Drop the unused error return and collapse the digest → tag → semver chain into a single \`cmp.Or\`.
- The single caller in \`pkg/helm/oci_chart.go\` had dead error handling around the call; updated to take the bare string.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)