### PR TITLE
fix(deferred): six small bugs + fragility traps from the audit

### DIFF
--- a/internal/testutil/certs.go
+++ b/internal/testutil/certs.go
@@ -11,6 +11,28 @@ import (
 	"time"
 )
 
+// certValidity is the lifetime stamped on every test cert. 24h
+// generously covers any test run while still bounding the practical
+// window for a leaked fixture if someone pastes the cert somewhere.
+// Previously 1h, which flaked on slow CI runners — long-running
+// integration tests against frozen clocks could expire mid-run.
+const certValidity = 24 * time.Hour
+
+// randomSerial returns a 128-bit random serial — different on every
+// invocation so the CA + server + client cert templates produced by
+// this package don't share serial numbers. Two certs with the same
+// (Issuer, Serial) tuple can short-circuit a verify-cache hit and
+// mask a real chain bug in the system under test.
+func randomSerial(t *testing.T) *big.Int {
+	t.Helper()
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	n, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		t.Fatalf("serial: %v", err)
+	}
+	return n
+}
+
 // SelfSignedCA returns a PEM-encoded CA certificate.
 func SelfSignedCA(t *testing.T) string {
 	t.Helper()
@@ -19,10 +41,10 @@ func SelfSignedCA(t *testing.T) string {
 		t.Fatalf("rsa: %v", err)
 	}
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: randomSerial(t),
 		Subject:      pkix.Name{CommonName: "flate-test-ca"},
 		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
+		NotAfter:     time.Now().Add(certValidity),
 		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
 		IsCA:         true,
 	}
@@ -43,10 +65,10 @@ func SelfSignedServerCert(t *testing.T) (cert, key string) {
 		t.Fatalf("rsa: %v", err)
 	}
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
+		SerialNumber: randomSerial(t),
 		Subject:      pkix.Name{CommonName: "flate-test"},
 		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
+		NotAfter:     time.Now().Add(certValidity),
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		IsCA:         true,
@@ -71,10 +93,10 @@ func SelfSignedClientCert(t *testing.T) (cert, key string) {
 		t.Fatalf("rsa: %v", err)
 	}
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(2),
+		SerialNumber: randomSerial(t),
 		Subject:      pkix.Name{CommonName: "flate-test-client"},
 		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
+		NotAfter:     time.Now().Add(certValidity),
 		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	}

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -35,6 +35,19 @@ func (h HelmChart) ChartName() string {
 	return h.RepoFullName() + "/" + h.Name
 }
 
+// IsResolved reports whether this HelmChart is in its final form —
+// i.e. NOT an unresolved chartRef placeholder. A chartRef pointing
+// at a HelmChart CRD lands in the store with RepoKind=KindHelmChart
+// and no chart Name; ResolveChartRef rewrites the HelmChart in
+// place by looking up the referenced HelmChartSource and setting
+// the chart name + version + the underlying source kind. Callers
+// that read h.Name / h.Version must either run after Prepare /
+// ResolveChartRef, or check IsResolved first — see also the empty
+// Name guarantee in chartFromHelmRelease.
+func (h HelmChart) IsResolved() bool {
+	return h.RepoKind != KindHelmChart || h.Version != ""
+}
+
 // chartFromHelmRelease projects the chart reference out of a typed
 // HelmRelease spec, unifying spec.chartRef and spec.chart into one
 // resolved shape. defaultNamespace fills in an omitted ref namespace.
@@ -46,8 +59,17 @@ func chartFromHelmRelease(spec *helmv2.HelmReleaseSpec, defaultNamespace string)
 		if ref.Name == "" {
 			return HelmChart{}, inputf("HelmRelease missing spec.chartRef.name")
 		}
+		// Leave Name empty for a chartRef → HelmChart CRD: the
+		// referenced HelmChartSource carries the actual chart name,
+		// which ResolveChartRef materializes via helmChartFromSource.
+		// The previous Name=ref.Name placeholder gave callers a wrong
+		// "<refName>" string if they read it before resolve — and
+		// IsResolved() now exposes the unresolved state explicitly so
+		// consumers can branch. For non-HelmChart chartRefs
+		// (OCIRepository/Bucket), the RepoKind is already final and
+		// Name stays empty intentionally — the underlying source's
+		// content determines the chart layout, not the ref name.
 		return HelmChart{
-			Name:          ref.Name,
 			RepoName:      ref.Name,
 			RepoNamespace: cmp.Or(ref.Namespace, defaultNamespace),
 			RepoKind:      ref.Kind,

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1220,6 +1220,36 @@ func TestStripResourceAttributes_StatefulSetPVCs(t *testing.T) {
 	}
 }
 
