### PR TITLE
perf(change,values): memoize ownership lookups + in-place values merge

### DIFF
--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -23,7 +23,21 @@ type ksClaim struct {
 
 // ownershipIndex maps changed files to the Flux Kustomizations that
 // would re-render in response. Built once per filter resolution.
-type ownershipIndex struct{ claims []ksClaim }
+//
+// Lookups memoize their (ownersOf, ancestorsOf) results per file —
+// the Filter.resolve BFS calls these functions O(keep) times over
+// O(distinct-files) input strings, so without caching the BFS walks
+// the full claims slice once per visit and runs at O(K²). The cache
+// drops it to O(distinct-files × claims) once + O(1) per BFS step.
+//
+// Caches are unsynchronized: Filter.resolve is serial within one
+// orchestrator construction and the index is never shared across
+// resolutions. Each resolve builds a fresh index.
+type ownershipIndex struct {
+	claims         []ksClaim
+	ownersCache    map[string][]manifest.NamedResource
+	ancestorsCache map[string][]manifest.NamedResource
+}
 
 // buildOwnership records every Flux KS's spec.path, spec.components,
 // and any `components:` referenced from the kustomization.yaml at
@@ -64,7 +78,11 @@ func buildOwnership(objs ObjectLister, repoRoot string) ownershipIndex {
 		}
 	}
 	slices.SortStableFunc(claims, func(a, b ksClaim) int { return len(b.path) - len(a.path) })
-	return ownershipIndex{claims: claims}
+	return ownershipIndex{
+		claims:         claims,
+		ownersCache:    make(map[string][]manifest.NamedResource),
+		ancestorsCache: make(map[string][]manifest.NamedResource),
+	}
 }
 
 // readKustomizeComponents returns the top-level `components:` field
