### PR TITLE
fix(loader): skip orphan YAMLs not referenced by their parent kustomization.yaml

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -61,22 +61,47 @@ func readKustomization(dir string) *kustomization {
 	return nil
 }
 
-// collectGeneratorDataFiles walks root and decodes every kustomization
-// file it finds, returning the set of absolute file paths declared as
-// configMapGenerator/secretGenerator data sources (files + envs).
+// kustomizationScan is the result of walking the tree once to inspect
+// every kustomization.yaml the loader cares about. The fields cover
+// the three exclusion/inclusion rules the main walk applies:
 //
-// Files that are ALSO declared in `resources:` are removed from the
-// set so a resource-and-data conflict still loads as a manifest: the
-// `resources:` entry is an authoritative "this IS a Flux manifest"
-// declaration, and the kustomize spec doesn't actually forbid the
-// same path from appearing in both lists (though it'd be unusual).
+//   - DataFiles: configMapGenerator / secretGenerator file paths.
+//     Skipped because they're YAML/env data the chart loader handles
+//     at render time, not Flux manifests.
+//   - ClaimedResources: absolute paths declared in some
+//     kustomization.yaml's resources list. Authoritative "this IS a
+//     Flux manifest" inclusions — they survive the orphan-skip check
+//     even if they happen to share a dir with other YAML.
+//   - KustomizationDirs: directories that contain a kustomization.yaml
+//     file. Used by the orphan check: a YAML file in a directory
+//     governed by a kustomization.yaml must be referenced as a
+//     resource to be loaded.
+type kustomizationScan struct {
+	DataFiles         map[string]struct{}
+	ClaimedResources  map[string]struct{}
+	KustomizationDirs map[string]struct{}
+}
+
+// collectKustomizationScan walks root and decodes every
+// kustomization.yaml it finds, building the three sets the main
+// loader uses to decide which YAML files to parse.
+//
+// Files declared as configMapGenerator/secretGenerator data are
+// captured separately from files declared as resources. When a path
+// appears in BOTH lists across the tree, the resource interpretation
+// wins (the data exclusion is dropped) — kustomize doesn't forbid
+// the duplication and the resource declaration is the more
+// authoritative "this IS a Flux manifest" signal.
 //
 // Honors ctx cancellation and the same shouldSkipDir rules as the
 // main walk so we don't descend into `.git`, `templates/`, Component
 // dirs, or ignore-matched paths.
