### PR TITLE
refactor(depwait): bundle existence closures into ExistenceLookup interface

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -46,9 +46,8 @@ type Controller struct {
 	//     the orchestrator's renderedSet.ParentOf, populated when the
 	//     parent KS's emitRenderedChildren fires.
 	// Nil means "no parent enforcement"; matches pre-#221 behavior.
-	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
-	resolveMissing func(manifest.NamedResource) bool
-	isFileIndexed  func(manifest.NamedResource) bool
+	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
+	existence depwait.ExistenceLookup
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -63,18 +62,14 @@ type Controller struct {
 type ReconcileOptions struct {
 	Filter   *change.Filter
 	ParentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
-	// ResolveMissing, when non-nil, is forwarded to every depwait
-	// Waiter built during reconcile. The orchestrator wires this
-	// against the loader's ExistenceIndex so file-indexed sources
-	// (HelmRepository, OCIRepository, HelmChart) can be lazy-loaded
-	// the moment the HR's chartRef gate needs them.
-	ResolveMissing func(manifest.NamedResource) bool
-	// IsFileIndexed reports whether id has a file-existence record. The
-	// orchestrator wires this so depwait distinguishes "dep is
-	// render-only and the producing chain hasn't finished yet"
-	// (no file record → keep waiting on per-dep ctx) from "dep is
-	// file-indexed but promote failed" (file record → fail fast).
-	IsFileIndexed func(manifest.NamedResource) bool
+	// Existence is the file-existence lookup the orchestrator wires
+	// against the loader's ExistenceIndex. depwait uses it to lazy-
+	// promote file-indexed deps (HelmRepository, OCIRepository,
+	// HelmChart, …) and to distinguish render-only deps from typo'd
+	// ones at the missing-dep grace boundary. See
+	// depwait.ExistenceLookup for the decision matrix. Forwarded
+	// to every Waiter built during reconcile.
+	Existence depwait.ExistenceLookup
 }
 
 // New constructs a HelmRelease controller.
@@ -93,8 +88,7 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
-	c.resolveMissing = opts.ResolveMissing
-	c.isFileIndexed = opts.IsFileIndexed
+	c.existence = opts.Existence
 }
 
 // lookupParent reports the structural parent KS of id via the
@@ -114,11 +108,10 @@ func (c *Controller) lookupParent(id manifest.NamedResource) (manifest.NamedReso
 // source wait don't drift apart.
 func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
 	return &depwait.Waiter{
-		Store:          c.Store,
-		Parent:         id,
-		Timeout:        depwait.TimeoutFromSpec(timeout),
-		ResolveMissing: c.resolveMissing,
-		IsFileIndexed:  c.isFileIndexed,
+		Store:     c.Store,
+		Parent:    id,
+		Timeout:   depwait.TimeoutFromSpec(timeout),
+		Existence: c.existence,
 	}
 }
 

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -40,10 +40,9 @@ type Controller struct {
 	WipeSecrets bool
 
 	// Set via Configure() — see Options.
-	parentOf       func(manifest.NamedResource) (manifest.NamedResource, bool)
-	renderTracker  RenderTracker
-	resolveMissing func(manifest.NamedResource) bool
-	isFileIndexed  func(manifest.NamedResource) bool
+	parentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
+	renderTracker RenderTracker
+	existence     depwait.ExistenceLookup
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -71,19 +70,13 @@ type Options struct {
 	Filter        *change.Filter
 	ParentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
 	RenderTracker RenderTracker
-	// ResolveMissing, when non-nil, is forwarded to every depwait
-	// Waiter built during reconcile. The orchestrator wires this
-	// against the loader's ExistenceIndex so a substituteFrom CM
-	// rendered by a sibling KS can be lazy-loaded on demand instead
-	// of failing the parent KS with "dependency not found."
-	ResolveMissing func(manifest.NamedResource) bool
-	// IsFileIndexed reports whether id has a file-existence record. The
-	// orchestrator wires this so depwait distinguishes "dep is
-	// render-only and the producing chain hasn't finished yet"
-	// (no file record → keep waiting on per-dep ctx) from "dep is
-	// file-indexed but promote failed" (file record → fail fast).
-	// Forwarded to every Waiter built during reconcile.
-	IsFileIndexed func(manifest.NamedResource) bool
+	// Existence is the file-existence lookup the orchestrator wires
+	// against the loader's ExistenceIndex. depwait uses it to lazy-
+	// promote file-indexed deps and to distinguish render-only
+	// deps from typo'd ones at the missing-dep grace boundary. See
+	// depwait.ExistenceLookup for the decision matrix. Forwarded
+	// to every Waiter built during reconcile.
+	Existence depwait.ExistenceLookup
 }
 
 // New constructs a Kustomization controller.
@@ -102,8 +95,7 @@ func (c *Controller) Configure(opts Options) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
 	c.renderTracker = opts.RenderTracker
-	c.resolveMissing = opts.ResolveMissing
-	c.isFileIndexed = opts.IsFileIndexed
+	c.existence = opts.Existence
 }
 
 // markRendered reports a parent→child render emission to the
@@ -120,11 +112,10 @@ func (c *Controller) markRendered(parent, child manifest.NamedResource) {
 // budgeted from timeout (typically ks.Timeout).
 func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
 	return &depwait.Waiter{
-		Store:          c.Store,
-		Parent:         id,
-		Timeout:        depwait.TimeoutFromSpec(timeout),
-		ResolveMissing: c.resolveMissing,
-		IsFileIndexed:  c.isFileIndexed,
+		Store:     c.Store,
+		Parent:    id,
+		Timeout:   depwait.TimeoutFromSpec(timeout),
+		Existence: c.existence,
 	}
 }
 

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -103,41 +103,52 @@ type Waiter struct {
 	// Ready check AND the ReadyExpr (additive mode).
 	AdditiveReadyExpr bool
 
-	// ResolveMissing, when non-nil, is consulted after the
-	// missing-dep grace window elapses and the dep is still absent
-	// from the Store. A true return means the resolver has (or can)
-	// promote the dep into the Store — the wait then continues
-	// instead of failing. Used by the orchestrator to lazy-load
-	// file-indexed objects (CMs/Secrets/HRs the DiscoveryOnly
-	// loader kept in Existence) the moment a depwait edge needs
-	// them. Without this hook, the render-driven loader breaks the
-	// bjw-s parent-patches pattern where a KS's substituteFrom CM
-	// lives inside that KS's own spec.path: the dep would never
-	// clear because the producing render hasn't run yet.
-	ResolveMissing func(manifest.NamedResource) bool
-
-	// IsFileIndexed reports whether id has a file-existence record (the
-	// loader saw a YAML on disk that defines it, even if the loader
-	// kept it out of the Store under render-driven discovery).
-	// depwait uses this to distinguish two missing-dep cases when
-	// the grace window expires:
-	//
-	//   - IsFileIndexed(id) == true and ResolveMissing(id) == false:
-	//     the file existed but promote failed (parse error, file
-	//     mutated since record). Fail fast as "dependency not found".
-	//   - IsFileIndexed(id) == false:
-	//     no file record. The dep can only appear via a parent
-	//     render's emitRenderedChildren chain. Keep watching for
-	//     up to the per-dep Timeout — a deeply-chained kustomize
-	//     component+replacement pattern can take longer than the
-	//     2s grace to land its render output, and failing fast
-	//     surfaces a spurious "dependency not found" for a dep
-	//     that would have arrived a few seconds later.
-	//
-	// When IsFileIndexed is nil, depwait preserves the historical fast-
+	// Existence, when non-nil, drives the post-grace branching for
+	// missing deps. The orchestrator wires this against the loader's
+	// ExistenceIndex (file-loaded YAML records); tests supply stubs.
+	// When Existence is nil, depwait preserves the historical fast-
 	// fail-after-grace behavior — callers that don't wire an
 	// existence index can't distinguish render-only from typo'd.
-	IsFileIndexed func(manifest.NamedResource) bool
+	//
+	// See ExistenceLookup for the decision matrix at the grace
+	// boundary.
+	Existence ExistenceLookup
+}
+
+// ExistenceLookup is the seam depwait uses to resolve missing
+// dependencies. Bundled into one interface so the orchestrator
+// (and any future embedder) wires a single object through the
+// controller Options pipe instead of two parallel closures.
+//
+// The orchestrator's implementation reads from the loader's
+// ExistenceIndex — file-indexed objects (CMs/Secrets/HRs the
+// DiscoveryOnly loader kept out of the Store) get lazy-promoted
+// the moment a depwait edge needs them, while render-only ids
+// (no file record) signal depwait to keep waiting for an
+// emitRenderedChildren chain instead of failing fast.
+//
+// When the grace window expires with id still missing:
+//
+//   - Promote(id) == true:
+//     dep is now in the Store (lazy-promoted from a file YAML).
+//     Wait continues against built-in status / exists semantics.
+//   - Promote(id) == false, IsFileIndexed(id) == true:
+//     file existed but promote failed (parse error, file mutated
+//     since record). Fail fast as "dependency not found".
+//   - Promote(id) == false, IsFileIndexed(id) == false:
+//     no file record. Dep can only arrive via a parent render's
+//     emitRenderedChildren chain. Keep watching for up to
+//     RenderProducingTimeout — a deeply-chained kustomize
+//     component+replacement pattern can take longer than the 2s
+//     grace, and failing fast surfaces a spurious "dependency not
+//     found" for a dep that would have arrived a few seconds later.
+type ExistenceLookup interface {
+	// IsFileIndexed reports whether id has a file-existence record.
+	IsFileIndexed(id manifest.NamedResource) bool
+	// Promote attempts to materialize id into the Store from the
+	// file-existence index. Returns true when promotion succeeded
+	// and id is now reachable via store.GetObject.
+	Promote(id manifest.NamedResource) bool
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -218,13 +229,15 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 		_, err := w.Store.WatchExists(graceCtx, id)
 		graceCancel()
 		if err != nil && !w.depExists(id) {
-			// Step 1: ask the resolver to materialize the dep from
-			// the file-indexed Existence map. A true return means
-			// the dep is now in the Store and the wait can continue
-			// against built-in status / exists semantics below.
-			if w.ResolveMissing != nil && w.ResolveMissing(id) {
+			// Step 1: ask the existence lookup to materialize the
+			// dep from the file-indexed Existence map. A true return
+			// means the dep is now in the Store and the wait can
+			// continue against built-in status / exists semantics
+			// below.
+			switch {
+			case w.Existence != nil && w.Existence.Promote(id):
 				// promoted; fall through to the regular wait.
-			} else if w.IsFileIndexed != nil && !w.IsFileIndexed(id) {
+			case w.Existence != nil && !w.Existence.IsFileIndexed(id):
 				// Step 2: dep has no file record — it can only arrive
 				// via a parent render's emitRenderedChildren chain.
 				// Wait up to RenderProducingTimeout for the dep to
@@ -264,10 +277,10 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 						return Event{Dep: id, Status: DepFailed, Reason: werr.Error()}
 					}
 				}
-			} else {
-				// Step 3: either no IsFileIndexed wired (legacy callers
+			default:
+				// Step 3: either no Existence wired (legacy callers
 				// can't distinguish render-only from typo) or the
-				// dep is file-indexed but promote failed (file
+				// dep is file-indexed but Promote failed (file
 				// disappeared / parse error). Either way the dep is
 				// not coming — fail fast at the grace boundary.
 				return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -22,6 +22,28 @@ func refs(ids ...manifest.NamedResource) []manifest.DependencyRef {
 	return out
 }
 
+// lookupStub satisfies ExistenceLookup from inline closures so
+// individual tests can express both halves of the contract without
+// declaring a custom type per case.
+type lookupStub struct {
+	promote     func(manifest.NamedResource) bool
+	fileIndexed func(manifest.NamedResource) bool
+}
+
+func (l lookupStub) Promote(id manifest.NamedResource) bool {
+	if l.promote == nil {
+		return false
+	}
+	return l.promote(id)
+}
+
+func (l lookupStub) IsFileIndexed(id manifest.NamedResource) bool {
+	if l.fileIndexed == nil {
+		return false
+	}
+	return l.fileIndexed(id)
+}
+
 func TestWaiter_AllReady(t *testing.T) {
 	s := store.New()
 	dep1 := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "a"}
@@ -122,11 +144,11 @@ func TestWaiter_ResolveMissingLazyPromotes(t *testing.T) {
 		return true
 	}
 
-	w := &Waiter{Store: s, Timeout: 5 * time.Second, ResolveMissing: resolve}
+	w := &Waiter{Store: s, Timeout: 5 * time.Second, Existence: lookupStub{promote: resolve}}
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
 
 	if !resolveCalled {
-		t.Errorf("ResolveMissing was never invoked")
+		t.Errorf("Existence.Promote was never invoked")
 	}
 	if !sum.AllReady() {
 		t.Errorf("expected dep to clear after lazy promotion: %+v", sum)
@@ -142,11 +164,11 @@ func TestWaiter_ResolveMissingFalseStillFails(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "ghost"}
 	resolve := func(manifest.NamedResource) bool { return false }
-	w := &Waiter{Store: s, Timeout: 5 * time.Second, ResolveMissing: resolve}
+	w := &Waiter{Store: s, Timeout: 5 * time.Second, Existence: lookupStub{promote: resolve}}
 
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
 	if !sum.AnyFailed() {
-		t.Errorf("ResolveMissing=false should still fail: %+v", sum)
+		t.Errorf("Existence.Promote=false should still fail: %+v", sum)
 	}
 }
 
@@ -178,10 +200,9 @@ func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
 	}()
 
 	w := &Waiter{
-		Store:          s,
-		Timeout:        MissingGrace + 5*time.Second,
-		ResolveMissing: resolve,
-		IsFileIndexed:  isFileIndexed,
+		Store:     s,
+		Timeout:   MissingGrace + 5*time.Second,
+		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
 	if !sum.AllReady() {
@@ -206,10 +227,9 @@ func TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout(t *testing.T) {
 	// meaningful gap (300ms) so the assertion that elapsed >=
 	// MissingGrace + 100ms actually pins the long-wait branch.
 	w := &Waiter{
-		Store:          s,
-		Timeout:        MissingGrace + 300*time.Millisecond,
-		ResolveMissing: resolve,
-		IsFileIndexed:  isFileIndexed,
+		Store:     s,
+		Timeout:   MissingGrace + 300*time.Millisecond,
+		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	start := time.Now()
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
@@ -247,10 +267,9 @@ func TestWaiter_FileIndexedPromoteFailsFastAtGrace(t *testing.T) {
 	isFileIndexed := func(manifest.NamedResource) bool { return true }
 
 	w := &Waiter{
-		Store:          s,
-		Timeout:        30 * time.Second, // generous; if step-2 ran we'd see it
-		ResolveMissing: resolve,
-		IsFileIndexed:  isFileIndexed,
+		Store:     s,
+		Timeout:   30 * time.Second, // generous; if step-2 ran we'd see it
+		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	start := time.Now()
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
@@ -289,10 +308,9 @@ func TestWaiter_RenderOnlyCappedAtRenderProducingTimeout(t *testing.T) {
 	isFileIndexed := func(manifest.NamedResource) bool { return false }
 
 	w := &Waiter{
-		Store:          s,
-		Timeout:        30 * time.Second, // huge — render cap should win
-		ResolveMissing: resolve,
-		IsFileIndexed:  isFileIndexed,
+		Store:     s,
+		Timeout:   30 * time.Second, // huge — render cap should win
+		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	start := time.Now()
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
@@ -331,10 +349,9 @@ func TestWaiter_RenderOnlyCancelDuringLongWaitSurfacesCancelled(t *testing.T) {
 	isFileIndexed := func(manifest.NamedResource) bool { return false }
 
 	w := &Waiter{
-		Store:          s,
-		Timeout:        30 * time.Second,
-		ResolveMissing: resolve,
-		IsFileIndexed:  isFileIndexed,
+		Store:     s,
+		Timeout:   30 * time.Second,
+		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 
 	// Cancel after grace expires + 500ms — well into step-2's wait.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -422,6 +422,28 @@ func (o *Orchestrator) attachFilter(f *change.Filter) {
 	o.filter = f
 }
 
+// orchestratorExistence adapts the orchestrator's
+// loader.ExistenceIndex + Store + WipeSecrets config into the
+// depwait.ExistenceLookup interface that flows through controller
+// Options into every Waiter. Bundled so controllers don't each
+// reach into the orchestrator's private fields, and so future
+// existence-related signals land on one type instead of plumbing
+// new closures through three call layers.
+type orchestratorExistence struct {
+	idx         *loader.ExistenceIndex
+	store       *store.Store
+	wipeSecrets bool
+}
+
+func (e *orchestratorExistence) Promote(id manifest.NamedResource) bool {
+	return e.idx.Promote(e.store, id, e.wipeSecrets)
+}
+
+func (e *orchestratorExistence) IsFileIndexed(id manifest.NamedResource) bool {
+	_, ok := e.idx.Get(id)
+	return ok
+}
+
 // Run starts every controller, blocks until the task service drains,
 // then aggregates and returns any failures. The post-drain reporting
 // + error-string assembly lives in finalize so Run reads as a clean
@@ -442,41 +464,31 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		}
 		return o.rendered.ParentOf(id)
 	}
-	// resolveMissing closes over the file-indexed Existence map the
-	// DiscoveryOnly loader populated. When a depwait grace window
-	// elapses on a missing dep, the closure lazy-promotes the dep
-	// from its indexed file into the Store. This is the seam that
-	// keeps the bjw-s parent-patches pattern (KS substituting from
-	// a CM rendered by its own spec.path) from deadlocking — the CM
-	// file is on disk, so we materialize it the moment the depwait
-	// asks instead of waiting for the producing render that can't
-	// run until the depwait clears.
-	resolveMissing := func(id manifest.NamedResource) bool {
-		return o.existence.Promote(o.store, id, o.cfg.WipeSecrets)
-	}
-	// isFileIndexed lets depwait distinguish "render-only dep still in
-	// flight" (no file record → wait on the per-dep ctx) from
-	// "file-indexed but promote failed" (file record → fail fast).
-	// Without this signal depwait would treat both as fast-fail,
-	// surfacing spurious "dependency not found" errors for chained
-	// kustomize-component+replacement renders (component/ks/app
-	// → leaf KS → child HR) that exceed the 2s grace window.
-	isFileIndexed := func(id manifest.NamedResource) bool {
-		_, ok := o.existence.Get(id)
-		return ok
+	// existence bundles the file-existence lookups depwait needs:
+	// Promote lazy-loads a file-indexed dep into the Store the
+	// moment a depwait edge asks for it (covering the bjw-s parent-
+	// patches pattern where a KS's substituteFrom CM lives inside
+	// the same KS's spec.path); IsFileIndexed distinguishes
+	// "render-only dep still in flight" (no file record → wait on
+	// the per-dep ctx) from "file-indexed but promote failed" (file
+	// record → fail fast). The orchestrator owns both signals; the
+	// controllers and Waiter consume them via the single
+	// depwait.ExistenceLookup interface.
+	existence := &orchestratorExistence{
+		idx:         o.existence,
+		store:       o.store,
+		wipeSecrets: o.cfg.WipeSecrets,
 	}
 	o.ksc.Configure(kustomization.Options{
-		Filter:         o.filter,
-		ParentOf:       parentResolver,
-		RenderTracker:  o.rendered,
-		ResolveMissing: resolveMissing,
-		IsFileIndexed:  isFileIndexed,
+		Filter:        o.filter,
+		ParentOf:      parentResolver,
+		RenderTracker: o.rendered,
+		Existence:     existence,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
-		Filter:         o.filter,
-		ParentOf:       parentResolver,
-		ResolveMissing: resolveMissing,
-		IsFileIndexed:  isFileIndexed,
+		Filter:    o.filter,
+		ParentOf:  parentResolver,
+		Existence: existence,
 	})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)


### PR DESCRIPTION
## Summary
Architectural follow-up from the post-merge cross-cutting review (Agent 3's recommendation): PRs #310 and #311 plumbed two parallel closures — \`ResolveMissing\` and \`IsFileIndexed\` — through three layers (orchestrator → controller Options → Waiter). The review flagged the duplication: same conceptual source (the loader's \`ExistenceIndex\`), always wired together, and a third existence-related signal would repeat the same wire-through.

Collapse to a single \`depwait.ExistenceLookup\` interface that bundles \`Promote\` + \`IsFileIndexed\`. The orchestrator owns one adapter (\`orchestratorExistence\`) that wraps \`loader.ExistenceIndex\` + the Store + WipeSecrets config; controllers and the Waiter consume the interface.

### Wiring chain after the change

\`\`\`
orchestrator.Run → orchestratorExistence{idx, store, wipe}
  → kustomization.Options.Existence
  → helmrelease.ReconcileOptions.Existence
  → depwait.Waiter.Existence
\`\`\`

Adding a future existence-related signal lands on this one type — no new Options field, no new Waiter field, no new closure plumbing.

### Docs consolidated

The three-branch contract that previously lived split across two field docs (Promote=true / Promote=false + IsFileIndexed=true / Promote=false + IsFileIndexed=false) now sits on the interface itself.

### Tests

- \`lookupStub\` satisfies the interface from inline closures so each test case still expresses both halves of the contract without declaring a custom type.
- All existing tests migrated to the new field name and structure; no behavior change.
- \`go build ./... && go vet ./... && go test ./...\` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)