### PR TITLE
refactor(cli): collapse rendersHelm to slices.Contains; inline single-kind sites

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,6 +14,7 @@ import (
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 )
 
@@ -131,12 +133,7 @@ type helmFlags struct {
 // e.g. `--show-only templates/foo.yaml` on `flate build ks` and
 // wondered why nothing changed.
 func rendersHelm(kinds []string) bool {
-	for _, k := range kinds {
-		if k == "HelmRelease" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(kinds, manifest.KindHelmRelease)
 }
 
 func bindHelmFlags(fs *pflag.FlagSet, h *helmFlags) {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -75,7 +75,7 @@ func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 	bindCommon(cmd.Flags(), c)
 	// `diff all` renders HRs as part of its scope, so always bind
 	// helm flags (matches `build all` / `test all` / `get all`).
-	if kind == "" || rendersHelm([]string{kind}) {
+	if kind == "" || kind == manifest.KindHelmRelease {
 		bindHelmFlags(cmd.Flags(), h)
 	}
 	bindDiffFlags(cmd, d)

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -206,7 +206,7 @@ func resourceListCmd[T manifest.BaseManifest](
 	// so showing --show-only / --no-hooks / --kube-version etc.
 	// confuses readers who'll wonder why the KS table cares about
 	// chart templating. Same gate `build` / `diff` / `test` use.
-	if rendersHelm([]string{kind}) {
+	if kind == manifest.KindHelmRelease {
 		bindHelmFlags(cmd.Flags(), h)
 	}
 	return cmd


### PR DESCRIPTION
## Summary
- Replace the hand-rolled \`rendersHelm\` for-loop with \`slices.Contains\` and reference \`manifest.KindHelmRelease\` rather than the inline \`\"HelmRelease\"\` string literal.
- Inline two call sites that wrapped a single kind into \`[]string{kind}\` just to feed \`rendersHelm\` (\`diff\` and \`get\`) — those now do a direct \`kind == manifest.KindHelmRelease\` comparison. Multi-kind callers (\`build\`, \`test\`) keep using \`rendersHelm\`.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/cli/...\` (full \`TestBindHelmFlags_OnHRSubcommandOnly\` table passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)