### PR TITLE
refactor(loader): export NormalizePrefix and reuse in orchestrator

### DIFF
--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -135,7 +135,7 @@ func indexFluxByPath(s *store.Store, sourceFiles map[manifest.NamedResource]stri
 			continue
 		}
 		out = append(out, pathEntry{
-			prefix: normalizePrefix(ks.Path),
+			prefix: NormalizePrefix(ks.Path),
 			ns:     ns,
 		})
 	}
@@ -185,9 +185,13 @@ func readKustomizeNamespace(repoRoot, dir string) string {
 	return ""
 }
 
-// normalizePrefix turns a Kustomization spec.path into a slash-
+// NormalizePrefix turns a Kustomization spec.path into a slash-
 // terminated repo-relative prefix suitable for HasPrefix matching.
-func normalizePrefix(p string) string {
+// Applies filepath.ToSlash first so Windows-style spec.path values
+// (rare, but possible since the Flux CRD doesn't constrain it)
+// normalize to the same shape as loader.SourceFiles entries.
+func NormalizePrefix(p string) string {
+	p = filepath.ToSlash(p)
 	p = strings.TrimPrefix(p, "./")
 	return strings.TrimSuffix(p, "/") + "/"
 }

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -29,7 +29,7 @@ func KSPathPrefixes(s *store.Store) []KSPathPrefix {
 		if ks.Path == "" {
 			continue
 		}
-		out = append(out, KSPathPrefix{ID: ks.Named(), Prefix: normalizePrefix(ks.Path)})
+		out = append(out, KSPathPrefix{ID: ks.Named(), Prefix: NormalizePrefix(ks.Path)})
 	}
 	slices.SortFunc(out, func(a, b KSPathPrefix) int {
 		return cmp.Compare(len(b.Prefix), len(a.Prefix))

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -8,6 +8,7 @@ import (
 
 	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 
+	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
 	"github.com/home-operations/flate/pkg/store"
@@ -43,12 +44,7 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		if ks.Path == "" {
 			continue
 		}
-		p := filepath.ToSlash(ks.Path)
-		p = strings.TrimPrefix(p, "./")
-		if !strings.HasSuffix(p, "/") {
-			p += "/"
-		}
-		owners = append(owners, owner{prefix: p, id: ks.Named()})
+		owners = append(owners, owner{prefix: loader.NormalizePrefix(ks.Path), id: ks.Named()})
 	}
 	slices.SortFunc(owners, func(a, b owner) int {
 		return cmp.Compare(len(b.prefix), len(a.prefix))


### PR DESCRIPTION
## Summary
- \`pkg/orchestrator/resourceset.go\` had a five-line inline copy of the ks.Path → slash-terminated repo-relative prefix transform that \`pkg/loader\` already implements as \`normalizePrefix\`.
- Promote the loader helper to exported \`NormalizePrefix\` and have it apply \`filepath.ToSlash\` internally so the safer behavior (Windows-style spec.path values normalize correctly) covers both callers — the orchestrator's version already had this; the loader version didn't.
- Replace the orchestrator inline with a single call.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite green, including loader + orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)