### PR TITLE
fix(kustomize): yaml.Node edit + stage-root lock + cancel-safe FetchRemote

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -17,10 +17,24 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-// pathLocks serialize concurrent renders against the same staged path —
-// Flux's Generator mutates kustomization.yaml in place, so parallel
-// builds against the same path race.
-var pathLocks = keylock.New[string]()
+// stageLocks serialize concurrent RenderFlux calls that share a
+// staged tree. The lock is keyed by the stage ROOT (one per source
+// directory), not the subPath, because Flux's Generator writes
+// kustomization.yaml at stagedSub AND SecureBuild walks downward
+// from stagedSub reading nested kustomization.yaml files. When two
+// calls hold ancestor/descendant subPaths under the same staged tree
+// — common in repos with a root KS that traverses nested apps — A's
+// SecureBuild reads B's kustomization.yaml mid-write. The per-subPath
+// locking that existed before couldn't see the overlap and produced
+// intermittent "patches accumulated" / wrong-rendered output that
+// disappeared on retry.
+//
+// The cost is reduced render parallelism within a single source
+// tree: KSes sharing a sourceRoot now serialize. For repos with a
+// single cluster root this is the bulk of renders. Sibling subPaths
+// that could otherwise have run in parallel are now sequenced.
+// Correctness is the priority — the previous parallelism was incorrect.
+var stageLocks = keylock.New[string]()
 
 // RenderFlux renders a Flux kustomize.toolkit.fluxcd.io Kustomization
 // using the same library that Flux's kustomize-controller uses
@@ -78,12 +92,10 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, subPath st
 		return nil, err
 	}
 
-	// Serialize concurrent reconciles of the same path. Flux's
-	// Generator merges patches / images / components into the
-	// kustomization file at the staged path — restoring the source
-	// baseline + writing the Generator output must happen atomically
-	// per Kustomization. ctx cancellation interrupts the acquire.
-	release, err := pathLocks.Acquire(ctx, stagedSub)
+	// Serialize concurrent reconciles within the same staged tree.
+	// See stageLocks docstring for why this is the stage root and
+	// not stagedSub. ctx cancellation interrupts the acquire.
+	release, err := stageLocks.Acquire(ctx, staged)
 	if err != nil {
 		return nil, err
 	}
@@ -232,6 +244,12 @@ func stringMap(v any) map[string]string {
 // any) over the staged one so each Flux Generator run sees a clean
 // baseline. A no-op when the source has none — Generator will create
 // one from scratch.
+//
+// Surfaces os.Remove errors via errors.Join: a failed remove leaves
+// two kustomization variants in stagedSub, which makes SecureBuild's
+// readdir-order-dependent precedence non-deterministic. Symptom is
+// repeat reconciles producing different output. fs.ErrNotExist is
+// the expected miss and is filtered.
 func restoreKustomizationFile(sourceRoot, stagedSub, subPath string) error {
 	srcDir := filepath.Join(sourceRoot, subPath)
 	for _, name := range kustomizationFilenames {
@@ -246,19 +264,29 @@ func restoreKustomizationFile(sourceRoot, stagedSub, subPath string) error {
 		}
 		// Remove every other variant from the stage so Generator
 		// writes to the canonical filename.
+		var rmErrs []error
 		for _, other := range kustomizationFilenames {
-			if other != name {
-				_ = os.Remove(filepath.Join(stagedSub, other))
+			if other == name {
+				continue
+			}
+			if err := os.Remove(filepath.Join(stagedSub, other)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				rmErrs = append(rmErrs, fmt.Errorf("remove staged %s: %w", other, err))
 			}
 		}
-		return os.WriteFile(filepath.Join(stagedSub, name), data, info.Mode().Perm()) //nolint:gosec // stagedSub is our own tempdir
+		if err := os.WriteFile(filepath.Join(stagedSub, name), data, info.Mode().Perm()); err != nil { //nolint:gosec // stagedSub is our own tempdir
+			rmErrs = append(rmErrs, fmt.Errorf("write staged %s: %w", name, err))
+		}
+		return errors.Join(rmErrs...)
 	}
 	// No source kustomization.yaml — remove any stale staged copy
 	// so Generator starts cleanly.
+	var rmErrs []error
 	for _, name := range kustomizationFilenames {
-		_ = os.Remove(filepath.Join(stagedSub, name))
+		if err := os.Remove(filepath.Join(stagedSub, name)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			rmErrs = append(rmErrs, fmt.Errorf("remove staged %s: %w", name, err))
+		}
 	}
-	return nil
+	return errors.Join(rmErrs...)
 }
 
 // kustomizationFilenames is the canonical set kustomize looks for

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -74,57 +74,89 @@ func preflightRemoteResources(ctx context.Context, cache *StagingCache, root str
 	})
 }
 
