### PR TITLE
refactor(source/cache): atomic-rename slot staging

### DIFF
--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -71,33 +71,33 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 		return nil, fmt.Errorf("bucket %s/%s: minio client: %w", b.Namespace, b.Name, err)
 	}
 
-	// Cache key: bucket+prefix; reset on first error so retries start
-	// clean. The revision identifier (sha256 over sorted etags) is
-	// recomputed after listing.
-	slot, _, release, err := f.Cache.Slot(endpoint+"/"+b.BucketName, b.Prefix)
+	// Cache key: bucket+prefix. Unlike OCI / Git, the bucket fetcher
+	// has no "is the cached slot still valid?" check — walkBucket is
+	// write-only, so any file present in the slot from a previous run
+	// that was DELETED upstream between runs would be served as a
+	// ghost file. The revision hash is computed from the upstream
+	// listing, so it correctly reflects "no change" while the slot
+	// still holds the dead file. We treat every fetch as a miss:
+	// write to a fresh staging dir, then atomic-rename into the final
+	// slot on success.
+	slot, err := f.Cache.Slot(endpoint+"/"+b.BucketName, b.Prefix)
 	if err != nil {
 		return nil, fmt.Errorf("bucket %s/%s cache slot: %w", b.Namespace, b.Name, err)
 	}
-	defer release()
-
-	// Reset before walking. Unlike OCI / Git, the bucket fetcher
-	// has no "is the cached slot still valid?" check — walkBucket
-	// is write-only, so any file present in the slot from a
-	// previous run that was DELETED upstream between runs would
-	// be served as a ghost file. The revision hash is computed
-	// from the upstream listing, so it correctly reflects "no
-	// change" while the slot still holds the dead file. Reset
-	// makes every fetch a clean snapshot of the upstream prefix.
-	if err := f.Cache.Reset(slot); err != nil {
-		return nil, fmt.Errorf("bucket %s/%s reset: %w", b.Namespace, b.Name, err)
-	}
-	if err := os.MkdirAll(slot, 0o750); err != nil {
-		return nil, fmt.Errorf("bucket %s/%s recreate slot: %w", b.Namespace, b.Name, err)
+	defer slot.Release()
+	if slot.Exists {
+		// Drop the prior committed slot and re-stage so the upcoming
+		// walk writes into an empty staging dir.
+		if err := slot.Reset(); err != nil {
+			return nil, fmt.Errorf("bucket %s/%s reset: %w", b.Namespace, b.Name, err)
+		}
+		if err := slot.Stage(); err != nil {
+			return nil, fmt.Errorf("bucket %s/%s stage: %w", b.Namespace, b.Name, err)
+		}
 	}
 
-	keys, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot)
+	keys, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot.Path)
 	if err != nil {
-		_ = f.Cache.Reset(slot)
 		return nil, fmt.Errorf("bucket %s/%s walk: %w", b.Namespace, b.Name, err)
 	}
 	// Bucket uses the no-defaults ignore variant — matches upstream
@@ -105,15 +105,17 @@ func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.
 	// ignore Matcher without VCS / extension defaults. Buckets are
 	// object stores with no VCS semantics; .jpg / .flux.yaml / etc.
 	// are legitimate content and must reach the artifact.
