### PR TITLE
fix(depwait,task): event-driven quiescence + missed-wake + cache + stack

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -2,6 +2,7 @@ package depwait
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/google/cel-go/cel"
@@ -13,14 +14,27 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// celCache memoizes compiled CEL programs keyed by their source text.
+// celCache memoizes compileReadyExpr results keyed by source text.
 // dependsOn typically references the same expression many times (one
 // per consumer), so compiling once per process saves the parse + check
-// pass that cel-go does internally.
-var (
-	celCacheMu sync.Mutex
-	celCache   = map[string]cel.Program{}
-)
+// pass that cel-go does internally. The cache also memoizes *errors*
+// so a malformed expression doesn't recompile on every fire of
+// watchReadyExpr — every re-evaluation against a known-bad expression
+// reuses the cached error.
+//
+// sync.Map (rather than map+Mutex) was chosen because the cache is
+// read-heavy and rarely-mutated: thousands of evaluations against a
+// stable corpus of a few dozen expressions. sync.Map's read path is
+// lock-free for hits, which removes the per-evaluation Mutex
+// contention multiple parallel waiters previously paid.
+var celCache sync.Map // map[string]celCacheEntry
+
+// celCacheEntry caches one of (program, error). Exactly one field is
+// non-nil; readers branch on err first.
+type celCacheEntry struct {
+	prog cel.Program
+	err  error
+}
 
 // celEnv is the singleton CEL environment used by all ReadyExpr
 // evaluations. The declared variables `self` and `dep` mirror what