-// rewriteURLResources rewrites URL entries in one kustomization file.
-// Reads the file as a generic YAML doc to preserve unknown fields,
-// rewrites the resources list, writes the file back. Returns the
-// first URL fetch failure encountered so the caller can fail the
-// Kustomization's reconcile rather than silently dropping the
-// missing resource.
+// rewriteURLResources rewrites URL entries in one kustomization file
+// via yaml.Node node-level editing. Previous implementations decoded
+// to map[string]any and re-marshaled, which round-tripped destroyed
+// YAML comments, key ordering, anchors/aliases, and block-vs-flow
+// distinctions — any downstream diff against the staged tree saw
+// noise unrelated to a user's edit, and re-marshal of map-decoded
+// values changed scalar quoting in ways kustomize can interpret
+// differently.
+//
+// Node-level editing modifies ONLY the resources sequence entries
+// that match HTTP/HTTPS URLs; every other byte in the file (comments,
+// other-key ordering, anchors) survives the round-trip intact.
+//
+// Returns the first URL fetch failure encountered so the caller can
+// fail the Kustomization's reconcile rather than silently dropping
+// the missing resource.
 func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string) error {
 	body, err := os.ReadFile(ksFile) //nolint:gosec // ksFile is a tree-walk result under our staged copy
 	if err != nil {
 		return err
 	}
-	var doc map[string]any
+	var doc yaml.Node
 	if err := yaml.Unmarshal(body, &doc); err != nil {
 		// Some kustomization files use unusual shapes (YAML anchors,
-		// strict-mode fields) that our generic decode can't round-trip.
-		// Skip them silently — kustomize will load them via its own
-		// parser, and if any of those carry URL resources we fall back
-		// to kustomize's HTTP-then-git path. Better to render imperfectly
-		// than fail loud on a doc kustomize itself handles.
+		// strict-mode fields) that decode can't handle. Skip silently
+		// — kustomize will load them via its own parser, and if any
+		// carry URL resources we fall back to kustomize's
+		// HTTP-then-git path. Better to render imperfectly than fail
+		// loud on a doc kustomize itself handles.
 		return nil
 	}
-	rawRes, _ := doc["resources"].([]any)
-	if len(rawRes) == 0 {
+	resourcesNode := findMappingValue(&doc, "resources")
+	if resourcesNode == nil || resourcesNode.Kind != yaml.SequenceNode || len(resourcesNode.Content) == 0 {
 		return nil
 	}
 	changed := false
 	dir := filepath.Dir(ksFile)
-	for i, entry := range rawRes {
-		urlStr, ok := entry.(string)
-		if !ok {
+	for _, entry := range resourcesNode.Content {
+		if entry.Kind != yaml.ScalarNode {
 			continue
 		}
-		if !isHTTPURL(urlStr) {
+		if !isHTTPURL(entry.Value) {
 			continue
 		}
-		localFile, fetchErr := fetchRemoteResource(ctx, cache, dir, urlStr)
+		localFile, fetchErr := fetchRemoteResource(ctx, cache, dir, entry.Value)
 		if fetchErr != nil {
-			return fmt.Errorf("remote resource %s: %w", urlStr, fetchErr)
+			return fmt.Errorf("remote resource %s: %w", entry.Value, fetchErr)
 		}
-		rawRes[i] = "./" + localFile
+		entry.Value = "./" + localFile
+		entry.Tag = "!!str"
+		entry.Style = 0 // plain scalar; preserve other entries' styles
 		changed = true
 	}
 	if !changed {
 		return nil
 	}
-	doc["resources"] = rawRes
-	out, err := yaml.Marshal(doc)
+	out, err := yaml.Marshal(&doc)
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(ksFile, out, 0o600)
+}
+
+// findMappingValue returns the value node for the first mapping
+// entry with the given key inside the document. Returns nil when
+// the document is not a single-mapping document or the key is
+// absent. Used by rewriteURLResources to locate the "resources:"
+// sequence without round-tripping the whole document.
+func findMappingValue(doc *yaml.Node, key string) *yaml.Node {
+	if doc == nil || doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	// MappingNode.Content is [key, value, key, value, ...].
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value == key {
+			return root.Content[i+1]
+		}
+	}
+	return nil
 }
 
 func isHTTPURL(s string) bool {

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -257,6 +257,65 @@ func TestHttpGetURL_RejectsOversizedBody(t *testing.T) {
 	}
 }
 
+// TestRewriteURLResources_PreservesCommentsAndOrder pins the
+// yaml.Node node-level edit fix: only the rewritten resource entry
+// changes, every other byte (comments, other-key ordering, trailing
+// content) survives intact. The previous map-decode + re-marshal
+// round-trip silently destroyed all of that.
+func TestRewriteURLResources_PreservesCommentsAndOrder(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("kind: ConfigMap\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	original := `# Owner comment that MUST survive.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# why we have this list
+resources:
+  # remote shared fragment
+  - ` + srv.URL + `/x.yaml
+  - ./local.yaml  # keep this comment
+namespace: my-app
+`
+	dir := t.TempDir()
+	ks := filepath.Join(dir, "kustomization.yaml")
+	mustWriteFile(t, ks, original)
+
+	if err := rewriteURLResources(context.Background(), newPreflightCache(t), ks); err != nil {
+		t.Fatalf("rewriteURLResources: %v", err)
+	}
+
+	got, err := os.ReadFile(ks) //nolint:gosec // ks under t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+
+	for _, expect := range []string{
+		"# Owner comment that MUST survive.",
+		"# why we have this list",
+		"# remote shared fragment",
+		"# keep this comment",
+	} {
+		if !strings.Contains(out, expect) {
+			t.Errorf("comment dropped on rewrite: %q\nfile is:\n%s", expect, out)
+		}
+	}
+	if !strings.Contains(out, "- ./local.yaml") {
+		t.Errorf("local resource path mangled:\n%s", out)
+	}
+	if !strings.Contains(out, ".flate-remote-") {
+		t.Errorf("URL entry not rewritten to local file:\n%s", out)
+	}
+	if strings.Contains(out, srv.URL) {
+		t.Errorf("URL still present after rewrite:\n%s", out)
+	}
+	if idxRes, idxNs := strings.Index(out, "\nresources:"), strings.Index(out, "\nnamespace:"); idxRes < 0 || idxNs < 0 || idxRes >= idxNs {
+		t.Errorf("key ordering not preserved (resources should precede namespace):\n%s", out)
+	}
+}
+
 // TestHttpGetURL_AcceptsBodyAtCap is the boundary check: a body
 // exactly at the cap must succeed. Guards against off-by-one in the
 // LimitReader+overflow-detection pattern.

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -36,8 +36,19 @@ type StagingCache struct {
 	remoteFetches sync.Map // url string -> *remoteFetch
 }
 
+// remoteFetch carries the result of one URL fetch. The fetch runs in
+// a single background goroutine (gated by start.Do) detached from any
+// caller's ctx so a cancellation on the first caller doesn't poison
+// the cached result for everyone else — the previous OnceValues+ctx
+// capture would freeze ctx.Canceled into every subsequent FetchRemote
+// call for the same URL. Callers select on their own ctx vs the
+// done channel; the fetch runs to completion under the package-level
+// remoteFetchTimeout.
 type remoteFetch struct {
-	once func() ([]byte, error)
+	start sync.Once
+	done  chan struct{}
+	body  []byte
+	err   error
 }
 
 type stage struct {
@@ -61,20 +72,32 @@ func NewStagingCache(parent string) (*StagingCache, error) {
 }
 
 // FetchRemote returns the body of urlStr, fetched at most once per
-// StagingCache lifetime. Both successful bodies and errors are
-// cached — concurrent callers block on a single sync.OnceValues and
-// every caller sees the same result. The error (if any) is returned
-// to the caller; logging is left to whichever reconcile path
-// surfaces the failure, so the user sees one structured error in
-// `flate test`'s report rather than a separate log line per call
-// site.
+// StagingCache lifetime. Both successful bodies and benign errors
+// (4xx/5xx/timeouts) are cached and returned to every subsequent
+// caller. Concurrent first-time callers share one fetch; later
+// callers always read the cached result without re-fetching.
+//
+// The fetch runs in a background goroutine seeded with a detached
+// context (httpGetURL applies remoteFetchTimeout internally) so a
+// cancellation on the first caller doesn't propagate into the
+// cached error — the previous OnceValues capture poisoned every
+// subsequent FetchRemote for the same URL with context.Canceled.
+// Each caller still honors its own ctx via the select below.
 func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, error) {
-	actual, _ := c.remoteFetches.LoadOrStore(urlStr, &remoteFetch{
-		once: sync.OnceValues(func() ([]byte, error) {
-			return httpGetURL(ctx, urlStr)
-		}),
+	loaded, _ := c.remoteFetches.LoadOrStore(urlStr, &remoteFetch{done: make(chan struct{})})
+	rf := loaded.(*remoteFetch)
+	rf.start.Do(func() {
+		go func() {
+			rf.body, rf.err = httpGetURL(context.Background(), urlStr)
+			close(rf.done)
+		}()
 	})
-	return actual.(*remoteFetch).once()
+	select {
+	case <-rf.done:
+		return rf.body, rf.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // Stage returns the on-disk staged copy of source. The copy is created

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -1,9 +1,14 @@
 package kustomize
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestStagingCache_CopyTree_SkipsBrokenSymlink locks the fix for
@@ -75,6 +80,72 @@ func TestStagingCache_CopyTree_FollowsLiveSymlink(t *testing.T) {
 	}
 	if string(got) != "kind: ConfigMap\n" {
 		t.Errorf("symlink target lost; got %q", got)
+	}
+}
+
+// TestStagingCache_FetchRemote_CancelDoesNotPoisonCache pins the
+// fix for ctx-capture poisoning: the previous implementation wrapped
+// the fetch in sync.OnceValues with the first caller's ctx, so a
+// cancel on caller A froze context.Canceled into the cached error for
+// every subsequent FetchRemote of the same URL — even with healthy
+// ctxs. The new implementation detaches the fetch's own ctx from
+// callers; only the per-call select on rf.done vs ctx.Done() respects
+// the caller's cancellation.
+func TestStagingCache_FetchRemote_CancelDoesNotPoisonCache(t *testing.T) {
+	// Slow server: holds requests until the harness signals release.
+	release := make(chan struct{})
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = w.Write([]byte("body: ok\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	// Caller A starts a fetch with a ctx we'll cancel.
+	ctxA, cancelA := context.WithCancel(context.Background())
+	doneA := make(chan error, 1)
+	go func() {
+		_, err := cache.FetchRemote(ctxA, srv.URL+"/x.yaml")
+		doneA <- err
+	}()
+
+	// Wait until the server has at least one in-flight request, then
+	// cancel A. Give the goroutine a chance to actually call select.
+	for hits.Load() == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancelA()
+	if err := <-doneA; err == nil {
+		t.Fatal("caller A should have seen ctx.Err()")
+	}
+
+	// Caller B with a healthy ctx must NOT see context.Canceled. The
+	// fetch is still running (release not signaled); B should observe
+	// it complete normally. Release the server now so B can finish.
+	close(release)
+	body, err := cache.FetchRemote(context.Background(), srv.URL+"/x.yaml")
+	if err != nil {
+		t.Errorf("caller B got poisoned error: %v", err)
+	}
+	if string(body) != "body: ok\n" {
+		t.Errorf("caller B got wrong body: %q", body)
+	}
+
+	// And the dedup invariant: at most one server hit for the same URL
+	// despite two callers.
+	if got := hits.Load(); got != 1 {
+		t.Errorf("server hit %d times; want 1 (singleflight broken)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR 4 of 10. Four kustomize correctness fixes from the audit.

- **7.1 FetchRemote cancel-poisoning** — the fetch now runs in a one-shot background goroutine with a detached ctx; each caller selects on \`rf.done\` vs its own ctx. Singleflight dedup preserved via \`sync.Once\`.
- **7.2 yaml.Node node-level edit** — replaces the map-decode + yaml.Marshal round-trip in rewriteURLResources. Only URL entries change; comments, key ordering, anchors, and scalar styles survive.
- **7.3 stageLocks lock the stage root** — the previous per-stagedSub lock missed the ancestor/descendant race when one KS at \`./\` and another at \`./apps\` ran concurrently. Renamed pathLocks → stageLocks. Cost: KSes sharing a sourceRoot now serialize. Correctness over prior incorrect parallelism.
- **7.5 restoreKustomizationFile surfaces os.Remove errors** — previously discarded permission/EBUSY failures could leave two kustomization variants in stagedSub. \`errors.Join\` now collects them.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestStagingCache_FetchRemote_CancelDoesNotPoisonCache\` — pins 7.1 (canceled caller A sees ctx.Err; healthy caller B gets cached body; one server hit)
- [x] New \`TestRewriteURLResources_PreservesCommentsAndOrder\` — pins 7.2 across four comment styles + key ordering + entry non-mangling
- [x] Existing kustomize integration tests + e2e green

🤖 Generated with [Claude Code](https://claude.com/claude-code)