### PR TITLE
fix(cleanup): bucket parallel + replaceValueAtPath panic + small fixes

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 
@@ -120,20 +121,18 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}, nil
 }
 
-// mergeParents combines per-kind parent maps into one. Earlier
-// arguments win on collision (which can't happen in practice — keys
-// are NamedResource with distinct Kind components — but the rule is
-// explicit so future callers don't accidentally clobber a KS parent
-// with an HR-built rebuild).
-func mergeParents(maps ...map[manifest.NamedResource]manifest.NamedResource) map[manifest.NamedResource]manifest.NamedResource {
+// mergeParents combines per-kind parent maps into one. NamedResource
+// keys are kind-segregated by construction (caller passes per-Kind
+// maps from BuildParentIndexForKind), so collisions are structurally
+// impossible. The previous "earlier wins on collision" clause was
+// dead defensive code that silently masked a programmer error if a
+// future caller leaked wrong-kind entries — drop it and let the
+// later-arguments-overwrite default surface the bug at the call
+// site instead.
+func mergeParents(perKind ...map[manifest.NamedResource]manifest.NamedResource) map[manifest.NamedResource]manifest.NamedResource {
 	out := map[manifest.NamedResource]manifest.NamedResource{}
-	for _, m := range maps {
-		for k, v := range m {
-			if _, exists := out[k]; exists {
-				continue
-			}
-			out[k] = v
-		}
+	for _, m := range perKind {
+		maps.Copy(out, m)
 	}
 	return out
 }

--- a/pkg/resourceset/permute.go
+++ b/pkg/resourceset/permute.go
@@ -26,10 +26,22 @@ func permute(groups []providerInputs, includeEmpty bool) ([]map[string]any, erro
 	// Validate names + project to per-provider scoped lists. The
 	// normalized name keys the nested wrapper; templates access values
 	// via `inputs.<normalized-name>.foo`.
+	//
+	// Empty providers short-circuit the entire product: when
+	// includeEmpty=true and any provider has zero inputs, the
+	// Cartesian product is zero — return early so the size cap
+	// check stays meaningful (the previous second-pass at the end
+	// caught this but the size accumulator went through 0 in the
+	// process, making the cap check vacuous for any single empty
+	// provider). Mirrors upstream
+	// computePermutationsWithBacktracking's early-return.
 	scoped := make([]scopedProvider, 0, len(groups))
 	expected := uint64(1)
 	for _, g := range groups {
-		if !includeEmpty && len(g.inputs) == 0 {
+		if len(g.inputs) == 0 {
+			if includeEmpty {
+				return nil, nil
+			}
 			continue
 		}
 		norm := normalizeKeyForTemplate(g.name)
@@ -49,14 +61,6 @@ func permute(groups []providerInputs, includeEmpty bool) ([]map[string]any, erro
 	}
 	if len(scoped) == 0 {
 		return nil, nil
-	}
-	// One empty provider collapses the product. Matches upstream:
-	// computePermutationsWithBacktracking returns early if any
-	// scoped list is empty.
-	for _, p := range scoped {
-		if len(p.sets) == 0 {
-			return nil, nil
-		}
 	}
 
 	out := make([]map[string]any, 0, expected)

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -17,6 +17,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
@@ -176,21 +177,33 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 	}
 	slices.SortFunc(entries, func(a, b entry) int { return cmp.Compare(a.key, b.key) })
 
+	// Download objects in parallel. Bucket fetches are network-bound
+	// (GetObject + Copy per key) and minio-go is concurrency-safe.
+	// The 8-way limit handles typical S3-style providers without
+	// hitting per-account rate caps; tuned narrow because the
+	// fetcher's job is one bucket at a time, not bulk transfer.
+	// Writes go to distinct paths under slot so no inter-goroutine
+	// coordination beyond the errgroup is needed.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(8)
 	for _, e := range entries {
-		rel := strings.TrimPrefix(strings.TrimPrefix(e.key, prefix), "/")
-		if rel == "" {
-			rel = filepath.Base(e.key)
-		}
-		dst, err := safeJoinUnderSlot(slot, rel)
-		if err != nil {
-			return nil, "", fmt.Errorf("bucket key %q: %w", e.key, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
-			return nil, "", err
-		}
-		if err := downloadObject(ctx, client, bucket, e.key, dst); err != nil {
-			return nil, "", err
-		}
+		g.Go(func() error {
+			rel := strings.TrimPrefix(strings.TrimPrefix(e.key, prefix), "/")
+			if rel == "" {
+				rel = filepath.Base(e.key)
+			}
+			dst, err := safeJoinUnderSlot(slot, rel)
+			if err != nil {
+				return fmt.Errorf("bucket key %q: %w", e.key, err)
+			}
+			if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+				return err
+			}
+			return downloadObject(gctx, client, bucket, e.key, dst)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, "", err
 	}
 
 	// Format matches source-controller's internal/index/digest.go:

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"regexp"
+	"slices"
 	"strings"
 
 	"helm.sh/helm/v4/pkg/strvals"
@@ -308,8 +309,14 @@ func replaceValueAtPath(values map[string]any, path, value string) (map[string]a
 		doubleQuote = `"`
 	)
 	var err error
-	if (strings.HasPrefix(value, singleQuote) && strings.HasSuffix(value, singleQuote)) ||
-		(strings.HasPrefix(value, doubleQuote) && strings.HasSuffix(value, doubleQuote)) {
+	// The len >= 2 guard is load-bearing: a single-char "'" or `"`
+	// has prefix == suffix == the same byte, which would pass the
+	// boolean test below and then trip a `value[1:0]` slice — runtime
+	// panic. Untrusted Secret data shouldn't be able to crash the
+	// renderer, so reject the degenerate case explicitly.
+	if len(value) >= 2 &&
+		((strings.HasPrefix(value, singleQuote) && strings.HasSuffix(value, singleQuote)) ||
+			(strings.HasPrefix(value, doubleQuote) && strings.HasSuffix(value, doubleQuote))) {
 		stripped := value[1 : len(value)-1]
 		err = strvals.ParseIntoString(path+"="+stripped, values)
 	} else {
@@ -389,11 +396,21 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 	// doesn't match `^[_[:alpha:]][_[:alpha:][:digit:]]*$`. Without this
 	// check flate would render with the invalid keys silently dropped
 	// while real Flux would fail the Kustomization — divergent output.
+	// Collect every invalid name and report them sorted so the error
+	// message is deterministic across runs. Map iteration is
+	// randomized in Go; the previous "return first invalid name"
+	// surfaced a different bad name on each run when multiple were
+	// present, making bisection and CI noise unnecessarily painful.
+	var invalid []string
 	for name := range values {
 		if !varsubRegex.MatchString(name) {
-			return fmt.Errorf("%w: substituteFrom var name %q is invalid (must match %s)",
-				manifest.ErrInvalidSubstituteReference, name, varsubRegex.String())
+			invalid = append(invalid, name)
 		}
+	}
+	if len(invalid) > 0 {
+		slices.Sort(invalid)
+		return fmt.Errorf("%w: substituteFrom var name(s) %v invalid (must match %s)",
+			manifest.ErrInvalidSubstituteReference, invalid, varsubRegex.String())
 	}
 	ks.UpdatePostBuildSubstitutions(values)
 	return nil

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -213,6 +213,27 @@ func TestExpandPostBuildSubstituteReference_RejectsInvalidVarName(t *testing.T) 
 	}
 }
 
+// TestReplaceValueAtPath_SingleCharQuoteNoPanic pins the
+// len(value) >= 2 guard: a single `'` or `"` previously slipped past
+// the prefix+suffix check (prefix == suffix on a single byte) and
+// then tripped a value[1:0] slice — runtime panic. Now treated as a
+// plain scalar by ParseInto, which returns either ok or a sensible
+// error — never a panic.
+func TestReplaceValueAtPath_SingleCharQuoteNoPanic(t *testing.T) {
+	for _, val := range []string{"'", `"`, "''"} {
+		// Wrap in func() so a panic surfaces as test failure rather
+		// than aborting the whole test binary.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("replaceValueAtPath panicked on value %q: %v", val, r)
+				}
+			}()
+			_, _ = replaceValueAtPath(map[string]any{}, "leaf", val)
+		}()
+	}
+}
+
 // TestReplaceValueAtPath_TypeCoercion locks the upstream Flux contract
 // (chartutil.ReplacePathValue → strvals.ParseInto): a value flowing
 // in through ValuesReference.TargetPath is parsed as a Helm CLI


### PR DESCRIPTION
## Summary

PR 10 of 10 — the cleanup bundle. Closes the audit's residual nits.

- **1.5 Bucket parallel downloads** via \`errgroup.SetLimit(8)\` — N×RTT → N/8×RTT on cold-path bucket fetches.
- **10.5 replaceValueAtPath len(value) >= 2 guard** — single-byte \`'\` or \`"\` previously panicked the renderer.
- **10.6 ExpandPostBuildSubstituteReference sorted invalid names** — deterministic error output across runs.
- **9.8 permute() empty-provider early return** — restores the meaningfulness of the maxPermutations cap.
- **9.6 mergeParents drops dead defensive clause** — let programmer-error wrong-kind entries surface at the call site.

## Deferred from audit

- **5.7 RawObject.Clone** — aliasing-trap, but no current consumer mutates RawObject.Spec.
- **5.8 chartFromHelmRelease chartRef** — needs careful behavior analysis around \`IsResolved()\` semantics.
- **10.2 Coalescer panic loses pending flag** — log+drop deferred until \`flate serve\` is on the roadmap (one-shot CLI is bounded).
- **10.4 decodeBag fmt.Sprint fallback** — works today; defer until a real \`[]byte\`-shape Secret materializes.
- **12.6 testutil cert serials** — flake on slow CI is theoretical; defer.
- **2.7 sanitizeFailed helper** — two-site duplication is small and stable.
- **4.7 placeholder-walk sidecar** — small relative to PR 8's main DeepMerge win.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestReplaceValueAtPath_SingleCharQuoteNoPanic\` pins the panic guard
- [x] Existing bucket / resourceset / discovery / values suites continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)