### PR TITLE
feat(test): hide SKIPPED rows by default; --show-skipped opts in

### DIFF
--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -43,6 +43,7 @@ func newTestCmd() *cobra.Command {
 func testCmd(use string, aliases []string, short string, args cobra.PositionalArgs, kinds ...string) *cobra.Command {
 	c := &commonFlags{}
 	h := &helmFlags{}
+	var showSkipped bool
 	cmd := &cobra.Command{
 		Use:     use,
 		Aliases: aliases,
@@ -65,6 +66,7 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 				Kinds: kinds,
 				Name:  firstArg(argv),
 			})
+			report.ShowSkipped = showSkipped
 			report.Write(cmd.OutOrStdout())
 			if report.AnyFailed() {
 				return errors.New("test failures detected")
@@ -73,6 +75,8 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 		},
 	}
 	bindCommon(cmd.Flags(), c)
+	cmd.Flags().BoolVar(&showSkipped, "show-skipped", false,
+		"include SKIPPED resources in the per-resource listing (changed-only mode hides them by default to mirror `flate diff`)")
 	if rendersHelm(kinds) {
 		bindHelmFlags(cmd.Flags(), h)
 	}

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -51,17 +51,34 @@ type Report struct {
 	Passed  int
 	Skipped int
 	Failed  int
+	// ShowSkipped controls whether SKIPPED cases appear in the
+	// per-resource listing that Write emits. When false (the
+	// default), only PASSED and FAILED rows are printed — matching
+	// `flate diff`'s output discipline (no output for unchanged
+	// resources). The summary footer still surfaces the SKIPPED
+	// count so callers know how many were filtered.
+	ShowSkipped bool
 }
 
 // AnyFailed reports whether any case failed.
 func (r Report) AnyFailed() bool { return r.Failed > 0 }
 
