### PR TITLE
fix(source/oci): tighten state machine — drop ref.Digest fallback, defer reset, cleanup zero-layer

### DIFF
--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -107,6 +107,18 @@ func applyLayerSelector(
 			return fmt.Errorf("no layer matched mediaType %q (manifest has %d layer(s))",
 				selector.MediaType, len(man.Layers))
 		}
+		// Zero-layer artifact (no layers, no selector). Wipe the
+		// OCI Image Layout artifacts before returning — without
+		// this, the cache-hit path's hasUnfinishedOCILayout
+		// sentinel fires on the next reconcile, the slot is
+		// reset, and the next fetch reproduces the same zero-
+		// layer state → infinite reset/re-pull loop. Returning
+		// nil here means the slot is finalized empty; the
+		// downstream chart consumer surfaces a clear "no
+		// recognizable chart layout" error rather than looping.
+		if err := cleanupOCILayout(slot); err != nil {
+			return fmt.Errorf("cleanup zero-layer oci layout: %w", err)
+		}
 		return nil
 	}
 

--- a/pkg/source/oci/layer_test.go
+++ b/pkg/source/oci/layer_test.go
@@ -239,6 +239,42 @@ func TestApplyLayerSelector_MultiLayerWithSelector(t *testing.T) {
 	}
 }
 
+// TestApplyLayerSelector_ZeroLayerCleansLayoutArtifacts pins the
+// zero-layer corner case: when an OCI manifest has no layers AND
+// no selector mediaType is requested, applyLayerSelector must
+// still wipe the OCI Image Layout artifacts (blobs/, oci-layout,
+// etc.) before returning nil. Without the cleanup, the next
+// reconcile's hasUnfinishedOCILayout sentinel fires → slot reset
+// → re-fetch → same zero-layer state → infinite loop.
+//
+// The downstream chart consumer (helm) will surface a clear "no
+// recognizable chart layout" error against the empty slot — which
+// is the right operator signal, distinct from the silent retry
+// storm the bug produced.
+func TestApplyLayerSelector_ZeroLayerCleansLayoutArtifacts(t *testing.T) {
+	slot := t.TempDir()
+	// Write a manifest with no layers at all.
+	_, manifestDigest := writeManifest(t, slot, nil)
+	// Also lay down at least one layout artifact so the sentinel
+	// would fire without the cleanup.
+	if err := os.WriteFile(filepath.Join(slot, ocispec.ImageLayoutFile), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := applyLayerSelector(t.Context(), slot, manifestDigest.String(), nil); err != nil {
+		t.Fatalf("zero-layer applyLayerSelector should not error: %v", err)
+	}
+
+	if hasUnfinishedOCILayout(slot) {
+		entries, _ := os.ReadDir(slot)
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("zero-layer slot still has OCI Image Layout artifacts after applyLayerSelector; leftover entries: %v", names)
+	}
+}
+
 // TestExtractTarGz_ZipBombRejected covers the maxExtractedBytes cap.
 // Lower the cap to 100 bytes for the test and write a 1 KiB entry —
 // extractTarGz's LimitReader catches the over-budget write and emits

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -227,15 +227,20 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		// or aborted prior run that left partial blobs/ layout behind.
 		// (Slot.exists returns true on ANY non-empty dir.) Without
 		// this guard, the next fetch silently serves the corrupt
-		// slot as a cache hit. Fall through to a fresh pull, and only
-		// honor ref.Digest as the cachedDigest when one is explicitly
-		// pinned in spec.ref.digest — the orig spec-pin path that
-		// never wrote `.flate-digest` in the first place.
-		if cachedDigest == "" && ref.Digest == "" {
+		// slot as a cache hit. Fall through to a fresh pull.
+		//
+		// The previous `ref.Digest` fallback (treating a missing
+		// marker as "trusted because the spec pinned a digest") was
+		// load-bearing only on the legacy spec-pin code path that no
+		// longer exists — every successful fetch since the marker
+		// was introduced writes `.flate-digest`. Keeping the
+		// fallback meant a spec.ref.digest-pinned OCIRepository
+		// whose prior fetch died after extract but before marker
+		// write would silently serve a partially-extracted slot.
+		// Always require the marker.
+		if cachedDigest == "" {
 			_ = cache.Reset(slot)
 			exists = false
-		} else if cachedDigest == "" {
-			cachedDigest = ref.Digest
 		}
 		// Defensive: a valid `.flate-digest` should imply
 		// applyLayerSelector ran to completion and wiped the OCI
@@ -290,25 +295,31 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		return nil, fmt.Errorf("oras oci store: %w", err)
 	}
 	// content/oci.Store has no Close() method — all writes flush
-	// synchronously per blob via os.Rename — so reset-on-error is the
-	// only cleanup we need.
-	resetOnErr := func() { _ = cache.Reset(slot) }
+	// synchronously per blob via os.Rename — so reset-on-error is
+	// the only cleanup we need. Deferred + flag pattern (instead of
+	// per-error-site closure calls) so a panic between oras.Copy
+	// and writeCachedDigest also wipes the torn slot. Set finalized
+	// to true at the END of the fetch, right before returning the
+	// SourceArtifact.
+	finalized := false
+	defer func() {
+		if !finalized {
+			_ = cache.Reset(slot)
+		}
+	}()
 
 	desc, err := oras.Copy(ctx, repoClient, tag, dest, tag, oras.DefaultCopyOptions)
 	if err != nil {
-		resetOnErr()
 		return nil, fmt.Errorf("oras copy %s: %w", versioned, err)
 	}
 
 	digest := desc.Digest.String()
 	if repo.Verify != nil {
 		if err := f.verifyCosignSignature(ctx, repoClient, repo, digest); err != nil {
-			resetOnErr()
 			return nil, err
 		}
 	}
 	if err := applyLayerSelector(ctx, slot, desc.Digest.String(), repo.LayerSelector); err != nil {
-		resetOnErr()
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
 	// Source-controller's default ignore set includes `*.tar.gz`. For
@@ -319,7 +330,6 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	// ignore semantics apply as Flux ships them.
 	if effectiveLayerOperation(repo.LayerSelector) == manifest.OCILayerOperationExtract {
 		if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
-			resetOnErr()
 			return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
 		}
 	}
@@ -333,6 +343,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 			"ociRepository", repo.Namespace+"/"+repo.Name,
 			"err", err)
 	}
