### PR TITLE
refactor(manifest): centralize doc field reads behind DocKind/DocAPIVersion/DocMetadata

### DIFF
--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -30,6 +30,14 @@ func DocKind(doc map[string]any) string {
 	return k
 }
 
+// DocAPIVersion returns the "apiVersion" field of a manifest document,
+// or "" if absent. Centralizes the doc["apiVersion"].(string) cast so
+// callers don't repeat the same one-liner.
+func DocAPIVersion(doc map[string]any) string {
+	v, _ := doc["apiVersion"].(string)
+	return v
+}
+
 // DropKinds returns docs with every entry whose `kind` appears in drop
 // removed. drop=nil is a no-op (returns docs unchanged). Used by the
 // orchestrator's Render and the CLI's build/diff paths to honor
@@ -78,8 +86,8 @@ func defaultParseDocOptions() ParseDocOptions {
 // parser. Unknown kinds become a RawObject; kustomize.config.k8s.io
 // build directives and bare data files are silently dropped.
 func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
-	kind, _ := doc["kind"].(string)
-	apiVersion, _ := doc["apiVersion"].(string)
+	kind := DocKind(doc)
+	apiVersion := DocAPIVersion(doc)
 	// kustomize.config.k8s.io build directives (Kustomization,
 	// Component) aren't k8s resources — they're build inputs we
 	// already follow via spec.path discovery. Drop them silently.
@@ -127,7 +135,7 @@ func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
 
 // checkAPIVersion enforces an api group prefix on a raw document.
 func checkAPIVersion(doc map[string]any, want string) error {
-	v, _ := doc["apiVersion"].(string)
+	v := DocAPIVersion(doc)
 	if v == "" {
 		return inputf("missing apiVersion")
 	}

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -88,11 +88,11 @@ func (r *RawObject) Named() NamedResource {
 
 // parseRawObject decodes any Kubernetes document into RawObject.
 func parseRawObject(doc map[string]any) (*RawObject, error) {
-	apiVersion, _ := doc["apiVersion"].(string)
+	apiVersion := DocAPIVersion(doc)
 	if apiVersion == "" {
 		return nil, inputf("missing apiVersion")
 	}
-	kind, _ := doc["kind"].(string)
+	kind := DocKind(doc)
 	if kind == "" {
 		return nil, inputf("missing kind")
 	}

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -1,6 +1,10 @@
 package resourceset
 
-import fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+import (
+	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
 
 // DedupKey identifies a rendered doc by (apiVersion, kind, namespace,
 // name) for cross-render deduplication. Returns "" when kind or name
@@ -12,15 +16,12 @@ import fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 // a name-grouped RS that emits the same child from two namespace
 // variants could land both copies in the parent KS's extension list.
 func DedupKey(doc map[string]any) string {
-	apiVersion, _ := doc["apiVersion"].(string)
-	kind, _ := doc["kind"].(string)
-	md, _ := doc["metadata"].(map[string]any)
-	name, _ := md["name"].(string)
-	ns, _ := md["namespace"].(string)
+	kind := manifest.DocKind(doc)
+	name, ns := manifest.DocMetadata(doc)
 	if kind == "" || name == "" {
 		return ""
 	}
-	return apiVersion + "|" + kind + "|" + ns + "|" + name
+	return manifest.DocAPIVersion(doc) + "|" + kind + "|" + ns + "|" + name
 }
 
 func defaultNamespace(doc map[string]any, ns string) {
@@ -44,8 +45,7 @@ func defaultNamespace(doc map[string]any, ns string) {
 }
 
 func isClusterScoped(doc map[string]any) bool {
-	kind, _ := doc["kind"].(string)
-	switch kind {
+	switch manifest.DocKind(doc) {
 	case "Namespace",
 		"ClusterRole", "ClusterRoleBinding",
 		"CustomResourceDefinition",


### PR DESCRIPTION
## Summary
- \`DocKind\` and \`DocMetadata\` already exist as canonical accessors for raw manifest doc maps, but call sites kept inlining the same \`doc[\"kind\"].(string)\` and \`doc[\"apiVersion\"].(string)\` casts.
- Add \`DocAPIVersion\` next to \`DocKind\` so the apiVersion cast has its own canonical helper.
- Migrate \`ParseDoc\`, \`checkAPIVersion\`, \`parseRawObject\` (pkg/manifest), and \`DedupKey\` / \`isClusterScoped\` (pkg/resourceset/output.go) to use the helpers.

No behavior change — the helpers are direct lifts of the casts they replace.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)