### PR TITLE
refactor(manifest): single-source helpers for RepoName, NamespacedName, secret-ref validation

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -325,7 +325,7 @@ func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, erro
 		// root instead of doubling ks.Path against itself (#105).
 		if ks.Path == "" {
 			return "", fmt.Errorf("%w: kustomization %s has no path and no source",
-				manifest.ErrInput, ks.NamespacedName())
+				manifest.ErrInput, ks.Named().NamespacedName())
 		}
 		srcID = manifest.BootstrapSourceID
 	}

--- a/pkg/discovery/rsexpand.go
+++ b/pkg/discovery/rsexpand.go
@@ -28,7 +28,7 @@ func (d *discoverer) renderResourceSet(rs *manifest.ResourceSet) (int, error) {
 	for _, doc := range docs {
 		obj, err := manifest.ParseDoc(doc, opts)
 		if err != nil {
-			slog.Debug("resourceset: skipped doc", "rs", rs.NamespacedName(), "err", err)
+			slog.Debug("resourceset: skipped doc", "rs", rs.Named().NamespacedName(), "err", err)
 			continue
 		}
 		if _, ok := obj.(*manifest.RawObject); ok {

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -53,7 +53,7 @@ func (c *Client) locateLocalChart(hr *manifest.HelmRelease) (string, error) {
 	art := c.resolveLocalSource(hr)
 	if art == nil {
 		return "", fmt.Errorf("%w: %s %s not available for HelmRelease %s",
-			manifest.ErrObjectNotFound, hr.Chart.RepoKind, hr.Chart.RepoFullName(), hr.NamespacedName())
+			manifest.ErrObjectNotFound, hr.Chart.RepoKind, hr.Chart.RepoFullName(), hr.Named().NamespacedName())
 	}
 	path := filepath.Join(art.LocalPath, hr.Chart.Name)
 	if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err != nil {
@@ -70,7 +70,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	r := c.resolveHelmRepo(hr)
 	if r == nil {
 		return "", fmt.Errorf("%w: HelmRepository %s not registered for HelmRelease %s",
-			manifest.ErrObjectNotFound, hr.Chart.RepoFullName(), hr.NamespacedName())
+			manifest.ErrObjectNotFound, hr.Chart.RepoFullName(), hr.Named().NamespacedName())
 	}
 
 	if r.Type == manifest.RepoTypeOCI || strings.HasPrefix(r.URL, "oci://") {

--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -53,20 +53,12 @@ func parseBucket(doc map[string]any) (*Bucket, error) {
 	}
 	cr.Spec.Provider = cmp.Or(cr.Spec.Provider, sourcev1.BucketProviderGeneric)
 	owner := cr.Namespace + "/" + cr.Name
-	if r := cr.Spec.SecretRef; r != nil {
-		if err := validateSecretRefName("Bucket", owner, "spec.secretRef", r.Name); err != nil {
-			return nil, err
-		}
-	}
-	if r := cr.Spec.CertSecretRef; r != nil {
-		if err := validateSecretRefName("Bucket", owner, "spec.certSecretRef", r.Name); err != nil {
-			return nil, err
-		}
-	}
-	if r := cr.Spec.ProxySecretRef; r != nil {
-		if err := validateSecretRefName("Bucket", owner, "spec.proxySecretRef", r.Name); err != nil {
-			return nil, err
-		}
+	if err := validateOptionalRefs("Bucket", owner,
+		secretRefCheck{Field: "spec.secretRef", Ref: cr.Spec.SecretRef},
+		secretRefCheck{Field: "spec.certSecretRef", Ref: cr.Spec.CertSecretRef},
+		secretRefCheck{Field: "spec.proxySecretRef", Ref: cr.Spec.ProxySecretRef},
+	); err != nil {
+		return nil, err
 	}
 	return &Bucket{
 		Name:       cr.Name,

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -205,9 +205,6 @@ func (h *HelmRelease) ReleaseNamespace() string {
 	return cmp.Or(h.TargetNamespace, h.Namespace)
 }
 
-// NamespacedName is "<namespace>/<name>".
-func (h *HelmRelease) NamespacedName() string { return h.Namespace + "/" + h.Name }
-
 // HelmChartLookup returns the HelmChartSource at (namespace, name) or
 // nil when not present. The shape ResolveChartRef accepts so callers
 // can pass either a SourceResolver method (orchestrator path) or a
@@ -233,7 +230,7 @@ func (h *HelmRelease) ResolveChartRef(lookup HelmChartLookup) error {
 	src := lookup(h.Chart.RepoNamespace, h.Chart.RepoName)
 	if src == nil {
 		return fmt.Errorf("%w: HelmChartSource %s not found for HelmRelease %s",
-			ErrObjectNotFound, h.Chart.RepoFullName(), h.NamespacedName())
+			ErrObjectNotFound, h.Chart.RepoFullName(), h.Named().NamespacedName())
 	}
 	h.Chart = helmChartFromSource(src)
 	if len(src.ValuesFiles) > 0 {

--- a/pkg/manifest/helmrepository.go
+++ b/pkg/manifest/helmrepository.go
@@ -21,8 +21,8 @@ func (h *HelmRepository) Named() NamedResource {
 	return NamedResource{Kind: KindHelmRepository, Namespace: h.Namespace, Name: h.Name}
 }
 
-// RepoName is "<namespace>-<name>".
-func (h *HelmRepository) RepoName() string { return h.Namespace + "-" + h.Name }
+// RepoName delegates to the canonical NamedResource helper.
+func (h *HelmRepository) RepoName() string { return h.Named().FluxResourceName() }
 
 // parseHelmRepository decodes a HelmRepository CR via the
 // source-controller typed schema.
@@ -42,15 +42,11 @@ func parseHelmRepository(doc map[string]any) (*HelmRepository, error) {
 	}
 	cr.Spec.Type = cmp.Or(cr.Spec.Type, RepoTypeDefault)
 	owner := cr.Namespace + "/" + cr.Name
-	if r := cr.Spec.SecretRef; r != nil {
-		if err := validateSecretRefName("HelmRepository", owner, "spec.secretRef", r.Name); err != nil {
-			return nil, err
-		}
-	}
-	if r := cr.Spec.CertSecretRef; r != nil {
-		if err := validateSecretRefName("HelmRepository", owner, "spec.certSecretRef", r.Name); err != nil {
-			return nil, err
-		}
+	if err := validateOptionalRefs("HelmRepository", owner,
+		secretRefCheck{Field: "spec.secretRef", Ref: cr.Spec.SecretRef},
+		secretRefCheck{Field: "spec.certSecretRef", Ref: cr.Spec.CertSecretRef},
+	); err != nil {
+		return nil, err
 	}
 	return &HelmRepository{
 		Name:               cr.Name,

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -98,9 +98,6 @@ func (k *Kustomization) Clone() *Kustomization {
 	return &out
 }
 
-// NamespacedName is "<namespace>/<name>".
-func (k *Kustomization) NamespacedName() string { return k.Namespace + "/" + k.Name }
-
 // FilterDependsOn returns a copy of deps with any entries whose target
 // is not present in known removed. known is a set of "namespace/name"
 // identifiers. The second return value is the count of dropped

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -38,9 +38,6 @@ func (r *ResourceSet) Named() NamedResource {
 	return NamedResource{Kind: KindResourceSet, Namespace: r.Namespace, Name: r.Name}
 }
 
-// NamespacedName is "<namespace>/<name>".
-func (r *ResourceSet) NamespacedName() string { return r.Namespace + "/" + r.Name }
-
 // parseResourceSet decodes a ResourceSet CR via the flux-operator
 // typed schema (controlplane.io/v1).
 func parseResourceSet(doc map[string]any) (*ResourceSet, error) {
@@ -85,9 +82,6 @@ type ResourceSetInputProvider struct {
 func (p *ResourceSetInputProvider) Named() NamedResource {
 	return NamedResource{Kind: KindResourceSetInputProvider, Namespace: p.Namespace, Name: p.Name}
 }
-
-// NamespacedName is "<namespace>/<name>".
-func (p *ResourceSetInputProvider) NamespacedName() string { return p.Namespace + "/" + p.Name }
 
 // parseResourceSetInputProvider decodes a ResourceSetInputProvider CR.
 func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvider, error) {

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -57,8 +57,10 @@ func (g *GitRepository) Named() NamedResource {
 // Suspended reports whether reconciliation is paused on this resource.
 func (g *GitRepository) Suspended() bool { return g.Suspend }
 
-// RepoName is "<namespace>-<name>".
-func (g *GitRepository) RepoName() string { return g.Namespace + "-" + g.Name }
+// RepoName delegates to the canonical NamedResource helper so all
+// three source kinds (Git, OCI, Helm) produce identical strings on
+// the same id.
+func (g *GitRepository) RepoName() string { return g.Named().FluxResourceName() }
 
 // validateSecretRefName rejects a Secret/LocalObjectReference whose
 // Name is empty. Without this check, a typo'd YAML like
@@ -72,6 +74,34 @@ func (g *GitRepository) RepoName() string { return g.Namespace + "-" + g.Name }
 func validateSecretRefName(kind, owner, field, name string) error {
 	if name == "" {
 		return inputf("%s %s: %s.name is empty", kind, owner, field)
+	}
+	return nil
+}
+
+// secretRefCheck pairs a spec.field path with a pointer to the
+// LocalObjectReference at that path. Used in slice form with
+// validateOptionalRefs to batch every Secret-ref validation at the
+// edge of a parser.
+type secretRefCheck struct {
+	Field string
+	Ref   *LocalObjectReference
+}
+
+// validateOptionalRefs runs validateSecretRefName for each non-nil
+// ref in checks. Caller hands the parser's full list of pointer-to-
+// LocalObjectReference fields in one shot so adding a new ref to a
+// source kind's schema is a one-line edit rather than 3-5 new
+// boilerplate blocks. Value-type refs (e.g. Verification.SecretRef,
+// nested inside a *Verification) stay inline since they don't
+// share the nil-pointer-guard shape.
+func validateOptionalRefs(kind, owner string, checks ...secretRefCheck) error {
+	for _, c := range checks {
+		if c.Ref == nil {
+			continue
+		}
+		if err := validateSecretRefName(kind, owner, c.Field, c.Ref.Name); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -109,15 +139,11 @@ func parseGitRepository(doc map[string]any) (*GitRepository, error) {
 		v.Mode = v.GetMode()
 	}
 	owner := cr.Namespace + "/" + cr.Name
-	if r := cr.Spec.SecretRef; r != nil {
-		if err := validateSecretRefName("GitRepository", owner, "spec.secretRef", r.Name); err != nil {
-			return nil, err
-		}
-	}
-	if r := cr.Spec.ProxySecretRef; r != nil {
-		if err := validateSecretRefName("GitRepository", owner, "spec.proxySecretRef", r.Name); err != nil {
-			return nil, err
-		}
+	if err := validateOptionalRefs("GitRepository", owner,
+		secretRefCheck{Field: "spec.secretRef", Ref: cr.Spec.SecretRef},
+		secretRefCheck{Field: "spec.proxySecretRef", Ref: cr.Spec.ProxySecretRef},
+	); err != nil {
+		return nil, err
 	}
 	if v := cr.Spec.Verification; v != nil {
 		if err := validateSecretRefName("GitRepository", owner, "spec.verify.secretRef", v.SecretRef.Name); err != nil {
@@ -172,8 +198,8 @@ func (o *OCIRepository) Named() NamedResource {
 // Suspended reports whether reconciliation is paused on this resource.
 func (o *OCIRepository) Suspended() bool { return o.Suspend }
 
-// RepoName is "<namespace>-<name>".
-func (o *OCIRepository) RepoName() string { return o.Namespace + "-" + o.Name }
+// RepoName delegates to the canonical NamedResource helper.
+func (o *OCIRepository) RepoName() string { return o.Named().FluxResourceName() }
 
 // Version returns the digest, tag, or semver expression in that order.
 // A semver expression is returned verbatim — callers wanting a concrete
@@ -212,23 +238,17 @@ func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
 		r.Digest = ResolveEnvsubstDefaults(r.Digest)
 	}
 	owner := cr.Namespace + "/" + cr.Name
-	if r := cr.Spec.SecretRef; r != nil {
-		if err := validateSecretRefName("OCIRepository", owner, "spec.secretRef", r.Name); err != nil {
-			return nil, err
-		}
+	if err := validateOptionalRefs("OCIRepository", owner,
+		secretRefCheck{Field: "spec.secretRef", Ref: cr.Spec.SecretRef},
+		secretRefCheck{Field: "spec.certSecretRef", Ref: cr.Spec.CertSecretRef},
+		secretRefCheck{Field: "spec.proxySecretRef", Ref: cr.Spec.ProxySecretRef},
+	); err != nil {
+		return nil, err
 	}
-	if r := cr.Spec.CertSecretRef; r != nil {
-		if err := validateSecretRefName("OCIRepository", owner, "spec.certSecretRef", r.Name); err != nil {
-			return nil, err
-		}
-	}
-	if r := cr.Spec.ProxySecretRef; r != nil {
-		if err := validateSecretRefName("OCIRepository", owner, "spec.proxySecretRef", r.Name); err != nil {
-			return nil, err
-		}
-	}
-	if v := cr.Spec.Verify; v != nil && v.SecretRef != nil {
-		if err := validateSecretRefName("OCIRepository", owner, "spec.verify.secretRef", v.SecretRef.Name); err != nil {
+	if v := cr.Spec.Verify; v != nil {
+		if err := validateOptionalRefs("OCIRepository", owner,
+			secretRefCheck{Field: "spec.verify.secretRef", Ref: v.SecretRef},
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -39,6 +39,16 @@ func (n NamedResource) NamespacedName() string {
 	return n.Namespace + "/" + n.Name
 }
 
+// FluxResourceName is the canonical "<namespace>-<name>" identifier
+// every Flux source CR uses for cache slots, OCI auth scopes, etc.
+// Single source of truth so GitRepository / OCIRepository /
+// HelmRepository all return identical strings on the same id and a
+// future format change (e.g. adding a kind prefix) only touches this
+// function.
+func (n NamedResource) FluxResourceName() string {
+	return n.Namespace + "-" + n.Name
+}
+
 // String returns "kind/namespace/name" — the canonical id form.
 func (n NamedResource) String() string {
 	return n.Kind + "/" + n.NamespacedName()

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -354,11 +354,11 @@ func (o *Orchestrator) validateDependsOn() {
 	}
 	ksList := store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization)
 	for _, ks := range ksList {
-		known[manifest.KindKustomization][ks.NamespacedName()] = struct{}{}
+		known[manifest.KindKustomization][ks.Named().NamespacedName()] = struct{}{}
 	}
 	hrList := store.ListAs[*manifest.HelmRelease](o.store, manifest.KindHelmRelease)
 	for _, hr := range hrList {
-		known[manifest.KindHelmRelease][hr.NamespacedName()] = struct{}{}
+		known[manifest.KindHelmRelease][hr.Named().NamespacedName()] = struct{}{}
 	}
 	// Mutate via the Store helper — encodes the clone-then-AddObject
 	// contract so callers don't have to remember it.

--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -115,12 +115,12 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 	for _, p := range providers {
 		exported, err := p.ExportedInputs()
 		if err != nil {
-			return nil, fmt.Errorf("ResourceSetInputProvider %s: %w", p.NamespacedName(), err)
+			return nil, fmt.Errorf("ResourceSetInputProvider %s: %w", p.Named().NamespacedName(), err)
 		}
 		if exported == nil && p.Type != "" && p.Type != fluxopv1.InputProviderStatic {
 			slog.Warn("resourceset: dynamic input provider contributes no inputs offline",
-				"resourceSet", rs.NamespacedName(),
-				"provider", p.NamespacedName(),
+				"resourceSet", rs.Named().NamespacedName(),
+				"provider", p.Named().NamespacedName(),
 				"type", p.Type)
 		}
 		provBlock := map[string]any{

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -64,7 +64,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 
 	inputs, err := buildInputSets(rs, resolve)
 	if err != nil {
-		return nil, fmt.Errorf("ResourceSet %s: %w", rs.NamespacedName(), err)
+		return nil, fmt.Errorf("ResourceSet %s: %w", rs.Named().NamespacedName(), err)
 	}
 	// Under Permute, an empty input slice means the Cartesian product
 	// genuinely collapsed (every-provider-empty with includeEmpty=true,
@@ -92,7 +92,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	for i, raw := range rs.Resources {
 		rendered, err := renderResources(raw, inputs)
 		if err != nil {
-			return nil, fmt.Errorf("ResourceSet %s: spec.resources[%d]: %w", rs.NamespacedName(), i, err)
+			return nil, fmt.Errorf("ResourceSet %s: spec.resources[%d]: %w", rs.Named().NamespacedName(), i, err)
 		}
 		for _, doc := range rendered {
 			appendUnique(doc)
@@ -102,7 +102,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	if rs.ResourcesTemplate != "" {
 		rendered, err := renderResourcesTemplate(rs.ResourcesTemplate, inputs)
 		if err != nil {
-			return nil, fmt.Errorf("ResourceSet %s: spec.resourcesTemplate: %w", rs.NamespacedName(), err)
+			return nil, fmt.Errorf("ResourceSet %s: spec.resourcesTemplate: %w", rs.Named().NamespacedName(), err)
 		}
 		for _, doc := range rendered {
 			appendUnique(doc)

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -119,7 +119,7 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 	for _, ref := range hr.ValuesFrom {
 		found, err := lookupValueRef(ref, hr.Namespace, provider)
 		if err != nil {
-			return fmt.Errorf("building HelmRelease %s: %w", hr.NamespacedName(), err)
+			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
 		if found == "" {
 			// Resource missing. lookupValueRef only returns "" when
@@ -128,13 +128,13 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 			// case where Optional applies.
 			if !ref.Optional {
 				return fmt.Errorf("%w: HelmRelease %s: valuesFrom %s %s/%s not found",
-					manifest.ErrObjectNotFound, hr.NamespacedName(), ref.Kind, hr.Namespace, ref.Name)
+					manifest.ErrObjectNotFound, hr.Named().NamespacedName(), ref.Kind, hr.Namespace, ref.Name)
 			}
 			continue
 		}
 		merged, err := updateHelmReleaseValues(ref, found, values)
 		if err != nil {
-			return fmt.Errorf("building HelmRelease %s: %w", hr.NamespacedName(), err)
+			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
 		values = merged
 	}


### PR DESCRIPTION
## Summary

PR 5 of 10. Mechanical de-duplications in pkg/manifest. No behavior change.

- **5.1 RepoName via NamedResource.FluxResourceName** — canonical helper; the three source kinds' \`RepoName()\` methods delegate so all four format-the-same-id sites converge.
- **5.4 Delete duplicated \`NamespacedName()\` overrides** — HR/KS/RS/RSIP each had \`Namespace+"/"+Name\` that mishandled cluster-scoped resources; callers now go through \`obj.Named().NamespacedName()\`.
- **5.5 validateOptionalRefs batches secret-ref checks** — 12 hand-rolled \`if r := ...; r != nil { validateSecretRefName(...) }\` blocks collapse to a single variadic call per parser.

## Deferred

- **5.2 generic Fetcher[T]** and **2.5 table-driven fetcher registration** require touching every fetcher impl + source controller + tests. Splitting into a focused follow-up rather than bundling here.

## Test plan

- [x] \`go test -count=1 ./...\` green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)