### PR TITLE
refactor(manifest): unify EnsureMetadata + MergeStringMap helpers

### DIFF
--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -211,12 +211,7 @@ func applyHROriginLabels(docs []map[string]any, hr *manifest.HelmRelease) {
 		if isHookDoc(doc) {
 			continue
 		}
-		md, _ := doc["metadata"].(map[string]any)
-		if md == nil {
-			md = map[string]any{}
-			doc["metadata"] = md
-		}
-		mergeStringMap(md, "labels", origin)
+		manifest.MergeStringMap(manifest.EnsureMetadata(doc), "labels", origin)
 	}
 }
 
@@ -243,13 +238,9 @@ func applyHRCommonMetadata(docs []map[string]any, cm *helmv2.CommonMetadata) {
 		if isHookDoc(doc) || manifest.DocKind(doc) == manifest.KindCustomResourceDefinition {
 			continue
 		}
-		md, _ := doc["metadata"].(map[string]any)
-		if md == nil {
-			md = map[string]any{}
-			doc["metadata"] = md
-		}
-		mergeStringMap(md, "labels", cm.Labels)
-		mergeStringMap(md, "annotations", cm.Annotations)
+		md := manifest.EnsureMetadata(doc)
+		manifest.MergeStringMap(md, "labels", cm.Labels)
+		manifest.MergeStringMap(md, "annotations", cm.Annotations)
 	}
 }
 
@@ -269,20 +260,6 @@ func isHookDoc(doc map[string]any) bool {
 	}
 	_, has := anns["helm.sh/hook"]
 	return has
-}
-
-func mergeStringMap(md map[string]any, key string, in map[string]string) {
-	if len(in) == 0 {
-		return
-	}
-	out, _ := md[key].(map[string]any)
-	if out == nil {
-		out = make(map[string]any, len(in))
-	}
-	for k, v := range in {
-		out[k] = v
-	}
-	md[key] = out
 }
 
 // releaseManifest joins rel.Manifest with hooks (when allowed) and

--- a/pkg/manifest/strip.go
+++ b/pkg/manifest/strip.go
@@ -92,3 +92,38 @@ func stripAttrs(metadata map[string]any, attrs []string) {
 		}
 	}
 }
+
+// EnsureMetadata returns doc["metadata"] as a map[string]any, lazily
+// creating one when absent (or when present as a non-map). Used by
+// writers that mutate metadata.labels / metadata.annotations; readers
+// should prefer a direct type-assert + nil-tolerant access so we
+// don't allocate when nothing will be written.
+func EnsureMetadata(doc map[string]any) map[string]any {
+	md, _ := doc["metadata"].(map[string]any)
+	if md == nil {
+		md = map[string]any{}
+		doc["metadata"] = md
+	}
+	return md
+}
+
+// MergeStringMap merges in into md[key] as a map[string]any. Creates
+// the inner map when absent; existing entries with the same key are
+// overwritten. No-op when in is empty.
+//
+// Used by the ResourceSet output + Helm post-render passes to merge
+// CommonMetadata (labels / annotations) onto rendered docs without
+// touching unrelated entries.
+func MergeStringMap(md map[string]any, key string, in map[string]string) {
+	if len(in) == 0 {
+		return
+	}
+	out, _ := md[key].(map[string]any)
+	if out == nil {
+		out = make(map[string]any, len(in))
+	}
+	for k, v := range in {
+		out[k] = v
+	}
+	md[key] = out
+}

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -41,7 +41,7 @@ func defaultNamespace(doc map[string]any, ns string) {
 	if isClusterScoped(doc) {
 		return
 	}
-	ensureMetadata(doc)["namespace"] = ns
+	manifest.EnsureMetadata(doc)["namespace"] = ns
 }
 
 func isClusterScoped(doc map[string]any) bool {
@@ -64,36 +64,9 @@ func applyCommonMetadata(doc map[string]any, cm *fluxopv1.CommonMetadata) {
 	if cm == nil || (len(cm.Labels) == 0 && len(cm.Annotations) == 0) {
 		return
 	}
-	md := ensureMetadata(doc)
-	mergeStringMap(md, "labels", cm.Labels)
-	mergeStringMap(md, "annotations", cm.Annotations)
-}
-
-// ensureMetadata returns doc["metadata"] as a map[string]any, lazily
-// creating one when absent (or when present as a non-map). Used by
-// the writers below; reads should prefer a direct type-assert + nil-
-// tolerant access so we don't allocate when nothing will be written.
-func ensureMetadata(doc map[string]any) map[string]any {
-	md, _ := doc["metadata"].(map[string]any)
-	if md == nil {
-		md = map[string]any{}
-		doc["metadata"] = md
-	}
-	return md
-}
-
-func mergeStringMap(md map[string]any, key string, in map[string]string) {
-	if len(in) == 0 {
-		return
-	}
-	out, _ := md[key].(map[string]any)
-	if out == nil {
-		out = make(map[string]any, len(in))
-	}
-	for k, v := range in {
-		out[k] = v
-	}
-	md[key] = out
+	md := manifest.EnsureMetadata(doc)
+	manifest.MergeStringMap(md, "labels", cm.Labels)
+	manifest.MergeStringMap(md, "annotations", cm.Annotations)
 }
 
 func disabledByReconcileAnnotation(doc map[string]any) bool {


### PR DESCRIPTION
## Summary
- \`pkg/helm/template.go\` and \`pkg/resourceset/output.go\` each kept private byte-for-byte copies of \`ensureMetadata\` (get-or-create \`doc[\"metadata\"]\`) and \`mergeStringMap\` (merge \`map[string]string\` into a labels/annotations sub-map).
- Promote both to \`pkg/manifest\` (next to the existing strip helpers) as exported \`EnsureMetadata\` and \`MergeStringMap\`. Both call sites switch to the shared helper.
- \`applyHROriginLabels\`' inline metadata-get-or-create collapses to a single composed call.

No behavior change.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite green, including helm + resourceset + orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)