### PR TITLE
refactor(depwait): rename IsKnown → IsFileIndexed for clarity

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -48,7 +48,7 @@ type Controller struct {
 	// Nil means "no parent enforcement"; matches pre-#221 behavior.
 	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
 	resolveMissing func(manifest.NamedResource) bool
-	isKnown        func(manifest.NamedResource) bool
+	isFileIndexed  func(manifest.NamedResource) bool
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -69,12 +69,12 @@ type ReconcileOptions struct {
 	// (HelmRepository, OCIRepository, HelmChart) can be lazy-loaded
 	// the moment the HR's chartRef gate needs them.
 	ResolveMissing func(manifest.NamedResource) bool
-	// IsKnown reports whether id has a file-existence record. The
+	// IsFileIndexed reports whether id has a file-existence record. The
 	// orchestrator wires this so depwait distinguishes "dep is
 	// render-only and the producing chain hasn't finished yet"
 	// (no file record → keep waiting on per-dep ctx) from "dep is
 	// file-indexed but promote failed" (file record → fail fast).
-	IsKnown func(manifest.NamedResource) bool
+	IsFileIndexed func(manifest.NamedResource) bool
 }
 
 // New constructs a HelmRelease controller.
@@ -94,7 +94,7 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
 	c.resolveMissing = opts.ResolveMissing
-	c.isKnown = opts.IsKnown
+	c.isFileIndexed = opts.IsFileIndexed
 }
 
 // lookupParent reports the structural parent KS of id via the
@@ -118,7 +118,7 @@ func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Durati
 		Parent:         id,
 		Timeout:        depwait.TimeoutFromSpec(timeout),
 		ResolveMissing: c.resolveMissing,
-		IsKnown:        c.isKnown,
+		IsFileIndexed:  c.isFileIndexed,
 	}
 }
 
@@ -308,6 +308,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs, Fingerprint: fp})
 	return nil
 }
+
 // collectHRDeps returns hr's typed dependsOn entries (carrying any
 // ReadyExpr) for the depwait Waiter. dependsOn on a HelmRelease
 // references other HelmReleases only (per Flux spec).
@@ -317,4 +318,3 @@ func (c *Controller) collectHRDeps(hr *manifest.HelmRelease) []manifest.Dependen
 	}
 	return append([]manifest.DependencyRef(nil), hr.DependsOn...)
 }
-

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -43,7 +43,7 @@ type Controller struct {
 	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
 	renderTracker  RenderTracker
 	resolveMissing func(manifest.NamedResource) bool
-	isKnown        func(manifest.NamedResource) bool
+	isFileIndexed  func(manifest.NamedResource) bool
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -77,13 +77,13 @@ type Options struct {
 	// rendered by a sibling KS can be lazy-loaded on demand instead
 	// of failing the parent KS with "dependency not found."
 	ResolveMissing func(manifest.NamedResource) bool
-	// IsKnown reports whether id has a file-existence record. The
+	// IsFileIndexed reports whether id has a file-existence record. The
 	// orchestrator wires this so depwait distinguishes "dep is
 	// render-only and the producing chain hasn't finished yet"
 	// (no file record → keep waiting on per-dep ctx) from "dep is
 	// file-indexed but promote failed" (file record → fail fast).
 	// Forwarded to every Waiter built during reconcile.
-	IsKnown func(manifest.NamedResource) bool
+	IsFileIndexed func(manifest.NamedResource) bool
 }
 
 // New constructs a Kustomization controller.
@@ -103,7 +103,7 @@ func (c *Controller) Configure(opts Options) {
 	c.parentOf = opts.ParentOf
 	c.renderTracker = opts.RenderTracker
 	c.resolveMissing = opts.ResolveMissing
-	c.isKnown = opts.IsKnown
+	c.isFileIndexed = opts.IsFileIndexed
 }
 
 // markRendered reports a parent→child render emission to the
@@ -124,7 +124,7 @@ func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Durati
 		Parent:         id,
 		Timeout:        depwait.TimeoutFromSpec(timeout),
 		ResolveMissing: c.resolveMissing,
-		IsKnown:        c.isKnown,
+		IsFileIndexed:  c.isFileIndexed,
 	}
 }
 
@@ -253,6 +253,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	})
 	return nil
 }
+
 // collectDeps assembles the dependency refs whose readiness must
 // precede this Kustomization: explicit dependsOn entries (carrying any
 // CEL ReadyExpr), the source ref, the implicit structural parent (the

