### PR TITLE
feat(depwait): add RenderInflight quiescence signal for step-2 fail-fast

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -48,6 +48,7 @@ type Controller struct {
 	// Nil means "no parent enforcement"; matches pre-#221 behavior.
 	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
 	existence depwait.ExistenceLookup
+	renders   depwait.RenderInflight
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -70,6 +71,11 @@ type ReconcileOptions struct {
 	// depwait.ExistenceLookup for the decision matrix. Forwarded
 	// to every Waiter built during reconcile.
 	Existence depwait.ExistenceLookup
+	// Renders is the quiescence signal the orchestrator wires
+	// against task.Service.ActiveCount. depwait's step-2 long wait
+	// short-circuits to "dependency not found" once Renders reports
+	// no other reconcile is in flight.
+	Renders depwait.RenderInflight
 }
 
 // New constructs a HelmRelease controller.
@@ -89,6 +95,7 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
 	c.parentOf = opts.ParentOf
 	c.existence = opts.Existence
+	c.renders = opts.Renders
 }
 
 // lookupParent reports the structural parent KS of id via the
@@ -112,6 +119,7 @@ func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Durati
 		Parent:    id,
 		Timeout:   depwait.TimeoutFromSpec(timeout),
 		Existence: c.existence,
+		Renders:   c.renders,
 	}
 }
 

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -43,6 +43,7 @@ type Controller struct {
 	parentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
 	renderTracker RenderTracker
 	existence     depwait.ExistenceLookup
+	renders       depwait.RenderInflight
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -77,6 +78,13 @@ type Options struct {
 	// depwait.ExistenceLookup for the decision matrix. Forwarded
 	// to every Waiter built during reconcile.
 	Existence depwait.ExistenceLookup
+	// Renders is the quiescence signal the orchestrator wires
+	// against task.Service.ActiveCount. depwait's step-2 long wait
+	// short-circuits to "dependency not found" once Renders reports
+	// no other reconcile is in flight — so a typo'd dependsOn
+	// fails as soon as the orchestrator drains instead of burning
+	// the full RenderProducingTimeout cap.
+	Renders depwait.RenderInflight
 }
 
 // New constructs a Kustomization controller.
@@ -96,6 +104,7 @@ func (c *Controller) Configure(opts Options) {
 	c.parentOf = opts.ParentOf
 	c.renderTracker = opts.RenderTracker
 	c.existence = opts.Existence
+	c.renders = opts.Renders
 }
 
 // markRendered reports a parent→child render emission to the
@@ -116,6 +125,7 @@ func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Durati
 		Parent:    id,
 		Timeout:   depwait.TimeoutFromSpec(timeout),
 		Existence: c.existence,
+		Renders:   c.renders,
 	}
 }
 

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -113,6 +113,16 @@ type Waiter struct {
 	// See ExistenceLookup for the decision matrix at the grace
 	// boundary.
 	Existence ExistenceLookup
+
+	// Renders, when non-nil, drives the step-2 fast-fail signal:
+	// during the render-only long wait, depwait polls
+	// Renders.OtherActive(); a false return means no other
+	// reconcile in the orchestrator is doing work, so no future
+	// render can produce the missing dep. The wait short-circuits
+	// to "dependency not found" instead of burning the full
+	// RenderProducingTimeout cap. When Renders is nil, step-2 falls
+	// back to the fixed cap alone (preserves the legacy timing).
+	Renders RenderInflight
 }
 
 // ExistenceLookup is the seam depwait uses to resolve missing
