### PR TITLE
refactor: adopt slices.Sorted(maps.Keys()) for collect+sort patterns

### DIFF
--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -44,13 +45,8 @@ func (s *Set) Paths() []string {
 	if s == nil {
 		return nil
 	}
-	out := make([]string, 0, len(s.paths))
-	for p := range s.paths {
-		out = append(out, p)
-	}
 	// Stable order makes logs and CI output deterministic.
-	slices.Sort(out)
-	return out
+	return slices.Sorted(maps.Keys(s.paths))
 }
 
 // Contains reports whether rel is in the change set. rel is expected

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -2,7 +2,9 @@ package discovery
 
 import (
 	"log/slog"
+	"maps"
 	"net/url"
+	"slices"
 	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -125,9 +127,8 @@ func debugLogRemotes(remotes map[string]struct{}) {
 	if len(remotes) == 0 {
 		return
 	}
-	keys := make([]string, 0, len(remotes))
-	for k := range remotes {
-		keys = append(keys, k)
-	}
+	// Sorted so repeated runs over the same working tree log the
+	// remotes in a stable order.
+	keys := slices.Sorted(maps.Keys(remotes))
 	slog.Debug("discovery: working tree remotes", "count", len(keys), "remotes", keys)
 }


### PR DESCRIPTION
## Summary
Two hand-rolled \`make + range + append + sort\` patterns collapse to \`slices.Sorted(maps.Keys(m))\`:
- \`pkg/change/detect.go\` \`Set.Paths()\`: collect-then-sort.
- \`pkg/discovery/remotes.go\` \`debugLogRemotes\`: was collect without sort, leaving log output tied to map iteration order. Switch to sorted so repeated runs over the same tree log remotes in a stable order — small ergonomic win on top of the modernization.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./pkg/change/... ./pkg/discovery/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)