--- a/pkg/controllers/kustomization/reconcile_test.go
+++ b/pkg/controllers/kustomization/reconcile_test.go
@@ -139,7 +139,7 @@ func TestReconcile_FingerprintDedup_SkipsRender(t *testing.T) {
 			},
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
-		Contents:   map[string]any{},
+		Contents: map[string]any{},
 	}
 	s.AddObject(ks)
 	waitForStatus(t, s, ks.Named(), store.StatusReady)
@@ -244,4 +244,3 @@ func TestReconcile_DependsOnFailed(t *testing.T) {
 		t.Error("expected failure message from dep cascade")
 	}
 }
-

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -34,7 +34,7 @@ const MissingGrace = 2 * time.Second
 // RenderProducingTimeout caps how long step-2 will wait for a
 // render-only dep (no file-existence record) to appear via a parent
 // render's emitRenderedChildren chain. Bounded so a typo'd
-// dependsOn — which also returns IsKnown(id)=false and falls into
+// dependsOn — which also returns IsFileIndexed(id)=false and falls into
 // step-2 — fails in a reasonable time instead of burning the full
 // per-dep Timeout. Chosen to comfortably cover a multi-level
 // kustomize component+replacement chain (~few seconds in practice)
@@ -116,16 +116,16 @@ type Waiter struct {
 	// clear because the producing render hasn't run yet.
 	ResolveMissing func(manifest.NamedResource) bool
 
-	// IsKnown reports whether id has a file-existence record (the
+	// IsFileIndexed reports whether id has a file-existence record (the
 	// loader saw a YAML on disk that defines it, even if the loader
 	// kept it out of the Store under render-driven discovery).
 	// depwait uses this to distinguish two missing-dep cases when
 	// the grace window expires:
 	//
-	//   - IsKnown(id) == true and ResolveMissing(id) == false:
+	//   - IsFileIndexed(id) == true and ResolveMissing(id) == false:
 	//     the file existed but promote failed (parse error, file
 	//     mutated since record). Fail fast as "dependency not found".
-	//   - IsKnown(id) == false:
+	//   - IsFileIndexed(id) == false:
 	//     no file record. The dep can only appear via a parent
 	//     render's emitRenderedChildren chain. Keep watching for
 	//     up to the per-dep Timeout — a deeply-chained kustomize
@@ -134,10 +134,10 @@ type Waiter struct {
 	//     surfaces a spurious "dependency not found" for a dep
 	//     that would have arrived a few seconds later.
 	//
-	// When IsKnown is nil, depwait preserves the historical fast-
+	// When IsFileIndexed is nil, depwait preserves the historical fast-
 	// fail-after-grace behavior — callers that don't wire an
 	// existence index can't distinguish render-only from typo'd.
-	IsKnown func(manifest.NamedResource) bool
+	IsFileIndexed func(manifest.NamedResource) bool
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -224,7 +224,7 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 			// against built-in status / exists semantics below.
 			if w.ResolveMissing != nil && w.ResolveMissing(id) {
 				// promoted; fall through to the regular wait.
-			} else if w.IsKnown != nil && !w.IsKnown(id) {
+			} else if w.IsFileIndexed != nil && !w.IsFileIndexed(id) {
 				// Step 2: dep has no file record — it can only arrive
 				// via a parent render's emitRenderedChildren chain.
 				// Wait up to RenderProducingTimeout for the dep to
@@ -234,7 +234,7 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 				// runs many kustomize builds + helm templates back-
 				// to-back, but unbounded waiting on the full per-dep
 				// budget burns ~30s on typo'd dependsOn that look
-				// identical to render-only at this point (IsKnown is
+				// identical to render-only at this point (IsFileIndexed is
 				// false in both cases).
 				//
 				// The render budget is derived from the parent ctx,
@@ -265,7 +265,7 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 					}
 				}
 			} else {
-				// Step 3: either no IsKnown wired (legacy callers
+				// Step 3: either no IsFileIndexed wired (legacy callers
 				// can't distinguish render-only from typo) or the
 				// dep is file-indexed but promote failed (file
 				// disappeared / parse error). Either way the dep is

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -151,13 +151,13 @@ func TestWaiter_ResolveMissingFalseStillFails(t *testing.T) {
 }
 
 // TestWaiter_RenderOnlyDepWaitsBeyondGrace covers the
-// chained-render race documented in the docstring on Waiter.IsKnown:
+// chained-render race documented in the docstring on Waiter.IsFileIndexed:
 // a HelmRelease emitted by a render-only leaf KS (components/ks/app
 // + APP-app-vars replacement pattern) can land in the Store seconds
 // AFTER the consuming HR's depwait started — well past the 2s
-// MissingGrace. Before IsKnown was wired, depwait would fast-fail
+// MissingGrace. Before IsFileIndexed was wired, depwait would fast-fail
 // at the grace boundary even though the dep was actively being
-// produced. With IsKnown(id)=false telling depwait "no file record,
+// produced. With IsFileIndexed(id)=false telling depwait "no file record,
 // only render emission can produce this", the Waiter keeps watching
 // on the per-dep ctx and clears the moment the dep lands.
 func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
@@ -165,7 +165,7 @@ func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
 	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "omada-controller"}
 
 	resolve := func(manifest.NamedResource) bool { return false }
