### PR TITLE
refactor: route same-kind comparators through NamedResource.Compare

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -102,8 +102,7 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 	// produce a different ordering each invocation, breaking shell-piped
 	// diffs and CI consumers.
 	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
-		ai, bi := a.Named(), b.Named()
-		return cmp.Or(cmp.Compare(ai.Namespace, bi.Namespace), cmp.Compare(ai.Name, bi.Name))
+		return a.Named().Compare(b.Named())
 	})
 	matched := 0
 	for _, obj := range objs {

--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -1,7 +1,6 @@
 package resourceset
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -106,9 +105,12 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 		}
 	}
 	// Sort providers by (namespace, name) for deterministic output,
-	// matching upstream's Combine routine ordering.
+	// matching upstream's Combine routine ordering. NamedResource.Compare
+	// orders by (kind, namespace, name); every provider here shares the
+	// same kind so the Kind comparison is always 0 and the order reduces
+	// to the desired (namespace, name).
 	slices.SortFunc(providers, func(a, b *manifest.ResourceSetInputProvider) int {
-		return cmp.Or(cmp.Compare(a.Namespace, b.Namespace), cmp.Compare(a.Name, b.Name))
+		return a.Named().Compare(b.Named())
 	})
 	for _, p := range providers {
 		exported, err := p.ExportedInputs()


### PR DESCRIPTION
## Summary
\`internal/cli/build.go\` and \`pkg/resourceset/inputs.go\` each hand-rolled a \`cmp.Or(cmp.Compare(ns), cmp.Compare(name))\` comparator for sorting same-kind \`BaseManifest\` / \`ResourceSetInputProvider\` slices.

\`NamedResource.Compare\` orders by \`(kind, namespace, name)\`; when every element shares the same kind the Kind comparison is always 0 and the result reduces to the \`(namespace, name)\` ordering the inline code expressed. Route both comparators through it.

Drops \`pkg/resourceset/inputs.go\`'s \`cmp\` import as a side effect.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./pkg/resourceset/... ./internal/cli/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)