### PR TITLE
fix(depwait): wait beyond grace for render-only deps still in flight

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -48,6 +48,7 @@ type Controller struct {
 	// Nil means "no parent enforcement"; matches pre-#221 behavior.
 	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
 	resolveMissing func(manifest.NamedResource) bool
+	isKnown        func(manifest.NamedResource) bool
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -68,6 +69,12 @@ type ReconcileOptions struct {
 	// (HelmRepository, OCIRepository, HelmChart) can be lazy-loaded
 	// the moment the HR's chartRef gate needs them.
 	ResolveMissing func(manifest.NamedResource) bool
+	// IsKnown reports whether id has a file-existence record. The
+	// orchestrator wires this so depwait distinguishes "dep is
+	// render-only and the producing chain hasn't finished yet"
+	// (no file record → keep waiting on per-dep ctx) from "dep is
+	// file-indexed but promote failed" (file record → fail fast).
+	IsKnown func(manifest.NamedResource) bool
 }
 
 // New constructs a HelmRelease controller.
@@ -87,6 +94,7 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
 	c.resolveMissing = opts.ResolveMissing
+	c.isKnown = opts.IsKnown
 }
 
 // lookupParent reports the structural parent KS of id via the
@@ -110,6 +118,7 @@ func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Durati
 		Parent:         id,
 		Timeout:        depwait.TimeoutFromSpec(timeout),
 		ResolveMissing: c.resolveMissing,
