### PR TITLE
refactor(helm): add private secretGetter() snapshot helper

### DIFF
--- a/pkg/helm/auth.go
+++ b/pkg/helm/auth.go
@@ -19,9 +19,7 @@ func (c *Client) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Optio
 	if r.SecretRef == nil {
 		return nil, nil
 	}
-	c.mu.RLock()
-	getSec := c.secrets
-	c.mu.RUnlock()
+	getSec := c.secretGetter()
 	if getSec == nil {
 		// Use the same sentinel as the "secret not found" path so
 		// --allow-missing-secrets covers both shapes — from the
@@ -61,9 +59,7 @@ func (c *Client) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option
 	if r.CertSecretRef == nil {
 		return nil, noCleanup, nil
 	}
-	c.mu.RLock()
-	getSec := c.secrets
-	c.mu.RUnlock()
+	getSec := c.secretGetter()
 	if getSec == nil {
 		return nil, noCleanup, fmt.Errorf("%w: HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
 			manifest.ErrMissingSecret, r.Namespace, r.Name)

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -87,6 +87,15 @@ func (c *Client) SetSecretGetter(g SecretGetter) {
 	c.secrets = g
 }
 
+// secretGetter returns the configured SecretGetter under a read lock —
+// the snapshot helper helmRepoAuthOptions / helmRepoTLSOptions use so
+// neither has to inline the RLock-copy-RUnlock dance.
+func (c *Client) secretGetter() SecretGetter {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.secrets
+}
+
 // SetSourceResolver installs the canonical lookup surface for
 // HelmRepository / OCIRepository / local-artifact sources. helm.Client
 // reads through the resolver on every Template call — there's no


### PR DESCRIPTION
## Summary
\`helmRepoAuthOptions\` and \`helmRepoTLSOptions\` both inlined the same RLock-copy-RUnlock dance to snapshot \`c.secrets\` — mirroring the \`Resolver()\` pattern already factored out for \`c.resolver\` in PR #301.

Introduce a private \`secretGetter()\` helper on \`Client\` and route both call sites through it. Lock semantics are unchanged.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./pkg/helm/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)