### PR TITLE
refactor: adopt modern stdlib helpers (maps.Copy, bytes.SplitSeq, errors.AsType)

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -304,8 +304,7 @@ func classify(dep manifest.NamedResource, err error, fallback string) Event {
 	case errors.Is(err, context.Canceled):
 		return Event{Dep: dep, Status: DepCancelled, Reason: "cancelled"}
 	}
-	var rfe *manifest.ResourceFailedError
-	if errors.As(err, &rfe) {
+	if rfe, ok := errors.AsType[*manifest.ResourceFailedError](err); ok {
 		return Event{Dep: dep, Status: DepFailed, Reason: cmp.Or(rfe.Reason, fallback)}
 	}
 	if err != nil {

--- a/pkg/loader/existence.go
+++ b/pkg/loader/existence.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"maps"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -82,8 +83,6 @@ func (i *ExistenceIndex) All() map[manifest.NamedResource]string {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 	out := make(map[manifest.NamedResource]string, len(i.entries))
-	for k, v := range i.entries {
-		out[k] = v
-	}
+	maps.Copy(out, i.entries)
 	return out
 }

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -185,7 +185,7 @@ func splitMultiDoc(tmplStr string, inputSet map[string]any) ([]map[string]any, e
 		return nil, err
 	}
 	var out []map[string]any
-	for _, chunk := range bytes.Split(rendered, []byte("\n---")) {
+	for chunk := range bytes.SplitSeq(rendered, []byte("\n---")) {
 		chunk = bytes.TrimSpace(chunk)
 		if len(chunk) == 0 {
 			continue


### PR DESCRIPTION
## Summary
Three lint-flagged stdlib modernizations:
- \`pkg/loader/existence.go\`: \`ExistenceIndex.All\`'s copy loop becomes \`maps.Copy\`.
- \`pkg/resourceset/render.go\`: \`splitMultiDoc\` switches \`bytes.Split\` → \`bytes.SplitSeq\` so the intermediate slice isn't materialized.
- \`pkg/depwait/depwait.go\`: \`classify\` adopts \`errors.AsType[*manifest.ResourceFailedError]\` instead of the var-declare-then-\`errors.As\` pattern, matching the surrounding \`errors.Is\` calls.

No behavior change.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)