### PR TITLE
refactor(controllers): base.Controller.Await + nil-safe filter + status preservation

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -17,9 +17,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
 
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/task"
@@ -42,9 +44,15 @@ type Controller struct {
 	Tasks *task.Service
 
 	started atomic.Bool
-	unsub   []store.Unsubscribe
 	coal    *task.Coalescer[manifest.NamedResource]
 	filter  *change.Filter
+
+	// unsubMu guards unsub so AddListener and Close can be called
+	// concurrently (e.g. shutdown racing a listener-triggered Submit).
+	// The slice is short-lived (registered at Start, drained at Close)
+	// and per-controller, so the lock has near-zero contention.
+	unsubMu sync.Mutex
+	unsub   []store.Unsubscribe
 
 	// kindLabel prefixes coalescer keys ("source/", "kustomization/",
 	// "helmrelease/") and labels panic logs. Set by Start.
@@ -81,17 +89,26 @@ func (c *Controller) StartLifecycle(kindLabel string) {
 
 // AddListener registers a store listener and records it so Close can
 // unsubscribe. snapshot=true matches every concrete controller's needs
-// (deliver the current store state on subscribe).
+// (deliver the current store state on subscribe). Safe to call
+// concurrently with Close.
 func (c *Controller) AddListener(event store.EventKind, l store.Listener) {
-	c.unsub = append(c.unsub, c.Store.AddListener(event, l, true))
+	u := c.Store.AddListener(event, l, true)
+	c.unsubMu.Lock()
+	c.unsub = append(c.unsub, u)
+	c.unsubMu.Unlock()
 }
 
-// Close removes every registered listener. Idempotent.
+// Close removes every registered listener. Idempotent. Safe to call
+// concurrently with AddListener — though typical use registers all
+// listeners during Start and never adds more.
 func (c *Controller) Close() {
-	for _, u := range c.unsub {
+	c.unsubMu.Lock()
+	unsubs := c.unsub
+	c.unsub = nil
+	c.unsubMu.Unlock()
+	for _, u := range unsubs {
 		u()
 	}
-	c.unsub = nil
 }
 
 // Submit enqueues a reconcile body keyed by id. Duplicate submits with
@@ -112,11 +129,59 @@ func (c *Controller) PreGate(id manifest.NamedResource, suspended bool) bool {
 		c.Store.UpdateStatus(id, store.StatusReady, store.MsgSuspended)
 		return true
 	}
-	if c.filter.Enabled() && !c.filter.ShouldReconcile(id) {
+	if c.filterActive() && !c.filter.ShouldReconcile(id) {
 		c.Store.UpdateStatus(id, store.StatusReady, store.MsgUnchanged)
 		return true
 	}
 	return false
+}
+
+// filterActive reports whether a non-nil, enabled change filter is
+// configured. Replaces the previous c.filter.Enabled() call that
+// relied on Filter.Enabled being nil-safe — making every future
+// non-pointer-deref method on *Filter latently NPE-prone. Routing
+// every read through this helper means a future method addition on
+// *Filter doesn't crash PreGate.
+func (c *Controller) filterActive() bool {
+	return c.filter != nil && c.filter.Enabled()
+}
+
+// Await blocks until each dep in deps reaches Ready, yielding the
+// caller's worker-pool slot during the wait so children depended on
+// can themselves acquire a slot and make progress. Centralizes the
+// "set pending → yield → WaitAll → check failed" dance the three
+// concrete controllers each implemented inline; the per-call-site
+// difference (which error sentinel wraps a failed summary) is
+// expressed via onFail.
+//
+// pendingMsg is the StatusPending message written before the wait —
+// surfaces in `flate test` reporting and the orchestrator's failure
+// rollup. Pass an empty string to skip the status write (e.g. when
+// the caller already set its own).
+//
+// onFail receives the depwait Summary on any AnyFailed and returns
+// the error the caller propagates. Use it to pick between
+// manifest.DependencyFailedError, ErrObjectNotFound, etc. — the
+// concrete controllers each have their own conventions.
+func (c *Controller) Await(
+	ctx context.Context,
+	id manifest.NamedResource,
+	w *depwait.Waiter,
+	deps []manifest.DependencyRef,
+	pendingMsg string,
+	onFail func(depwait.Summary) error,
+) error {
+	if pendingMsg != "" {
+		c.Store.UpdateStatus(id, store.StatusPending, pendingMsg)
+	}
+	var sum depwait.Summary
+	c.Tasks.YieldSlot(func() {
+		sum = depwait.WaitAll(w.Watch(ctx, deps))
+	})
+	if sum.AnyFailed() {
+		return onFail(sum)
+	}
+	return nil
 }
 
 // Recover catches a panic from the current goroutine and marks id
@@ -138,6 +203,15 @@ func Recover(s *store.Store, id manifest.NamedResource, logKind string) {
 // rather than the stale payload from the original event. A missing
 // object (deleted between coalescer enqueue and run) is treated as a
 // no-op rather than a failure.
+//
+// On success the terminal status write is conditional: if the
+// current status already carries an informative Ready message (a
+// soft-skip from --allow-missing-secrets, an MsgUnchanged from the
+// change filter, an MsgSuspended from PreGate), the empty-message
+// overwrite is suppressed so the informative message survives a
+// short-circuited coalesced re-run that returns nil. Plain Ready
+// (no message) and any non-Ready status get the standard "" Ready
+// write so the controller's terminal contract is preserved.
 func RunWithStatus[T manifest.BaseManifest](
 	ctx context.Context,
 	s *store.Store,
@@ -162,6 +236,11 @@ func RunWithStatus[T manifest.BaseManifest](
 			return
 		}
 		s.UpdateStatus(id, store.StatusFailed, err.Error())
+		return
+	}
+	if existing, ok := s.GetStatus(id); ok && existing.Status == store.StatusReady && existing.Message != "" {
+		// Existing Ready message is informative (skipped:, unchanged,
+		// suspended, or any future Ready sub-state) — don't clobber.
 		return
 	}
 	s.UpdateStatus(id, store.StatusReady, "")

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -89,3 +89,33 @@ func TestRunWithStatus_MissingObject(t *testing.T) {
 		t.Error("missing object should not get a status entry")
 	}
 }
+
+// TestRunWithStatus_PreservesInformativeReadyMessage pins the
+// 3.5 fix: when a coalesced re-run returns nil but the current
+// status carries an informative Ready message (skipped:, unchanged,
+// suspended), the terminal "" Ready write must NOT clobber it. The
+// previous unconditional s.UpdateStatus(id, Ready, "") at the end
+// of RunWithStatus erased these sub-states whenever a short-circuit
+// returned nil after the message had been set.
+func TestRunWithStatus_PreservesInformativeReadyMessage(t *testing.T) {
+	for _, message := range []string{store.MsgUnchanged, store.MsgSuspended, store.SkippedPrefix + " missing secret"} {
+		t.Run(message, func(t *testing.T) {
+			s := store.New()
+			hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+			s.AddObject(hr)
+			id := hr.Named()
+			s.UpdateStatus(id, store.StatusReady, message)
+
+			base.RunWithStatus(t.Context(), s, id, "helmrelease",
+				func(_ context.Context, _ *manifest.HelmRelease) error { return nil },
+			)
+			got, _ := s.GetStatus(id)
+			if got.Status != store.StatusReady {
+				t.Errorf("status = %v, want Ready", got.Status)
+			}
+			if got.Message != message {
+				t.Errorf("informative Ready message %q was clobbered: now %q", message, got.Message)
+			}
+		})
+	}
+}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -166,14 +166,15 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// driftDetection / install.crds / upgrade strategy / rollback to
 	// every HR, so all of them were hit by this).
 	if parent, ok := c.lookupParent(id); ok {
-		c.Store.UpdateStatus(id, store.StatusPending, "waiting for parent KS")
-		var sum depwait.Summary
-		c.Tasks.YieldSlot(func() {
-			sum = depwait.WaitAll(c.newWaiter(id, hr.Timeout).Watch(ctx, []manifest.DependencyRef{{NamedResource: parent}}))
-		})
-		if sum.AnyFailed() {
-			return fmt.Errorf("%w: parent Kustomization %s not ready: %s",
-				manifest.ErrObjectNotFound, parent.String(), sum.Messages[parent])
+		err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout),
+			[]manifest.DependencyRef{{NamedResource: parent}},
+			"waiting for parent KS",
+			func(sum depwait.Summary) error {
+				return fmt.Errorf("%w: parent Kustomization %s not ready: %s",
+					manifest.ErrObjectNotFound, parent.String(), sum.Messages[parent])
+			})
+		if err != nil {
+			return err
 		}
 		// The parent's render may have replaced this HR in the store
 		// with a patched copy; re-read so the rest of reconcile uses
@@ -186,31 +187,26 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 
 	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
 	// each dependency reaching Ready before this HR reconciles.
-	// YieldSlot releases the worker-pool slot during the wait so the
-	// dependencies can themselves acquire one.
 	if deps := c.collectHRDeps(hr); len(deps) > 0 {
-		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
-		var sum depwait.Summary
-		c.Tasks.YieldSlot(func() {
-			sum = depwait.WaitAll(c.newWaiter(id, hr.Timeout).Watch(ctx, deps))
-		})
-		if sum.AnyFailed() {
-			return &manifest.DependencyFailedError{
-				Parent:  id,
-				Failed:  sum.Failed,
-				Reasons: sum.Messages,
-			}
+		err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout), deps,
+			"resolving dependencies",
+			func(sum depwait.Summary) error {
+				return &manifest.DependencyFailedError{
+					Parent:  id,
+					Failed:  sum.Failed,
+					Reasons: sum.Messages,
+				}
+			})
+		if err != nil {
+			return err
 		}
-		// Re-read the HR after the dependsOn wait: while we were
-		// yielding our slot, the parent KS could have re-rendered
-		// (e.g. its own dependsOn cleared in the meantime, freeing
-		// up parent-render-time substitutions that mutate our
-		// spec). Without this refresh, an HR with explicit
+		// Re-read the HR after the dependsOn wait: the parent KS may
+		// have re-rendered (e.g. its own dependsOn cleared in the
+		// meantime, freeing up parent-render-time substitutions that
+		// mutate our spec). Without this refresh, an HR with explicit
 		// spec.dependsOn but no structural parent — or one whose
-		// parent re-emitted us after the parent-gate cleared —
-		// keeps the pre-mutation snapshot through chart
-		// resolution. Mirrors the KS controller's single
-		// refresh after its combined dep wait.
+		// parent re-emitted us after the parent-gate cleared — keeps
+		// the pre-mutation snapshot through chart resolution.
 		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
 			hr = obj
 		}
@@ -247,13 +243,14 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	srcID := manifest.NamedResource{
 		Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
 	}
-	var sum depwait.Summary
-	c.Tasks.YieldSlot(func() {
-		sum = depwait.WaitAll(c.newWaiter(id, hr.Timeout).Watch(ctx, []manifest.DependencyRef{{NamedResource: srcID}}))
-	})
-	if sum.AnyFailed() {
-		return fmt.Errorf("%w: chart source %s not ready: %s",
-			manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
+	if err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout),
+		[]manifest.DependencyRef{{NamedResource: srcID}},
+		"", // status already set above
+		func(sum depwait.Summary) error {
+			return fmt.Errorf("%w: chart source %s not ready: %s",
+				manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
+		}); err != nil {
+		return err
 	}
 	// A chart source that soft-skipped (--allow-missing-secrets on its
 	// auth) marks Ready but writes no artifact and almost certainly

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -159,20 +159,17 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 
 	deps := c.collectDeps(ks)
 	if len(deps) > 0 {
-		// Release our worker slot for the duration of the dep wait so
-		// children we depend on can acquire one and make progress.
-		// Without this, N parents on a bounded Service consume all
-		// slots while waiting for children that need a slot to run.
-		var sum depwait.Summary
-		c.Tasks.YieldSlot(func() {
-			sum = depwait.WaitAll(c.newWaiter(id, ks.Timeout).Watch(ctx, deps))
-		})
-		if sum.AnyFailed() {
-			return &manifest.DependencyFailedError{
-				Parent:  id,
-				Failed:  sum.Failed,
-				Reasons: sum.Messages,
-			}
+		err := c.Await(ctx, id, c.newWaiter(id, ks.Timeout), deps,
+			"", // status set above
+			func(sum depwait.Summary) error {
+				return &manifest.DependencyFailedError{
+					Parent:  id,
+					Failed:  sum.Failed,
+					Reasons: sum.Messages,
+				}
+			})
+		if err != nil {
+			return err
 		}
 		// Refresh the KS — our structural parent may have re-emitted
 		// us with mutated spec (e.g. `replacements:` injecting

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -101,13 +101,17 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 // Ready+"skipped: ..." status; any other error yields Failed.
 func (c *Controller) reconcile(ctx context.Context, obj manifest.BaseManifest) error {
 	id := obj.Named()
-	fetcher, registered := c.Fetchers[id.Kind]
-	if !registered {
-		return nil
-	}
+	// The listener already filtered by registered Kind (see
+	// onObjectAdded), so this Fetchers lookup can't miss; lookup is
+	// cheap and lets us hold a typed reference for the rest of the
+	// function. Note: the second-redundant `c.Fetchers[id.Kind]`
+	// check that lived here was dropped — it was unreachable.
+	fetcher := c.Fetchers[id.Kind]
 	// Existence short-circuit: a source we already fetched in this run
 	// stays fetched. Idempotent re-AddObject (e.g. a parent KS
 	// re-emitting a stamped copy) returns without touching the network.
+	// Read once; the coalescer guarantees no concurrent reconcile of
+	// the same id, so an existing artifact is stable across this call.
 	if c.Store.GetArtifact(id) != nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

PR 7 of 10. Five controller-layer fixes from the audit.

- **3.1 PreGate via filterActive()** — isolates the nil-pointer guard so future methods on *Filter don't latently NPE.
- **3.2 mutex-guarded base.Controller.unsub** — AddListener/Close are now safe to call concurrently.
- **3.3 base.Controller.Await collapses YieldSlot+WaitAll boilerplate** — four near-identical blocks (3 HR + 1 KS) become one function call each. \`onFail\` closure lets each call site pick its own error sentinel.
- **3.4 Source controller dead code + GetArtifact race comment** — drops the unreachable second \`Fetchers[id.Kind]\` check; documents the coalescer's per-id serialization guarantee.
- **3.5 RunWithStatus preserves informative Ready messages** — short-circuited reconciles no longer clobber MsgUnchanged / MsgSuspended / SkippedPrefix with empty Ready.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestRunWithStatus_PreservesInformativeReadyMessage\` — covers unchanged/suspended/skipped subtests
- [x] Existing HR/KS/source controller suites pass on the Await refactor unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)