### PR TITLE
refactor(source/cache): slugify by repo name, not by tag

### DIFF
--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -115,10 +115,46 @@ var nonAlnum = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
 // filesystem name limits and remain greppable.
 const maxSlugLen = 50
 
-// slugifyRepo reduces a URL to a short, filesystem-safe identifier. It
-// preserves the last path segment so cache directories are recognizable
-// when poking around manually.
+// slugifyRepo reduces a URL to a short, filesystem-safe identifier
+// matching the LAST PATH SEGMENT of the repo URL — not the version.
+// Strip OCI version suffixes (`:tag`, `@digest`) and the `.git`
+// suffix BEFORE picking the last segment, so:
+//
+//	oci://ghcr.io/bjw-s-labs/helm/app-template:5.0.1 → "app-template"
+//	oci://ghcr.io/foo/bar@sha256:abc...               → "bar"
+//	https://github.com/owner/repo.git                 → "repo"
+//	git@github.com:owner/repo.git                     → "repo"
+//
+// Without the version strip, the OCI flow always presents
+// versionedURL (URL + ":" + tag) to slugifyRepo, and every OCI
+// slot ends up under `&lt;root&gt;/sources/&lt;tag&gt;/&lt;hash&gt;` — e.g. every
+// app-template release piles under `5.0.1/`, `5.0.2/`, `5.0.3/`,
+// indistinguishable from any other chart pinned to those tags.
+// Functionally safe (hash is the real uniqueness key) but
+// useless for operators inspecting the cache. The hash component
+// of the slot path is unchanged by this function; it remains
+// computed from the raw URL + ref upstream.
 func slugifyRepo(url string) string {
+	// Strip version suffixes added by versionedURL (or hand-typed
+	// URLs that include `:tag` / `@digest`). Done in two steps to
+	// preserve scheme colons (e.g. `https:`, `oci:`): split on the
+	// LAST `@` first (digest), then look for a trailing `:` that
+	// follows the last `/` (tag, not port — registry host:port has
+	// the colon BEFORE the path's last `/`).
+	if i := strings.LastIndex(url, "@"); i >= 0 {
+		// Only treat `@` as digest if what follows looks like
+		// `<algo>:<hex>` — otherwise it's userinfo
+		// (`git@github.com`) and must be preserved for the
+		// last-segment split below.
+		if rest := url[i+1:]; strings.Contains(rest, ":") && !strings.Contains(rest, "/") {
+			url = url[:i]
+		}
+	}
+	if lastSlash := strings.LastIndex(url, "/"); lastSlash >= 0 {
+		if colon := strings.IndexByte(url[lastSlash+1:], ':'); colon >= 0 {
+			url = url[:lastSlash+1+colon]
+		}
+	}
 	url = strings.TrimSuffix(url, ".git")
 	if idx := strings.LastIndexAny(url, "/:"); idx >= 0 && idx < len(url)-1 {
 		url = url[idx+1:]

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -122,6 +122,21 @@ func TestSlugifyRepo(t *testing.T) {
 		"https://example.com/long-path/with/slashes/repo.git": "repo",
 		"oci://ghcr.io/stefanprodan/charts/podinfo":           "podinfo",
 		"": "repo",
+
+		// Tag suffix: versionedURL passes URL:tag into slugify
+		// for OCI fetches. Slug should be the chart name, NOT
+		// the tag — otherwise the cache layout collapses
+		// every release of every chart into the same `&lt;tag&gt;/`
+		// directory.
+		"oci://ghcr.io/bjw-s-labs/helm/app-template:5.0.1":           "app-template",
+		"oci://ghcr.io/bjw-s-labs/helm/app-template:1.2.3-rc4":       "app-template",
+		"oci://registry.local:5000/charts/mychart:1.2.3":             "mychart",
+		"oci://registry.local:5000/charts/mychart":                   "mychart",
+		// Digest suffix: same concern as tags.
+		"oci://ghcr.io/foo/bar@sha256:1111111111111111111111111111111111111111111111111111111111111111": "bar",
+		// SCP-style git URL with `@` userinfo must NOT be
+		// mistaken for a digest suffix.
+		"git@github.com:owner/repo": "repo",
 	}
 	for in, want := range cases {
 		if got := slugifyRepo(in); got != want {


### PR DESCRIPTION
## Summary
Audit finding B2 from the cache-layer review. The OCI fetcher passes \`versionedURL\` (URL + \":\" + tag) into \`Cache.Slot\`, so \`slugifyRepo\`'s \"last segment of URL\" rule returned the TAG for every OCI source:

  \`oci://ghcr.io/bjw-s-labs/helm/app-template:5.0.1 → slug \"5.0.1\"\`

Functionally safe (the hash is the real uniqueness key) but operationally awful: every chart pinned to \`5.0.1\` ends up under one inodes-pressure directory, and \`ls \$flate_cache/sources/\` shows version numbers instead of chart names. Reports kept showing paths like \`5.0.1/ed21a6cae3789358\` masking 30 different HRs sharing app-template.

Strip the \`:tag\` and \`@digest\` suffixes before picking the last segment:

| Input | Old slug | New slug |
|-------|----------|----------|
| \`oci://ghcr.io/.../app-template:5.0.1\` | \`5.0.1\` | \`app-template\` |
| \`oci://.../bar@sha256:...\` | \`abc...\` | \`bar\` |
| \`registry.local:5000/charts/mychart:1.2.3\` | \`1.2.3\` | \`mychart\` |
| \`git@github.com:owner/repo\` (SCP-style) | \`repo\` (unchanged) | \`repo\` |

The hash component is unchanged — still computed from the raw URL + ref upstream. Slot uniqueness, mutex serialization, all semantics preserved. Only the human-visible slot directory naming improves.

## Test plan
- Expanded \`TestSlugifyRepo\` with versioned-OCI URLs, digest-suffixed URLs, port-vs-tag disambiguation, and the SCP-userinfo case (must NOT be mistaken for a digest suffix).
- \`go vet ./... && go test ./...\` — full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)