-func collectGeneratorDataFiles(ctx context.Context, root string, ignore *ignoreSet) (map[string]struct{}, error) {
-	data := map[string]struct{}{}
-	resources := map[string]struct{}{}
+func collectKustomizationScan(ctx context.Context, root string, ignore *ignoreSet) (*kustomizationScan, error) {
+	scan := &kustomizationScan{
+		DataFiles:         map[string]struct{}{},
+		ClaimedResources:  map[string]struct{}{},
+		KustomizationDirs: map[string]struct{}{},
+	}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
@@ -98,9 +123,10 @@ func collectGeneratorDataFiles(ctx context.Context, root string, ignore *ignoreS
 			return nil
 		}
 		base := filepath.Dir(path)
+		scan.KustomizationDirs[base] = struct{}{}
 		for _, r := range k.Resources {
 			if abs, ok := resolveDataPath(base, r); ok {
-				resources[abs] = struct{}{}
+				scan.ClaimedResources[abs] = struct{}{}
 			}
 		}
 		addEntries := func(entries []string, parseKey bool) {
@@ -110,7 +136,7 @@ func collectGeneratorDataFiles(ctx context.Context, root string, ignore *ignoreS
 					p = stripFileEntryKey(e)
 				}
 				if abs, ok := resolveDataPath(base, p); ok {
-					data[abs] = struct{}{}
+					scan.DataFiles[abs] = struct{}{}
 				}
 			}
 		}
@@ -130,13 +156,13 @@ func collectGeneratorDataFiles(ctx context.Context, root string, ignore *ignoreS
 	// Resource interpretation wins over data interpretation if the same
 	// path appears in both lists across any kustomization.yaml in the
 	// tree.
-	for r := range resources {
-		delete(data, r)
+	for r := range scan.ClaimedResources {
+		delete(scan.DataFiles, r)
 	}
-	if len(data) > 0 {
-		slog.Debug("loader: data files excluded from manifest scan", "count", len(data))
+	if len(scan.DataFiles) > 0 {
+		slog.Debug("loader: data files excluded from manifest scan", "count", len(scan.DataFiles))
 	}
-	return data, nil
+	return scan, nil
 }
 
 // stripFileEntryKey returns the path portion of a kustomize

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -90,12 +91,22 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 	}
 
 	// Pre-pass: decode every kustomization.yaml in the tree and
-	// collect the set of files referenced as configMapGenerator /
-	// secretGenerator data sources. The main walk skips those — they
-	// are valid YAML data files, not Flux manifests, and would
-	// otherwise trip the generic decode-as-map fallback with noisy
-	// WARN logs that look like real failures (issue #192).
-	dataFiles, err := collectGeneratorDataFiles(ctx, abs, ignore)
+	// collect (a) data files declared as generator inputs, (b) files
+	// declared as `resources:`, and (c) the directories that have a
+	// kustomization.yaml at all. The main walk applies three rules
+	// from this scan:
+	//
+	//   - skip generator data files (issue #192)
+	//   - skip "orphan" YAML files: a YAML in a directory governed by
+	//     a kustomization.yaml is loaded only when explicitly
+	//     referenced via `resources:`. Closes #342 — toggle stubs
+	//     left lying around next to a kustomization.yaml (a common
+	//     pattern: comment a `./vrising.yaml` line in resources to
+	//     disable that wrapper) were being discovered and reconciled
+	//     against the wrong namespace, since the parent overlay's
+	//     transforms never applied. kustomize build follows the
+	//     same graph; flate now matches that behavior.
+	scan, err := collectKustomizationScan(ctx, abs, ignore)
 	if err != nil {
 		return 0, err
 	}
@@ -120,12 +131,22 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 		if ignore.matches(path, abs) {
 			return nil
 		}
-		if _, isData := dataFiles[path]; isData {
+		if _, isData := scan.DataFiles[path]; isData {
 			// Declared as configMapGenerator/secretGenerator data by
 			// a kustomization.yaml in the tree. krusty handles the
 			// file correctly at render time; the loader's job is to
 			// stay out of the way.
 			slog.Debug("loader: skipping generator data file", "path", path)
+			return nil
+		}
+		if orphan := isOrphanYAML(path, scan); orphan {
+			// Orphan: this YAML lives in a directory governed by a
+			// kustomization.yaml but isn't referenced via the
+			// `resources:` list. kustomize build wouldn't include it;
+			// flate now matches that. Common shape: a disabled toggle
+			// stub like `./vrising.yaml` left in the directory after
+			// a maintainer commented out the line in `resources:`.
+			slog.Debug("loader: skipping orphan YAML not referenced in parent kustomization.yaml", "path", path)
 			return nil
 		}
 		n, err := l.loadFile(path)
@@ -274,4 +295,35 @@ func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 func isKustomizeComponent(dir string) bool {
 	k := readKustomization(dir)
 	return k != nil && k.Kind == "Component"
+}
+
+// isOrphanYAML reports whether path should be skipped by the main
+// loader walk because it's an unreferenced YAML in a directory
+// governed by a kustomization.yaml. The rule:
+//
+//   - If the path's directory does NOT have a kustomization.yaml,
+//     the file is loaded normally (e.g. --path entry points, the
+//     bootstrap dir before the first overlay).
+//   - The kustomization.yaml file itself always loads.
+//   - Files explicitly listed in the kustomization.yaml's
+//     `resources:` always load.
+//   - Everything else in the same directory is "orphan" — toggle
+//     stubs, kustomize patches, `replacements:` payloads — and is
+//     skipped. Patches/replacements would parse as RawObject and
+//     get filtered downstream anyway; toggle stubs (the #342 case)
+//     would parse as a Flux Kustomization and reconcile against
+//     the wrong overlay state.
+//
+// Mirrors kustomize build's graph traversal: only the transitive
+// closure of `resources:` (+ generators) ends up rendered.
+func isOrphanYAML(path string, scan *kustomizationScan) bool {
+	dir := filepath.Dir(path)
+	if _, ok := scan.KustomizationDirs[dir]; !ok {
+		return false
+	}
+	if slices.Contains(kustomizationFileNames, filepath.Base(path)) {
+		return false
+	}
+	_, claimed := scan.ClaimedResources[path]
+	return !claimed
 }

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -272,10 +272,18 @@ metadata: {name: shared, namespace: ns}
 // declared by a kustomization.yaml deep in the tree is excluded
 // during the load of a higher-level --path. Same exclusion logic;
 // just verifies the pre-pass actually walks recursively.
+//
+// manifest.yaml must be declared in resources for the loader to
+// pick it up — the orphan-skip rule (issue #342) skips YAMLs in a
+// kustomization-governed directory that aren't referenced. Without
+// the resources entry, manifest.yaml would be a toggle-stub orphan
+// and correctly excluded.
 func TestLoader_NestedKustomizationDataFile(t *testing.T) {
 	dir := t.TempDir()
 	testutil.WriteFile(t, dir, "apps/notifier/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+resources:
+  - ./manifest.yaml
 configMapGenerator:
   - name: cm
     files:
@@ -292,6 +300,65 @@ metadata: {name: real, namespace: ns}
 	}
 	if s.GetObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "real"}) == nil {
 		t.Errorf("the real manifest under the same kustomization dir must still load")
+	}
+}
+
+// TestLoader_OrphanYAMLSkipped pins the issue-#342 fix: a YAML
+// file in a directory governed by a kustomization.yaml is loaded
+// only when it appears in `resources:`. The unreferenced file (a
+// "toggle stub" — common pattern where maintainers comment out
+// resources entries to disable a wrapper without deleting the file)
+// must NOT reach the store. Before the fix, the orphan was
+// discovered and reconciled against the wrong overlay state,
+// producing spurious "dependency not found" failures for any chart
+// source the parent's namespace transform was supposed to inject.
+func TestLoader_OrphanYAMLSkipped(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "apps/games/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: games
+resources:
+  - ./valheim.yaml
+  # - ./vrising.yaml   # disabled toggle stub
+`)
+	testutil.WriteFile(t, dir, "apps/games/valheim.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: valheim
+spec:
+  interval: 1h
+  path: ./apps/base/games/valheim
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/games/vrising.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: vrising
+spec:
+  interval: 1h
+  path: ./apps/base/games/vrising
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	s := store.New()
+	if _, err := New(s).Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// valheim is referenced — must load. Kustomization namespace
+	// is left empty by the parser (the YAML has no
+	// metadata.namespace); the parent kustomization.yaml's
+	// `namespace:` overlay would fill it at render time.
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Name: "valheim"}) == nil {
+		t.Error("referenced Kustomization 'valheim' missing from store")
+	}
+	// vrising is NOT referenced — must be skipped as orphan.
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Name: "vrising"}) != nil {
+		t.Error("orphan Kustomization 'vrising' should not be loaded (issue #342)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #342.

The loader walked the tree blindly and parsed every \`.yaml\` file. When a Flux \`Kustomization\` yaml lived next to a \`kustomization.yaml\` that did NOT list it under \`resources:\` (a common "toggle stub" pattern — comment out the line to disable the wrapper without deleting the file), flate discovered and reconciled it anyway. The parent overlay's transforms (e.g. \`namespace: games\`) never applied to the orphan, so the rendered HR landed in the wrong namespace and chart-source lookups failed with "dependency not found".

The reporter hit this on three disabled wrappers in joryirving/home-ops after migrating from flux-local — flux-local followed the kustomize overlay graph correctly.

## Fix

Pre-pass collects three sets from every \`kustomization.yaml\` in the tree:
- data files (existing — generator inputs to skip)
- files explicitly claimed by \`resources:\` (new)
- directories that contain a \`kustomization.yaml\` (new)

The main walk applies the orphan-skip rule: a YAML in a directory governed by a \`kustomization.yaml\` is loaded only when it's the \`kustomization.yaml\` itself or appears in \`resources:\`. Mirrors \`kustomize build\`'s graph traversal — the reporter's exact expectation.

Skipped files are debug-logged so an operator chasing "where did my resource go?" can see the decision.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestLoader_OrphanYAMLSkipped\` reproduces the bug shape from #342 and pins the fix
- [x] Existing \`TestLoader_NestedKustomizationDataFile\` updated to declare its "real manifest" under \`resources:\` (it was implicitly depending on the bug)
- [x] Manual repro from the issue: \`flate get ks --path /tmp/repro\` previously listed both \`valheim\` and \`vrising\`; now correctly lists only \`valheim\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)