+// TestRawObject_DoesNotAliasParsedDoc pins the deep-copy fix: a
+// RawObject.Spec must not alias the loader's parsed YAML map.
+// Previously r.Spec = doc["spec"].(map[string]any) shared the map
+// pointer; mutating r.Spec corrupted the original doc the loader
+// reused across passes.
+func TestRawObject_DoesNotAliasParsedDoc(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata":   map[string]any{"name": "foo"},
+		"spec":       map[string]any{"key": "original"},
+	}
+	obj, err := parseRawObject(doc)
+	if err != nil {
+		t.Fatalf("parseRawObject: %v", err)
+	}
+	// Mutate the RawObject's spec. The original doc must NOT change.
+	obj.Spec["key"] = "mutated"
+	got := doc["spec"].(map[string]any)["key"]
+	if got != "original" {
+		t.Errorf("RawObject.Spec aliases parsed doc; got %q in source after mutation", got)
+	}
+	// Clone() produces an independent copy too.
+	clone := obj.Clone()
+	clone.Spec["key"] = "clone-only"
+	if obj.Spec["key"] != "mutated" {
+		t.Errorf("Clone aliases original: clone mutation propagated to source")
+	}
+}
+
 func TestParseDoc_MissingFields(t *testing.T) {
 	if _, err := ParseDoc(map[string]any{"kind": "Foo"}, defaultParseDocOptions()); err == nil || !strings.Contains(err.Error(), "apiVersion") {
 		t.Errorf("expected apiVersion error, got %v", err)

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -96,6 +96,24 @@ func (r *RawObject) Named() NamedResource {
 	return NamedResource{Kind: r.Kind, Namespace: r.Namespace, Name: r.Name}
 }
 
+// Clone returns a deep copy safe for mutation without aliasing the
+// store-owned source. The Spec map is recursively cloned so
+// downstream transformations (e.g. namespace inheritance,
+// substitution overlays) don't mutate the loader's parsed doc.
+//
+// The package doc advertises store-stored objects as immutable
+// (store.AddObject's reflect.DeepEqual dedup compares against shared
+// pointers), but RawObject's pre-Clone construction aliased the
+// loader's `doc[spec]` map directly — any consumer that wrote
+// through r.Spec corrupted the underlying multi-doc YAML the loader
+// reused across passes. Clone makes the immutability contract
+// enforceable instead of nominal.
+func (r *RawObject) Clone() *RawObject {
+	out := *r
+	out.Spec = DeepCopyMap(r.Spec)
+	return &out
+}
+
 // parseRawObject decodes any Kubernetes document into RawObject.
 func parseRawObject(doc map[string]any) (*RawObject, error) {
 	apiVersion := DocAPIVersion(doc)
@@ -116,6 +134,11 @@ func parseRawObject(doc map[string]any) (*RawObject, error) {
 	}
 	ns := stringOr(metadata, "namespace", DefaultNamespace)
 	spec, _ := doc["spec"].(map[string]any)
+	// Deep-copy the spec map so RawObject doesn't alias the loader's
+	// parsed YAML — mutating r.Spec then corrupts the multi-doc
+	// stream the loader reuses across passes. Cheap; spec sub-trees
+	// are small relative to chart-style HR.Values.
+	spec = DeepCopyMap(spec)
 	return &RawObject{
 		Kind:       kind,
 		APIVersion: apiVersion,

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -100,7 +100,7 @@ func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.Status
 }
 
 func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]store.StatusInfo) {
-	for id, info := range failed {
+	for id, info := range sanitizeFailed(failed) {
 		// Demoted to Debug: the same failure list is surfaced as a
 		// structured error by aggregateFailures (with file paths
 		// included) AND echoed by the test runner / build CLI's own
@@ -108,7 +108,7 @@ func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]sto
 		// stderr alongside the user-facing report and reads as
 		// "flate had an internal error" when it's just normal
 		// per-resource Flux failures the user expects to see.
-		args := []any{"id", id.String(), "reason", manifest.TrimSentinelPrefix(info.Message)}
+		args := []any{"id", id.String(), "reason", info.Message}
 		if f := o.sourceFiles[id]; f != "" {
 			args = append(args, "file", f)
 		}
@@ -118,20 +118,33 @@ func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]sto
 
 func (o *Orchestrator) aggregateFailures(failed map[manifest.NamedResource]store.StatusInfo) error {
 	msgs := make([]string, 0, len(failed))
-	for id, info := range failed {
-		// Strip the `flux error: …: ` chain from user-facing messages —
-		// it's three layers of noise before the actual cause. The
-		// sentinels are still wired up for errors.Is callers (e.g.
-		// embedders branching on ErrObjectNotFound); this only affects
-		// the formatted text the CLI ultimately prints.
-		msg := manifest.TrimSentinelPrefix(info.Message)
+	for id, info := range sanitizeFailed(failed) {
 		if f := o.sourceFiles[id]; f != "" {
-			msgs = append(msgs, fmt.Sprintf("%s (%s): %s", id.String(), f, msg))
+			msgs = append(msgs, fmt.Sprintf("%s (%s): %s", id.String(), f, info.Message))
 		} else {
-			msgs = append(msgs, fmt.Sprintf("%s: %s", id.String(), msg))
+			msgs = append(msgs, fmt.Sprintf("%s: %s", id.String(), info.Message))
 		}
 	}
 	slices.Sort(msgs) // deterministic ordering across runs
 	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",
 		len(msgs), strings.Join(msgs, "\n  "))
+}
+
+// sanitizeFailed returns a copy of the failure map with each entry's
+// Message stripped of the `flux error: …: ` sentinel chain. Three
+// callers (logResourceFailures, aggregateFailures, Result.Failed)
+// previously inlined the same manifest.TrimSentinelPrefix call; if a
+// fourth reader appears the strip rule must be applied once at
+// snapshot time rather than re-derived at every consumer.
+//
+// The Store keeps the raw, sentinel-prefixed messages so errors.Is
+// chains on user-facing strings still work — only the projection
+// the orchestrator hands out is sanitized.
+func sanitizeFailed(failed map[manifest.NamedResource]store.StatusInfo) map[manifest.NamedResource]store.StatusInfo {
+	out := make(map[manifest.NamedResource]store.StatusInfo, len(failed))
+	for id, info := range failed {
+		info.Message = manifest.TrimSentinelPrefix(info.Message)
+		out[id] = info
+	}
+	return out
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -652,13 +652,11 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 			}
 		}
 	}