-	isKnown := func(manifest.NamedResource) bool { return false }
+	isFileIndexed := func(manifest.NamedResource) bool { return false }
 
 	// Add the dep AFTER MissingGrace expires but well before the
 	// per-dep Timeout. Mark it Ready so the regular Ready wait
@@ -181,7 +181,7 @@ func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
 		Store:          s,
 		Timeout:        MissingGrace + 5*time.Second,
 		ResolveMissing: resolve,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	}
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
 	if !sum.AllReady() {
@@ -200,7 +200,7 @@ func TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout(t *testing.T) {
 	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "never-arrives"}
 
 	resolve := func(manifest.NamedResource) bool { return false }
-	isKnown := func(manifest.NamedResource) bool { return false }
+	isFileIndexed := func(manifest.NamedResource) bool { return false }
 
 	// Use a tight Timeout so the test doesn't burn 30s. Add a
 	// meaningful gap (300ms) so the assertion that elapsed >=
@@ -209,7 +209,7 @@ func TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout(t *testing.T) {
 		Store:          s,
 		Timeout:        MissingGrace + 300*time.Millisecond,
 		ResolveMissing: resolve,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	}
 	start := time.Now()
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
@@ -232,7 +232,7 @@ func TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout(t *testing.T) {
 }
 
 // TestWaiter_FileIndexedPromoteFailsFastAtGrace pins the
-// docstring's "IsKnown(id) == true and ResolveMissing(id) == false"
+// docstring's "IsFileIndexed(id) == true and ResolveMissing(id) == false"
 // branch: the dep is file-indexed but promote failed (parse error,
 // file mutated since record). depwait must fail fast at the grace
 // boundary — keeping the legacy "typo / broken file" UX where a
@@ -241,16 +241,16 @@ func TestWaiter_FileIndexedPromoteFailsFastAtGrace(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "broken"}
 
-	// Both wirings: ResolveMissing fails (promote unhappy), IsKnown
+	// Both wirings: ResolveMissing fails (promote unhappy), IsFileIndexed
 	// returns true (file-indexed). depwait should NOT enter step-2.
 	resolve := func(manifest.NamedResource) bool { return false }
-	isKnown := func(manifest.NamedResource) bool { return true }
+	isFileIndexed := func(manifest.NamedResource) bool { return true }
 
 	w := &Waiter{
 		Store:          s,
 		Timeout:        30 * time.Second, // generous; if step-2 ran we'd see it
 		ResolveMissing: resolve,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	}
 	start := time.Now()
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
@@ -272,7 +272,7 @@ func TestWaiter_FileIndexedPromoteFailsFastAtGrace(t *testing.T) {
 // step-2 budget cap: when a render-only dep never appears AND the
 // per-dep Timeout is much larger than RenderProducingTimeout, the
 // wait must end at the cap, not at the full per-dep budget. Before
-// the cap landed, a typo'd dependsOn (IsKnown returns false the
+// the cap landed, a typo'd dependsOn (IsFileIndexed returns false the
 // same as a render-only dep) burned the full per-dep Timeout —
 // ~30s instead of ~2s — surfacing as a UX regression vs the old
 // MissingGrace fast-fail.
@@ -286,13 +286,13 @@ func TestWaiter_RenderOnlyCappedAtRenderProducingTimeout(t *testing.T) {
 	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "typo-or-broken"}
 
 	resolve := func(manifest.NamedResource) bool { return false }
-	isKnown := func(manifest.NamedResource) bool { return false }
+	isFileIndexed := func(manifest.NamedResource) bool { return false }
 
 	w := &Waiter{
 		Store:          s,
 		Timeout:        30 * time.Second, // huge — render cap should win
 		ResolveMissing: resolve,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	}
 	start := time.Now()
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
@@ -328,13 +328,13 @@ func TestWaiter_RenderOnlyCancelDuringLongWaitSurfacesCancelled(t *testing.T) {
 	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "cancelled-mid-wait"}
 
 	resolve := func(manifest.NamedResource) bool { return false }
-	isKnown := func(manifest.NamedResource) bool { return false }
+	isFileIndexed := func(manifest.NamedResource) bool { return false }
 
 	w := &Waiter{
 		Store:          s,
 		Timeout:        30 * time.Second,
 		ResolveMissing: resolve,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	}
 
 	// Cancel after grace expires + 500ms — well into step-2's wait.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -211,8 +211,8 @@ func New(cfg Config) (*Orchestrator, error) {
 		ksc:      kustomization.New(st, ts, staging, cfg.WipeSecrets),
 		hrc:      helmrelease.New(st, ts, helmClient, cfg.HelmOptions, cfg.WipeSecrets),
 		rendered: newRenderedSet(),
-		helm:    helmClient,
-		staging: staging,
+		helm:     helmClient,
+		staging:  staging,
 	}
 	return o, nil
 }
