### PR TITLE
refactor(source): generic TypedFetcher[T] + Wrap adapter

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -194,18 +194,27 @@ func New(cfg Config) (*Orchestrator, error) {
 	// would otherwise have to keep in sync via Add* push-API calls.
 	helmClient.SetSourceResolver(helm.NewStoreSourceResolver(st))
 	srcCtrl := sourcectrl.New(st, ts)
-	srcCtrl.Fetchers[manifest.KindGitRepository] = &git.Fetcher{Cache: cache, Secrets: secretGet}
-	srcCtrl.Fetchers[manifest.KindExternalArtifact] = &external.Fetcher{}
-	srcCtrl.Fetchers[manifest.KindBucket] = &bucket.Fetcher{Cache: cache, Secrets: secretGet}
+	// Every kind-specific fetcher is wired through source.Wrap so the
+	// concrete Fetch signature stays typed (no per-impl type
+	// assertion). The wrap label is the kind string; a mismatched
+	// payload at dispatch surfaces "<kind> fetcher: unexpected
+	// payload <T>" from the single adapter site rather than from
+	// four nearly-identical type assertions.
+	srcCtrl.Fetchers[manifest.KindGitRepository] = source.Wrap[*manifest.GitRepository](
+		manifest.KindGitRepository, &git.Fetcher{Cache: cache, Secrets: secretGet})
+	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap[*manifest.ExternalArtifact](
+		manifest.KindExternalArtifact, &external.Fetcher{})
+	srcCtrl.Fetchers[manifest.KindBucket] = source.Wrap[*manifest.Bucket](
+		manifest.KindBucket, &bucket.Fetcher{Cache: cache, Secrets: secretGet})
 	// HelmRepository: existence-only — flate resolves charts via the
 	// Helm client's registry/repo machinery directly, the controller
 	// just needs the resource to land in Ready so HelmRelease deps
 	// unblock.
 	srcCtrl.Fetchers[manifest.KindHelmRepository] = source.ExistenceFetcher{}
 	if cfg.EnableOCI {
-		srcCtrl.Fetchers[manifest.KindOCIRepository] = &oci.Fetcher{
-			Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet,
-		}
+		srcCtrl.Fetchers[manifest.KindOCIRepository] = source.Wrap[*manifest.OCIRepository](
+			manifest.KindOCIRepository,
+			&oci.Fetcher{Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet})
 	} else {
 		// --enable-oci=false: skip the real fetch but still mark each
 		// OCIRepository Ready so HRs that dependsOn one don't time out.

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -34,12 +34,9 @@ type Fetcher struct {
 	Secrets source.SecretGetter
 }
 
-// Fetch implements source.Fetcher for *manifest.Bucket.
-func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
-	b, ok := obj.(*manifest.Bucket)
-	if !ok {
-		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
-	}
+// Fetch implements source.TypedFetcher[*manifest.Bucket]. The typed
+// signature is wrapped via source.Wrap at orchestrator registration.
+func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceArtifact, error) {
 	if b.Provider != "" && b.Provider != sourcev1.BucketProviderGeneric {
 		return nil, fmt.Errorf(
 			"bucket %s/%s provider %q is not implemented; flate currently supports only %q (S3-compatible)",

--- a/pkg/source/external/external.go
+++ b/pkg/source/external/external.go
@@ -31,12 +31,9 @@ import (
 //     emitting empty output.
 type Fetcher struct{}
 
-// Fetch implements source.Fetcher for *manifest.ExternalArtifact.
-func (f *Fetcher) Fetch(_ context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
-	ea, ok := obj.(*manifest.ExternalArtifact)
-	if !ok {
-		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
-	}
+// Fetch implements source.TypedFetcher[*manifest.ExternalArtifact].
+// Wrapped via source.Wrap at orchestrator registration.
+func (f *Fetcher) Fetch(_ context.Context, ea *manifest.ExternalArtifact) (*store.SourceArtifact, error) {
 	if ea.ArtifactURL == "" {
 		return nil, fmt.Errorf(
 			"ExternalArtifact %s/%s requires status.artifact to be populated for offline use — "+

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -35,12 +35,11 @@ type Fetcher struct {
 // httpsTransportMu is declared in tls.go (with the only caller —
 // the TLS-customized InstallProtocol path in Fetch below).
 
-// Fetch implements source.Fetcher for *manifest.GitRepository.
-func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
-	repo, ok := obj.(*manifest.GitRepository)
-	if !ok {
-		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
-	}
+// Fetch implements source.TypedFetcher[*manifest.GitRepository].
+// The typed signature is wrapped via source.Wrap at orchestrator
+// registration — a payload mismatch returns ErrInput once at the
+// adapter site rather than panicking here.
+func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*store.SourceArtifact, error) {
 	if repo.Provider != "" && repo.Provider != sourcev1.GitProviderGeneric {
 		return nil, fmt.Errorf(
 			"GitRepository %s/%s provider %q is not implemented; flate currently supports only %q (SecretRef-based credentials)",

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -46,12 +46,11 @@ type Fetcher struct {
 	Secrets        source.SecretGetter
 }
 
-// Fetch implements source.Fetcher for *manifest.OCIRepository.
-func (f *Fetcher) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
-	repo, ok := obj.(*manifest.OCIRepository)
-	if !ok {
-		return nil, fmt.Errorf("%w: Fetcher: unexpected payload %T", manifest.ErrInput, obj)
-	}
+// Fetch implements source.TypedFetcher[*manifest.OCIRepository].
+// The typed signature is wrapped via source.Wrap at orchestrator
+// registration — a payload mismatch returns ErrInput once at the
+// adapter site rather than panicking here.
+func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.OCIRepository) (*store.SourceArtifact, error) {
 	if repo.Provider != "" && repo.Provider != sourcev1.GenericOCIProvider {
 		return nil, fmt.Errorf(
 			"OCIRepository %s/%s provider %q is not implemented; flate currently supports only %q (SecretRef or --registry-config credentials)",

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -15,20 +15,51 @@ package source
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// Fetcher resolves a single source CR into an on-disk artifact. Each
-// kind (GitRepository, OCIRepository, Bucket, …) provides its own
-// implementation; the source controller dispatches by id.Kind.
-//
-// obj is the typed manifest payload (e.g. *manifest.GitRepository).
-// Implementations type-assert and return an InputError on mismatch
-// rather than panic.
+// Fetcher resolves a single source CR into an on-disk artifact. The
+// source controller stores Fetchers in a map keyed by Kind and
+// dispatches via this untyped interface. Concrete implementations
+// satisfy it through Wrap[T] — see TypedFetcher.
 type Fetcher interface {
 	Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error)
+}
+
+// TypedFetcher is the kind-specific Fetcher each concrete source kind
+// implements (e.g. TypedFetcher[*manifest.GitRepository] for git).
+// The typed signature removes the per-implementation
+// `obj, ok := obj.(*manifest.X)` boilerplate every fetcher
+// previously opened with — a missing assertion would have panicked.
+// Wrap[T] turns a TypedFetcher into the untyped Fetcher the
+// source controller's map needs.
+type TypedFetcher[T manifest.BaseManifest] interface {
+	Fetch(ctx context.Context, obj T) (*store.SourceArtifact, error)
+}
+
+// Wrap converts a TypedFetcher into the untyped Fetcher interface
+// used by the source-controller dispatcher map. The single
+// type-assertion site is here — a mismatched payload returns
+// ErrInput rather than panicking. Embeds the Kind label so the
+// error message names the responsible fetcher.
+func Wrap[T manifest.BaseManifest](kindLabel string, f TypedFetcher[T]) Fetcher {
+	return typedAdapter[T]{label: kindLabel, inner: f}
+}
+
+type typedAdapter[T manifest.BaseManifest] struct {
+	label string
+	inner TypedFetcher[T]
+}
+
+func (a typedAdapter[T]) Fetch(ctx context.Context, obj manifest.BaseManifest) (*store.SourceArtifact, error) {
+	typed, ok := obj.(T)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s fetcher: unexpected payload %T", manifest.ErrInput, a.label, obj)
+	}
+	return a.inner.Fetch(ctx, typed)
 }
 
 // Suspendable is satisfied by source CR types that carry a

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -1,0 +1,66 @@
+package source
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// stubTypedFetcher records its Fetch calls so the Wrap test can pin
+// the typed-dispatch path.
+type stubTypedFetcher struct {
+	called *manifest.GitRepository
+}
+
+func (s *stubTypedFetcher) Fetch(_ context.Context, obj *manifest.GitRepository) (*store.SourceArtifact, error) {
+	s.called = obj
+	return &store.SourceArtifact{Kind: manifest.KindGitRepository, URL: obj.URL}, nil
+}
+
+// TestWrap_DispatchesTypedPayload pins the happy path: Wrap turns a
+// TypedFetcher into a Fetcher whose Fetch routes a matching payload
+// through the typed inner function.
+func TestWrap_DispatchesTypedPayload(t *testing.T) {
+	inner := &stubTypedFetcher{}
+	f := Wrap(manifest.KindGitRepository, inner)
+	repo := &manifest.GitRepository{Name: "r", Namespace: "ns"}
+	repo.URL = "https://example.com/repo.git"
+
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if inner.called != repo {
+		t.Errorf("Wrap did not pass typed payload through")
+	}
+	if art.URL != repo.URL {
+		t.Errorf("art.URL = %q, want %q", art.URL, repo.URL)
+	}
+}
+
+// TestWrap_MismatchedPayloadReturnsInputError pins the single
+// type-assertion site: a wrong-kind payload returns a wrapped
+// ErrInput naming the responsible kind. Previously every concrete
+// fetcher's Fetch opened with its own assertion — four copies of
+// the same boilerplate, each a potential panic site if anyone
+// forgot the `, ok` check.
+func TestWrap_MismatchedPayloadReturnsInputError(t *testing.T) {
+	inner := &stubTypedFetcher{}
+	f := Wrap(manifest.KindGitRepository, inner)
+	// An OCIRepository payload going through a Git-typed wrapper.
+	wrong := &manifest.OCIRepository{Name: "o", Namespace: "ns"}
+
+	_, err := f.Fetch(context.Background(), wrong)
+	if err == nil {
+		t.Fatal("expected ErrInput on mismatched payload")
+	}
+	if !errors.Is(err, manifest.ErrInput) {
+		t.Errorf("expected wrapped ErrInput; got %v", err)
+	}
+	if inner.called != nil {
+		t.Errorf("inner Fetch was invoked on mismatched payload")
+	}
+}


### PR DESCRIPTION
## Summary

PR 13 — closes 5.2. Generic \`TypedFetcher[T BaseManifest]\` + \`source.Wrap\` adapter.

Every concrete fetcher previously opened its Fetch with the same defensive type-assertion boilerplate (4 copies). The Wrap adapter performs the assertion once at orchestrator registration; concrete fetchers now have typed signatures.

**2.5 (table-driven registration) deliberately skipped** — the EnableOCI branch wouldn't collapse meaningfully into a table; per-kind constructors carry distinct shapes.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestWrap_DispatchesTypedPayload\` + \`TestWrap_MismatchedPayloadReturnsInputError\` pin the adapter
- [x] All existing fetcher tests pass on the typed signature (\`t.Fetch(ctx, *manifest.X)\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)