-// Write renders the report in a pytest-like format to w.
+// Write renders the report in a pytest-like format to w. SKIPPED
+// cases are suppressed from the per-resource listing unless
+// ShowSkipped is set, mirroring `flate diff`'s "only what changed"
+// output. The summary footer reports the full count regardless.
 func (r Report) Write(w io.Writer) {
 	var b strings.Builder
+	visible := len(r.Cases)
+	if !r.ShowSkipped {
+		visible = r.Passed + r.Failed
+	}
 	fmt.Fprintln(&b, "============================================= test session starts =============================================")
-	fmt.Fprintf(&b, "collected %d items\n\n", len(r.Cases))
+	fmt.Fprintf(&b, "collected %d items\n\n", visible)
 	for _, c := range r.Cases {
+		if c.Outcome == OutcomeSkipped && !r.ShowSkipped {
+			continue
+		}
 		var status string
 		switch c.Outcome {
 		case OutcomePassed:

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -69,3 +69,87 @@ func TestRun_NoStatus(t *testing.T) {
 		t.Errorf("expected failure for no-status case")
 	}
 }
+
+// TestWrite_HidesSkippedByDefault pins the output-consistency
+// behavior: under changed-only mode, unchanged resources are
+// SKIPPED — they have no per-resource information worth surfacing
+// (the summary count is enough). `flate diff` already follows this
+// discipline (no diff line for unchanged); `flate test` matches.
+func TestWrite_HidesSkippedByDefault(t *testing.T) {
+	s := store.New()
+	passed := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "changed"}
+	skipped := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "untouched"}
+	s.AddObject(&manifest.Kustomization{Name: passed.Name, Namespace: passed.Namespace})
+	s.AddObject(&manifest.Kustomization{Name: skipped.Name, Namespace: skipped.Namespace})
+	s.UpdateStatus(passed, store.StatusReady, "")
+	s.UpdateStatus(skipped, store.StatusReady, store.MsgUnchanged)
+
+	rep := Run(Job{Store: s})
+
+	var b bytes.Buffer
+	rep.Write(&b)
+	out := b.String()
+
+	if !strings.Contains(out, "changed") {
+		t.Errorf("PASSED row must appear: %s", out)
+	}
+	if strings.Contains(out, "untouched") {
+		t.Errorf("SKIPPED row must be hidden by default; got:\n%s", out)
+	}
+	// Summary line still surfaces the SKIPPED count so callers
+	// can see how many resources the change-filter excluded.
+	if !strings.Contains(out, "1 skipped") {
+		t.Errorf("summary must report SKIPPED count even when rows are hidden: %s", out)
+	}
+	// "collected" reflects the rendered row count, not the raw
+	// case count — otherwise users see "collected 2" but only one
+	// row of output, which reads as a bug.
+	if !strings.Contains(out, "collected 1 items") {
+		t.Errorf("collected-count must match visible rows: %s", out)
+	}
+}
+
+// TestWrite_ShowSkippedSurfacesEverything pins the opt-in path:
+// callers that DO want the full breakdown (debugging unexpected
+// skips, verifying changed-only mode is working as intended) get
+// every row back when ShowSkipped is true.
+func TestWrite_ShowSkippedSurfacesEverything(t *testing.T) {
+	s := store.New()
+	passed := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "changed"}
+	skipped := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "untouched"}
+	s.AddObject(&manifest.Kustomization{Name: passed.Name, Namespace: passed.Namespace})
+	s.AddObject(&manifest.Kustomization{Name: skipped.Name, Namespace: skipped.Namespace})
+	s.UpdateStatus(passed, store.StatusReady, "")
+	s.UpdateStatus(skipped, store.StatusReady, store.MsgUnchanged)
+
+	rep := Run(Job{Store: s})
+	rep.ShowSkipped = true
+
+	var b bytes.Buffer
+	rep.Write(&b)
+	out := b.String()
+
+	if !strings.Contains(out, "untouched") {
+		t.Errorf("SKIPPED row must appear with ShowSkipped: %s", out)
+	}
+	if !strings.Contains(out, "SKIPPED (unchanged)") {
+		t.Errorf("SKIPPED row should carry its reason: %s", out)
+	}
+}
+
+// TestWrite_FailedNeverHidden ensures the suppression is scoped to
+// SKIPPED only — a FAILED row must always print regardless of
+// ShowSkipped, since that's the row the user reads to fix things.
+func TestWrite_FailedNeverHidden(t *testing.T) {
+	s := store.New()
+	failed := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "broken"}
+	s.AddObject(&manifest.Kustomization{Name: failed.Name, Namespace: failed.Namespace})
+	s.UpdateStatus(failed, store.StatusFailed, "boom")
+
+	rep := Run(Job{Store: s})
+	var b bytes.Buffer
+	rep.Write(&b)
+	if !strings.Contains(b.String(), "FAILED") {
+		t.Errorf("FAILED row must appear by default: %s", b.String())
+	}
+}


### PR DESCRIPTION
## Summary
User asked the question on buroa/k8s-gitops#5347's CI output: \`flate test\` ks shows \`Kustomization/flux-system/flux-repositories SKIPPED (unchanged)\` for a one-file change, but \`flate diff\` doesn't print anything for unchanged resources. They should behave consistently.

Make test match diff's discipline:

- \`Report.Write\` hides \`OutcomeSkipped\` rows from the per-resource listing by default. The summary footer still surfaces \`N skipped\` so callers see how many resources were filtered.
- \`collected N items\` reflects the visible row count, not the raw case count — otherwise users see \`collected 60 items\` above a 3-row output.
- New \`--show-skipped\` flag opts back into the verbose listing for users debugging unexpected skips or verifying changed-only mode is working as intended.
- FAILED rows are never hidden — the user reads those to fix things, so they print regardless of the SKIPPED toggle.

### Impact on the user's PR
A one-file change to cloudflared's HR previously produced a ~60-line test report with 59 SKIPPED rows. After this change the output shrinks to just the PASSED rows for the actual reconcile chain (\`cluster-apps\` + \`cloudflared\`), with a summary line confirming \`N skipped\`.

## Test plan
- New \`TestWrite_HidesSkippedByDefault\` pins the hiding + summary-count survival + collected-count adjustment.
- New \`TestWrite_ShowSkippedSurfacesEverything\` pins the opt-in path.
- New \`TestWrite_FailedNeverHidden\` ensures FAILED rows always print.
- \`go test ./...\` (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)