+		IsKnown:        c.isKnown,
 	}
 }
 

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -43,6 +43,7 @@ type Controller struct {
 	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
 	renderTracker  RenderTracker
 	resolveMissing func(manifest.NamedResource) bool
+	isKnown        func(manifest.NamedResource) bool
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -76,6 +77,13 @@ type Options struct {
 	// rendered by a sibling KS can be lazy-loaded on demand instead
 	// of failing the parent KS with "dependency not found."
 	ResolveMissing func(manifest.NamedResource) bool
+	// IsKnown reports whether id has a file-existence record. The
+	// orchestrator wires this so depwait can distinguish typo'd
+	// dependsOn (no record, fail fast — but only when IsKnown is
+	// nil) from a render-only dep still in flight (no record, keep
+	// waiting on the per-dep ctx). Forwarded to every Waiter built
+	// during reconcile.
+	IsKnown func(manifest.NamedResource) bool
 }
 
 // New constructs a Kustomization controller.
@@ -95,6 +103,7 @@ func (c *Controller) Configure(opts Options) {
 	c.parentOf = opts.ParentOf
 	c.renderTracker = opts.RenderTracker
 	c.resolveMissing = opts.ResolveMissing
+	c.isKnown = opts.IsKnown
 }
 
 // markRendered reports a parent→child render emission to the
@@ -115,6 +124,7 @@ func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Durati
 		Parent:         id,
 		Timeout:        depwait.TimeoutFromSpec(timeout),
 		ResolveMissing: c.resolveMissing,
+		IsKnown:        c.isKnown,
 	}
 }
 

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -103,6 +103,29 @@ type Waiter struct {
 	// lives inside that KS's own spec.path: the dep would never
 	// clear because the producing render hasn't run yet.
 	ResolveMissing func(manifest.NamedResource) bool
+
+	// IsKnown reports whether id has a file-existence record (the
+	// loader saw a YAML on disk that defines it, even if the loader
+	// kept it out of the Store under render-driven discovery).
+	// depwait uses this to distinguish two missing-dep cases when
+	// the grace window expires:
+	//
+	//   - IsKnown(id) == true and ResolveMissing(id) == false:
+	//     the file existed but promote failed (parse error, file
+	//     mutated since record). Fail fast as "dependency not found".
+	//   - IsKnown(id) == false:
+	//     no file record. The dep can only appear via a parent
+	//     render's emitRenderedChildren chain. Keep watching for
+	//     up to the per-dep Timeout — a deeply-chained kustomize
+	//     component+replacement pattern can take longer than the
+	//     2s grace to land its render output, and failing fast
+	//     surfaces a spurious "dependency not found" for a dep
+	//     that would have arrived a few seconds later.
+	//
+	// When IsKnown is nil, depwait preserves the historical fast-
+	// fail-after-grace behavior — callers that don't wire an
+	// existence index can't distinguish render-only from typo'd.
+	IsKnown func(manifest.NamedResource) bool
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -183,12 +206,29 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 		_, err := w.Store.WatchExists(graceCtx, id)
 		graceCancel()
 		if err != nil && !w.depExists(id) {
-			// Final fallback: ask the resolver to materialize the
-			// dep from the file-indexed Existence map. A true
-			// return means the dep is now in the Store and the
-			// wait can continue against built-in status / exists
-			// semantics below; false confirms it really is missing.
-			if w.ResolveMissing == nil || !w.ResolveMissing(id) {
+			// Step 1: ask the resolver to materialize the dep from
+			// the file-indexed Existence map. A true return means
+			// the dep is now in the Store and the wait can continue
+			// against built-in status / exists semantics below.
+			if w.ResolveMissing != nil && w.ResolveMissing(id) {
+				// promoted; fall through to the regular wait.
+			} else if w.IsKnown != nil && !w.IsKnown(id) {
+				// Step 2: dep has no file record — it can only arrive
+				// via a parent render's emitRenderedChildren chain.
+				// Keep watching for up to the per-dep Timeout. The
+				// 2s grace is too short for deeply-chained kustomize
+				// component+replacement patterns (parent KS → leaf
+				// KS → child HR) where the producing chain runs many
+				// kustomize builds + helm templates back-to-back.
+				if _, err := w.Store.WatchExists(ctx, id); err != nil {
+					return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+				}
+			} else {
+				// Step 3: either no IsKnown wired (legacy callers
+				// can't distinguish render-only from typo) or the
+				// dep is file-indexed but promote failed (file
+				// disappeared / parse error). Either way the dep is
+				// not coming — fail fast at the grace boundary.
 				return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
 			}
 		}

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -150,6 +150,81 @@ func TestWaiter_ResolveMissingFalseStillFails(t *testing.T) {
 	}
 }
 
+// TestWaiter_RenderOnlyDepWaitsBeyondGrace covers the
+// chained-render race documented in the docstring on Waiter.IsKnown:
+// a HelmRelease emitted by a render-only leaf KS (components/ks/app
+// + APP-app-vars replacement pattern) can land in the Store seconds
+// AFTER the consuming HR's depwait started — well past the 2s
+// MissingGrace. Before IsKnown was wired, depwait would fast-fail
+// at the grace boundary even though the dep was actively being
+// produced. With IsKnown(id)=false telling depwait "no file record,
+// only render emission can produce this", the Waiter keeps watching
+// on the per-dep ctx and clears the moment the dep lands.
+func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "omada-controller"}
+
+	resolve := func(manifest.NamedResource) bool { return false }
+	isKnown := func(manifest.NamedResource) bool { return false }
+
+	// Add the dep AFTER MissingGrace expires but well before the
+	// per-dep Timeout. Mark it Ready so the regular Ready wait
+	// (which runs after we fall through the missing-dep path)
+	// completes.
+	go func() {
+		time.Sleep(MissingGrace + 500*time.Millisecond)
+		s.AddObject(&manifest.HelmRelease{Name: dep.Name, Namespace: dep.Namespace})
+		s.UpdateStatus(dep, store.StatusReady, "")
+	}()
+
+	w := &Waiter{
+		Store:          s,
+		Timeout:        MissingGrace + 5*time.Second,
+		ResolveMissing: resolve,
+		IsKnown:        isKnown,
+	}
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	if !sum.AllReady() {
+		t.Errorf("render-only dep that arrived after grace should clear, not fail: %+v", sum)
+	}
+}
+
+// TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout pins the
+// terminal case: a render-only dep that NEVER appears (typo'd
+// dependsOn, deleted resource, or a producing chain that itself
+// failed) must still surface as "dependency not found" — just at
+// the per-dep Timeout instead of MissingGrace. The error message
+// stays the same so users grep for it the same way.
+func TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "never-arrives"}
+
+	resolve := func(manifest.NamedResource) bool { return false }
+	isKnown := func(manifest.NamedResource) bool { return false }
+
+	// Use a tight Timeout so the test doesn't burn 30s.
+	w := &Waiter{
+		Store:          s,
+		Timeout:        MissingGrace + 200*time.Millisecond,
+		ResolveMissing: resolve,
+		IsKnown:        isKnown,
+	}
+	start := time.Now()
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	elapsed := time.Since(start)
+
+	if !sum.AnyFailed() {
+		t.Fatalf("expected fail for never-appearing dep: %+v", sum)
+	}
+	// Must have waited past MissingGrace — that's the whole point.
+	if elapsed < MissingGrace {
+		t.Errorf("wait returned before grace expired: elapsed=%s, grace=%s", elapsed, MissingGrace)
+	}
+	if got := sum.Messages[dep]; got != "dependency not found" {
+		t.Errorf("expected 'dependency not found', got %q", got)
+	}
+}
+
 func TestWaiter_NoDeps(t *testing.T) {
 	w := &Waiter{Store: store.New()}
 	sum := WaitAll(w.Watch(context.Background(), nil))

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -454,16 +454,29 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	resolveMissing := func(id manifest.NamedResource) bool {
 		return o.existence.Promote(o.store, id, o.cfg.WipeSecrets)
 	}
+	// isKnown lets depwait distinguish "render-only dep still in
+	// flight" (no file record → wait on the per-dep ctx) from
+	// "file-indexed but promote failed" (file record → fail fast).
+	// Without this signal depwait would treat both as fast-fail,
+	// surfacing spurious "dependency not found" errors for chained
+	// kustomize-component+replacement renders (component/ks/app
+	// → leaf KS → child HR) that exceed the 2s grace window.
+	isKnown := func(id manifest.NamedResource) bool {
+		_, ok := o.existence.Get(id)
+		return ok
+	}
 	o.ksc.Configure(kustomization.Options{
 		Filter:         o.filter,
 		ParentOf:       parentResolver,
 		RenderTracker:  o.rendered,
 		ResolveMissing: resolveMissing,
+		IsKnown:        isKnown,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
 		Filter:         o.filter,
 		ParentOf:       parentResolver,
 		ResolveMissing: resolveMissing,
+		IsKnown:        isKnown,
 	})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)


