### PR TITLE
fix(source/oci): atomic .flate-digest write + format validation + staged-layer sentinel

### DIFF
--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -199,16 +199,21 @@ func digestPath(slot string, d digest.Digest) string {
 	return filepath.Join(slot, ocispec.ImageBlobsDir, algo, hex)
 }
 
-// hasUnfinishedOCILayout reports whether slot still carries any of
-// the OCI Image Layout artifacts cleanupOCILayout is supposed to
-// wipe at the end of a successful fetch. Their presence means the
-// slot is in an inconsistent state: either applyLayerSelector
-// didn't run to completion, or a concurrent process modified the
-// slot after a successful fetch landed `.flate-digest`. The OCI
-// fetcher's cache-hit path uses this as a sentinel to reset stale
-// slots before serving them.
+// hasUnfinishedOCILayout reports whether slot still carries any
+// in-progress fetch artifacts:
+//
+//   - The OCI Image Layout dirs/files (blobs/, ingest/, oci-layout,
+//     index.json) cleanupOCILayout is supposed to wipe.
+//   - The staged layer file (.flate-layer.tar.gz) applyLayerSelector
+//     renames into place before extract / copy. A crash between the
+//     stage rename and the cleanup leaves it behind even when the
+//     layout dirs were already wiped.
+//
+// Either signals an inconsistent slot. The OCI fetcher's cache-hit
+// path uses this to reset stale slots before serving them.
 func hasUnfinishedOCILayout(slot string) bool {
-	for _, name := range ociLayoutArtifacts {
+	candidates := append([]string{stagedLayerFilename}, ociLayoutArtifacts...)
+	for _, name := range candidates {
 		if _, err := os.Stat(filepath.Join(slot, name)); err == nil {
 			return true
 		}

--- a/pkg/source/oci/layer_test.go
+++ b/pkg/source/oci/layer_test.go
@@ -456,6 +456,21 @@ func TestHasUnfinishedOCILayout(t *testing.T) {
 			t.Errorf("hasUnfinishedOCILayout(%s) = true on a clean slot with only layer.tar.gz", slot)
 		}
 	})
+
+	// The staged layer file (.flate-layer.tar.gz) is renamed into
+	// place between cleanupOCILayout and the extract/copy step.
+	// A crash in that window leaves the staging file alongside an
+	// otherwise-cleaned slot, and the next fetch would serve it
+	// as if it were a chart. Sentinel must catch this.
+	t.Run("staged_layer_leftover", func(t *testing.T) {
+		slot := t.TempDir()
+		if err := os.WriteFile(filepath.Join(slot, stagedLayerFilename), []byte("staged"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if !hasUnfinishedOCILayout(slot) {
+			t.Errorf("hasUnfinishedOCILayout(%s) = false; expected true with %s present", slot, stagedLayerFilename)
+		}
+	})
 }
 
 // writeManifest writes an OCI manifest blob (under blobs/sha256) for

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -358,16 +358,61 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 // hit when spec.verify is configured.
 const cachedDigestFile = ".flate-digest"
 
+// digestRE matches a well-formed OCI content digest:
+// "<algorithm>:<hex>" where the hex side is at least 32 chars (sha256
+// truncated, the OCI spec minimum). Catches torn writes where the
+// previous run died mid-WriteFile and left a partial digest string —
+// rather than passing the partial to cosign and getting a misleading
+// "signature not found" error, treat it as a missing marker.
+var digestRE = regexp.MustCompile(`^[a-z0-9]+:[a-fA-F0-9]{32,}$`)
+
+// writeCachedDigest persists digest atomically: write to a sibling
+// temp file, fsync, then rename into place. Without atomicity, a
+// crash mid-write could leave a partial digest string that would
+// later mis-read on cache hit and trigger a misleading cosign
+// failure on the next reconcile.
 func writeCachedDigest(slot, digest string) error {
-	return os.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(digest), 0o600)
+	dst := filepath.Join(slot, cachedDigestFile)
+	tmp, err := os.CreateTemp(slot, ".flate-digest-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpPath) }
+	if _, err := tmp.WriteString(digest); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		cleanup()
+		return err
+	}
+	return nil
 }
 
+// readCachedDigest returns the cached digest only when it parses as a
+// well-formed OCI content digest. Empty + malformed both return "" so
+// the caller's "no marker" branch handles the recovery uniformly.
 func readCachedDigest(slot string) string {
 	b, err := os.ReadFile(filepath.Join(slot, cachedDigestFile)) //nolint:gosec // slot is fetcher-owned cache path
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(b))
+	s := strings.TrimSpace(string(b))
+	if !digestRE.MatchString(s) {
+		return ""
+	}
+	return s
 }
 
 // ociRevision composes a Flux-style "<tag>@<digest>" revision string.

--- a/pkg/source/oci/oci_unit_test.go
+++ b/pkg/source/oci/oci_unit_test.go
@@ -8,16 +8,23 @@ import (
 	"testing"
 )
 
