### PR TITLE
fix(change): close AddEmitted race + symmetric BFS upgrade + cascade depth test

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -163,13 +163,32 @@ func (f *Filter) AddEmitted(emitter, child manifest.NamedResource) {
 	if !f.Enabled() {
 		return
 	}
-	f.mu.RLock()
-	_, primaryEmitter := f.primary[emitter]
-	f.mu.RUnlock()
-	if !primaryEmitter {
+	// Gate the primacy check and the keep-set mutation under a
+	// single lock acquisition so a concurrent Add or AddEmitted
+	// that promotes `emitter` to primary between our gate read and
+	// the recurse can't cause `child` to be silently dropped.
+	// addEmittedLocked reads primary and (when gated through) does
+	// the addRecursive walk under the same WLock.
+	added := f.addEmittedLocked(emitter, child)
+	if f.OnAdd == nil || len(added) == 0 {
 		return
 	}
-	f.Add(child)
+	for _, newID := range added {
+		f.OnAdd(newID)
+	}
+}
+
+// addEmittedLocked is the WLock-held body of AddEmitted: it reads
+// primary[emitter] and the recurse for child without dropping the
+// lock between them. Returns the slice of newly-keep'd ids so the
+// caller can fire OnAdd outside the lock.
+func (f *Filter) addEmittedLocked(emitter, child manifest.NamedResource) []manifest.NamedResource {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, primaryEmitter := f.primary[emitter]; !primaryEmitter {
+		return nil
+	}
+	return f.addRecursiveLocked(child)
 }
 
 // Add unconditionally extends the keep set with id (and its
@@ -209,7 +228,13 @@ func (f *Filter) Add(id manifest.NamedResource) {
 func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResource {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	return f.addRecursiveLocked(id)
+}
 
+// addRecursiveLocked is the lock-free body of addRecursive — the
+// caller MUST hold f.mu.Lock(). Pulled out so AddEmitted can do its
+// gate-and-recurse atomically under a single lock acquisition.
+func (f *Filter) addRecursiveLocked(id manifest.NamedResource) []manifest.NamedResource {
 	var added []manifest.NamedResource
 	stack := []manifest.NamedResource{id}
 	for len(stack) > 0 {
@@ -228,9 +253,11 @@ func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResourc
 			added = append(added, cur)
 		}
 		// Promote ancestor-only entries to primary when a runtime
-		// add reaches them: an ancestor that ALSO becomes the emit-
-		// chain target of a primary parent is itself rendering a
-		// changed graph, so its further emissions should cascade.
+		// add reaches them: the primary parent's render contains
+		// this entry's manifest, so the entry's spec-as-rendered
+		// differs from baseline and its own emissions must cascade
+		// too. This is symmetric with resolve()'s enqueuePrimary
+		// upgrade path.
 		f.primary[cur] = struct{}{}
 		// Transitive walk: a runtime-added KS / HR pulls its
 		// sourceRef / chartRef / valuesFrom into keep with it.
@@ -260,8 +287,16 @@ func (f *Filter) resolve(objs ObjectLister) {
 		primary[id] = struct{}{}
 		if _, seen := keep[id]; !seen {
 			keep[id] = struct{}{}
-			queue = append(queue, id)
 		}
+		// Always re-queue when promoting an ancestor-only entry
+		// to primary: the BFS body uses the head's primacy at
+		// dequeue time to decide whether transitiveDeps propagate
+		// as primary or ancestor. Without the re-queue, an entry
+		// walked first as ancestor would never have its deps re-
+		// walked as primary, so chained transitive deps (a future
+		// chart-source-of-source or similar) silently stay ancestor-
+		// only. Symmetric with addRecursive's stack push.
+		queue = append(queue, id)
 	}
 	// enqueueAncestor adds id to keep without marking it primary.
 	// Ancestors render so their patches/substituteFrom apply to

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -460,6 +460,99 @@ func TestFilter_AddEmittedRejectsAncestorOnlyEmitter(t *testing.T) {
 	}
 }
 
+// TestFilter_AddEmittedNoCascadeAcrossDeepAncestorChain pins the
+// 3+ level ancestor case from the home-ops layout: a single file
+// change deep under cluster-apps → kube-system → reloader →
+// reloader-app should land ONLY reloader-app and the ancestor
+// chain in keep, NOT every other ancestor's siblings (media-apps,
+// network-apps, etc.). Each ancestor renders so its patches
+// propagate (#58) but its AddEmitted calls for unrelated children
+// must skip because the ancestor itself is not primary.
+//
+// The fix's correctness rests on this chain depth — the single-
+// ancestor test alone wouldn't catch a future change that
+// accidentally promoted an ancestor to primary mid-cascade.
+func TestFilter_AddEmittedNoCascadeAcrossDeepAncestorChain(t *testing.T) {
+	clusterApps := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	kubeSystem := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "kube-system"}
+	reloader := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "reloader"}
+	reloaderApp := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "reloader-app"}
+
+	// Unrelated siblings at each ancestor level — none should
+	// land in keep regardless of which level emits them.
+	mediaSibling := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "media-apps"}
+	spegelSibling := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "spegel"}
+	reloaderSibling := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "descheduler-app"}
+
+	objs := mapLister{
+		clusterApps: &manifest.Kustomization{Name: clusterApps.Name, Namespace: clusterApps.Namespace,
+			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"}},
+		kubeSystem: &manifest.Kustomization{Name: kubeSystem.Name, Namespace: kubeSystem.Namespace,
+			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system"}},
+		reloader: &manifest.Kustomization{Name: reloader.Name, Namespace: reloader.Namespace,
+			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system/reloader"}},
+		reloaderApp: &manifest.Kustomization{Name: reloaderApp.Name, Namespace: reloaderApp.Namespace,
+			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system/reloader/app"}},
+		mediaSibling:    &manifest.Kustomization{Name: mediaSibling.Name, Namespace: mediaSibling.Namespace},
+		spegelSibling:   &manifest.Kustomization{Name: spegelSibling.Name, Namespace: spegelSibling.Namespace},
+		reloaderSibling: &manifest.Kustomization{Name: reloaderSibling.Name, Namespace: reloaderSibling.Namespace},
+	}
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/apps/kube-system/reloader/app/ocirepository.yaml"}),
+		map[manifest.NamedResource]string{
+			clusterApps:     "kubernetes/flux/cluster-apps.yaml",
+			kubeSystem:      "kubernetes/flux/kube-system.yaml",
+			reloader:        "kubernetes/apps/kube-system/reloader/ks.yaml",
+			reloaderApp:     "kubernetes/apps/kube-system/reloader/app/ks.yaml",
+			mediaSibling:    "kubernetes/flux/media-apps.yaml",
+			spegelSibling:   "kubernetes/apps/kube-system/spegel/ks.yaml",
+			reloaderSibling: "kubernetes/apps/kube-system/descheduler/app/ks.yaml",
+		},
+		"",
+		objs,
+	)
+
+	// Precondition: the leaf and its ancestor chain are in keep.
+	for _, id := range []manifest.NamedResource{reloaderApp, reloader, kubeSystem, clusterApps} {
+		if !f.ShouldReconcile(id) {
+			t.Fatalf("expected %s in keep at resolve time; keep=%v", id, f.KeepNames())
+		}
+	}
+	// And the unrelated siblings are NOT.
+	for _, id := range []manifest.NamedResource{mediaSibling, spegelSibling, reloaderSibling} {
+		if f.ShouldReconcile(id) {
+			t.Fatalf("precondition: %s must NOT be in keep before emissions; keep=%v", id, f.KeepNames())
+		}
+	}
+
+	// Simulate cascade: each ancestor renders and emits all of
+	// its children — including the unrelated siblings. Walking
+	// the chain top-down so we cover the worst case where a
+	// primary could theoretically leak through an upper ancestor.
+	f.AddEmitted(clusterApps, kubeSystem)
+	f.AddEmitted(clusterApps, mediaSibling)
+	f.AddEmitted(kubeSystem, reloader)
+	f.AddEmitted(kubeSystem, spegelSibling)
+	f.AddEmitted(reloader, reloaderApp)
+	f.AddEmitted(reloader, reloaderSibling)
+
+	// Each ancestor (clusterApps, kubeSystem, reloader) is in
+	// keep only as ancestor-only — none of their AddEmitted calls
+	// should promote a file-loaded sibling into keep.
+	for _, id := range []manifest.NamedResource{mediaSibling, spegelSibling, reloaderSibling} {
+		if f.ShouldReconcile(id) {
+			t.Errorf("ancestor-only cascade leaked: %s joined keep via AddEmitted; keep=%v", id, f.KeepNames())
+		}
+	}
+	// Sanity: the ancestor chain itself is still kept.
+	for _, id := range []manifest.NamedResource{reloaderApp, reloader, kubeSystem, clusterApps} {
+		if !f.ShouldReconcile(id) {
+			t.Errorf("ancestor chain entry %s dropped after AddEmitted churn; keep=%v", id, f.KeepNames())
+		}
+	}
+}
+
 // TestFilter_AddEmittedFromPrimaryParent verifies the #204 path
 // still works: a primary parent (its own file changed, or it owns
 // the changed file) emitting any child — render-only or file-loaded


### PR DESCRIPTION
## Summary
Follow-up to #308 from the post-merge review. Three changes:

1. **Race**: \`AddEmitted\` dropped its RLock between the \`primary[emitter]\` read and \`Add(child)\`. A concurrent promotion of the emitter between gate and recurse could silently drop the child. Pull the recurse into \`addRecursiveLocked\` and have \`AddEmitted\` hold a single WLock across the gate + recurse via \`addEmittedLocked\`. Atomic.

2. **BFS asymmetry**: \`resolve()\`'s \`enqueuePrimary\` upgrade path didn't re-walk deps when promoting an ancestor entry to primary. \`addRecursive\` does. Latent today (transitiveDeps don't chain past one level), but a future chart-source-of-source would expose the gap. Always re-queue on promotion; the BFS loop reads primacy at dequeue, so the re-walk produces correctly-primary deps. Bounded by the primary-already-set short-circuit.

3. **Test**: \`TestFilter_AddEmittedNoCascadeAcrossDeepAncestorChain\` pins the 3+ level home-ops scenario (cluster-apps → kube-system → reloader → reloader-app) with siblings at each ancestor level. Single-ancestor test alone wouldn't catch a future change that accidentally promoted an upper ancestor to primary mid-cascade.

## Test plan
- [x] \`go build ./... && go vet ./...\`
- [x] \`go test ./... -race\` (full suite green; new test passes)
- [x] Existing \`TestFilter_AddEmittedRejectsAncestorOnlyEmitter\`, \`TestFilter_AddEmittedFromPrimaryParent\`, \`TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings\`, \`TestIssue260_OCIRepoFetchedWhenConsumerJoinsKeepSetAtRuntime\` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)