### PR TITLE
fix(change): stop keep-set cascade through ancestor-only renders

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -39,11 +39,19 @@ type Filter struct {
 	// its internal lock so callbacks are free to take other locks.
 	OnAdd func(manifest.NamedResource)
 
-	// mu guards keep + keepByName for runtime Add(); resolve() runs
-	// once during construction before the controllers start, so it
-	// doesn't need to hold the lock.
+	// mu guards keep + keepByName + primary for runtime Add();
+	// resolve() runs once during construction before the controllers
+	// start, so it doesn't need to hold the lock.
 	mu   sync.RWMutex
 	keep map[manifest.NamedResource]struct{}
+
+	// primary is the subset of keep whose render output likely differs
+	// from baseline — file-change owners, their siblings, and runtime
+	// adds emitted by another primary entry. Ancestor-only entries
+	// (kept so parent patches apply per #58) are explicitly NOT
+	// marked primary so their render emissions don't cascade-include
+	// every file-loaded sibling via AddEmitted.
+	primary map[manifest.NamedResource]struct{}
 
 	// keepByName: (Kind, Name) presence set used as an O(1) fallback
 	// when either side of a lookup has an empty namespace.
@@ -115,35 +123,60 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	return false
 }
 
-// Add extends the keep set with id at runtime. Used by the KS
-// controller when a parent in the keep set emits id as a rendered
-// child — the file walk that built the keep set can't see those
-// emissions, but they're conceptually in-scope because the parent
-// only reconciled by passing the filter. Without this, the kustomize
-// component+replacement pattern (a parent KS emitting a per-app KS
-// via a ConfigMap-driven replacement) produces silent gaps in
-// changed-only diffs: the leaf KS isn't keep-set'd, never reconciles,
-// and its render output is missing from the diff. Issue #204.
+// AddEmitted extends the keep set with child when emitter is a
+// "primary" keep entry — i.e. one whose own render output differs
+// from baseline (its source file changed, it's a sibling of a
+// changed file under a shared owner KS, or it was itself emitted
+// by another primary parent at runtime). Ancestor-only emitters
+// (kept so their patches/substituteFrom apply to descendants per
+// #58) DON'T propagate keep to file-loaded children: their render
+// output for unrelated siblings is identical to baseline, and
+// cascading those siblings through the keep set turns a one-file
+// change into a full-tree reconcile.
 //
-// Add ALSO walks transitiveDeps recursively so a Kustomization /
-// HelmRelease added at runtime carries its sourceRef and chartRef
-// into the keep set with it. Without this, a leaf KS emitted via a
-// parent's render lands in keep, runs reconcile, asks for its
-// sourceRef's artifact, and finds nothing — the source controller
-// PreGate-skipped that source at startup because nothing in keep
-// referenced it yet. Issue #260.
+// child inherits the emitter's primacy: AddEmitted walks
+// transitiveDeps recursively for sourceRef / chartRef / valuesFrom
+// (issue #260) and marks every newly-added entry primary so their
+// own future emissions cascade correctly.
+//
+// Used by the KS controller when a parent KS in the keep set
+// renders and emits id as a child. Covers the kustomize
+// component+replacement pattern (parent emits render-only per-app
+// Kustomization from a CM-driven replacement, see #204) AND the
+// patch-propagation chain (primary parent emits patched file-loaded
+// child whose render-with-new-patches differs from baseline).
 //
 // Newly-added ids are passed to OnAdd (when configured) so the
 // orchestrator can refire dependent listeners (e.g. retrigger the
 // source controller's fetch for a source whose PreGate-skip happened
 // before its consumer joined keep).
 //