+	finalized = true
 	return &store.SourceArtifact{
 		Kind: manifest.KindOCIRepository,
 		URL:  repo.URL, LocalPath: slot,


### PR DESCRIPTION
## Summary
Audit findings B2, B3, B4 from the artifact-rendering review.

### B2 — drop \`.flate-digest\`-missing \`ref.Digest\` fallback
The branch at \`oci.go:237-239\` treated a missing marker as \"trusted because \`spec.ref.digest\` was pinned\". That fallback was load-bearing for a legacy code path that no longer exists — every successful fetch since the marker was introduced writes \`.flate-digest\`. Keeping it meant a \`spec.ref.digest\`-pinned OCIRepository whose prior fetch died after extract but before marker write would silently serve a partially-extracted slot. Always require the marker; absence → reset → fresh pull.

### B4 — defer resetOnErr for panic safety
\`resetOnErr\` was a regular closure called from each error site. A panic between \`oras.Copy\` and \`writeCachedDigest\` (e.g. gzip library panic on adversarial tarball, oras-go panic) would NOT fire the resets — the slot would be left torn AND the panic would propagate to the orchestrator. Converted to a deferred-flag pattern: set \`finalized=true\` right before the success return; the deferred func resets the slot when finalized is still false (any error return, any panic).

### B3 — \`applyLayerSelector\` cleans up on zero-layer artifact
When an OCI manifest had zero layers AND no selector mediaType, \`applyLayerSelector\` returned nil without running \`cleanupOCILayout\`. The slot kept \`blobs/\` + \`oci-layout\` + \`index.json\` → next reconcile's \`hasUnfinishedOCILayout\` sentinel fired → \`cache.Reset\` → re-pull → same zero-layer state → infinite loop. Always wipe the layout before returning nil so the slot is finalized empty; downstream consumers surface a clear \"no recognizable chart layout\" error rather than looping.

## Test plan
- New \`TestApplyLayerSelector_ZeroLayerCleansLayoutArtifacts\` pins B3.
- \`go vet ./... && go test ./...\` (full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)