### PR TITLE
feat(orchestrator,helm): widen and surface the EnableOCI=false warnings

### DIFF
--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -60,9 +60,17 @@ func (c *Client) locateOCIChart(ctx context.Context, hr *manifest.HelmRelease) (
 			r.Namespace, r.Name)
 	}
 	ver := r.Version()
-	slog.Debug("helm: OCIRepository SourceArtifact missing; falling back to helm registry client",
-		"ociRepository", r.Namespace+"/"+r.Name, "url", r.URL, "version", ver,
-		"note", "OCIRepository spec.verify/layerSelector/etc. NOT applied on this path")
+	// Operator-visible: the fallback path silently drops every
+	// security-relevant spec.* field (verify, layerSelector,
+	// certSecretRef, proxySecretRef, insecure, ignore). Bootstrap-
+	// time warnOnDisabledOCIFeatures already calls this out per
+	// CR; the per-lookup log surfaces the actual moment the
+	// fallback runs — useful both for diagnosing missing-feature
+	// surprises and for noticing when the fallback is hit
+	// unexpectedly. Upgraded from Debug to Warn so operators on
+	// default log level (info) see it.
+	slog.Warn("helm: OCIRepository SourceArtifact missing; falling back to helm registry client — spec.verify/layerSelector/etc. NOT applied on this path",
+		"ociRepository", r.Namespace+"/"+r.Name, "url", r.URL, "version", ver)
 	return c.fetchOCIChart(ctx, r.URL, ver)
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -288,15 +288,27 @@ func (o *Orchestrator) warnOnDisabledOCIFeatures() {
 		return
 	}
 	for _, repo := range store.ListAs[*manifest.OCIRepository](o.store, manifest.KindOCIRepository) {
-		if repo.Verify == nil && repo.LayerSelector == nil {
-			continue
-		}
-		fields := []string{}
+		var fields []string
 		if repo.Verify != nil {
 			fields = append(fields, "spec.verify")
 		}
 		if repo.LayerSelector != nil {
 			fields = append(fields, "spec.layerSelector")
+		}
+		if repo.CertSecretRef != nil {
+			fields = append(fields, "spec.certSecretRef")
+		}
+		if repo.ProxySecretRef != nil {
+			fields = append(fields, "spec.proxySecretRef")
+		}
+		if repo.Insecure {
+			fields = append(fields, "spec.insecure")
+		}
+		if repo.Ignore != nil {
+			fields = append(fields, "spec.ignore")
+		}
+		if len(fields) == 0 {
+			continue
 		}
 		slog.Warn("OCIRepository spec fields ignored — EnableOCI=false wires ExistenceFetcher",
 			"ociRepository", repo.Namespace+"/"+repo.Name,


### PR DESCRIPTION
## Summary
Audit findings F8 + F9 from the artifact-rendering review.

### F9 — \`warnOnDisabledOCIFeatures\` was too narrow
The guard \`if repo.Verify == nil && repo.LayerSelector == nil\` silently skipped repos that set \`CertSecretRef\`, \`ProxySecretRef\`, \`Insecure\`, or \`Ignore\` — also security/behavior-relevant fields the EnableOCI=false fallback path drops on the floor. A user with \`certSecretRef\` configured would never know flate ignored it. Widened the check to include all five remaining \`spec.*\` fields the fallback can't honor.

### F8 — fallback per-lookup log was Debug, invisible at default level
The helm-side \`locateOCIChart\` fallback (taken when EnableOCI=false leaves the source artifact missing) logged at Debug. Operators on the default info level never saw the moment their \`spec.verify\` was silently bypassed. Bumped to Warn — same level as the bootstrap-time per-CR warning. Both the \"you configured this and it won't be applied\" pre-warning AND the \"we're using the fallback right now\" event now surface.

## Test plan
- \`go build ./... && go vet ./... && go test ./...\`
- No new tests — these are operator-visibility tweaks (existing behavior tests unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)