@@ -428,7 +428,7 @@ func (o *Orchestrator) attachFilter(f *change.Filter) {
 // start → drain → finalize sequence.
 func (o *Orchestrator) Run(ctx context.Context) error {
 	o.src.Configure(sourcectrl.FetchOptions{
-		Filter:             o.filter,
+		Filter:              o.filter,
 		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
 	})
 	// parentResolver unifies the two sources of structural-parent
@@ -454,14 +454,14 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	resolveMissing := func(id manifest.NamedResource) bool {
 		return o.existence.Promote(o.store, id, o.cfg.WipeSecrets)
 	}
-	// isKnown lets depwait distinguish "render-only dep still in
+	// isFileIndexed lets depwait distinguish "render-only dep still in
 	// flight" (no file record → wait on the per-dep ctx) from
 	// "file-indexed but promote failed" (file record → fail fast).
 	// Without this signal depwait would treat both as fast-fail,
 	// surfacing spurious "dependency not found" errors for chained
 	// kustomize-component+replacement renders (component/ks/app
 	// → leaf KS → child HR) that exceed the 2s grace window.
-	isKnown := func(id manifest.NamedResource) bool {
+	isFileIndexed := func(id manifest.NamedResource) bool {
 		_, ok := o.existence.Get(id)
 		return ok
 	}
@@ -470,13 +470,13 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		ParentOf:       parentResolver,
 		RenderTracker:  o.rendered,
 		ResolveMissing: resolveMissing,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
 		Filter:         o.filter,
 		ParentOf:       parentResolver,
 		ResolveMissing: resolveMissing,
-		IsKnown:        isKnown,
+		IsFileIndexed:  isFileIndexed,
 	})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
@@ -486,7 +486,6 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	o.tasks.BlockTillDone()
 	return o.finalize()
 }
-
 
 // Render is the structured embed-friendly entry point: Bootstrap +
 // Run + collect everything an external caller needs to consume the
@@ -561,7 +560,6 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 	return res, runErr
 }
 
-
 // Stop shuts the controllers down in reverse-construction order and
 // releases the staging cache.
 func (o *Orchestrator) Stop() {
@@ -572,4 +570,3 @@ func (o *Orchestrator) Stop() {
 		_ = o.staging.Close()
 	}
 }
-


### PR DESCRIPTION
## Summary
Post-merge review feedback on #310: \`IsKnown\` reads as a generic predicate but actually answers one specific question — \"does id have a file-existence record after the discovery scan?\". The name \`IsFileIndexed\` matches the implementation literally (the closure delegates to \`existence.Get(id).ok\`) and makes the docstring's two branches read naturally:

\`\`\`go
if !w.IsFileIndexed(id) {
    // not file-indexed → render-only → wait on per-dep ctx
}
\`\`\`

vs the previous \`if !w.IsKnown(id)\` which left readers asking \"unknown to whom?\".

Renamed across:
- \`pkg/depwait/depwait.go\` — \`Waiter.IsKnown\` field + docstring + body.
- \`pkg/controllers/kustomization/controller.go\` — Options field + private storage.
- \`pkg/controllers/helmrelease/controller.go\` — ReconcileOptions field + private storage.
- \`pkg/orchestrator/orchestrator.go\` — wiring closure.
- Tests in both packages.

No behavior change.

## Test plan
- [x] \`go build ./... && go vet ./...\`
- [x] \`go test ./...\` (full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)