@@ -149,6 +159,32 @@ type ExistenceLookup interface {
 	// file-existence index. Returns true when promotion succeeded
 	// and id is now reachable via store.GetObject.
 	Promote(id manifest.NamedResource) bool
+}
+
+// RenderInflight is the positive quiescence signal depwait's step-2
+// uses to fail fast on truly-missing render-only deps. The
+// orchestrator's implementation reads from task.Service.ActiveCount
+// — true when more than the caller's own goroutine is active in
+// the task pool (and could therefore still emit the missing dep);
+// false when the orchestrator has drained.
+//
+// Semantically the inverse of the Existence-based step-2 wait: that
+// path keeps waiting on the absence of a finite signal
+// (RenderProducingTimeout); RenderInflight short-circuits the wait
+// once a positive signal ("no more work could produce this") fires.
+// Both together pin the wait between a fast-fail floor (no other
+// work running) and a hard ceiling (the timeout cap).
+//
+// When Renders is nil, step-2 still works via the timeout cap alone
+// — embedders that don't drive a task pool get the legacy
+// behavior.
+type RenderInflight interface {
+	// OtherActive reports whether at least one reconcile beyond the
+	// caller's own task is still running in the orchestrator's task
+	// pool. depwait calls this from inside a Submit'd reconcile
+	// body, so the caller's goroutine is counted; OtherActive
+	// returns true iff the total active count exceeds 1.
+	OtherActive() bool
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -240,41 +276,33 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 			case w.Existence != nil && !w.Existence.IsFileIndexed(id):
 				// Step 2: dep has no file record — it can only arrive
 				// via a parent render's emitRenderedChildren chain.
-				// Wait up to RenderProducingTimeout for the dep to
-				// land. The 2s grace is too short for deeply-chained
-				// kustomize component+replacement patterns (parent
-				// KS → leaf KS → child HR) where the producing chain
-				// runs many kustomize builds + helm templates back-
-				// to-back, but unbounded waiting on the full per-dep
-				// budget burns ~30s on typo'd dependsOn that look
-				// identical to render-only at this point (IsFileIndexed is
-				// false in both cases).
+				// Two complementary signals bound the wait:
 				//
-				// The render budget is derived from the parent ctx,
-				// so the per-dep Timeout still caps total wall time:
-				// if the user sets spec.timeout=5s, we wait at most
-				// 5s here. If they set the default 30s, we cap at
-				// RenderProducingTimeout (10s) and the remaining
-				// budget is available for the downstream Ready check.
-				renderCtx, renderCancel := context.WithTimeout(ctx, RenderProducingTimeout)
-				_, werr := w.Store.WatchExists(renderCtx, id)
-				renderCancel()
-				if werr != nil {
-					// Route through classify() so parent ctx
-					// cancellation propagates as DepCancelled
-					// instead of being flattened. A renderCtx
-					// timeout (dep didn't arrive within the cap)
-					// looks like context.DeadlineExceeded — same
-					// as parent ctx expiry — and gets the same
-					// "dependency not found" treatment because
-					// both mean "dep never appeared in time."
+				//   - RenderProducingTimeout caps the absolute wall
+				//     time so a missing Renders signal doesn't burn
+				//     the full per-dep Timeout. Legacy embedders
+				//     without a task pool get this cap as the only
+				//     bound.
+				//   - Renders.OtherActive() short-circuits the wait
+				//     once no other reconcile in the pool is doing
+				//     work — at that point, no future render can
+				//     produce the missing dep. Typo'd dependsOn
+				//     fails as soon as the orchestrator drains
+				//     instead of waiting the full cap.
+				//
+				// On a real chain (the omada-controller-style
+				// component+replacement render), other reconciles
+				// stay active while the producing chain runs, so
+				// OtherActive returns true and the wait holds open
+				// until the dep arrives via subscription.
+				if err := w.waitRenderEmission(ctx, id); err != nil {
 					switch {
 					case errors.Is(ctx.Err(), context.Canceled):
 						return classify(id, ctx.Err(), "")
-					case errors.Is(werr, context.DeadlineExceeded):
+					case errors.Is(err, context.DeadlineExceeded), errors.Is(err, errRenderDrained):
 						return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
 					default:
-						return Event{Dep: id, Status: DepFailed, Reason: werr.Error()}
+						return Event{Dep: id, Status: DepFailed, Reason: err.Error()}
 					}
 				}
 			default:
@@ -389,6 +417,71 @@ func (w *Waiter) depExists(dep manifest.NamedResource) bool {
 	}
 	_, ok := w.Store.GetStatus(dep)
 	return ok
+}
+
+// errRenderDrained is the sentinel waitRenderEmission returns when
+// the orchestrator's task pool drains while step-2 is still waiting
+// — no future emission can produce the missing dep, so the wait
+// fails fast as "dependency not found" without burning the full
+// RenderProducingTimeout cap. Internal to depwait; not exported.
+var errRenderDrained = errors.New("render pool drained without emission")
+
+// waitRenderEmission is step-2's bounded wait for a render-only dep
+// to arrive. It composes three termination signals:
+//
+//   - Store.EventObjectAdded fires for id → returns nil (caller
+//     falls through to the regular Ready wait).
+//   - Renders.OtherActive() flips to false → returns errRenderDrained
+//     (no future emission could produce id; caller fails fast).
+//   - ctx hits its deadline / cancellation → returns ctx.Err().
+//
+// An overall cap of RenderProducingTimeout is layered onto ctx so
+// the wait can't run past it even when Renders is nil (legacy
+// embedders without a task pool).
+func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResource) error {
+	renderCtx, renderCancel := context.WithTimeout(ctx, RenderProducingTimeout)
+	defer renderCancel()
+
+	// Subscribe FIRST, then re-check the store, to close the race
+	// between subscribe and a concurrent AddObject.
+	arrived := make(chan struct{}, 1)
+	unsub := w.Store.AddListener(store.EventObjectAdded, func(other manifest.NamedResource, _ any) {
+		if other != id {
+			return
+		}
+		select {
+		case arrived <- struct{}{}:
+		default:
+		}
+	}, false)
+	defer unsub()
+	if w.depExists(id) {
+		return nil
+	}
+
+	// Polling cadence for the RenderInflight quiescence check. 100ms
+	// keeps drain detection responsive without burning CPU on tight
+	// loops; the typo case fails within ~100ms of the orchestrator's
+	// last reconcile finishing.
+	const pollInterval = 100 * time.Millisecond
+	poll := time.NewTicker(pollInterval)
+	defer poll.Stop()
+
+	for {
+		select {
+		case <-arrived:
+			return nil
+		case <-renderCtx.Done():
+			return renderCtx.Err()
+		case <-poll.C:
+			if w.depExists(id) {
+				return nil
+			}
+			if w.Renders != nil && !w.Renders.OtherActive() {
+				return errRenderDrained
+			}
+		}
+	}
 }
 
 func classify(dep manifest.NamedResource, err error, fallback string) Event {

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -44,6 +44,19 @@ func (l lookupStub) IsFileIndexed(id manifest.NamedResource) bool {
 	return l.fileIndexed(id)
 }
 
+// rendersStub satisfies RenderInflight from an inline closure so
+// tests can pin the OtherActive() flip behavior precisely.
+type rendersStub struct {
+	otherActive func() bool
+}
+
+func (r rendersStub) OtherActive() bool {
+	if r.otherActive == nil {
+		return false
+	}
+	return r.otherActive()
+}
+
 func TestWaiter_AllReady(t *testing.T) {
 	s := store.New()
 	dep1 := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "a"}
@@ -331,6 +344,96 @@ func TestWaiter_RenderOnlyCappedAtRenderProducingTimeout(t *testing.T) {
 	}
 	if got := sum.Messages[dep]; got != "dependency not found" {
 		t.Errorf("expected 'dependency not found', got %q", got)
+	}
+}
+
+// TestWaiter_RenderInflightDrainShortCircuits pins the
+// RenderInflight quiescence path: when no other reconcile is in
+// flight, depwait's step-2 long wait must NOT burn the full
+// RenderProducingTimeout cap. It detects "no more emissions can
+// produce this dep" via Renders.OtherActive() and fails fast.
+//
+// The realistic scenario this defends: a typo'd dependsOn at the
+// end of a reconcile pass. The orchestrator drains all real work
+// (active count goes to 1 = just the depwait's own task), depwait
+// observes quiescence on its next poll, and returns
+// "dependency not found" within ~100ms — instead of waiting the
+// full cap.
+func TestWaiter_RenderInflightDrainShortCircuits(t *testing.T) {
+	// Tighten the cap and grace so the test runs fast; the win we
+	// pin here is "ended well before the cap fired", which only
+	// works if the cap is large enough that the RenderInflight
+	// path is the actual termination signal.
+	oldCap := RenderProducingTimeout
+	RenderProducingTimeout = 10 * time.Second
+	defer func() { RenderProducingTimeout = oldCap }()
+
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "typo-or-gone"}
+
+	w := &Waiter{
+		Store:     s,
+		Timeout:   30 * time.Second,
+		Existence: lookupStub{
+			promote:     func(manifest.NamedResource) bool { return false },
+			fileIndexed: func(manifest.NamedResource) bool { return false },
+		},
+		Renders: rendersStub{
+			otherActive: func() bool { return false }, // quiescent
+		},
+	}
+
+	start := time.Now()
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	elapsed := time.Since(start)
+
+	if !sum.AnyFailed() {
+		t.Fatalf("expected fail when no other renders active: %+v", sum)
+	}
+	// Must end well before the RenderProducingTimeout cap. We
+	// allow grace + a few poll intervals; anything past 1s past
+	// grace means the drain check didn't fire.
+	upper := MissingGrace + 1*time.Second
+	if elapsed > upper {
+		t.Errorf("drain short-circuit didn't fire: elapsed=%s, upper=%s", elapsed, upper)
+	}
+	if got := sum.Messages[dep]; got != "dependency not found" {
+		t.Errorf("expected 'dependency not found', got %q", got)
+	}
+}
+
+// TestWaiter_RenderInflightActiveHoldsTheWait pins the inverse:
+// while Renders.OtherActive() returns true, depwait keeps waiting
+// past the grace boundary for the dep to land. We flip the signal
+// to false after the dep has already arrived; the wait should
+// return via the subscription, not via the drain.
+func TestWaiter_RenderInflightActiveHoldsTheWait(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "produced-late"}
+
+	// Renders is "active" throughout; the only thing that ends the
+	// wait is the dep arriving via AddObject.
+	w := &Waiter{
+		Store:     s,
+		Timeout:   MissingGrace + 5*time.Second,
+		Existence: lookupStub{
+			promote:     func(manifest.NamedResource) bool { return false },
+			fileIndexed: func(manifest.NamedResource) bool { return false },
+		},
+		Renders: rendersStub{
+			otherActive: func() bool { return true },
+		},
+	}
+
+	go func() {
+		time.Sleep(MissingGrace + 500*time.Millisecond)
+		s.AddObject(&manifest.HelmRelease{Name: dep.Name, Namespace: dep.Namespace})
+		s.UpdateStatus(dep, store.StatusReady, "")
+	}()
+
+	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	if !sum.AllReady() {
+		t.Errorf("dep arrived after grace with Renders active; expected Ready: %+v", sum)
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -444,6 +444,18 @@ func (e *orchestratorExistence) IsFileIndexed(id manifest.NamedResource) bool {
 	return ok
 }
 
+// orchestratorRenderInflight adapts task.Service.ActiveCount into
+// depwait.RenderInflight. OtherActive returns true when the pool
+// has more than one task running — the caller's own goroutine is
+// always one of them since depwait runs inside a Submit'd reconcile
+// body, so a count of 1 means "just me, no future emissions can
+// produce my missing dep".
+type orchestratorRenderInflight struct{ tasks *task.Service }
+
+func (r *orchestratorRenderInflight) OtherActive() bool {
+	return r.tasks.ActiveCount() > 1
+}
+
 // Run starts every controller, blocks until the task service drains,
 // then aggregates and returns any failures. The post-drain reporting
 // + error-string assembly lives in finalize so Run reads as a clean
@@ -479,16 +491,19 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		store:       o.store,
 		wipeSecrets: o.cfg.WipeSecrets,
 	}
