### PR TITLE
fix(source/oci): reset cache slot when leftover OCI layout artifacts found

### DIFF
--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -187,6 +187,23 @@ func digestPath(slot string, d digest.Digest) string {
 	return filepath.Join(slot, ocispec.ImageBlobsDir, algo, hex)
 }
 
+// hasUnfinishedOCILayout reports whether slot still carries any of
+// the OCI Image Layout artifacts cleanupOCILayout is supposed to
+// wipe at the end of a successful fetch. Their presence means the
+// slot is in an inconsistent state: either applyLayerSelector
+// didn't run to completion, or a concurrent process modified the
+// slot after a successful fetch landed `.flate-digest`. The OCI
+// fetcher's cache-hit path uses this as a sentinel to reset stale
+// slots before serving them.
+func hasUnfinishedOCILayout(slot string) bool {
+	for _, name := range ociLayoutArtifacts {
+		if _, err := os.Stat(filepath.Join(slot, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
 // cleanupOCILayout removes the OCI Image Layout artifacts oras-go wrote
 // alongside the artifact blobs. By the time this runs the selected
 // layer has already been staged outside the layout subtree, so removal

--- a/pkg/source/oci/layer_test.go
+++ b/pkg/source/oci/layer_test.go
@@ -369,6 +369,59 @@ func writeBlob(t *testing.T, slot string, payload []byte) digest.Digest {
 	return digest.Digest("sha256:" + hexs)
 }
 
+// TestHasUnfinishedOCILayout pins the cache-corruption sentinel
+// the OCI fetcher uses to invalidate stale cache hits: any of the
+// OCI Image Layout artifacts (blobs/, ingest/, oci-layout,
+// index.json) lingering in the slot AFTER applyLayerSelector
+// should have cleaned them up means the slot is in an
+// inconsistent state and must be reset.
+//
+// The user-visible symptom (onedr0p/home-ops repro): a crashed or
+// older flate version leaves `blobs/` + `oci-layout` in the slot
+// alongside a valid `.flate-digest`, and every subsequent fetch
+// reports "OCIRepository artifact has neither Chart.yaml,
+// layer.tar.gz, nor a <name>/Chart.yaml subdir" because the
+// `.flate-digest` marker greenlit the cache hit. The sentinel
+// catches this before the chart consumer ever sees it.
+func TestHasUnfinishedOCILayout(t *testing.T) {
+	for _, name := range ociLayoutArtifacts {
+		t.Run(name, func(t *testing.T) {
+			slot := t.TempDir()
+			// Lay down a recognized chart artifact (layer.tar.gz)
+			// so the slot looks "valid" except for the leftover
+			// layout file we're testing.
+			if err := os.WriteFile(filepath.Join(slot, copiedLayerFilename), []byte("chart"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			target := filepath.Join(slot, name)
+			// blobs/ and ingest/ are directories; oci-layout and
+			// index.json are files. Both shapes count.
+			if name == ocispec.ImageBlobsDir || name == "ingest" {
+				if err := os.MkdirAll(target, 0o750); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := os.WriteFile(target, []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if !hasUnfinishedOCILayout(slot) {
+				t.Errorf("hasUnfinishedOCILayout(%s) = false; expected true with %s present", slot, name)
+			}
+		})
+	}
+
+	t.Run("clean_slot", func(t *testing.T) {
+		slot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(slot, copiedLayerFilename), []byte("chart"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if hasUnfinishedOCILayout(slot) {
+			t.Errorf("hasUnfinishedOCILayout(%s) = true on a clean slot with only layer.tar.gz", slot)
+		}
+	})
+}
+
 // writeManifest writes an OCI manifest blob (under blobs/sha256) for
 // layers and returns (raw bytes, digest).
 func writeManifest(t *testing.T, slot string, layers []ocispec.Descriptor) ([]byte, digest.Digest) {

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -237,6 +237,24 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		} else if cachedDigest == "" {
 			cachedDigest = ref.Digest
 		}
+		// Defensive: a valid `.flate-digest` should imply
+		// applyLayerSelector ran to completion and wiped the OCI
+		// Image Layout artifacts (blobs/, ingest/, oci-layout,
+		// index.json). If any of those still exist, the slot is in
+		// an inconsistent state — either an older flate version
+		// wrote `.flate-digest` before the cleanup, a concurrent
+		// process clobbered the layer.tar.gz after the marker
+		// landed, or the slot was hand-modified. Trusting the marker
+		// in that state produces the user-visible "OCIRepository
+		// artifact has neither Chart.yaml, layer.tar.gz, nor a
+		// <name>/Chart.yaml subdir" error every run. Reset so the
+		// next pull rebuilds the slot cleanly.
+		if exists && hasUnfinishedOCILayout(slot) {
+			slog.Warn("oci: cache slot has leftover OCI Image Layout artifacts; resetting and re-fetching",
+				"slot", slot, "url", versioned)
+			_ = cache.Reset(slot)
+			exists = false
+		}
 		// When verification is configured, re-verify the cached digest
 		// against the registry. Cheap (one metadata fetch) and closes the
 		// gap where a slot was populated under a prior policy.


### PR DESCRIPTION
## Repro
onedr0p/home-ops, running \`just kube render-local-ks default opengist\`:

\`\`\`
OCIRepository artifact at .../flate-cache/sources/5.0.1/ed21a6cae3789358 has
  neither Chart.yaml, layer.tar.gz, nor a <name>/Chart.yaml subdir — chart
  layer missing or layerSelector misconfigured
\`\`\`

across every OCIRepository (~60 HRs), sticky across reruns. Inspecting the cache slot showed \`blobs/\` + \`oci-layout\` directories AND a valid \`.flate-digest\` marker: the marker greenlit the cache-hit path, but the layout cleanup \`applyLayerSelector\` runs never finished — so consumers found no recognizable chart artifact.

Trigger conditions (any of):
- A crashed flate run that wrote \`.flate-digest\` before cleanup landed.
- A concurrent process modified the slot after a successful fetch.
- A \`flate-cache\` directory carried across a version that wrote \`.flate-digest\` at a different point in the fetch.
- Hand-edited slots.

I reproduced it locally by manually corrupting a slot:

\`\`\`bash
SLOT=$(...)/sources/5.0.1/ed21a6cae3789358
rm $SLOT/layer.tar.gz
mkdir -p $SLOT/blobs/sha256 && echo fake > $SLOT/blobs/sha256/abc
echo > $SLOT/oci-layout
\`\`\`

Then \`flate build ks\` produced the exact 64-failure error from the report.

## Fix
In the OCI fetcher's cache-hit branch, after the \`.flate-digest\`-presence check, probe for any of the OCI Image Layout artifacts (\`blobs/\`, \`ingest/\`, \`oci-layout\`, \`index.json\`) the successful path is supposed to wipe in \`cleanupOCILayout\`. If any survive, the slot is inconsistent — log a WARN, \`cache.Reset\`, and fall through to a fresh pull.

A clean slot (just \`layer.tar.gz\`, or just the extracted chart tree, plus \`.flate-digest\`) is unaffected — \`hasUnfinishedOCILayout\` returns false.

## Tests
- \`TestHasUnfinishedOCILayout\` pins the sentinel for each of the four layout artifacts plus the negative \"clean slot\" case.
- Manual repro: corrupt the slot → run \`flate build ks ...\` → WARN logged → slot reset → second pull → \`failed=0\`. Verified on onedr0p/home-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)