-// Ordering contract for embedders: call Add(child) BEFORE the
-// emitting Store.AddObject(child). Store events fire synchronously
-// on the calling goroutine, so the controller's listener invokes
-// PreGate (and thus ShouldReconcile) inside that AddObject — if
-// Add ran after, the listener sees the old keep set and short-
-// circuits to Ready/"unchanged".
+// Ordering contract for embedders: call AddEmitted(parent, child)
+// BEFORE the emitting Store.AddObject(child). Store events fire
+// synchronously on the calling goroutine, so the controller's
+// listener invokes PreGate (and thus ShouldReconcile) inside that
+// AddObject — if AddEmitted ran after, the listener sees the old
+// keep set and short-circuits to Ready/"unchanged".
+//
+// No-op when the filter is disabled. Safe for concurrent use.
+func (f *Filter) AddEmitted(emitter, child manifest.NamedResource) {
+	if !f.Enabled() {
+		return
+	}
+	f.mu.RLock()
+	_, primaryEmitter := f.primary[emitter]
+	f.mu.RUnlock()
+	if !primaryEmitter {
+		return
+	}
+	f.Add(child)
+}
+
+// Add unconditionally extends the keep set with id (and its
+// transitive sourceRef/chartRef/valuesFrom deps) at runtime, marking
+// every newly-inserted entry primary. Callers that need the
+// "skip when emitter is ancestor-only" gating should use AddEmitted
+// instead.
 //
 // No-op when the filter is disabled. Safe for concurrent use.
 func (f *Filter) Add(id manifest.NamedResource) {
@@ -162,10 +195,17 @@ func (f *Filter) Add(id manifest.NamedResource) {
 	}
 }
 
