### PR TITLE
docs(change): sync filter doc comments with AddEmitted-based runtime API

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -12,28 +12,43 @@ import (
 // NewFilter — the zero value is the "no filtering" sentinel and
 // returns true from ShouldReconcile for every id.
 //
-// The keep set is built once at construction and then extended at
-// runtime by Add: a parent KS already in the keep set may render and
-// emit child KS / HR resources that the file-walk discovery phase
-// couldn't see (kustomize component + replacement patterns generate
-// Flux Kustomizations on the fly). Those children inherit the
-// parent's in-scope-ness because the parent only reconciled by
-// passing the filter in the first place. See issue #204.
+// The keep set has two tiers:
+//
+//   - "keep" entries reconcile. resolve() seeds this from file
+//     changes + ancestors of changed files (#58) + structural
+//     parents of owner KSes (#103).
+//   - "primary" is the subset whose render output likely differs
+//     from baseline: file-change owners, their siblings under the
+//     same owner, transitive deps walked from a primary entry, and
+//     runtime entries inserted by AddEmitted from a primary
+//     emitter. Ancestor-only entries are explicitly NOT primary.
+//
+// The keep set extends at runtime via AddEmitted when a primary
+// parent KS renders and emits a child the file-walk couldn't see
+// (kustomize component + replacement patterns generate Flux
+// Kustomizations on the fly — see #204). Ancestor-only emitters
+// don't propagate keep to file-loaded children, which prevents a
+// one-file change from cascading the entire tree into keep.
 type Filter struct {
 	changes     *Set
 	sourceFiles map[manifest.NamedResource]string
 	repoRoot    string
 
-	// objs is captured from NewFilter so runtime Add() can walk
-	// transitiveDeps without the caller re-supplying it. Set once
-	// at construction; never mutated.
+	// objs is captured from NewFilter so runtime AddEmitted can
+	// walk transitiveDeps without the caller re-supplying it. The
+	// pointer is set once at construction and never reassigned —
+	// but the underlying *store.Store IS mutated post-Bootstrap by
+	// controllers, so reads through objs.GetObject /
+	// objs.ListObjects must take the Store's own RLock (which
+	// transitiveDeps does internally).
 	objs ObjectLister
 
 	// OnAdd, when non-nil, fires for every id newly added to the
-	// keep set by Add (including transitive-dep recursion). The
-	// orchestrator wires this to refire EventObjectAdded for source-
-	// kind ids whose listener already short-circuited via PreGate
-	// before the consuming KS joined keep. Issue #260.
+	// keep set by AddEmitted / Add (including transitive-dep
+	// recursion). The orchestrator wires this to refire
+	// EventObjectAdded for source-kind ids whose listener already
+	// short-circuited via PreGate before the consuming KS joined
+	// keep. Issue #260.
 	//
 	// Set BEFORE controllers start. The Filter calls OnAdd outside
 	// its internal lock so callbacks are free to take other locks.
@@ -193,9 +208,13 @@ func (f *Filter) addEmittedLocked(emitter, child manifest.NamedResource) []manif
 
 // Add unconditionally extends the keep set with id (and its
 // transitive sourceRef/chartRef/valuesFrom deps) at runtime, marking
-// every newly-inserted entry primary. Callers that need the
-// "skip when emitter is ancestor-only" gating should use AddEmitted
-// instead.
+// every newly-inserted entry primary.
+//
+// PRODUCTION CODE SHOULD USE AddEmitted INSTEAD: Add bypasses the
+// primary-emitter gate that prevents the ancestor-cascade failure
+// mode. The only legitimate uses are test scaffolding that needs
+// to seed an entry without simulating a render emission, and the
+// unconditional-add primitive that AddEmitted composes onto.
 //
 // No-op when the filter is disabled. Safe for concurrent use.
 func (f *Filter) Add(id manifest.NamedResource) {

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -329,8 +329,12 @@ func TestFilter_DependsOnNotFollowed(t *testing.T) {
 // KS in the keep set may render and emit a child KS that wasn't
 // discoverable at filter-build time (kustomize component +
 // replacement patterns generate per-app Kustomizations on the fly).
-// The KS controller calls Filter.Add(child) before AddObject so the
-// listener's PreGate filter check sees the extended keep set.
+// The KS controller calls Filter.AddEmitted(parent, child) before
+// AddObject so the listener's PreGate filter check sees the
+// extended keep set. This test uses Filter.Add directly (skipping
+// the primacy gate) to seed the runtime keep without simulating
+// a parent render; the gated path is covered by the AddEmitted
+// tests below.
 //
 // Without this, the kept parent reconciles but every render-emitted
 // child gets marked Ready "unchanged" by PreGate, never reconciles,
@@ -584,8 +588,8 @@ func TestFilter_AddEmittedFromPrimaryParent(t *testing.T) {
 // (Kind, Name). Without this, a kept
 // Kustomization/cluster-infra/external-secrets would silently scope-in
 // an unrelated Kustomization/database/external-secrets (and likewise
-// for the runtime Filter.Add path), broadening changed-only mode in
-// ways the user can't see. The empty-namespace bridge in
+// for the runtime AddEmitted / Add paths), broadening changed-only
+// mode in ways the user can't see. The empty-namespace bridge in
 // TestFilter_ShouldReconcileEmptyNamespaceFallback is preserved
 // because it indexes only entries whose Namespace is empty.
 func TestFilter_KeepByNameDoesNotLeakAcrossNamespaces(t *testing.T) {

--- a/pkg/change/issue260_test.go
+++ b/pkg/change/issue260_test.go
@@ -49,19 +49,20 @@ func (f fakeOCIFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*stor
 //
 // At runtime, cluster-apps renders ./kubernetes/apps and emits
 // homepage-config. The KS controller's keepEmitted calls
-// Filter.Add(homepage-config) and AddObject(homepage-config). The
-// child KS reconciles — and its sourceRef points at the OCIRepository
-// that was PreGate-skipped at startup with no artifact.
+// Filter.AddEmitted(cluster-apps, homepage-config) and then
+// AddObject(homepage-config). The child KS reconciles — and its
+// sourceRef points at the OCIRepository that was PreGate-skipped
+// at startup with no artifact.
 //
-// Bug: Filter.Add was a one-shot add — it didn't walk transitiveDeps,
-// so the OCIRepository never entered the keep set, the source
-// controller never re-fetched it, and homepage-config's
+// Bug: the runtime add was a one-shot add — it didn't walk
+// transitiveDeps, so the OCIRepository never entered the keep set,
+// the source controller never re-fetched it, and homepage-config's
 // resolveSourceRoot surfaced "source ... artifact not found".
 //
-// Fix: Filter.Add now walks transitiveDeps recursively AND the
-// orchestrator wires Filter.OnAdd to Store.Refire so source kinds
-// that newly join keep at runtime get their listener re-fired with
-// the updated filter state.
+// Fix: addRecursive (called via AddEmitted) now walks transitiveDeps
+// recursively AND the orchestrator wires Filter.OnAdd to
+// Store.Refire so source kinds that newly join keep at runtime get
+// their listener re-fired with the updated filter state.
 func TestIssue260_OCIRepoFetchedWhenConsumerJoinsKeepSetAtRuntime(t *testing.T) {
 	dir := t.TempDir()
 	mustWrite(t, filepath.Join(dir, "kubernetes/flux/cluster/ks.yaml"), clusterKS)


### PR DESCRIPTION
## Summary
Follow-up to #308 and #312 from the post-merge review: PRs #308/#312 changed the runtime keep-extension entry point from \`Filter.Add\` to \`Filter.AddEmitted\`, but the docstrings + test comments kept naming the old path. No code change; pure documentation alignment so a future reviewer doesn't have to triangulate the actual API from mismatched comments.

Sweeps:
- \`Filter\` type doc — re-explains the keep/primary two-tier model and where AddEmitted fits in.
- \`Filter.objs\` comment — clarifies "never mutated" refers to the pointer field, not the underlying \`*store.Store\`.
- \`Filter.OnAdd\` comment — names both AddEmitted and Add as the firing path.
- \`Filter.Add\` docstring — adds a warning that production code should use AddEmitted (Add bypasses the primacy gate that prevents the ancestor-cascade failure mode).
- \`TestFilter_AddExtendsKeepSetAtRuntime\` header — attributes runtime extension to AddEmitted with a note that the test uses Add to skip the gate.
- \`TestFilter_KeepByNameDoesNotLeakAcrossNamespaces\` comment — references both AddEmitted and Add.
- \`TestIssue260_OCIRepoFetchedWhenConsumerJoinsKeepSetAtRuntime\` narrative — names AddEmitted as the call site.

## Test plan
- [x] \`go build ./...\` (no code change; purely comments)
- [x] \`go test ./pkg/change/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)