### PR TITLE
refactor(change): unexport Filter.Add → addUngated

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -206,18 +206,17 @@ func (f *Filter) addEmittedLocked(emitter, child manifest.NamedResource) []manif
 	return f.addRecursiveLocked(child)
 }
 
-// Add unconditionally extends the keep set with id (and its
+// addUngated unconditionally extends the keep set with id (and its
 // transitive sourceRef/chartRef/valuesFrom deps) at runtime, marking
 // every newly-inserted entry primary.
 //
-// PRODUCTION CODE SHOULD USE AddEmitted INSTEAD: Add bypasses the
-// primary-emitter gate that prevents the ancestor-cascade failure
-// mode. The only legitimate uses are test scaffolding that needs
-// to seed an entry without simulating a render emission, and the
-// unconditional-add primitive that AddEmitted composes onto.
+// Internal-only: production code MUST use AddEmitted so the
+// primary-emitter gate prevents the ancestor-cascade failure mode.
+// Test scaffolding that needs to seed an entry without simulating a
+// render emission can call this directly from within the package.
 //
 // No-op when the filter is disabled. Safe for concurrent use.
-func (f *Filter) Add(id manifest.NamedResource) {
+func (f *Filter) addUngated(id manifest.NamedResource) {
 	if !f.Enabled() {
 		return
 	}

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -331,7 +331,7 @@ func TestFilter_DependsOnNotFollowed(t *testing.T) {
 // replacement patterns generate per-app Kustomizations on the fly).
 // The KS controller calls Filter.AddEmitted(parent, child) before
 // AddObject so the listener's PreGate filter check sees the
-// extended keep set. This test uses Filter.Add directly (skipping
+// extended keep set. This test uses addUngated directly (skipping
 // the primacy gate) to seed the runtime keep without simulating
 // a parent render; the gated path is covered by the AddEmitted
 // tests below.
@@ -359,7 +359,7 @@ func TestFilter_AddExtendsKeepSetAtRuntime(t *testing.T) {
 		t.Fatalf("precondition: child must NOT be in keep set before Add; keep=%v", f.KeepNames())
 	}
 
-	f.Add(child)
+	f.addUngated(child)
 	if !f.ShouldReconcile(child) {
 		t.Errorf("Add(child) should extend keep set; ShouldReconcile(child)=false; keep=%v", f.KeepNames())
 	}
@@ -372,7 +372,7 @@ func TestFilter_AddExtendsKeepSetAtRuntime(t *testing.T) {
 func TestFilter_AddOnDisabledFilterIsNoOp(t *testing.T) {
 	var f Filter
 	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}
-	f.Add(id)
+	f.addUngated(id)
 	other := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "y"}
 	if !f.ShouldReconcile(other) {
 		t.Errorf("disabled filter must still keep everything after Add()")
@@ -609,7 +609,7 @@ func TestFilter_KeepByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
 	}
 
 	// Same invariant via the runtime Add path (issue #204 surface).
-	f.Add(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "cert-manager"})
+	f.addUngated(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "cert-manager"})
 	if f.ShouldReconcile(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "monitoring-system", Name: "cert-manager"}) {
 		t.Errorf("Add() leaked across namespaces: monitoring-system/cert-manager matched on name alone; keep=%v", f.KeepNames())
 	}


### PR DESCRIPTION
## Summary
Last follow-up from the post-merge review (Agent 1's design concern D1): production code now uses \`AddEmitted\` exclusively (the gate-and-recurse atomic from #312 inlines the \`addRecursive\` walk under WLock, so \`Add\` was no longer the public composition primitive). The only remaining callers are three test scaffolding sites that need to seed an entry without simulating a render emission.

Unexport to \`addUngated\` so a future controller can't accidentally bypass the primary-emitter gate that prevents the ancestor-cascade failure mode. Package-private naming surfaces \"this is internal plumbing — production paths go through AddEmitted\" by visibility alone, without relying on doc warnings.

## Test plan
- [x] \`go build ./...\` (no production caller affected)
- [x] \`go test ./...\` (full suite green; three test sites updated to \`addUngated\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)