-	if err := source.ApplyIgnoreNoDefaults(slot, b.Ignore); err != nil {
-		_ = f.Cache.Reset(slot)
+	if err := source.ApplyIgnoreNoDefaults(slot.Path, b.Ignore); err != nil {
 		return nil, fmt.Errorf("bucket %s/%s: %w", b.Namespace, b.Name, err)
+	}
+	if err := slot.Commit(); err != nil {
+		return nil, fmt.Errorf("bucket %s/%s: commit slot: %w", b.Namespace, b.Name, err)
 	}
 
 	return &store.SourceArtifact{
 		Kind:      manifest.KindBucket,
 		URL:       fmt.Sprintf("%s://%s/%s", schemeFor(secure), endpoint, b.BucketName),
-		LocalPath: slot,
+		LocalPath: slot.Path,
 		Revision:  revHash,
 		Metadata: map[string]string{
 			"objectCount": fmt.Sprintf("%d", len(keys)),

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -52,59 +52,177 @@ func (c *Cache) slotMu(path string) *sync.Mutex {
 	return m
 }
 
-// Slot returns the path under which (url, ref) should be cached, the
-// per-slot release function the caller MUST defer, and an exists flag
-// indicating the directory was already populated.
+// Slot allocates a per-(url, ref) slot under the cache root with
+// atomic-rename finalization. Holds the slot mutex until Release is
+// called; serializes against other Slot acquisitions on the same key.
 //
-// Holding the returned release across the full fetch-and-publish
-// lifecycle serializes other fetchers (different CRs, same (url, ref))
-// against the in-flight one — see Cache type doc for the race motivation.
-func (c *Cache) Slot(url, ref string) (path string, exists bool, release func(), err error) {
+// The returned Slot's Path is:
+//
+//   - The final slot directory when Exists is true (cache hit — the
+//     fetcher reads from it directly).
+//   - A sibling staging directory when Exists is false (cache miss —
+//     the fetcher writes into it, then calls Commit to atomic-rename
+//     into the final slot).
+//
+// The staging dir lives at `<final>.tmp.<rand>`, on the same filesystem
+// as the final, so os.Rename is atomic per POSIX. If the fetcher
+// returns without committing (any error path, any panic), Release
+// removes the staging dir and the final slot is left absent — the
+// next fetch starts clean. This atomicity replaces the older
+// "write in place + .flate-* sentinels" pattern: the final slot is
+// either complete or doesn't exist, never torn.
+func (c *Cache) Slot(url, ref string) (*Slot, error) {
 	slug := slugifyRepo(url)
 	h := sha256.Sum256([]byte(url + "@" + ref))
 	hash := hex.EncodeToString(h[:])[:16]
-	path = filepath.Join(c.root, slug, hash)
+	final := filepath.Join(c.root, "sources", slug, hash)
 
-	m := c.slotMu(path)
+	m := c.slotMu(final)
 	m.Lock()
-	release = m.Unlock
+	s := &Slot{final: final, mu: m}
 
-	info, statErr := os.Stat(path)
+	info, statErr := os.Stat(final)
 	switch {
 	case statErr == nil && info.IsDir():
 		// Non-empty directory counts as populated. We use the presence
 		// of any entry as the indicator so a bare `mkdir` from a prior
 		// aborted run doesn't masquerade as a hit.
-		f, ferr := os.Open(path) //nolint:gosec // path is a cache slot under our cache root
+		f, ferr := os.Open(final) //nolint:gosec // final is under the cache root
 		if ferr == nil {
 			entries, _ := f.Readdirnames(1)
 			_ = f.Close()
-			exists = len(entries) > 0
+			s.Exists = len(entries) > 0
 		}
-		return path, exists, release, nil
+		if s.Exists {
+			s.Path = final
+			return s, nil
+		}
+		// Empty directory left from a prior aborted run — remove
+		// so the staging dir can take over cleanly.
+		if err := os.RemoveAll(final); err != nil {
+			s.unlock()
+			return nil, fmt.Errorf("cache slot clean empty: %w", err)
+		}
+		fallthrough
 	case os.IsNotExist(statErr):
-		if mkErr := os.MkdirAll(path, 0o750); mkErr != nil {
-			release()
-			return "", false, nil, mkErr
+		// Allocate a sibling staging dir on the same filesystem so
+		// the eventual rename is atomic.
+		if err := os.MkdirAll(filepath.Dir(final), 0o750); err != nil {
+			s.unlock()
+			return nil, fmt.Errorf("cache slot parent: %w", err)
 		}
-		return path, false, release, nil
+		staging, err := os.MkdirTemp(filepath.Dir(final), filepath.Base(final)+".tmp.*")
+		if err != nil {
+			s.unlock()
+			return nil, fmt.Errorf("cache slot staging: %w", err)
+		}
+		s.Path = staging
+		s.staging = staging
+		return s, nil
 	default:
-		release()
-		return "", false, nil, fmt.Errorf("cache slot stat: %w", statErr)
+		s.unlock()
+		return nil, fmt.Errorf("cache slot stat: %w", statErr)
 	}
 }
 
-// Reset removes a previously allocated slot. Called when a fetch fails
-// so retries start clean. The caller is expected to hold the slot
-// release (i.e. Reset is called from within the Slot-Acquire critical
-// section). This function does NOT take the per-slot lock — doing so
-// would self-deadlock — but it does serialize against new Slot
-// acquisitions via the absence of a sibling holder.
-func (c *Cache) Reset(path string) error {
-	if path == "" {
+// Slot is one allocated cache slot. Acquired by Cache.Slot, released
+// by the caller's deferred Release. On a cache miss the fetcher writes
+// into Path (a staging dir) and calls Commit to atomic-rename into the
+// final slot; on a cache hit Path is already the final slot.
+type Slot struct {
+	// Path is where the fetcher reads / writes:
+	//   Exists == true  → Path is the final slot (read-only use).
+	//   Exists == false → Path is the staging dir (write here, then
+	//                     Commit to finalize).
+	Path string
+	// Exists reports whether the final slot was already populated by
+	// a prior fetch. When true, the staging dance is skipped and
+	// Path is the final slot directly.
+	Exists bool
+
+	final     string
+	staging   string
+	mu        *sync.Mutex
+	committed bool
+	unlocked  bool
+}
+
+// Commit finalizes a successful fetch: atomic-rename the staging dir
+// over the final slot. No-op on a cache hit (Exists == true). Safe to
+// call multiple times. After a successful commit, Path is updated to
+// the final slot so subsequent reads work uniformly.
+func (s *Slot) Commit() error {
+	if s.Exists || s.committed {
 		return nil
 	}
-	return os.RemoveAll(path)
+	// os.Rename across an existing target is platform-dependent —
+	// remove the (definitely empty by our protocol; we checked it on
+	// Slot construction) target first so the rename is unambiguous.
+	if err := os.RemoveAll(s.final); err != nil {
+		return fmt.Errorf("cache commit prep: %w", err)
+	}
+	if err := os.Rename(s.staging, s.final); err != nil {
+		return fmt.Errorf("cache commit: %w", err)
+	}
+	s.committed = true
+	s.staging = ""
+	s.Path = s.final
+	return nil
+}
+
+// Release drops the slot mutex AND, if Commit wasn't called, removes
+// the orphan staging dir. MUST be deferred by every Cache.Slot caller.
+// Safe to call multiple times — second+ calls are no-ops.
+func (s *Slot) Release() {
+	if s.unlocked {
+		return
+	}
+	if !s.committed && s.staging != "" {
+		_ = os.RemoveAll(s.staging)
+	}
+	s.unlock()
+}
+
+// Reset wipes the final slot — used by callers that detected a stale
+// cache hit (e.g. cosign signature changed against the cached digest).
+// After Reset the slot looks like an Exists=false miss; the caller
+// can write to a new staging via a fresh Cache.Slot call, OR can call
+// Stage on this same Slot to allocate staging in place.
+func (s *Slot) Reset() error {
+	if err := os.RemoveAll(s.final); err != nil {
+		return err
+	}
+	s.Exists = false
+	s.Path = ""
+	return nil
+}
+
+// Stage allocates the staging dir for a Slot that was returned with
+// Exists == true and then explicitly Reset by the caller. The new Path
+// is the staging dir. No-op when staging is already allocated.
+func (s *Slot) Stage() error {
+	if s.staging != "" {
+		s.Path = s.staging
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(s.final), 0o750); err != nil {
+		return fmt.Errorf("cache slot stage parent: %w", err)
+	}
+	staging, err := os.MkdirTemp(filepath.Dir(s.final), filepath.Base(s.final)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("cache slot stage: %w", err)
+	}
+	s.staging = staging
+	s.Path = staging
+	return nil
+}
+
+func (s *Slot) unlock() {
+	if s.unlocked {
+		return
+	}
+	s.unlocked = true
+	s.mu.Unlock()
 }
 
 // nonAlnum collapses non-alphanumeric (plus `.-_`) runs into a single

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 )
 
-// TestCache_ResetSerializesAgainstSlot exercises the mutex Cache.Reset
-// acquires alongside Cache.Slot. A goroutine race-detector run with
-// many parallel Slot/Reset pairs targeting the same path must complete
-// without -race tripping. A regression that drops the lock from Reset
-// (or removes it from Slot) would fail under `go test -race`.
+// TestCache_ResetSerializesAgainstSlot exercises the per-slot mutex
+// that Slot/Release acquire. A goroutine race-detector run with many
+// parallel Slot/Commit/Reset cycles targeting the same path must
+// complete without -race tripping. A regression that drops the lock
+// from Slot would fail under `go test -race`.
 func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 	c := NewCache(t.TempDir())
 	const goroutines = 16
@@ -24,29 +24,30 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range iterations {
-				path, _, release, err := c.Slot("https://shared.example/repo", "main")
+				slot, err := c.Slot("https://shared.example/repo", "main")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
 				}
-				_ = path
-				release()
+				slot.Release()
 			}
 		}()
 		go func() {
 			defer wg.Done()
 			for range iterations {
-				path, _, release, err := c.Slot("https://shared.example/repo", "main")
+				slot, err := c.Slot("https://shared.example/repo", "main")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
 				}
-				if err := c.Reset(path); err != nil {
-					t.Errorf("Reset: %v", err)
-					release()
-					return
+				if slot.Exists {
+					if err := slot.Reset(); err != nil {
+						t.Errorf("Reset: %v", err)
+						slot.Release()
+						return
+					}
 				}
-				release()
+				slot.Release()
 			}
 		}()
 	}
@@ -55,8 +56,8 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 
 // TestCache_SlotSerializesSameKey: two goroutines competing for the
 // same (url, ref) must execute their critical sections serially — the
-// second caller's exists=true observation must follow the first
-// caller's writes, not race them. Reproduces the PR-137 cross-CR slot
+// second caller's Exists=true observation must follow the first
+// caller's Commit, not race it. Reproduces the PR-137 cross-CR slot
 // collision the previous Cache mutex (which guarded only allocation)
 // allowed.
 func TestCache_SlotSerializesSameKey(t *testing.T) {
@@ -71,7 +72,7 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 	g2Start := make(chan struct{})
 	done := make(chan struct{}, 2)
 	go func() {
-		path, _, release, err := c.Slot("https://shared.example/repo", "main")
+		slot, err := c.Slot("https://shared.example/repo", "main")
 		if err != nil {
 			t.Errorf("Slot: %v", err)
 			done <- struct{}{}
@@ -81,14 +82,17 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 		// Hold until the harness has launched G2 and confirmed it is
 		// blocked on acquisition.
 		<-g2Start
-		_ = os.WriteFile(filepath.Join(path, ".inprogress"), []byte("x"), 0o600)
+		_ = os.WriteFile(filepath.Join(slot.Path, ".inprogress"), []byte("x"), 0o600)
+		if err := slot.Commit(); err != nil {
+			t.Errorf("Commit: %v", err)
+		}
 		firstReleased.Store(true)
-		release()
+		slot.Release()
 		done <- struct{}{}
 	}()
 	<-g1Entered // G1 holds the lock.
 	go func() {
-		_, exists, release, err := c.Slot("https://shared.example/repo", "main")
+		slot, err := c.Slot("https://shared.example/repo", "main")
 		if err != nil {
 			t.Errorf("Slot: %v", err)
 			done <- struct{}{}
@@ -99,10 +103,10 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 			t.Errorf("G2 acquired before G1 released — serialization failed")
 		}
 		secondAcquired.Store(true)
-		if !exists {
-			t.Errorf("expected exists=true on second acquisition after G1 wrote a file")
+		if !slot.Exists {
+			t.Errorf("expected Exists=true on second acquisition after G1 committed a file")
 		}
-		release()
+		slot.Release()
 		done <- struct{}{}
 	}()
 	// G2 has been launched and is now blocking on the slot lock. Tell
@@ -113,6 +117,136 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 	if !secondAcquired.Load() {
 		t.Errorf("G2 never acquired the slot")
 	}
+}
+
+// TestCache_SlotCommitAtomicRename validates the central atomic-rename
+// guarantee: a fetcher that writes into Path and returns without
+// calling Commit leaves the final slot absent. The NEXT Slot call
+// must observe Exists=false. Without atomic rename, a torn fetch would
+// leak its partial directory and the next call would see it as a hit.
+func TestCache_SlotCommitAtomicRename(t *testing.T) {
+	c := NewCache(t.TempDir())
+
+	// First fetcher aborts after writing partial state.
+	slot, err := c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot: %v", err)
+	}
+	if slot.Exists {
+		t.Fatal("fresh slot should be miss")
+	}
+	if err := os.WriteFile(filepath.Join(slot.Path, "partial"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	staging := slot.Path
+	slot.Release() // no Commit — staging must be wiped, final must stay absent
+
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Errorf("staging dir leaked after Release without Commit: stat err = %v", err)
+	}
+
+	// Next caller must see Exists=false.
+	slot, err = c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot 2: %v", err)
+	}
+	if slot.Exists {
+		t.Error("second Slot observed Exists=true after first fetcher aborted; atomic-rename guarantee broken")
+	}
+	slot.Release()
+}
+
+// TestCache_SlotCommitPersists validates the success path: write
+// staging, Commit, Release, next Slot observes Exists=true with the
+// committed contents at Path.
+func TestCache_SlotCommitPersists(t *testing.T) {
+	c := NewCache(t.TempDir())
+
+	slot, err := c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(slot.Path, "ok"), []byte("y"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := slot.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	committed := slot.Path
+	slot.Release()
+
+	slot, err = c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot 2: %v", err)
+	}
+	if !slot.Exists {
+		t.Error("expected Exists=true after Commit")
+	}
+	if slot.Path != committed {
+		t.Errorf("Path drift: committed %q, second-acquire %q", committed, slot.Path)
+	}
+	if _, err := os.Stat(filepath.Join(slot.Path, "ok")); err != nil {
+		t.Errorf("committed file missing: %v", err)
+	}
+	slot.Release()
+}
+
+// TestCache_SlotResetThenStage validates the reset-while-holding path
+// fetchers use when a cache-hit slot is detected as stale (e.g. cosign
+// rejected the cached digest). Reset wipes the final, Stage allocates
+// a fresh staging dir, write + Commit publishes the new contents.
+func TestCache_SlotResetThenStage(t *testing.T) {
+	c := NewCache(t.TempDir())
+
+	// Seed a committed slot.
+	slot, err := c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(slot.Path, "old"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := slot.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	slot.Release()
+
+	// Acquire again, detect stale, reset-and-restage.
+	slot, err = c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot 2: %v", err)
+	}
+	if !slot.Exists {
+		t.Fatal("expected Exists=true after seed Commit")
+	}
+	if err := slot.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	if err := slot.Stage(); err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(slot.Path, "new"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := slot.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	slot.Release()
+
+	slot, err = c.Slot("https://example.com/repo", "v1")
+	if err != nil {
+		t.Fatalf("Slot 3: %v", err)
+	}
+	if !slot.Exists {
+		t.Error("expected Exists=true after reset+stage+Commit")
+	}
+	if _, err := os.Stat(filepath.Join(slot.Path, "old")); err == nil {
+		t.Error("old contents survived Reset+Commit; expected wipe")
+	}
+	if _, err := os.Stat(filepath.Join(slot.Path, "new")); err != nil {
+		t.Errorf("new contents missing: %v", err)
+	}
+	slot.Release()
 }
 
 func TestSlugifyRepo(t *testing.T) {

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -106,28 +106,29 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		refStr = cmp.Or(manifest.GitRefString(*repo.Reference), refStr)
 	}
 
-	slot, exists, release, err := cache.Slot(repo.URL, refStr)
+	slot, err := cache.Slot(repo.URL, refStr)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", repo.URL, err)
 	}
-	defer release()
+	defer slot.Release()
 
-	if exists {
+	if slot.Exists {
 		// The flate-revision marker is written AFTER a successful
-		// clone+checkout, and survives ApplyIgnore (the caller wipes
-		// .git/ as part of source-controller-compatible artifact
-		// shaping; a `git.PlainOpen` check here would always fail on
-		// a previously-cached slot). Presence + non-empty content is
-		// enough to declare the slot valid.
-		if rev := readCachedRevision(slot); rev != "" {
+		// clone+checkout (and committed via atomic rename only after
+		// the marker write), so any committed slot will have it. A
+		// missing marker means a legacy slot from a pre-marker flate
+		// version or a hand-modified cache.
+		if rev := readCachedRevision(slot.Path); rev != "" {
 			return &store.SourceArtifact{
 				Kind: manifest.KindGitRepository,
-				URL:  repo.URL, LocalPath: slot, Revision: rev,
+				URL:  repo.URL, LocalPath: slot.Path, Revision: rev,
 			}, nil
 		}
-		// Stale slot — wipe and re-clone.
-		_ = cache.Reset(slot)
-		if err := os.MkdirAll(slot, 0o750); err != nil {
+		// Stale slot — wipe and stage a fresh clone target.
+		if err := slot.Reset(); err != nil {
+			return nil, err
+		}
+		if err := slot.Stage(); err != nil {
 			return nil, err
 		}
 	}
@@ -149,9 +150,12 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	if repo.RecurseSubmodules {
 		cloneOpts.RecurseSubmodules = git.DefaultSubmoduleRecursionDepth
 	}
-	cloned, err := git.PlainCloneContext(ctx, slot, false, cloneOpts)
+	// go-git's PlainCloneContext refuses to clone into a non-empty
+	// directory — but our staging dir IS that empty directory, so
+	// pass it directly. On any error, Release wipes staging; the
+	// final slot is never touched.
+	cloned, err := git.PlainCloneContext(ctx, slot.Path, false, cloneOpts)
 	if err != nil {
-		_ = cache.Reset(slot)
 		return nil, fmt.Errorf("clone %s: %w", url, err)
 	}
 
@@ -160,28 +164,26 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		ref = *repo.Reference
 	}
 	if err := checkoutRef(cloned, ref, repo.SparseCheckout); err != nil {
-		_ = cache.Reset(slot)
 		return nil, fmt.Errorf("checkout %s: %w", refStr, err)
 	}
 	if repo.RecurseSubmodules {
 		if err := updateSubmodules(cloned, auth); err != nil {
-			_ = cache.Reset(slot)
 			return nil, fmt.Errorf("submodules: %w", err)
 		}
 	}
 
-	rev, _ := readResolvedRevision(slot)
+	rev, _ := readResolvedRevision(slot.Path)
 	art := &store.SourceArtifact{
 		Kind: manifest.KindGitRepository,
-		URL:  repo.URL, LocalPath: slot, Revision: rev,
+		URL:  repo.URL, LocalPath: slot.Path, Revision: rev,
 	}
-	// Post-clone work — verification, ignore, marker — runs under the
-	// slot lock so a sibling Fetcher of the same (url, ref) can't race
-	// our writes or our error-path cache.Reset.
 	if err := f.finalize(repo, art); err != nil {
-		_ = cache.Reset(slot)
 		return nil, err
 	}
+	if err := slot.Commit(); err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
+	}
+	art.LocalPath = slot.Path
 	return art, nil
 }
 

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -215,71 +215,65 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	}
 
 	versioned := versionedURL(repo.URL, ref)
-	slot, exists, release, err := cache.Slot(versioned, "")
+	slot, err := cache.Slot(versioned, "")
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
-	defer release()
-	if exists {
-		cachedDigest := readCachedDigest(slot)
+	defer slot.Release()
+	if slot.Exists {
+		cachedDigest := readCachedDigest(slot.Path)
 		// `.flate-digest` is written as the FINAL step of a successful
-		// fetch, so its absence on a non-empty slot signals a crashed
-		// or aborted prior run that left partial blobs/ layout behind.
-		// (Slot.exists returns true on ANY non-empty dir.) Without
-		// this guard, the next fetch silently serves the corrupt
-		// slot as a cache hit. Fall through to a fresh pull.
-		//
-		// The previous `ref.Digest` fallback (treating a missing
-		// marker as "trusted because the spec pinned a digest") was
-		// load-bearing only on the legacy spec-pin code path that no
-		// longer exists — every successful fetch since the marker
-		// was introduced writes `.flate-digest`. Keeping the
-		// fallback meant a spec.ref.digest-pinned OCIRepository
-		// whose prior fetch died after extract but before marker
-		// write would silently serve a partially-extracted slot.
-		// Always require the marker.
+		// fetch (and the slot is committed via atomic rename only after
+		// that write), so its absence in a slot that has a final
+		// directory means the slot was committed from a pre-marker
+		// flate version or someone hand-modified the cache. Either way,
+		// reset and re-fetch.
 		if cachedDigest == "" {
-			_ = cache.Reset(slot)
-			exists = false
-		}
-		// Defensive: a valid `.flate-digest` should imply
-		// applyLayerSelector ran to completion and wiped the OCI
-		// Image Layout artifacts (blobs/, ingest/, oci-layout,
-		// index.json). If any of those still exist, the slot is in
-		// an inconsistent state — either an older flate version
-		// wrote `.flate-digest` before the cleanup, a concurrent
-		// process clobbered the layer.tar.gz after the marker
-		// landed, or the slot was hand-modified. Trusting the marker
-		// in that state produces the user-visible "OCIRepository
-		// artifact has neither Chart.yaml, layer.tar.gz, nor a
-		// <name>/Chart.yaml subdir" error every run. Reset so the
-		// next pull rebuilds the slot cleanly.
-		if exists && hasUnfinishedOCILayout(slot) {
+			if err := slot.Reset(); err != nil {
+				return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
+			}
+		} else if hasUnfinishedOCILayout(slot.Path) {
+			// Defensive: a valid `.flate-digest` should imply
+			// applyLayerSelector ran to completion and wiped the OCI
+			// Image Layout artifacts. Atomic-rename makes this much
+			// less likely (a crashed run never publishes a final
+			// slot), but legacy slots from older flate versions or
+			// hand-modifications can still trip this. Reset so the
+			// next pull rebuilds the slot cleanly.
 			slog.Warn("oci: cache slot has leftover OCI Image Layout artifacts; resetting and re-fetching",
-				"slot", slot, "url", versioned)
-			_ = cache.Reset(slot)
-			exists = false
-		}
-		// When verification is configured, re-verify the cached digest
-		// against the registry. Cheap (one metadata fetch) and closes the
-		// gap where a slot was populated under a prior policy.
-		if exists && repo.Verify != nil {
+				"slot", slot.Path, "url", versioned)
+			if err := slot.Reset(); err != nil {
+				return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
+			}
+		} else if repo.Verify != nil {
+			// When verification is configured, re-verify the cached
+			// digest against the registry. Cheap (one metadata fetch)
+			// and closes the gap where a slot was populated under a
+			// prior policy.
 			if err := f.verifyCosignSignature(ctx, repoClient, repo, cachedDigest); err != nil {
-				// Cosign rejected the cached bytes. Without resetting, the
-				// next reconcile re-hits the same poisoned slot and fails
-				// verify identically — a hard-to-debug repeated failure.
-				// Reset so a fresh pull is attempted.
-				_ = cache.Reset(slot)
+				// Cosign rejected the cached bytes. Without
+				// resetting, the next reconcile re-hits the same
+				// poisoned slot and fails verify identically.
+				_ = slot.Reset()
 				return nil, err
 			}
-		}
-		if exists {
 			return &store.SourceArtifact{
 				Kind: manifest.KindOCIRepository,
-				URL:  repo.URL, LocalPath: slot,
+				URL:  repo.URL, LocalPath: slot.Path,
 				Revision: ociRevision(ref, cachedDigest),
 				Digest:   cachedDigest,
 			}, nil
+		} else {
+			return &store.SourceArtifact{
+				Kind: manifest.KindOCIRepository,
+				URL:  repo.URL, LocalPath: slot.Path,
+				Revision: ociRevision(ref, cachedDigest),
+				Digest:   cachedDigest,
+			}, nil
+		}
+		// Either reset-then-stage path falls through to a fresh pull.
+		if err := slot.Stage(); err != nil {
+			return nil, fmt.Errorf("cache stage for %s: %w", versioned, err)
 		}
 	}
 
@@ -290,23 +284,16 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	// no longer need a custom fallback to keep unnamed blobs on disk.
 	// applyLayerSelector reads from the same standard layout and wipes
 	// it after extracting the selected layer.
-	dest, err := orasoci.New(slot)
+	//
+	// Writes go to slot.Path which is the staging dir at this point;
+	// on success slot.Commit() atomic-renames it over the final slot.
+	// Any error path returns without committing, and Release wipes
+	// the staging dir — the final slot stays absent / unchanged,
+	// never torn.
+	dest, err := orasoci.New(slot.Path)
 	if err != nil {
 		return nil, fmt.Errorf("oras oci store: %w", err)
 	}
-	// content/oci.Store has no Close() method — all writes flush
-	// synchronously per blob via os.Rename — so reset-on-error is
-	// the only cleanup we need. Deferred + flag pattern (instead of
-	// per-error-site closure calls) so a panic between oras.Copy
-	// and writeCachedDigest also wipes the torn slot. Set finalized
-	// to true at the END of the fetch, right before returning the
-	// SourceArtifact.
-	finalized := false
-	defer func() {
-		if !finalized {
-			_ = cache.Reset(slot)
-		}
-	}()
 
 	desc, err := oras.Copy(ctx, repoClient, tag, dest, tag, oras.DefaultCopyOptions)
 	if err != nil {
@@ -319,7 +306,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 			return nil, err
 		}
 	}
-	if err := applyLayerSelector(ctx, slot, desc.Digest.String(), repo.LayerSelector); err != nil {
+	if err := applyLayerSelector(ctx, slot.Path, desc.Digest.String(), repo.LayerSelector); err != nil {
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
 	// Source-controller's default ignore set includes `*.tar.gz`. For
@@ -329,24 +316,24 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	// extract the slot holds the extracted directory tree and the
 	// ignore semantics apply as Flux ships them.
 	if effectiveLayerOperation(repo.LayerSelector) == manifest.OCILayerOperationExtract {
-		if err := source.ApplyIgnore(slot, repo.Ignore); err != nil {
+		if err := source.ApplyIgnore(slot.Path, repo.Ignore); err != nil {
 			return nil, fmt.Errorf("OCIRepository %s/%s: %w", repo.Namespace, repo.Name, err)
 		}
 	}
-	// Persist the resolved digest so a subsequent cache hit can
-	// re-verify against the exact bytes we wrote, even when the spec
-	// pinned only a tag. A write failure isn't fatal — the next fetch
-	// just falls through to a fresh pull — but it does silently weaken
-	// spec.verify on cache hits, so log it.
-	if err := writeCachedDigest(slot, digest); err != nil {
-		slog.Warn("oci: failed to persist cached digest",
-			"ociRepository", repo.Namespace+"/"+repo.Name,
-			"err", err)
+	if err := writeCachedDigest(slot.Path, digest); err != nil {
+		// A write failure here is fatal — without it the next fetch
+		// would treat the committed slot as having "no marker" and
+		// reset+re-pull on every reconcile. Returning the error
+		// (and skipping Commit) means the staging dir is wiped by
+		// Release and the next run starts clean.
+		return nil, fmt.Errorf("OCIRepository %s/%s: persist cached digest: %w", repo.Namespace, repo.Name, err)
 	}
-	finalized = true
+	if err := slot.Commit(); err != nil {
+		return nil, fmt.Errorf("OCIRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
+	}
 	return &store.SourceArtifact{
 		Kind: manifest.KindOCIRepository,
-		URL:  repo.URL, LocalPath: slot,
+		URL:  repo.URL, LocalPath: slot.Path,
 		Revision: ociRevision(ref, digest),
 		Digest:   digest,
 		Size:     desc.Size,


### PR DESCRIPTION
## Summary

The big-lift refactor of the artifact rendering pipeline. Replaces the "write in place + sentinel marker" cache slot protocol with atomic-rename staging.

- A `Slot` returned by `Cache.Slot` has its `Path` set to a sibling staging directory on miss; the fetcher writes there and calls `Commit()` to atomic-rename over the final slot.
- Any error path returns without committing; `Release()` wipes the orphan staging dir on the way out. The final slot is either complete or absent — never torn.
- OCI / Git / Bucket fetchers migrated; the OCI `finalized` flag dance and the bucket `Reset + MkdirAll` dance both collapse into the new API.
- `.flate-digest` / `.flate-git-revision` markers are kept (still needed to record the resolved digest / revision for cosign re-verify on cache hit), but `hasUnfinishedOCILayout` is now defensive-only — a committed slot can no longer have leftover layout artifacts because Commit runs after layout cleanup.

This subsumes the audit findings B1–B4 + F3 from the prior batches: the recovery sentinels (`.flate-digest` absence on a non-empty slot, leftover `blobs/`, leftover staged layer) are still detected on the cache-hit path for legacy caches, but they cannot be produced by a new fetcher anymore.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `go test -race ./...`
- [x] New cache tests pin the central guarantees:
  - `TestCache_SlotCommitAtomicRename` — abort without Commit must leave final slot absent
  - `TestCache_SlotCommitPersists` — success path publishes Path → Exists on next acquire
  - `TestCache_SlotResetThenStage` — stale cache hit reset-and-restage path used by OCI cosign / git stale-marker recovery
- [x] Existing `TestFetcher_PartialSlotInvalidated` continues to pass — the recovery semantics for legacy / hand-modified caches are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)