@@ -63,21 +77,29 @@ func evaluateReadyExpr(expr string, s *store.Store, self, dep manifest.NamedReso
 }
 
 func compileReadyExpr(expr string) (cel.Program, error) {
-	celCacheMu.Lock()
-	defer celCacheMu.Unlock()
-	if prog, ok := celCache[expr]; ok {
-		return prog, nil
+	if v, ok := celCache.Load(expr); ok {
+		e := v.(celCacheEntry)
+		return e.prog, e.err
 	}
+	entry := celCacheEntry{}
 	ast, issues := celEnv.Compile(expr)
 	if issues != nil && issues.Err() != nil {
-		return nil, fmt.Errorf("compile: %w", issues.Err())
+		entry.err = fmt.Errorf("compile: %w", issues.Err())
+	} else {
+		prog, err := celEnv.Program(ast)
+		if err != nil {
+			entry.err = fmt.Errorf("program: %w", err)
+		} else {
+			entry.prog = prog
+		}
 	}
-	prog, err := celEnv.Program(ast)
-	if err != nil {
-		return nil, fmt.Errorf("program: %w", err)
-	}
-	celCache[expr] = prog
-	return prog, nil
+	// LoadOrStore: a concurrent compile of the same expr both lose
+	// races; the loser's prog/err is discarded and we return the
+	// winner's. cel-go's compilation is deterministic so the two
+	// results are equivalent.
+	actual, _ := celCache.LoadOrStore(expr, entry)
+	e := actual.(celCacheEntry)
+	return e.prog, e.err
 }
 
 // projectObject builds the unstructured-shaped value the CEL
@@ -102,6 +124,18 @@ func projectObject(s *store.Store, id manifest.NamedResource) map[string]any {
 	// the mixed snapshot can render a false positive/negative until
 	// the next event triggers re-evaluation.
 	obj, conds := s.Snapshot(id)
+	if obj == nil {
+		// Status entry without an object — only the metadata/status
+		// derived from id is reachable; labels and annotations are
+		// absent. A CEL expression like dep.metadata.labels['x']
+		// evaluating against this view sees no labels (has() returns
+		// false), which is correct: the dep isn't fully visible yet.
+		// Logged at Debug so an operator chasing a "readyExpr never
+		// satisfied" can see whether the dep had reached the store as
+		// an object or only as a phantom status entry.
+		slog.Debug("depwait: projectObject sees status without object",
+			"id", id.String())
+	}
 	condsAny := make([]any, 0, len(conds))
 	for _, c := range conds {
 		condsAny = append(condsAny, conditionToMap(c))

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -185,6 +186,15 @@ type RenderInflight interface {
 	// body, so the caller's goroutine is counted; OtherActive
 	// returns true iff the total active count exceeds 1.
 	OtherActive() bool
+
+	// QuiescenceCh returns a channel closed when the pool drains to
+	// "no other work in flight" — the event-driven counterpart of
+	// OtherActive that lets waitRenderEmission select on the
+	// quiescence signal instead of polling. Each call returns a
+	// fresh channel; callers Receive once. Implementations that
+	// can't deliver an event-driven signal may return a nil channel,
+	// in which case waitRenderEmission falls back to the legacy poll.
+	QuiescenceCh() <-chan struct{}
 }
 
 // Watch concurrently watches each dep and returns a channel of Events.
@@ -234,10 +244,19 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 // safeWatchOne wraps watchOne with panic recovery — a malformed CEL
 // ReadyExpr (or any other internal bug) reports the dep as failed
 // instead of taking the orchestrator down with it.
+//
+// The recovered panic is logged with its goroutine stack so the
+// reporter can attribute "depwait panic: ..." failures to a concrete
+// site (CEL projection panicking against a malformed Snapshot, a
+// nil-typed assertion in labelsAndAnnotations, etc.). Without the
+// stack the panic message alone is often opaque.
 func safeWatchOne(ctx context.Context, w *Waiter, dep manifest.DependencyRef, timeout time.Duration) (ev Event) {
 	defer func() {
 		if r := recover(); r != nil {
-			slog.Error("depwait: panic in watchOne", "dep", dep.String(), "panic", r)
+			slog.Error("depwait: panic in watchOne",
+				"dep", dep.String(),
+				"panic", r,
+				"stack", string(debug.Stack()))
 			ev = Event{
 				Dep:    dep.NamedResource,
 				Status: DepFailed,
@@ -351,24 +370,31 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 
 // watchReadyExpr evaluates expr against id's projected state and
 // returns DepReady when it produces true. On false / eval error it
-// blocks on the next EventStatusUpdated for id and re-evaluates.
-// Surfaces the parent ctx's timeout/cancel.
+// blocks on the next wake — fired by EITHER an EventStatusUpdated or
+// an EventObjectAdded for id — and re-evaluates.
+//
+// Subscribing to both events closes a wedge class: CEL exprs commonly
+// read `dep.metadata.labels[...]` (a property of the *object*, not
+// status), and an AddObject that lands new labels without a paired
+// SetCondition fires only EventObjectAdded. Without that subscription
+// the waiter would miss the wake and ride the per-dep timeout. For
+// kinds that emit both events on every reconcile this is harmless
+// (the chan is wake-only with a buffer-1 coalesce).
 //
 // The eval pattern runs three times — pre-subscribe (initial),
-// post-subscribe (race window between subscribe and live event),
-// and on each fire — so the evaluate-and-translate-to-Event step is
+// post-subscribe (race window between subscribe and live event), and
+// on each fire — so the evaluate-and-translate-to-Event step is
 // extracted into tryReadyExpr to keep the control flow readable.
 func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, expr string) Event {
 	if ev, done := w.tryReadyExpr(expr, id); done {
 		return ev
 	}
 
-	// Subscribe AFTER the initial eval, then re-check — closes the
-	// race where id flipped Ready between the first eval and the
-	// subscribe (we'd otherwise miss the EventStatusUpdated and
-	// block on the channel forever).
+	// One channel, two listeners — every wake re-evaluates against
+	// the latest store state. Coalesced via buffer-1 + default-send
+	// so a burst of events doesn't queue redundant evaluations.
 	ch := make(chan struct{}, 1)
-	unsub := w.Store.AddListener(store.EventStatusUpdated, func(other manifest.NamedResource, _ any) {
+	wake := func(other manifest.NamedResource, _ any) {
 		if other != id {
 			return
 		}
@@ -376,8 +402,15 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 		case ch <- struct{}{}:
 		default:
 		}
-	}, false)
-	defer unsub()
+	}
+	unsubStatus := w.Store.AddListener(store.EventStatusUpdated, wake, false)
+	defer unsubStatus()
+	unsubObject := w.Store.AddListener(store.EventObjectAdded, wake, false)
+	defer unsubObject()
+
+	// Close the subscribe-vs-fire race window: an event that landed
+	// between the initial tryReadyExpr and AddListener would otherwise
+	// be missed.
 	if ev, done := w.tryReadyExpr(expr, id); done {
 		return ev
 	}
@@ -431,13 +464,19 @@ var errRenderDrained = errors.New("render pool drained without emission")
 //
 //   - Store.EventObjectAdded fires for id → returns nil (caller
 //     falls through to the regular Ready wait).
-//   - Renders.OtherActive() flips to false → returns errRenderDrained
-//     (no future emission could produce id; caller fails fast).
+//   - Renders.QuiescenceCh closes (the event-driven counterpart of
+//     OtherActive) → returns errRenderDrained (no future emission
+//     could produce id; caller fails fast).
 //   - ctx hits its deadline / cancellation → returns ctx.Err().
 //
 // An overall cap of RenderProducingTimeout is layered onto ctx so
 // the wait can't run past it even when Renders is nil (legacy
 // embedders without a task pool).
+//
+// The previous implementation polled OtherActive every 100ms. With
+// N concurrent waiters during a render that's N×10 wakes/sec doing
+// nothing useful most of the time; the quiescence channel replaces
+// the poll with one event per drain.
 func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResource) error {
 	renderCtx, renderCancel := context.WithTimeout(ctx, RenderProducingTimeout)
 	defer renderCancel()
@@ -459,27 +498,29 @@ func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResour
 		return nil
 	}
 
-	// Polling cadence for the RenderInflight quiescence check. 100ms
-	// keeps drain detection responsive without burning CPU on tight
-	// loops; the typo case fails within ~100ms of the orchestrator's
-	// last reconcile finishing.
-	const pollInterval = 100 * time.Millisecond
-	poll := time.NewTicker(pollInterval)
-	defer poll.Stop()
+	// quiesce is a one-shot signal channel. A nil channel selects
+	// never, so embedders without a Renders wired (legacy callers)
+	// fall back to "wait for arrived or ctx" exactly as before.
+	var quiesce <-chan struct{}
+	if w.Renders != nil {
+		quiesce = w.Renders.QuiescenceCh()
+	}
 
 	for {
 		select {
 		case <-arrived:
 			return nil
-		case <-renderCtx.Done():
-			return renderCtx.Err()
-		case <-poll.C:
+		case <-quiesce:
+			// Quiescence: no other reconcile in the pool is doing
+			// work. Re-check arrived once in case the AddObject
+			// landed in the same scheduler tick as the drain; if
+			// the dep isn't here, no future emission can produce it.
 			if w.depExists(id) {
 				return nil
 			}
-			if w.Renders != nil && !w.Renders.OtherActive() {
-				return errRenderDrained
-			}
+			return errRenderDrained
+		case <-renderCtx.Done():
+			return renderCtx.Err()
 		}
 	}
 }

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -44,10 +44,11 @@ func (l lookupStub) IsFileIndexed(id manifest.NamedResource) bool {
 	return l.fileIndexed(id)
 }
 
-// rendersStub satisfies RenderInflight from an inline closure so
-// tests can pin the OtherActive() flip behavior precisely.
+// rendersStub satisfies RenderInflight from inline closures so tests
+// can pin the OtherActive / QuiescenceCh behavior precisely.
 type rendersStub struct {
 	otherActive func() bool
+	quiesce     func() <-chan struct{}
 }
 
 func (r rendersStub) OtherActive() bool {
@@ -55,6 +56,22 @@ func (r rendersStub) OtherActive() bool {
 		return false
 	}
 	return r.otherActive()
+}
+
+// QuiescenceCh returns a channel matching otherActive: closed when
+// otherActive returns false (drained), open otherwise. Returning nil
+// when no quiesce closure is wired exercises the "fall back to ctx
+// deadline" path in waitRenderEmission.
+func (r rendersStub) QuiescenceCh() <-chan struct{} {
+	if r.quiesce != nil {
+		return r.quiesce()
+	}
+	if r.otherActive != nil && !r.otherActive() {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return nil
 }
 
 func TestWaiter_AllReady(t *testing.T) {
@@ -491,6 +508,84 @@ func TestWaiter_PanicReportedAsFailed(t *testing.T) {
 	}
 	if msg := sum.Messages[dep]; !strings.Contains(msg, "depwait panic:") {
 		t.Errorf("expected 'depwait panic:' prefix, got %q", msg)
+	}
+}
+
+// TestWaiter_ReadyExprWakesOnObjectAdded pins the EventObjectAdded
+// subscription added alongside EventStatusUpdated in watchReadyExpr.
+// A CEL expression like `dep.metadata.labels['ready'] == 'true'`
+// depends on labels on the OBJECT, not on its status. If the labels
+// land via AddObject without a paired SetCondition, the watcher
+// previously missed the event and wedged until the per-dep timeout.
+//
+// We reproduce the wedge condition by adding the dep with the
+// required label fields AFTER the watcher subscribes, with no
+// status update at any point; the wait must return DepReady well
+// before the timeout.
+func TestWaiter_ReadyExprWakesOnObjectAdded(t *testing.T) {
+	s := store.New()
+	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "r"}
+
+	w := &Waiter{Store: s, Timeout: 3 * time.Second}
+
+	// Pre-seed status so the existence grace short-circuits and the
+	// watcher enters watchReadyExpr immediately. Status is Pending,
+	// so the built-in WatchReady would block — but the ReadyExpr
+	// path replaces that check.
+	s.UpdateStatus(id, store.StatusPending, "")
+
+	// Use a has()-guarded expression so the initial eval against a
+	// status-only projection (no object yet) doesn't error on the
+	// missing labels map — it returns false and the watcher blocks
+	// waiting for an event. The bug being pinned is that the wake
+	// MUST come via EventObjectAdded (the AddObject below), since
+	// no SetCondition fires.
+	dep := manifest.DependencyRef{
+		NamedResource: id,
+		ReadyExpr:     `has(dep.metadata.labels) && dep.metadata.labels['ready'] == 'true'`,
+	}
+
+	// Start the wait, then asynchronously AddObject with the
+	// expected label after a short delay. No SetCondition fires —
+	// the only wake source is EventObjectAdded.
+	done := make(chan Summary, 1)
+	go func() {
+		done <- WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{dep}))
+	}()
+	// Sleep long enough that the watcher has subscribed; longer than
+	// scheduler jitter, much shorter than the per-dep timeout.
+	time.Sleep(50 * time.Millisecond)
+	hr := &manifest.HelmRelease{Name: id.Name, Namespace: id.Namespace}
+	hr.Labels = map[string]string{"ready": "true"}
+	s.AddObject(hr)
+
+	select {
+	case sum := <-done:
+		if sum.AnyFailed() || !sum.AllReady() {
+			t.Fatalf("expected ready; got %+v", sum)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("watchReadyExpr wedged — missed EventObjectAdded wake")
+	}
+}
+
+// TestCompileReadyExpr_MemoizesErrors pins the compile-error cache:
+// a known-bad expression should not recompile (and re-error) on
+// every fire. We compile twice and assert both calls return the
+// same error instance — sync.Map.LoadOrStore guarantees pointer
+// identity for the cached entry.
+func TestCompileReadyExpr_MemoizesErrors(t *testing.T) {
+	const bad = `this is not valid CEL ((` // unclosed paren = compile error
+	_, err1 := compileReadyExpr(bad)
+	if err1 == nil {
+		t.Fatal("expected compile error")
+	}
+	_, err2 := compileReadyExpr(bad)
+	if err2 == nil {
+		t.Fatal("expected error on second call")
+	}
+	if err1 != err2 {
+		t.Errorf("compile error not memoized: %p vs %p", err1, err2)
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -496,6 +496,15 @@ func (r *orchestratorRenderInflight) OtherActive() bool {
 	return r.tasks.ActiveCount() > 1
 }
 
+// QuiescenceCh delegates to task.Service.QuiescenceCh(1). The
+// threshold matches OtherActive's "> 1" check: the caller's own
+// goroutine is one slot, so a drain to <= 1 means no other reconcile
+// is running. depwait's waitRenderEmission selects on this channel
+// instead of polling OtherActive.
+func (r *orchestratorRenderInflight) QuiescenceCh() <-chan struct{} {
+	return r.tasks.QuiescenceCh(1)
+}
+
 // Run starts every controller, blocks until the task service drains,
 // then aggregates and returns any failures. The post-drain reporting
 // + error-string assembly lives in finalize so Run reads as a clean

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -27,6 +27,19 @@ type Service struct {
 	//
 	// nil = unbounded (every Go runs in parallel). Set via NewBounded.
 	sem chan struct{}
+
+	// quiesceMu guards quiesceWaiters. Acquired only on Go/Done and
+	// QuiescenceCh; never inside fn. The waiter list is small and
+	// short-lived (one entry per depwait waitRenderEmission call).
+	quiesceMu      sync.Mutex
+	quiesceWaiters []quiesceWaiter
+}
+
+// quiesceWaiter pairs a threshold with the channel to close when the
+// active count drops to <= threshold.
+type quiesceWaiter struct {
+	threshold int64
+	ch        chan struct{}
 }
 
 // New constructs a fresh Service with unbounded concurrency.
@@ -59,7 +72,7 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 	s.wgActive.Add(1)
 	go func() {
 		defer s.wgActive.Done()
-		defer s.active.Add(-1)
+		defer s.taskDone()
 		defer func() {
 			if r := recover(); r != nil {
 				s.failures.Add(1)
@@ -76,6 +89,51 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 		}
 		fn(ctx)
 	}()
+}
+
+// taskDone decrements active and notifies any quiescence waiters
+// whose threshold the new count satisfies. Called via defer from
+// Go's body so panics and clean returns both fire it.
+func (s *Service) taskDone() {
+	now := s.active.Add(-1)
+	s.quiesceMu.Lock()
+	if len(s.quiesceWaiters) == 0 {
+		s.quiesceMu.Unlock()
+		return
+	}
+	kept := s.quiesceWaiters[:0]
+	for _, w := range s.quiesceWaiters {
+		if now <= w.threshold {
+			close(w.ch)
+			continue
+		}
+		kept = append(kept, w)
+	}
+	s.quiesceWaiters = kept
+	s.quiesceMu.Unlock()
+}
+
+// QuiescenceCh returns a channel closed when ActiveCount drops to
+// <= threshold. The channel is fresh per call; callers waiting on
+// distinct thresholds work independently. When ActiveCount is
+// already <= threshold at call time, the channel is returned closed.
+//
+// Used by depwait's render-emission wait to fire the moment no other
+// reconcile is in flight, instead of polling every 100ms. The
+// orchestrator drains exactly once per run, so a successful
+// quiescence signal is a one-shot event.
+func (s *Service) QuiescenceCh(threshold int64) <-chan struct{} {
+	ch := make(chan struct{})
+	s.quiesceMu.Lock()
+	defer s.quiesceMu.Unlock()
+	// Re-read active under quiesceMu so we don't race a concurrent
+	// taskDone that already closed waiters at the current threshold.
+	if s.active.Load() <= threshold {
+		close(ch)
+		return ch
+	}
+	s.quiesceWaiters = append(s.quiesceWaiters, quiesceWaiter{threshold: threshold, ch: ch})
+	return ch
 }
 
 // YieldSlot releases the worker-pool slot held by the current goroutine,


### PR DESCRIPTION
## Summary

PR 3 of 10. Five depwait fixes from the audit; one additive method on \`RenderInflight\`.

- **8.1 watchReadyExpr wakes on EventObjectAdded too** — fixes the wedge class where a readyExpr inspects \`dep.metadata.labels[...]\` and the labels land via AddObject without a paired SetCondition.
- **8.4 celCache: sync.Map + compile-error memoization** — read-heavy cache no longer contends on Mutex for hits; known-bad expressions don't recompile on every fire.
- **8.5 waitRenderEmission drops the 100ms poll** — new \`task.Service.QuiescenceCh(threshold)\` returns a one-shot channel closed when ActiveCount drops. depwait selects on it instead of polling. Legacy embedders returning a nil channel fall back to the ctx-deadline path.
- **8.6 safeWatchOne logs the goroutine stack** — recovered panics now attach \`runtime/debug.Stack()\`.
- **8.8 projectObject Debug-logs status-without-object** — operator visibility for missing-labels-yet vs labels-don't-match.

The new \`QuiescenceCh\` is the only interface change. The orchestrator's existing \`orchestratorRenderInflight\` adapter implements it by delegating to \`task.Service.QuiescenceCh(1)\` (matching the OtherActive "> 1" threshold).

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestWaiter_ReadyExprWakesOnObjectAdded\` — pins 8.1; would wedge before the fix
- [x] New \`TestCompileReadyExpr_MemoizesErrors\` — pins 8.4 error memoization
- [x] Existing \`TestWaiter_RenderInflightDrainShortCircuits\` continues to pass on the event-driven path

🤖 Generated with [Claude Code](https://claude.com/claude-code)