### PR TITLE
perf(discovery,orchestrator): skip converged RSes + parallel post-run RS render

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -175,19 +175,21 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	// PreferExisting lets repeated AddObject re-emission be a no-op so
 	// the loop terminates on convergence (no new objects added).
 	//
-	// ResourceSets are re-rendered every iteration rather than memoized,
-	// because a RS's inputsFrom selector may match RSIPs that only
-	// arrive after a downstream Kustomization chain expands. Without
-	// the retry, a RS whose RSIPs are produced by a child KS renders
-	// to zero docs on first pass and never recovers — observed in
-	// tholinka/home-ops where `dragonfly-acls` (a Permute RS) selects
-	// RSIPs created by an unrelated `dragonfly/manual` component
-	// applied through `renovate-operator-jobs-jobs`. Re-rendering is
-	// safe: renderResourceSet skips already-present objects in the
-	// store, so a steady-state RS contributes 0 new docs and the loop
-	// converges via the `added == 0` exit.
+	// ResourceSets are re-rendered when new inputs may have arrived.
+	// A RS's inputsFrom selector may match RSIPs that only show up
+	// after a downstream Kustomization chain expands — observed in
+	// tholinka/home-ops where `dragonfly-acls` (Permute) selects RSIPs
+	// from `renovate-operator-jobs-jobs`. The optimization: skip
+	// re-rendering an RS that already converged (produced 0 new docs
+	// on its last render) UNLESS the count of available RSIPs in the
+	// store has grown since the previous pass. RSIPs are only ever
+	// added during discovery, never removed, so a count check is
+	// sufficient — RSes that added zero docs at count C stay
+	// converged through any later pass with count == C.
 	l.PreferExisting = true
 	ksExpanded := map[manifest.NamedResource]struct{}{}
+	rsConverged := map[manifest.NamedResource]struct{}{}
+	prevRSIPCount := len(store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider))
 	for {
 		added := 0
 		for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
@@ -212,7 +214,19 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			}
 			added++
 		}
+		// Re-evaluate the convergence cache when new RSIPs arrived
+		// between passes — they may match selectors that previously
+		// returned zero inputs.
+		currentRSIPCount := len(store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider))
+		if currentRSIPCount != prevRSIPCount {
+			rsConverged = map[manifest.NamedResource]struct{}{}
+			prevRSIPCount = currentRSIPCount
+		}
 		for _, rs := range store.ListAs[*manifest.ResourceSet](d.cfg.Store, manifest.KindResourceSet) {
+			rsID := rs.Named()
+			if _, done := rsConverged[rsID]; done {
+				continue
+			}
 			n, err := d.renderResourceSet(rs)
 			if err != nil {
 				return err
@@ -220,6 +234,8 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			if n > 0 {
 				added++
 				total += n
+			} else {
+				rsConverged[rsID] = struct{}{}
 			}
 		}
 		if added == 0 {

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -5,8 +5,10 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -66,67 +68,93 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		}
 	}
 