+	renders := &orchestratorRenderInflight{tasks: o.tasks}
 	o.ksc.Configure(kustomization.Options{
 		Filter:        o.filter,
 		ParentOf:      parentResolver,
 		RenderTracker: o.rendered,
 		Existence:     existence,
+		Renders:       renders,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
 		Filter:    o.filter,
 		ParentOf:  parentResolver,
 		Existence: existence,
+		Renders:   renders,
 	})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -106,6 +106,16 @@ func (s *Service) YieldSlot(fn func()) {
 // Failures returns the number of panicked tasks observed.
 func (s *Service) Failures() int64 { return s.failures.Load() }
 
+// ActiveCount returns the number of in-flight tasks. Includes
+// tasks that have been Go'd but are still parked on the worker
+// semaphore (NewBounded). Useful as a quiescence signal — when
+// every reconcile has finished, ActiveCount returns 0.
+//
+// Callers asking from inside a Go'd body should remember their
+// own goroutine is counted: a "no other work" check needs
+// ActiveCount() > 1, not > 0.
+func (s *Service) ActiveCount() int64 { return s.active.Load() }
+
 // BlockTillDone waits until every active task has finished. Safe to
 // call concurrently with Go.
 func (s *Service) BlockTillDone() { s.wgActive.Wait() }


### PR DESCRIPTION
## Summary
Agent 3's "positive signal" follow-up sketch from the post-merge cross-cutting review: instead of asking \"could a render produce this dep?\" via the negative \`IsFileIndexed\` check (and capping at \`RenderProducingTimeout\` to bound typo waits), depwait now also asks \"is any other reconcile still running?\". When the answer is no, no future emission can produce the missing dep — fail fast immediately instead of burning the cap.

### Plumbing

- \`pkg/task\`: expose \`Service.ActiveCount()\`.
- \`pkg/depwait\`: add \`RenderInflight\` interface with \`OtherActive()\`; add \`Waiter.Renders\` field. Step-2's new \`waitRenderEmission\` composes three termination signals — Store subscription for the dep arriving, \`RenderInflight\` quiescence for fast-fail, \`RenderProducingTimeout\` as the absolute cap. 100ms poll cadence.
- \`pkg/orchestrator\`: implement \`orchestratorRenderInflight\` as a thin wrapper over \`task.Service.ActiveCount\` with the \`> 1\` self-count caveat documented (the caller's own depwait runs inside a Submit'd reconcile body and contributes 1 to the count).
- \`pkg/controllers/{kustomization,helmrelease}\`: forward \`Renders\` through Options into \`newWaiter\`.

### Behavior

- **Legitimate slow chain** (omada-controller-style \`components/ks/app\` fan-out): other reconciles stay active while the producing chain runs → \`OtherActive\` returns true → step-2 holds the wait open until the dep arrives via subscription.
- **Typo'd dependsOn at end of pass**: orchestrator drains, active drops to 1 (the depwait's own task), \`OtherActive\` returns false on the next poll tick (≤100ms after drain), step-2 returns \"dependency not found\" instead of burning the full \`RenderProducingTimeout\` cap.
- **Embedders without a task pool / Renders wired**: cap alone still bounds the wait — legacy behavior preserved.

### Tests
- \`TestWaiter_RenderInflightDrainShortCircuits\` pins the fast-fail path (cap large, quiescent stub).
- \`TestWaiter_RenderInflightActiveHoldsTheWait\` pins the inverse (active stub holds the wait open past grace, dep arrives via AddObject, wait returns Ready).
- Existing \`TestWaiter_RenderOnlyCappedAtRenderProducingTimeout\` still passes (no Renders wired → cap remains the bound).
- Cancellation routing through \`classify()\` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)