### PR DESCRIPTION
## Summary
A HelmRelease whose \`dependsOn\` points at another HR emitted via the kustomize \`components/ks/app\` + \`APP-app-vars\` replacement pattern was spuriously failing with \`dependency not found\` during \`flate test all\`. Both HRs come from render-only leaf Kustomizations; the consumer's depwait ran the 2s \`MissingGrace\`, observed the dep absent, called \`ResolveMissing\` (which can only resolve file-loaded ids), got false, and gave up — even though the producing chain (parent KS → leaf KS → child HR) was still in flight and the dep landed a few seconds later.

Repro from aclerici38/home-ops#3055:

\`\`\`
HelmRelease/network/omada-exporter   FAILED (dependencies failed:
  HelmRelease/network/omada-controller: dependency not found)
HelmRelease/network/omada-controller PASSED
\`\`\`

The dep DOES end up Ready — depwait just gave up before it landed.

## Fix
Add \`Waiter.IsKnown\` — a closure the orchestrator wires against the loader's \`ExistenceIndex\`. After the grace window expires and \`ResolveMissing\` returns false, depwait splits the missing-dep path:

- \`IsKnown(id) == false\` (render-only): keep watching on the per-dep ctx. The dep can only arrive via \`emitRenderedChildren\` and the chain may legitimately need longer than the brief grace window.
- \`IsKnown(id) == true\` OR \`IsKnown == nil\`: fail fast as \`dependency not found\`, preserving the historical behavior for typo'd \`dependsOn\` and file-indexed deps whose promote failed.

Wiring chain: orchestrator → \`kustomization.Options\` / \`helmrelease.ReconcileOptions\` → \`Waiter.IsKnown\`.

## Test plan
- [x] Existing \`TestWaiter_MissingDepFailsFast\` (no \`IsKnown\` wired) continues to fast-fail at \`MissingGrace\`.
- [x] Existing \`TestWaiter_ResolveMissingLazyPromotes\` / \`TestWaiter_ResolveMissingFalseStillFails\` unchanged.
- [x] New \`TestWaiter_RenderOnlyDepWaitsBeyondGrace\` covers the repro: dep arrives \`MissingGrace+500ms\` in; wait clears.
- [x] New \`TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout\` pins the terminal case: render-only dep that never arrives still surfaces \`dependency not found\` — just at \`Timeout\` instead of \`MissingGrace\`.
- [x] \`go build ./... && go vet ./... && go test ./...\` (full suite green).

## On the kustomization/HR count question

Different observation, same PR run: \`flate test all\` reports \`kustomizations=139 helmReleases=98\`, but the \`flate diff\` jobs report \`kustomizations=40 helmReleases=10\`. That's the changed-only-mode keep-set in action (PR #308 should shrink that further on \`diff\` runs since the action is pinned at 0.1.18, before the cascade fix lands). \`test all\` runs without \`--path-orig\` so it always reconciles the whole tree. No bug there — just expected divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)