-// addRecursive adds id (and transitive deps) to keep, returning the
-// list of ids that were newly added (so the caller can dispatch
-// OnAdd notifications outside the lock). Holds mu for the full
-// graph walk so the recursion sees a coherent keep snapshot.
+// addRecursive adds id (and transitive deps) to keep AND primary,
+// returning the list of ids that were newly added (so the caller
+// can dispatch OnAdd notifications outside the lock). Holds mu for
+// the full graph walk so the recursion sees a coherent keep
+// snapshot.
+//
+// Every entry inserted by this path is primary: runtime adds happen
+// when a primary parent emits a child, so the child inherits primacy
+// and any future emissions IT produces also propagate. Ancestor-only
+// entries are inserted directly into f.keep (NOT f.primary) by
+// resolve()'s own walks, never via addRecursive.
 func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResource {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -175,14 +215,23 @@ func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResourc
 	for len(stack) > 0 {
 		cur := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		if _, ok := f.keep[cur]; ok {
+		_, alreadyKeep := f.keep[cur]
+		_, alreadyPrimary := f.primary[cur]
+		if alreadyKeep && alreadyPrimary {
 			continue
 		}
-		f.keep[cur] = struct{}{}
-		if cur.Namespace == "" {
-			f.keepByName[nameKey{cur.Kind, cur.Name}] = struct{}{}
+		if !alreadyKeep {
+			f.keep[cur] = struct{}{}
+			if cur.Namespace == "" {
+				f.keepByName[nameKey{cur.Kind, cur.Name}] = struct{}{}
+			}
+			added = append(added, cur)
 		}
-		added = append(added, cur)
+		// Promote ancestor-only entries to primary when a runtime
+		// add reaches them: an ancestor that ALSO becomes the emit-
+		// chain target of a primary parent is itself rendering a
+		// changed graph, so its further emissions should cascade.
+		f.primary[cur] = struct{}{}
 		// Transitive walk: a runtime-added KS / HR pulls its
 		// sourceRef / chartRef / valuesFrom into keep with it.
 		// objs may be nil for tests that construct a Filter without
@@ -192,7 +241,7 @@ func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResourc
 			continue
 		}
 		for _, dep := range transitiveDeps(f.objs, cur) {
-			if _, ok := f.keep[dep]; !ok {
+			if _, ok := f.primary[dep]; !ok {
 				stack = append(stack, dep)
 			}
 		}
@@ -202,8 +251,25 @@ func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResourc
 
 func (f *Filter) resolve(objs ObjectLister) {
 	keep := make(map[manifest.NamedResource]struct{})
+	primary := make(map[manifest.NamedResource]struct{})
 	var queue []manifest.NamedResource
-	enqueue := func(id manifest.NamedResource) {
+	enqueuePrimary := func(id manifest.NamedResource) {
+		if _, isPrimary := primary[id]; isPrimary {
+			return
+		}
+		primary[id] = struct{}{}
+		if _, seen := keep[id]; !seen {
+			keep[id] = struct{}{}
+			queue = append(queue, id)
+		}
+	}
+	// enqueueAncestor adds id to keep without marking it primary.
+	// Ancestors render so their patches/substituteFrom apply to
+	// descendants (#58), but their render output for unrelated
+	// sibling children is identical to baseline — so AddEmitted
+	// must NOT keep-add those siblings on the cascade path. The
+	// primary/non-primary distinction is the gate.
+	enqueueAncestor := func(id manifest.NamedResource) {
 		if _, seen := keep[id]; seen {
 			return
 		}
@@ -217,35 +283,43 @@ func (f *Filter) resolve(objs ObjectLister) {
 	for _, file := range f.changes.Paths() {
 		for _, owner := range owners.ownersOf(file) {
 			ownersHit[owner] = struct{}{}
-			enqueue(owner)
+			enqueuePrimary(owner)
 		}
 		// Also include ancestor/meta Kustomizations whose render
 		// mutates the leaf owner's spec — parent-injected spec.patches
 		// and postBuild.substituteFrom land at parent-render time, so
 		// in changed-only mode the parent has to run too. Ancestors
 		// are NOT added to ownersHit, so the sibling-pull-in below
-		// doesn't drag in everything else they own. See #58.
+		// doesn't drag in everything else they own. See #58. They're
+		// also NOT marked primary so AddEmitted skips their unrelated
+		// emitted children — preventing the keep cascade where a
+		// one-file change pulls in the entire cluster.
 		for _, ancestor := range owners.ancestorsOf(file) {
-			enqueue(ancestor)
+			enqueueAncestor(ancestor)
 		}
 	}
 	for id, src := range f.sourceFiles {
 		if f.changes.Contains(src) {
-			enqueue(id)
+			enqueuePrimary(id)
 			continue
 		}
 		// Pull in every sibling resource that shares an affected owner.
 		for _, owner := range owners.ownersOf(src) {
 			if _, hit := ownersHit[owner]; hit {
-				enqueue(id)
+				enqueuePrimary(id)
 				break
 			}
 		}
 	}
 
 	for head := 0; head < len(queue); head++ {
+		_, headPrimary := primary[queue[head]]
 		for _, d := range transitiveDeps(objs, queue[head]) {
-			enqueue(d)
+			if headPrimary {
+				enqueuePrimary(d)
+			} else {
+				enqueueAncestor(d)
+			}
 		}
 		// Also walk the structural-parent chain of any Flux
 		// Kustomization in the keep set. A leaf change pulls in its
@@ -270,17 +344,20 @@ func (f *Filter) resolve(objs ObjectLister) {
 		// so deeper chains of meta-Kustomizations get pulled in too.
 		// queue[head] itself owns its OWN spec.path, not its source
 		// file, so the parent never collides with the KS we're walking.
+		// Structural parents are ancestor-only (their unrelated children
+		// shouldn't cascade into keep — same rationale as ancestorsOf).
 		for _, owner := range owners.ownersOf(src) {
 			if owner == queue[head] {
 				continue
 			}
-			enqueue(owner)
+			enqueueAncestor(owner)
 		}
 		for _, ancestor := range owners.ancestorsOf(src) {
-			enqueue(ancestor)
+			enqueueAncestor(ancestor)
 		}
 	}
 	f.keep = keep
+	f.primary = primary
 
 	// Index ONLY empty-namespace keep entries by (Kind, Name) — see
 	// ShouldReconcile's doc for the asymmetry rationale. Indexing

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -391,6 +391,100 @@ func TestFilter_ShouldReconcileEmptyNamespaceFallback(t *testing.T) {
 	}
 }
 
+// TestFilter_AddEmittedRejectsAncestorOnlyEmitter pins the
+// keep-cascade fix: when a parent KS is in the keep set only as an
+// ancestor (kept so its patches/substituteFrom render before the
+// leaf descendants per #58), its file-loaded emitted children must
+// NOT auto-join keep. Without this gate, a one-file change in a
+// deeply-nested leaf cascades the entire tree into keep — every
+// ancestor renders, emits every file-loaded child, AddEmitted
+// previously called Add unconditionally, every emitted child then
+// emits its own children, and the cluster is back to a full reconcile.
+//
+// The change: AddEmitted no-ops when the emitter is in keep only
+// as an ancestor. Render-only children (no sourceFile entry) of an
+// ancestor parent are also gated out — if the ancestor's own render
+// is unchanged from baseline, anything it emits at render time is
+// unchanged too, and there's no diff to capture.
+func TestFilter_AddEmittedRejectsAncestorOnlyEmitter(t *testing.T) {
+	// reloader's OCIRepository file is the only file change. The
+	// leaf KS (reloader/app) owns that file → marked primary. The
+	// "cluster-apps" ancestor whose spec.path covers everything is
+	// kept (so its patches apply) but is NOT primary.
+	leafKS := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "reloader-app"}
+	clusterApps := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	siblingApp := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "media", Name: "plex-app"}
+
+	leafKSObj := &manifest.Kustomization{Name: "reloader-app", Namespace: "kube-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system/reloader/app"}}
+	clusterAppsObj := &manifest.Kustomization{Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"}}
+	siblingObj := &manifest.Kustomization{Name: "plex-app", Namespace: "media",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/media/plex/app"}}
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/apps/kube-system/reloader/app/ocirepository.yaml"}),
+		map[manifest.NamedResource]string{
+			leafKS:      "kubernetes/apps/kube-system/reloader/app/ks.yaml",
+			clusterApps: "kubernetes/flux/cluster-apps.yaml",
+			siblingApp:  "kubernetes/apps/media/plex/ks.yaml",
+		},
+		"",
+		mapLister{leafKS: leafKSObj, clusterApps: clusterAppsObj, siblingApp: siblingObj},
+	)
+
+	if !f.ShouldReconcile(leafKS) {
+		t.Fatalf("leaf KS (owner of changed file) must be in keep; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(clusterApps) {
+		t.Fatalf("cluster-apps ancestor must be in keep (so its patches render); keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(siblingApp) {
+		t.Fatalf("precondition: sibling under same ancestor must NOT be in keep at resolve time; keep=%v", f.KeepNames())
+	}
+
+	// Simulate cluster-apps rendering and emitting the file-loaded
+	// sibling. AddEmitted must NOT keep-add it.
+	f.AddEmitted(clusterApps, siblingApp)
+	if f.ShouldReconcile(siblingApp) {
+		t.Errorf("AddEmitted(ancestor, sibling) over-extended keep set; sibling should remain SKIPPED; keep=%v", f.KeepNames())
+	}
+
+	// Same path but with a render-only child (no sourceFiles entry):
+	// still rejected because the emitter (ancestor) is not primary
+	// and an unchanged emitter wouldn't produce a different child.
+	renderOnly := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "rendered", Name: "from-replacement"}
+	f.AddEmitted(clusterApps, renderOnly)
+	if f.ShouldReconcile(renderOnly) {
+		t.Errorf("AddEmitted(ancestor, render-only) should reject when ancestor is not primary; keep=%v", f.KeepNames())
+	}
+}
+
+// TestFilter_AddEmittedFromPrimaryParent verifies the #204 path
+// still works: a primary parent (its own file changed, or it owns
+// the changed file) emitting any child — render-only or file-loaded
+// — keep-adds the child. This is the original AddEmitted purpose
+// and the bug-cascade prevention should not regress it.
+func TestFilter_AddEmittedFromPrimaryParent(t *testing.T) {
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "database"}
+	child := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "database", Name: "leaf-app"}
+
+	f := NewFilter(
+		NewSet([]string{"apps/database/parent.yaml"}),
+		map[manifest.NamedResource]string{parent: "apps/database/parent.yaml"},
+		"",
+		emptyLister{},
+	)
+	if !f.ShouldReconcile(parent) {
+		t.Fatalf("parent must be primary from direct file change; keep=%v", f.KeepNames())
+	}
+
+	f.AddEmitted(parent, child)
+	if !f.ShouldReconcile(child) {
+		t.Errorf("AddEmitted(primary parent, child) should keep-add child; keep=%v", f.KeepNames())
+	}
+}
+
 // TestFilter_KeepByNameDoesNotLeakAcrossNamespaces pins the
 // asymmetric-fallback contract: a fully-namespaced keep entry must
 // NOT match a fully-namespaced lookup that happens to share

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -54,7 +54,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			continue
 		}
 		if p.reconcilable {
-			c.keepEmitted(p.obj.Named())
+			c.keepEmitted(id, p.obj.Named())
 			c.Store.AddObject(p.obj)
 			c.markRendered(id, p.obj.Named())
 		} else {
@@ -64,7 +64,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	// Pass 2 — leaf reconcilables.
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
-			c.keepEmitted(p.obj.Named())
+			c.keepEmitted(id, p.obj.Named())
 			c.Store.AddObject(p.obj)
 			c.markRendered(id, p.obj.Named())
 		}
@@ -79,12 +79,19 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 // because it didn't exist on disk, never reconciles, and its render
 // output never reaches the diff comparison. Issue #204.
 //
+// Routed through Filter.AddEmitted so an ancestor-only parent
+// (kept for #58's patch-propagation but with no file change of its
+// own) doesn't cascade unrelated file-loaded children into keep on
+// every render. Primary parents — those whose own file changed or
+// that share an owner with a changed file — still propagate their
+// emissions normally.
+//
 // Called BEFORE Store.AddObject so the listener that fires
 // synchronously during AddObject sees the extended keep set when it
 // invokes PreGate.
-func (c *Controller) keepEmitted(id manifest.NamedResource) {
+func (c *Controller) keepEmitted(parent, child manifest.NamedResource) {
 	if f := c.Filter(); f != nil {
-		f.Add(id)
+		f.AddEmitted(parent, child)
 	}
 }
 


### PR DESCRIPTION
## Summary
A single-file change deep in the tree was producing a full-cluster reconcile under \`--path-orig\` changed-only mode. Diagnosis from buroa/k8s-gitops#5346 (reloader OCIRepository version bump):

> \`changedFiles=1\` was detected, but \`61 passed, 0 skipped, 0 failed\` for HelmReleases — every chart was pulled, every template was rendered.

### Why

1. \`resolve()\` correctly marks the changed file's leaf-owner KS as primary AND every ancestor KS as keep (so parent \`patches\` / \`postBuild.substituteFrom\` apply to descendants per #58).
2. At runtime, ancestors reconcile (they're in keep) and render. Their render emits every file-loaded child kustomize sees.
3. \`keepEmitted → Filter.Add\` was unconditional, so every emitted child joined keep and reconciled. Those children rendered and emitted their own children, and the keep-set absorbed the whole tree.

### Fix

Distinguish **primary** keep entries (own file changed, sibling of a changed file under a shared owner, or runtime-added via a primary emitter) from **ancestor-only** entries (kept for #58 but render output is identical to baseline for unrelated children).

\`Filter.AddEmitted(parent, child)\` no-ops when the parent is ancestor-only — file-loaded children stay \`SKIPPED\`; render-only children of an unchanged parent likewise produce no diff and stay out. Primary emitters still cascade their emissions normally.

Preserves:
- **#204** — per-app KS emitted via kustomize replacements (primary parent → render-only child still keep-added).
- **#260** — source-kind join-at-runtime triggers \`Refire\` (\`OnAdd\` fires for newly-added primaries).
- **#58** — ancestor KS still reconciles so its patches reach descendants in the change chain.

### Expected impact on reloader-bump PR

Before: 73 KS reconciled, 1 SKIPPED · 61 HR reconciled, 0 SKIPPED.
After: only reloader's chain (\`reloader-app\` leaf + ancestor KSs \`reloader\`, \`kube-system\`, \`cluster-apps\`) reconciles · ~69 KSs and ~60 HRs SKIPPED. No helm pull / kustomize build for SKIPPED resources.

## Test plan
- [x] New \`TestFilter_AddEmittedRejectsAncestorOnlyEmitter\` pins ancestor-only emitter gating end-to-end (file-loaded + render-only children).
- [x] New \`TestFilter_AddEmittedFromPrimaryParent\` guards #204's path.
- [x] Existing \`TestFilter_AncestorKSAlsoKept\` (#58), \`TestFilter_StructuralParentOfOwnerKSAlsoKept\` (#103), \`TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings\`, and \`TestIssue260_OCIRepoFetchedWhenConsumerJoinsKeepSetAtRuntime\` still pass.
- [x] \`go build ./... && go vet ./... && go test ./...\` (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)