### PR TITLE
refactor(source/git): inline refStr fallback with cmp.Or

### DIFF
--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -2,6 +2,7 @@
 package git
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -102,9 +103,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 
 	refStr := "HEAD"
 	if repo.Reference != nil {
-		if s := manifest.GitRefString(*repo.Reference); s != "" {
-			refStr = s
-		}
+		refStr = cmp.Or(manifest.GitRefString(*repo.Reference), refStr)
 	}
 
 	slot, exists, release, err := cache.Slot(repo.URL, refStr)


### PR DESCRIPTION
## Summary
\`Fetcher.fetch\`'s \`refStr := \"HEAD\"; if Reference != nil { if s := GitRefString(...); s != \"\" { refStr = s } }\` block collapses into a single \`cmp.Or\` inside the outer Reference-nil guard. The guard stays because the deref needs it; \`cmp.Or\` returns the existing \`refStr\` unchanged when \`GitRefString\` produces \`\"\"\`.

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./pkg/source/git/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)