@@ -88,19 +106,22 @@ func readKustomizeComponents(repoRoot, base string) []string {
 
 // ownersOf returns every KS that claims the longest-matching prefix
 // of file. Multiple KSes are possible when a shared component is in
-// play.
+// play. Results are memoized — see ownershipIndex doc.
 func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
 	if file == "" {
 		return nil
 	}
-	file = file + "/" // so prefix matching catches whole-segment boundaries
+	if cached, ok := idx.ownersCache[file]; ok {
+		return cached
+	}
+	prefixed := file + "/" // so prefix matching catches whole-segment boundaries
 	var bestLen int
 	var owners []manifest.NamedResource
 	for _, c := range idx.claims {
 		if len(c.path) < bestLen {
 			break // sorted longest-first; nothing shorter can beat
 		}
-		if !strings.HasPrefix(file, c.path) {
+		if !strings.HasPrefix(prefixed, c.path) {
 			continue
 		}
 		if len(c.path) > bestLen {
@@ -109,6 +130,7 @@ func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
 		}
 		owners = append(owners, c.id)
 	}
+	idx.ownersCache[file] = owners
 	return owners
 }
 
@@ -118,16 +140,20 @@ func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
 // parent/meta Kustomizations in scope under changed-only mode —
 // their render injects spec.patches and postBuild.substituteFrom
 // onto children, and skipping them produces undefined-${VAR}
-// failures when the leaf renders. See #58.
+// failures when the leaf renders. See #58. Results are memoized —
+// see ownershipIndex doc.
 func (idx ownershipIndex) ancestorsOf(file string) []manifest.NamedResource {
 	if file == "" {
 		return nil
 	}
-	file = file + "/"
+	if cached, ok := idx.ancestorsCache[file]; ok {
+		return cached
+	}
+	prefixed := file + "/"
 	var bestLen int
 	var ancestors []manifest.NamedResource
 	for _, c := range idx.claims {
-		if !strings.HasPrefix(file, c.path) {
+		if !strings.HasPrefix(prefixed, c.path) {
 			continue
 		}
 		if bestLen == 0 {
@@ -138,6 +164,7 @@ func (idx ownershipIndex) ancestorsOf(file string) []manifest.NamedResource {
 			ancestors = append(ancestors, c.id)
 		}
 	}
+	idx.ancestorsCache[file] = ancestors
 	return ancestors
 }
 

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -79,7 +79,8 @@ func (p *storeProvider) Secret(namespace, name string) *manifest.Secret {
 
 // DeepMerge returns a new map with override's keys merged into base.
 // Nested maps recurse; lists and scalars from override fully replace
-// values from base — matching Helm's merge semantics.
+// values from base — matching Helm's merge semantics. Both inputs
+// are read-only.
 func DeepMerge(base, override map[string]any) map[string]any {
 	out := make(map[string]any, len(base)+len(override))
 	maps.Copy(out, base)
@@ -95,6 +96,36 @@ func DeepMerge(base, override map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+// DeepMergeInto merges override's keys into dst in place. Same merge
+// semantics as DeepMerge but mutates dst instead of allocating a new
+// map. Callers MUST own dst and any sub-maps reachable from it —
+// passing a map that shares sub-trees with another reachable
+// reference will corrupt that reference. Designed for hot paths
+// (ExpandValueReferences's per-ref loop) where the caller is
+// building up a fresh map across N refs and the N-1 intermediate
+// allocations DeepMerge would do are wasted.
+//
+// Sub-maps coming from override are inserted by reference (not
+// cloned) when no existing key collides — same as DeepMerge.
+// Returns dst for fluent-style use.
+func DeepMergeInto(dst, override map[string]any) map[string]any {
+	if dst == nil {
+		dst = map[string]any{}
+	}
+	for k, v := range override {
+		if existing, ok := dst[k]; ok {
+			ebm, eok := existing.(map[string]any)
+			vbm, vok := v.(map[string]any)
+			if eok && vok {
+				dst[k] = DeepMergeInto(ebm, vbm)
+				continue
+			}
+		}
+		dst[k] = v
+	}
+	return dst
 }
 
 // ExpandValueReferences resolves all spec.valuesFrom references on hr,
@@ -139,7 +170,13 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 		values = merged
 	}
 	if len(hr.Values) > 0 {
-		values = DeepMerge(values, hr.Values)
+		// hr.Values is the inline-values map decoded from the HR
+		// manifest. The Prepare path clones hr before calling here
+		// (helm.Prepare in pkg/helm), so mutating hr.Values's
+		// sub-tree is safe; reaching values as the dst would
+		// however share sub-references back into hr.Values, so
+		// build the inline layer ON TOP of our owned values map.
+		values = DeepMergeInto(values, hr.Values)
 	}
 	hr.Values = values
 	return nil
@@ -232,6 +269,10 @@ func decodeBag(stringData, binaryData map[string]any) (map[string]string, error)
 // (strvals.ParseIntoString). A naive `inner[k] = found` left every
 // targetPath value as a literal string, which broke chart-schema
 // validation against `replicaCount: integer` and similar.
+//
+// Mutates values in place — ExpandValueReferences owns the map and
+// chaining N refs through DeepMerge previously paid for N-1 wasted
+// full-tree clones (the O(N²) shape the audit flagged).
 func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values map[string]any) (map[string]any, error) {
 	if ref.TargetPath != "" {
 		return replaceValueAtPath(values, ref.TargetPath, found)
@@ -250,9 +291,9 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 		return nil, fmt.Errorf("expected '%s' values to be valid YAML: %w", ref.Name, err)
 	}
 	if parsed == nil {
-		parsed = map[string]any{}
+		return values, nil
 	}
-	return DeepMerge(values, parsed), nil
+	return DeepMergeInto(values, parsed), nil
 }
 
 // replaceValueAtPath writes value into values at path using Helm's

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -9,6 +9,44 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// TestDeepMergeInto_MutatesDstPreservesSemantics pins the in-place
+// variant's contract: dst is mutated, override is read-only, and
+// the resulting tree matches DeepMerge's output for the same inputs.
+// Sub-maps from override are inserted by reference when no key
+// collides (same as DeepMerge); on a collision the recursive merge
+// produces a single in-place result, not a fresh allocation per
+// level. Used in ExpandValueReferences's hot path to avoid O(N²)
+// clones across N valuesFrom refs.
+func TestDeepMergeInto_MutatesDstPreservesSemantics(t *testing.T) {
+	dst := map[string]any{
+		"a": 1,
+		"b": map[string]any{"x": 1, "y": 2},
+	}
+	override := map[string]any{
+		"a": 2,
+		"b": map[string]any{"y": 99, "z": 3},
+		"c": []any{1, 2},
+	}
+	result := DeepMergeInto(dst, override)
+	if result["a"] != 2 {
+		t.Errorf("scalar override failed: %v", result["a"])
+	}
+	bb := result["b"].(map[string]any)
+	if bb["x"] != 1 || bb["y"] != 99 || bb["z"] != 3 {
+		t.Errorf("nested merge wrong: %v", bb)
+	}
+	// In-place semantics: dst is mutated AND returned. Maps don't
+	// have native pointer identity, but the two share state — write
+	// through dst, observe in result.
+	dst["sentinel"] = "v"
+	if result["sentinel"] != "v" {
+		t.Error("DeepMergeInto must return dst itself, got distinct map")
+	}
+	if dst["a"] != 2 || dst["b"].(map[string]any)["y"] != 99 {
+		t.Error("dst not mutated as expected")
+	}
+}
+
 func TestDeepMerge(t *testing.T) {
 	base := map[string]any{
 		"a": 1,


### PR DESCRIPTION
## Summary

PR 8 of 10. Two algorithmic-class perf wins from the audit.

- **9.5 ownershipIndex memoizes ownersOf / ancestorsOf** — Filter.resolve's BFS was O(K²); now O(distinct-files × claims) once + O(1) per visit.
- **4.6 / 10.3 DeepMergeInto + ExpandValueReferences in-place** — eliminates the O(N²) clone-chain across K valuesFrom refs.

## Deferred to follow-up

- **9.4** RS expansion fingerprint — needs careful design around late-arriving RSIPs.
- **2.6** Parallel post-drain RS render — small wall-clock win; needs to coordinate with the orchestrator's lifecycle.
- **4.7** Placeholder-walk sidecar bool — secondary cost; the main DeepMerge churn (the audit's primary concern) is addressed.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestDeepMergeInto_MutatesDstPreservesSemantics\` pins the in-place contract
- [x] Existing values + change BFS tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)