+// fullDigest is a sha256-shaped digest used across the cached-
+// digest tests. Real OCI digests are sha256:<64-hex-chars>; the
+// readCachedDigest regex requires at least 32 hex chars after the
+// algorithm prefix, so test inputs must match the shape that real
+// fetches produce.
+const fullDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
 // TestCachedDigest_Roundtrip covers writeCachedDigest + readCachedDigest:
 // the digest written by one survives a re-read on cache hit.
 func TestCachedDigest_Roundtrip(t *testing.T) {
 	slot := t.TempDir()
-	if err := writeCachedDigest(slot, "sha256:abc123"); err != nil {
+	if err := writeCachedDigest(slot, fullDigest); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 	got := readCachedDigest(slot)
-	if got != "sha256:abc123" {
-		t.Errorf("readCachedDigest = %q, want sha256:abc123", got)
+	if got != fullDigest {
+		t.Errorf("readCachedDigest = %q, want %q", got, fullDigest)
 	}
 }
 
@@ -33,11 +40,65 @@ func TestReadCachedDigest_MissingReturnsEmpty(t *testing.T) {
 // an editor adding a trailing newline shouldn't break cache matching.
 func TestReadCachedDigest_TrimsTrailingNewline(t *testing.T) {
 	slot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(slot, cachedDigestFile), []byte("sha256:abc\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(fullDigest+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := readCachedDigest(slot); got != "sha256:abc" {
+	if got := readCachedDigest(slot); got != fullDigest {
 		t.Errorf("got %q, want trimmed digest", got)
+	}
+}
+
+// TestReadCachedDigest_MalformedTreatedAsMissing pins the
+// format-validation contract: a torn write (partial digest, garbage,
+// or an old-shorter-than-spec value) must read as "" so the
+// fetcher's cache-hit path resets the slot instead of passing the
+// partial digest to cosign (which would produce a misleading
+// "signature not found" failure).
+func TestReadCachedDigest_MalformedTreatedAsMissing(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty", ""},
+		{"no_colon", "abc123"},
+		{"too_short_hex", "sha256:abc"},
+		{"non_hex", "sha256:Z" + strings.Repeat("Z", 64)},
+		{"only_algorithm", "sha256:"},
+		{"random_junk", "this is not a digest"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			slot := t.TempDir()
+			if err := os.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(tc.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if got := readCachedDigest(slot); got != "" {
+				t.Errorf("malformed digest %q read as %q; want empty", tc.content, got)
+			}
+		})
+	}
+}
+
+// TestWriteCachedDigest_AtomicNoPartial pins the atomic-write
+// contract: writeCachedDigest must not leave the destination file
+// in a partial state at any point. We can't trigger a real crash
+// mid-write, but we CAN assert that no .flate-digest-* temp files
+// linger after a successful write (those would be created by the
+// atomic path and renamed away).
+func TestWriteCachedDigest_AtomicNoPartial(t *testing.T) {
+	slot := t.TempDir()
+	if err := writeCachedDigest(slot, fullDigest); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() == cachedDigestFile {
+			continue
+		}
+		t.Errorf("unexpected leftover entry in slot after writeCachedDigest: %q (atomic write should have cleaned up the temp)", e.Name())
 	}
 }
 


### PR DESCRIPTION
## Summary
Audit findings F1, F2, F3 from the artifact-rendering review.

### F1 — atomic \`.flate-digest\` write
Previous \`os.WriteFile\` is non-atomic: a crash mid-write leaves a truncated digest string on disk. On the next reconcile, \`readCachedDigest\` returns the partial value, the cache-hit path uses it as \`cachedDigest\`, and (when \`spec.verify\` is set) cosign fails with \"signature manifest not found\" against the partial digest. Misleading recurring error. Switch to temp file + fsync + rename — destination is either fully written or entirely absent.

### F2 — \`readCachedDigest\` format validation
A torn or hand-edited \`.flate-digest\` can hold anything. Bind the contract: parse as \`^[a-z0-9]+:[a-fA-F0-9]{32,}\$\` (OCI content-digest shape). Malformed reads as \`\"\"\` so the cache-hit path treats it as a missing marker and resets uniformly. Removes a class of cryptic cosign failures.

### F3 — \`hasUnfinishedOCILayout\` catches leftover staged layer
\`applyLayerSelector\` renames the selected blob to \`slot/.flate-layer.tar.gz\`, wipes the OCI Image Layout, then renames to \`layer.tar.gz\` (copy) or extracts (extract). A crash between the stage rename and the cleanup leaves the staged file alongside an otherwise-clean slot. Sentinel only checked layout artifacts; missing this state. Add \`stagedLayerFilename\` to the candidate list.

## Test plan
- New \`TestReadCachedDigest_MalformedTreatedAsMissing\` (6 subtests).
- New \`TestWriteCachedDigest_AtomicNoPartial\` — no temp leftover after success.
- New \`TestHasUnfinishedOCILayout/staged_layer_leftover\`.
- Existing roundtrip / trim / clean-slot tests updated to use proper sha256-shaped digests (the previous \`sha256:abc123\` didn't survive format validation, which is the point of F2).
- \`go vet ./... && go test ./...\` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)