-	// Dedupe by (apiVersion, kind, ns, name) across the union of every
-	// RS's render — a name-grouped RS may legitimately render the same
-	// child from each namespace variant, and we don't want to double-
-	// emit it under the parent KS.
-	seen := map[string]struct{}{}
-	out := map[manifest.NamedResource][]map[string]any{}
+	// Render each RS in parallel — they only read shared state (the
+	// store + owners index) which is safe under concurrent reads. The
+	// dedup + accumulation step runs under a mutex so the cross-RS
+	// "first-wins" invariant is preserved (a name-grouped RS may
+	// legitimately render the same child from each namespace variant
+	// and we don't want to double-emit it under the parent KS).
+	//
+	// Concurrency limit matches the bucket fetcher (8) — render is
+	// CPU-bound, so the cap exists more to prevent goroutine
+	// explosion on huge RS-counts than as a rate limiter.
+	var (
+		mu   sync.Mutex
+		seen = map[string]struct{}{}
+		out  = map[manifest.NamedResource][]map[string]any{}
+	)
+	g := new(errgroup.Group)
+	g.SetLimit(8)
 	for _, rs := range rsList {
-		docs, err := resourceset.Render(rs, o.resolveInputProvider)
-		if err != nil || len(docs) == 0 {
-			continue
-		}
-		// Resolve parent KS in priority order:
-		//
-		//   1. renderedSet.ParentOf — most direct; set when the RS
-		//      arrived via emitRenderedChildren. No prefix matching
-		//      needed.
-		//   2. sourceFiles + path-prefix match — file-loaded RSes.
-		//   3. Name-keyed sourceFile fallback — covers a KS-
-		//      substituted variant whose namespace shifted at emit
-		//      time, identified by sharing a name with a file-loaded
-		//      sibling.
-		var parentKS manifest.NamedResource
-		var matched bool
-		if parent, ok := o.rendered.ParentOf(rs.Named()); ok {
-			parentKS, matched = parent, true
-		} else {
-			file := cmp.Or(o.sourceFiles[rs.Named()], sourceByName[rs.Name])
-			if file == "" {
-				continue
+		g.Go(func() error {
+			docs, err := resourceset.Render(rs, o.resolveInputProvider)
+			if err != nil || len(docs) == 0 {
+				return nil
 			}
-			slashFile := filepath.ToSlash(file)
-			for _, w := range owners {
-				if strings.HasPrefix(slashFile, w.prefix) {
-					parentKS = w.id
-					matched = true
-					break
+			// Resolve parent KS in priority order:
+			//   1. renderedSet.ParentOf — direct lookup.
+			//   2. sourceFiles + path-prefix match — file-loaded.
+			//   3. Name-keyed sourceFile fallback — KS-substituted
+			//      variant whose namespace shifted at emit time.
+			var parentKS manifest.NamedResource
+			if parent, ok := o.rendered.ParentOf(rs.Named()); ok {
+				parentKS = parent
+			} else {
+				file := cmp.Or(o.sourceFiles[rs.Named()], sourceByName[rs.Name])
+				if file == "" {
+					return nil
+				}
+				slashFile := filepath.ToSlash(file)
+				matched := false
+				for _, w := range owners {
+					if strings.HasPrefix(slashFile, w.prefix) {
+						parentKS = w.id
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					return nil
 				}
 			}
-			if !matched {
-				continue
+			// Filter docs to RawObjects + collect dedup keys
+			// outside the mutex; the mutex only holds for the
+			// commit-to-shared-state step.
+			type emit struct {
+				key string
+				doc map[string]any
 			}
-		}
-		for _, doc := range docs {
-			parsed, perr := manifest.ParseDoc(doc, manifest.ParseDocOptions{WipeSecrets: o.cfg.WipeSecrets})
-			if perr != nil {
-				continue
+			pending := make([]emit, 0, len(docs))
+			for _, doc := range docs {
+				parsed, perr := manifest.ParseDoc(doc, manifest.ParseDocOptions{WipeSecrets: o.cfg.WipeSecrets})
+				if perr != nil {
+					continue
+				}
+				if _, raw := parsed.(*manifest.RawObject); !raw {
+					continue
+				}
+				key := resourceset.DedupKey(doc)
+				if key == "" {
+					continue
+				}
+				pending = append(pending, emit{key, doc})
 			}
-			if _, raw := parsed.(*manifest.RawObject); !raw {
-				continue
+			if len(pending) == 0 {
+				return nil
 			}
-			key := resourceset.DedupKey(doc)
-			if key == "" {
-				continue
+			mu.Lock()
+			defer mu.Unlock()
+			for _, e := range pending {
+				if _, dup := seen[e.key]; dup {
+					continue
+				}
+				seen[e.key] = struct{}{}
+				out[parentKS] = append(out[parentKS], e.doc)
 			}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-			out[parentKS] = append(out[parentKS], doc)
-		}
+			return nil
+		})
 	}
+	_ = g.Wait() // render errors are intentionally swallowed (same as before)
 	o.rsExtensions = out
 }
 


### PR DESCRIPTION
## Summary

PR 12 — two perf wins deferred from PR 8.

- **9.4 Discovery skips converged ResourceSets between passes** — track per-RS convergence; clear when new RSIPs land. O(passes × RS) → O(RS × distinct-RSIP-counts), typically O(RS).
- **2.6 Post-Run RS expansion runs parallel via errgroup(8)** — CPU was cold; dedup is mutex-guarded so first-wins is preserved.

**4.7 (placeholder-walk sidecar) deliberately skipped** — micro-opt per the synthesis triage; the walk is dominated by template execution on the same path.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] Existing resourceset/discovery/orchestrator suites continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)