-	for id, info := range o.store.FailedResources() {
-		// Strip the `flux error: <subcategory>:` sentinel chain from the
-		// rendered message so embedders get the actual cause first.
-		// The Status field and the Store entry stay untouched — only
-		// the user-visible string is reshaped, matching the treatment
-		// the aggregated Run error and the WARN log already give.
-		info.Message = manifest.TrimSentinelPrefix(info.Message)
+	// Same projection logRecourceFailures + aggregateFailures use —
+	// see sanitizeFailed for the contract. Centralizing in one
+	// helper keeps the three readers in sync if the strip rule
+	// changes.
+	for id, info := range sanitizeFailed(o.store.FailedResources()) {
 		res.Failed[id] = info
 	}
 	maps.Copy(res.Orphans, o.orphans)

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -7,6 +7,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -219,13 +220,25 @@ func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(c
 		// On panic, Service.Go's recover catches it; we still need to
 		// clear running so a future Submit on this key is dispatched
 		// instead of silently coalescing into a slot that no longer
-		// has a runner.
+		// has a runner. If a coalesced submit had landed during the
+		// panicked run (s.pending == true), the previous code
+		// silently dropped that re-run — the event the submitter
+		// counted on was lost. Log at Warn so the loss is at least
+		// visible; the panicked run itself is already reported via
+		// Service.Go's recover. The pending re-run is genuinely
+		// dead — restarting it here would loop on the same panic if
+		// the input state is deterministic.
 		defer func() {
 			if r := recover(); r != nil {
 				c.mu.Lock()
+				lostPending := s.pending
 				s.running = false
 				s.pending = false
 				c.mu.Unlock()
+				if lostPending {
+					slog.Warn("task coalescer: dropped pending re-run because the previous run panicked",
+						"key", fmt.Sprintf("%v", key))
+				}
 				panic(r)
 			}
 		}()

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -232,23 +232,28 @@ func lookupValueRef(ref manifest.ValuesReference, namespace string, p Provider) 
 }
 
 // decodeBag normalizes ConfigMap/Secret data so callers see a single
-// map[string]string. binaryData values are base64-decoded.
+// map[string]string. binaryData values are base64-decoded. Non-string
+// shapes (a Secret.Data field decoded as []byte, a number leaf the
+// parser produced from an unquoted YAML scalar) get explicit handling
+// — the previous fmt.Sprint fallback silently rendered Go's Stringer
+// output, which for []byte is "[107 58]" rather than the intended
+// "k:" — silently breaking values-reference resolution.
 func decodeBag(stringData, binaryData map[string]any) (map[string]string, error) {
 	if len(stringData) == 0 && len(binaryData) == 0 {
 		return nil, nil
 	}
 	out := make(map[string]string, len(stringData)+len(binaryData))
 	for k, v := range stringData {
-		s, ok := v.(string)
-		if !ok {
-			s = fmt.Sprint(v)
+		s, err := bagValueAsString(v)
+		if err != nil {
+			return nil, fmt.Errorf("stringData[%s]: %w", k, err)
 		}
 		out[k] = s
 	}
 	for k, v := range binaryData {
-		s, ok := v.(string)
-		if !ok {
-			s = fmt.Sprint(v)
+		s, err := bagValueAsString(v)
+		if err != nil {
+			return nil, fmt.Errorf("binaryData[%s]: %w", k, err)
 		}
 		decoded, err := base64.StdEncoding.DecodeString(s)
 		if err != nil {
@@ -257,6 +262,32 @@ func decodeBag(stringData, binaryData map[string]any) (map[string]string, error)
 		out[k] = string(decoded)
 	}
 	return out, nil
+}
+
+// bagValueAsString coerces a single ConfigMap.Data / Secret.Data value
+// into the string form helm values / postBuild substitution consume.
+// Distinguishes the JSON/YAML shapes the decoder actually produces
+// (string, []byte after future schema corrections, JSON-numeric
+// scalars) from the "garbage value" case which now returns an error
+// instead of silently rendering "[107 58]"-style Stringer output.
+func bagValueAsString(v any) (string, error) {
+	switch t := v.(type) {
+	case string:
+		return t, nil
+	case []byte:
+		// Hypothetical today (the YAML decoder lands strings), but
+		// the spec-correct shape for Secret.Data is []byte and a
+		// future schema fix could land us here.
+		return string(t), nil
+	case nil:
+		return "", nil
+	case bool, int, int32, int64, uint, uint32, uint64, float32, float64:
+		// JSON scalar shapes — render via fmt.Sprint, deterministic
+		// for these types.
+		return fmt.Sprint(t), nil
+	default:
+		return "", fmt.Errorf("unsupported value type %T", v)
+	}
 }
 
 // updateHelmReleaseValues writes found into values using ref.TargetPath


### PR DESCRIPTION
## Summary

PR 11 of the architectural pass — the first batch of deferred audit items. Six findings, all small, none with user-visible behavior change today; each closes a fragility trap a future change would have tripped silently.

- **5.7 RawObject.Clone + parseRawObject deep-copy** — \`r.Spec\` no longer aliases the loader's parsed YAML map.
- **5.8 chartFromHelmRelease leaves Name empty for unresolved chartRefs** + new \`HelmChart.IsResolved()\` predicate.
- **2.7 sanitizeFailed single helper** — three readers funnel through one strip site.
- **10.2 Coalescer Warn-logs the dropped pending re-run** on panic-with-pending.
- **10.4 decodeBag explicit type switch** — typed handling for string/[]byte/nil/numeric, error otherwise.
- **12.6 Test certs use random 128-bit serials + 24h validity**.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestRawObject_DoesNotAliasParsedDoc\` pins the deep-copy
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)