### PR TITLE
refactor(orchestrator): use slices.SortedFunc + NamedResource.Compare in cycles

### DIFF
--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -1,8 +1,8 @@
 package orchestrator
 
 import (
-	"cmp"
 	"log/slog"
+	"maps"
 	"slices"
 	"strings"
 
@@ -112,23 +112,20 @@ func findDependencyCycles(s *store.Store, kind string) [][]manifest.NamedResourc
 	var stack []manifest.NamedResource
 	var cycles [][]manifest.NamedResource
 
-	nodes := make([]manifest.NamedResource, 0, len(graph))
-	for n := range graph {
-		nodes = append(nodes, n)
-	}
-	slices.SortFunc(nodes, func(a, b manifest.NamedResource) int {
-		return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
-	})
+	// Sort the visit order so cycle output is deterministic across
+	// runs. NamedResource.Compare orders by (kind, namespace, name);
+	// every node here shares the same kind, so the comparison
+	// reduces to (namespace, name) — the historical inline ordering.
+	nodes := slices.SortedFunc(maps.Keys(graph), manifest.NamedResource.Compare)
 
 	var visit func(n manifest.NamedResource)
 	visit = func(n manifest.NamedResource) {
 		color[n] = gray
 		stack = append(stack, n)
-		// Sort outgoing edges for determinism.
+		// Sort outgoing edges for determinism. Clone the slice first
+		// so the SortFunc doesn't mutate the underlying graph entry.
 		out := append([]manifest.NamedResource(nil), graph[n]...)
-		slices.SortFunc(out, func(a, b manifest.NamedResource) int {
-			return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
-		})
+		slices.SortFunc(out, manifest.NamedResource.Compare)
 		for _, m := range out {
 			switch color[m] {
 			case white:


### PR DESCRIPTION
## Summary
\`pkg/orchestrator/cycles.go\` inlined the same \`(namespace, name)\` comparator twice (sorting nodes and outgoing edges) and built the nodes slice via a manual make + range loop.

- Replace both inline comparators with \`manifest.NamedResource.Compare\`. It orders by \`(kind, namespace, name)\` but reduces to \`(namespace, name)\` when all inputs share the same kind, exactly the case here (\`buildDepGraph\` filters cross-kind deps).
- Collapse the nodes collection to \`slices.SortedFunc(maps.Keys(graph), manifest.NamedResource.Compare)\`.
- Drop the \`cmp\` import — both \`cmp.Or\` / \`cmp.Compare\` callers are gone.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./pkg/orchestrator/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)