### PR TITLE
fix(source/bucket): reset slot before walk to avoid ghost files

### DIFF
--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -80,6 +80,21 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	}
 	defer release()
 
+	// Reset before walking. Unlike OCI / Git, the bucket fetcher
+	// has no "is the cached slot still valid?" check — walkBucket
+	// is write-only, so any file present in the slot from a
+	// previous run that was DELETED upstream between runs would
+	// be served as a ghost file. The revision hash is computed
+	// from the upstream listing, so it correctly reflects "no
+	// change" while the slot still holds the dead file. Reset
+	// makes every fetch a clean snapshot of the upstream prefix.
+	if err := f.Cache.Reset(slot); err != nil {
+		return nil, fmt.Errorf("bucket %s/%s reset: %w", b.Namespace, b.Name, err)
+	}
+	if err := os.MkdirAll(slot, 0o750); err != nil {
+		return nil, fmt.Errorf("bucket %s/%s recreate slot: %w", b.Namespace, b.Name, err)
+	}
+
 	keys, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot)
 	if err != nil {
 		_ = f.Cache.Reset(slot)


### PR DESCRIPTION
## Summary
Audit finding B1 from the artifact-rendering review.

The bucket \`Fetcher\` discarded \`cache.Slot\`'s \`exists\` return and walked the bucket on top of whatever was in the slot from prior runs. \`walkBucket\` WRITES newly-listed objects but never REMOVES files that disappeared upstream between runs. Result: a slot can accumulate ghost files — files no longer in the bucket but still on disk, served to downstream consumers as if they were live.

Worse, the revision hash is computed from the listing only, so \`art.Revision\` correctly reflects \"no change\" while the slot's contents are wrong. Consumers reading \`LocalPath\` see the stale file mixed with current content and have no way to detect the divergence.

## Fix
\`Cache.Reset\` + recreate the slot dir as the first step of the fetch. Bucket is fundamentally write-only (every fetch is a fresh snapshot of the upstream prefix), so trusting the cached contents was wrong from the start. OCI / Git both have their own \"is the cached slot still valid?\" sentinels and don't suffer this — bucket needs the inverse defense: trust nothing in the slot.

## Test plan
- [x] \`go build ./...\` / \`go vet ./...\` / \`go test ./...\` (existing suite green)
- E2E test for ghost-file recovery requires a mock S3 server; the change is minimal + the invariant is now clear in the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)