### PR TITLE
fix(loader): graph-driven walk skips orphan subtrees, not just same-dir orphans

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -63,23 +63,32 @@ func readKustomization(dir string) *kustomization {
 
 // kustomizationScan is the result of walking the tree once to inspect
 // every kustomization.yaml the loader cares about. The fields cover
-// the three exclusion/inclusion rules the main walk applies:
+// the exclusion/inclusion rules the main walk applies:
 //
 //   - DataFiles: configMapGenerator / secretGenerator file paths.
 //     Skipped because they're YAML/env data the chart loader handles
 //     at render time, not Flux manifests.
 //   - ClaimedResources: absolute paths declared in some
 //     kustomization.yaml's resources list. Authoritative "this IS a
-//     Flux manifest" inclusions — they survive the orphan-skip check
-//     even if they happen to share a dir with other YAML.
+//     Flux manifest" inclusions.
 //   - KustomizationDirs: directories that contain a kustomization.yaml
-//     file. Used by the orphan check: a YAML file in a directory
-//     governed by a kustomization.yaml must be referenced as a
-//     resource to be loaded.
+//     file. Used by the orphan check (legacy walk) and by graph-walk
+//     reachability.
+//   - ResourceEdges: kustomize-graph edges keyed by dir →
+//     (file paths claimed, sub-dir paths claimed). Built lazily on
+//     first reachability call to avoid double-decoding.
 type kustomizationScan struct {
 	DataFiles         map[string]struct{}
 	ClaimedResources  map[string]struct{}
 	KustomizationDirs map[string]struct{}
+	ResourceEdges     map[string]*resourceEdges
+}
+
+// resourceEdges holds the file + directory resource claims of one
+// kustomization.yaml, as resolved absolute paths.
+type resourceEdges struct {
+	files []string
+	dirs  []string
 }
 
 // collectKustomizationScan walks root and decodes every
@@ -101,6 +110,7 @@ func collectKustomizationScan(ctx context.Context, root string, ignore *ignoreSe
 		DataFiles:         map[string]struct{}{},
 		ClaimedResources:  map[string]struct{}{},
 		KustomizationDirs: map[string]struct{}{},
+		ResourceEdges:     map[string]*resourceEdges{},
 	}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if cerr := ctx.Err(); cerr != nil {
@@ -124,11 +134,24 @@ func collectKustomizationScan(ctx context.Context, root string, ignore *ignoreSe
 		}
 		base := filepath.Dir(path)
 		scan.KustomizationDirs[base] = struct{}{}
+		edges := &resourceEdges{}
 		for _, r := range k.Resources {
-			if abs, ok := resolveDataPath(base, r); ok {
-				scan.ClaimedResources[abs] = struct{}{}
+			abs, ok := resolveDataPath(base, r)
+			if !ok {
+				continue
+			}
+			scan.ClaimedResources[abs] = struct{}{}
+			// Split file vs directory edges so the reachability BFS
+			// can recurse only into directory resources. Stat once
+			// here; the main walk skips unstat'able entries via
+			// shouldSkipDir / parseFile.
+			if info, err := os.Stat(abs); err == nil && info.IsDir() {
+				edges.dirs = append(edges.dirs, abs)
+			} else {
+				edges.files = append(edges.files, abs)
 			}
 		}
+		scan.ResourceEdges[base] = edges
 		addEntries := func(entries []string, parseKey bool) {
 			for _, e := range entries {
 				p := e
@@ -163,6 +186,75 @@ func collectKustomizationScan(ctx context.Context, root string, ignore *ignoreSe
 		slog.Debug("loader: data files excluded from manifest scan", "count", len(scan.DataFiles))
 	}
 	return scan, nil
+}
+
+// reachable computes the set of YAML files reachable from entry via
+// the kustomize resource graph: starting at the entry directory's
+// kustomization.yaml, BFS through resource entries — file resources
+// land in the returned set, directory resources recurse. Returns nil
+// when entry has no kustomization.yaml (callers fall back to a
+// recursive walk).
+//
+// This is the load-time analogue of `kustomize build`'s graph
+// traversal. flate previously walked the filesystem blindly, which
+// caused two regressions vs. flux-local:
+//
+//  1. A YAML file in a directory governed by a kustomization.yaml
+//     but not in its `resources:` (toggle stubs, commented entries)
+//     was discovered and reconciled — issue #342. PR #346 fixed this
+//     for the "file in same dir as kustomization.yaml" shape.
+//
+//  2. A YAML file in a SUBDIRECTORY that only reaches the kustomize
+//     graph via an orphan wrapper Kustomization was still discovered
+//     because the walk descended into every directory regardless of
+//     graph reachability. Reproduced in buroa/k8s-gitops's
+//     `apps/default/atuin/app/helmrelease.yaml`: when
+//     `./atuin/ks.yaml` is commented out from
+//     `apps/default/kustomization.yaml`, the HR two levels down
+//     should also disappear.
+//
+// Graph-walk also subsumes the kustomization.yaml file itself —
+// every kustomize package's kustomization.yaml is added to the
+// reachable set so its parsing/loading by the orphan-aware walker
+// works uniformly.
+//
+// configMapGenerator / secretGenerator data files are NOT in the
+// reachable set; the caller still consults scan.DataFiles to skip
+// them. patches / replacements / transformers entries are not
+// followed either (they reference YAMLs that are kustomize
+// directives, not Flux manifests).
+func (s *kustomizationScan) reachable(entry string) map[string]struct{} {
+	if _, hasK := s.KustomizationDirs[entry]; !hasK {
+		return nil
+	}
+	out := map[string]struct{}{}
+	visited := map[string]struct{}{}
+	queue := []string{entry}
+	for len(queue) > 0 {
+		d := queue[0]
+		queue = queue[1:]
+		if _, seen := visited[d]; seen {
+			continue
+		}
+		visited[d] = struct{}{}
+		// Mark the directory's kustomization.yaml as reachable so the
+		// walker visits it (kustomize manifests decode as RawObjects
+		// downstream; harmless if not stored).
+		for _, name := range kustomizationFileNames {
+			out[filepath.Join(d, name)] = struct{}{}
+		}
+		edges, ok := s.ResourceEdges[d]
+		if !ok {
+			continue
+		}
+		for _, f := range edges.files {
+			out[f] = struct{}{}
+		}
+		for _, sub := range edges.dirs {
+			queue = append(queue, sub)
+		}
+	}
+	return out
 }
 
 // stripFileEntryKey returns the path portion of a kustomize

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -1,12 +1,8 @@
 package loader
 
 import (
-	"context"
-	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -61,200 +57,54 @@ func readKustomization(dir string) *kustomization {
 	return nil
 }
 
-// kustomizationScan is the result of walking the tree once to inspect
-// every kustomization.yaml the loader cares about. The fields cover
-// the exclusion/inclusion rules the main walk applies:
+// dataFilesFor returns the set of file paths declared as
+// configMapGenerator/secretGenerator data in k, resolved against
+// dir. The caller's walkKustomize uses this to exclude generator
+// inputs from the resource-scan — kustomize reads them at render
+// time and they aren't Flux manifests.
 //
-//   - DataFiles: configMapGenerator / secretGenerator file paths.
-//     Skipped because they're YAML/env data the chart loader handles
-//     at render time, not Flux manifests.
-//   - ClaimedResources: absolute paths declared in some
-//     kustomization.yaml's resources list. Authoritative "this IS a
-//     Flux manifest" inclusions.
-//   - KustomizationDirs: directories that contain a kustomization.yaml
-//     file. Used by the orphan check (legacy walk) and by graph-walk
-//     reachability.
-//   - ResourceEdges: kustomize-graph edges keyed by dir →
-//     (file paths claimed, sub-dir paths claimed). Built lazily on
-//     first reachability call to avoid double-decoding.
-type kustomizationScan struct {
-	DataFiles         map[string]struct{}
-	ClaimedResources  map[string]struct{}
-	KustomizationDirs map[string]struct{}
-	ResourceEdges     map[string]*resourceEdges
-}
-
-// resourceEdges holds the file + directory resource claims of one
-// kustomization.yaml, as resolved absolute paths.
-type resourceEdges struct {
-	files []string
-	dirs  []string
-}
-
-// collectKustomizationScan walks root and decodes every
-// kustomization.yaml it finds, building the three sets the main
-// loader uses to decide which YAML files to parse.
-//
-// Files declared as configMapGenerator/secretGenerator data are
-// captured separately from files declared as resources. When a path
-// appears in BOTH lists across the tree, the resource interpretation
-// wins (the data exclusion is dropped) — kustomize doesn't forbid
-// the duplication and the resource declaration is the more
-// authoritative "this IS a Flux manifest" signal.
-//
-// Honors ctx cancellation and the same shouldSkipDir rules as the
-// main walk so we don't descend into `.git`, `templates/`, Component
-// dirs, or ignore-matched paths.
-func collectKustomizationScan(ctx context.Context, root string, ignore *ignoreSet) (*kustomizationScan, error) {
-	scan := &kustomizationScan{
-		DataFiles:         map[string]struct{}{},
-		ClaimedResources:  map[string]struct{}{},
-		KustomizationDirs: map[string]struct{}{},
-		ResourceEdges:     map[string]*resourceEdges{},
+// When a path appears in both the generator list AND k.Resources,
+// the resource interpretation wins (the data exclusion is dropped):
+// kustomize doesn't forbid the overlap, and the resource
+// declaration is the more authoritative "this IS a Flux manifest"
+// signal. The overlap-resolve runs per-kustomization, scoped to one
+// directory — there's no cross-tree state to manage anymore.
+func dataFilesFor(dir string, k *kustomization) map[string]struct{} {
+	if k == nil || (len(k.ConfigMapGenerator) == 0 && len(k.SecretGenerator) == 0) {
+		return nil
 	}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if cerr := ctx.Err(); cerr != nil {
-			return cerr
+	resources := map[string]struct{}{}
+	for _, r := range k.Resources {
+		if abs, ok := resolveDataPath(dir, r); ok {
+			resources[abs] = struct{}{}
 		}
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			if shouldSkipDir(d.Name(), path, root, ignore) {
-				return filepath.SkipDir
+	}
+	data := map[string]struct{}{}
+	addEntries := func(entries []string, parseKey bool) {
+		for _, e := range entries {
+			p := e
+			if parseKey {
+				p = stripFileEntryKey(e)
 			}
-			return nil
-		}
-		if !slices.Contains(kustomizationFileNames, d.Name()) {
-			return nil
-		}
-		k := readKustomization(filepath.Dir(path))
-		if k == nil {
-			return nil
-		}
-		base := filepath.Dir(path)
-		scan.KustomizationDirs[base] = struct{}{}
-		edges := &resourceEdges{}
-		for _, r := range k.Resources {
-			abs, ok := resolveDataPath(base, r)
+			abs, ok := resolveDataPath(dir, p)
 			if !ok {
 				continue
 			}
-			scan.ClaimedResources[abs] = struct{}{}
-			// Split file vs directory edges so the reachability BFS
-			// can recurse only into directory resources. Stat once
-			// here; the main walk skips unstat'able entries via
-			// shouldSkipDir / parseFile.
-			if info, err := os.Stat(abs); err == nil && info.IsDir() {
-				edges.dirs = append(edges.dirs, abs)
-			} else {
-				edges.files = append(edges.files, abs)
+			if _, isRes := resources[abs]; isRes {
+				continue
 			}
-		}
-		scan.ResourceEdges[base] = edges
-		addEntries := func(entries []string, parseKey bool) {
-			for _, e := range entries {
-				p := e
-				if parseKey {
-					p = stripFileEntryKey(e)
-				}
-				if abs, ok := resolveDataPath(base, p); ok {
-					scan.DataFiles[abs] = struct{}{}
-				}
-			}
-		}
-		for _, g := range k.ConfigMapGenerator {
-			addEntries(g.Files, true)
-			addEntries(g.Envs, false)
-		}
-		for _, g := range k.SecretGenerator {
-			addEntries(g.Files, true)
-			addEntries(g.Envs, false)
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	// Resource interpretation wins over data interpretation if the same
-	// path appears in both lists across any kustomization.yaml in the
-	// tree.
-	for r := range scan.ClaimedResources {
-		delete(scan.DataFiles, r)
-	}
-	if len(scan.DataFiles) > 0 {
-		slog.Debug("loader: data files excluded from manifest scan", "count", len(scan.DataFiles))
-	}
-	return scan, nil
-}
-
-// reachable computes the set of YAML files reachable from entry via
-// the kustomize resource graph: starting at the entry directory's
-// kustomization.yaml, BFS through resource entries — file resources
-// land in the returned set, directory resources recurse. Returns nil
-// when entry has no kustomization.yaml (callers fall back to a
-// recursive walk).
-//
-// This is the load-time analogue of `kustomize build`'s graph
-// traversal. flate previously walked the filesystem blindly, which
-// caused two regressions vs. flux-local:
-//
-//  1. A YAML file in a directory governed by a kustomization.yaml
-//     but not in its `resources:` (toggle stubs, commented entries)
-//     was discovered and reconciled — issue #342. PR #346 fixed this
-//     for the "file in same dir as kustomization.yaml" shape.
-//
-//  2. A YAML file in a SUBDIRECTORY that only reaches the kustomize
-//     graph via an orphan wrapper Kustomization was still discovered
-//     because the walk descended into every directory regardless of
-//     graph reachability. Reproduced in buroa/k8s-gitops's
-//     `apps/default/atuin/app/helmrelease.yaml`: when
-//     `./atuin/ks.yaml` is commented out from
-//     `apps/default/kustomization.yaml`, the HR two levels down
-//     should also disappear.
-//
-// Graph-walk also subsumes the kustomization.yaml file itself —
-// every kustomize package's kustomization.yaml is added to the
-// reachable set so its parsing/loading by the orphan-aware walker
-// works uniformly.
-//
-// configMapGenerator / secretGenerator data files are NOT in the
-// reachable set; the caller still consults scan.DataFiles to skip
-// them. patches / replacements / transformers entries are not
-// followed either (they reference YAMLs that are kustomize
-// directives, not Flux manifests).
-func (s *kustomizationScan) reachable(entry string) map[string]struct{} {
-	if _, hasK := s.KustomizationDirs[entry]; !hasK {
-		return nil
-	}
-	out := map[string]struct{}{}
-	visited := map[string]struct{}{}
-	queue := []string{entry}
-	for len(queue) > 0 {
-		d := queue[0]
-		queue = queue[1:]
-		if _, seen := visited[d]; seen {
-			continue
-		}
-		visited[d] = struct{}{}
-		// Mark the directory's kustomization.yaml as reachable so the
-		// walker visits it (kustomize manifests decode as RawObjects
-		// downstream; harmless if not stored).
-		for _, name := range kustomizationFileNames {
-			out[filepath.Join(d, name)] = struct{}{}
-		}
-		edges, ok := s.ResourceEdges[d]
-		if !ok {
-			continue
-		}
-		for _, f := range edges.files {
-			out[f] = struct{}{}
-		}
-		for _, sub := range edges.dirs {
-			queue = append(queue, sub)
+			data[abs] = struct{}{}
 		}
 	}
-	return out
+	for _, g := range k.ConfigMapGenerator {
+		addEntries(g.Files, true)
+		addEntries(g.Envs, false)
+	}
+	for _, g := range k.SecretGenerator {
+		addEntries(g.Files, true)
+		addEntries(g.Envs, false)
+	}
+	return data
 }
 
 // stripFileEntryKey returns the path portion of a kustomize

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -1,3 +1,25 @@
+// Package loader hydrates a Store from on-disk Flux manifests.
+//
+// The loader's discovery model mirrors `kustomize build` (and
+// flux-local): the kustomize resource graph is the source of truth.
+// A directory with a kustomization.yaml defines a kustomize package
+// — the loader follows its `resources:` entries (files load,
+// directories recurse) and ignores everything else in the directory.
+// Files outside the resource graph are invisible by construction;
+// there is no "tree walk + filter" post-pass, no orphan-skip rule,
+// no reachability set computed up front.
+//
+// Entry points without a kustomization.yaml use a fall-back tree
+// walk that loads every YAML it finds and switches into graph-walk
+// mode when it encounters a subdirectory that IS a kustomize
+// package. This keeps the bootstrap-style "bare directory of CRs"
+// shape working without forcing every user to wrap their entry
+// point in a kustomization.yaml.
+//
+// Each loader.Load call is one independent graph root. The
+// orchestrator's iterative discovery — a Flux KS's spec.path
+// triggers another Load — composes naturally: each spec.path is its
+// own graph root with its own resource graph.
 package loader
 
 import (
@@ -5,8 +27,8 @@ import (
 	"errors"
 	"io/fs"
 	"log/slog"
+	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -70,13 +92,13 @@ func New(s *store.Store) *Loader {
 	return &Loader{Store: s, Options: Options{WipeSecrets: true}}
 }
 
-// Load walks root recursively, decoding every .yaml/.yml/.json document
-// and adding recognized Flux objects to the Store. Returns the count of
-// added objects.
+// Load discovers Flux objects under root by walking the kustomize
+// resource graph. When root has a kustomization.yaml it's treated as
+// a kustomize package and only files reachable through `resources:`
+// are loaded; when it has none, a recursive walk finds and enters
+// kustomize packages it encounters, loading every YAML otherwise.
 //
-// Honors ctx cancellation between directory entries — a stuck NFS
-// mount or symlink loop aborts cleanly instead of blocking the whole
-// orchestrator.
+// Honors ctx cancellation; visited-set protects against cycles.
 func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 	if l.Store == nil {
 		return 0, errors.New("loader: Store is nil")
@@ -89,35 +111,142 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	w := walker{
+		loader:  l,
+		ignore:  ignore,
+		visited: map[string]struct{}{},
+	}
+	return w.descend(ctx, abs)
+}
 
-	// Pre-pass: decode every kustomization.yaml in the tree to
-	// (a) identify generator data files (issue #192), (b) collect
-	// per-kustomization-dir resource edges (file + directory), and
-	// (c) record which directories are kustomize packages. The
-	// main walk uses either the kustomize-graph reachability or
-	// the orphan-aware legacy walk depending on the entry-point
-	// shape — see entryReachable below.
-	scan, err := collectKustomizationScan(ctx, abs, ignore)
-	if err != nil {
-		return 0, err
+// walker carries the per-Load state — ignore matcher, visited-dir
+// dedup, loader back-reference — so the recursive functions don't
+// need to thread the same args through every call.
+type walker struct {
+	loader  *Loader
+	ignore  *ignoreSet
+	visited map[string]struct{}
+}
+
+// descend dispatches on the kind of directory dir is:
+//   - Kustomize Component: skipped entirely (transforms applied at
+//     render time, not loaded as standalone Flux CRs).
+//   - Kustomize package (has kustomization.yaml, kind != Component):
+//     follow the resource graph via walkKustomize.
+//   - Ad-hoc directory (no kustomization.yaml): walk the filesystem,
+//     loading every YAML and switching to walkKustomize on encounter
+//     of a sub-package.
+//   - Already-visited: no-op (cycle protection for circular
+//     `resources:` references).
+func (w *walker) descend(ctx context.Context, dir string) (int, error) {
+	if cerr := ctx.Err(); cerr != nil {
+		return 0, cerr
+	}
+	if _, seen := w.visited[dir]; seen {
+		return 0, nil
+	}
+	w.visited[dir] = struct{}{}
+
+	k := readKustomization(dir)
+	if k != nil {
+		if k.Kind == "Component" {
+			slog.Debug("loader: skipping kustomize Component directory", "dir", dir)
+			return 0, nil
+		}
+		return w.walkKustomize(ctx, dir, k)
+	}
+	return w.walkAdHoc(ctx, dir)
+}
+
+// walkKustomize traverses the kustomize resource graph rooted at dir.
+// File resources load via loadFile; directory resources recurse via
+// descend. configMapGenerator / secretGenerator data files are
+// excluded since they're consumed at render time, not loaded as
+// Flux manifests.
+//
+// kustomization.yaml itself is loadFile'd so parseFile can decide
+// whether it's a Flux Kustomization CR (different apiVersion than
+// kustomize's own Kustomization). If not, parseFile returns no
+// objects and the count is unchanged.
+//
+// patches / replacements / transformers / generators (the rest of
+// kustomize's directive fields) reference YAMLs that are kustomize
+// directives, NOT Flux manifests — they're not in `resources:` so
+// they don't load. Matches `kustomize build` precisely.
+func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization) (int, error) {
+	dataFiles := dataFilesFor(dir, k)
+	count := 0
+
+	// Load the kustomization.yaml itself — preserves source-file
+	// visibility for any consumer that inspects on-disk shape, and
+	// lets parseFile recognize a Flux Kustomization that happens to
+	// be authored at the `kustomization.yaml` filename (rare but
+	// permitted).
+	if kpath, ok := kustomizationFilePath(dir); ok && !w.ignore.matches(kpath, dir) {
+		n, err := w.loader.loadFile(kpath)
+		if err != nil {
+			slog.Warn("loader: kustomization file failed to parse", "path", kpath, "err", err)
+		}
+		count += n
 	}
 
-	// When the entry-point IS a kustomize package, restrict the
-	// load set to files transitively reachable through the
-	// `resources:` graph. This matches `kustomize build` (and
-	// flux-local) semantics: toggle stubs commented out of
-	// kustomization.yaml stay absent, and a HelmRelease in a
-	// subtree whose only kustomize-graph reach is through an
-	// orphan wrapper KS is also absent. Closes the orphan-tree
-	// regression from #342 / buroa/k8s-gitops report.
-	//
-	// When the entry has no kustomization.yaml (an ad-hoc directory
-	// of YAMLs, the legacy --path entry shape), fall back to the
-	// recursive walk + same-dir orphan-skip from #346.
-	reachable := scan.reachable(abs)
+	for _, r := range k.Resources {
+		if cerr := ctx.Err(); cerr != nil {
+			return count, cerr
+		}
+		abs, ok := resolveDataPath(dir, r)
+		if !ok {
+			// URL resources, paths escaping the package, malformed
+			// entries — kustomize handles these at render time;
+			// the loader's job is to ignore them at discovery time.
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			// Resource pointer that doesn't exist on disk. Don't
+			// surface here; kustomize.RenderFlux will produce a
+			// clearer error with the right context at render time.
+			continue
+		}
+		if info.IsDir() {
+			n, err := w.descend(ctx, abs)
+			if err != nil {
+				return count, err
+			}
+			count += n
+			continue
+		}
+		if !isManifestFile(abs) {
+			continue
+		}
+		if _, isData := dataFiles[abs]; isData {
+			continue
+		}
+		if w.ignore.matches(abs, dir) {
+			continue
+		}
+		n, err := w.loader.loadFile(abs)
+		if err != nil {
+			slog.Warn("loader: file failed to parse", "path", abs, "err", err)
+			continue
+		}
+		count += n
+	}
+	return count, nil
+}
 
+// walkAdHoc handles entry points that aren't themselves kustomize
+// packages: walks the filesystem tree, loading every YAML, and
+// switching to walkKustomize when it encounters a sub-directory
+// that IS a kustomize package (the package's subtree is then
+// graph-walked and the filesystem walk skips it via SkipDir).
+//
+// This preserves flate's pre-#346 behavior for "bare directory of
+// flux CRs" entry shapes — e.g. a --path that doesn't have a
+// kustomization.yaml at its root.
+func (w *walker) walkAdHoc(ctx context.Context, root string) (int, error) {
 	count := 0
-	err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
 		}
@@ -125,13 +254,25 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 			return walkErr
 		}
 		if d.IsDir() {
-			if shouldSkipDir(d.Name(), path, abs, ignore) {
+			if shouldSkipDir(d.Name(), path, root, w.ignore) {
 				return filepath.SkipDir
 			}
-			// Graph-walk: skip subdirectories that contain no
-			// reachable files. Compared against ancestors of every
-			// reachable file (computed lazily via prefix check).
-			if reachable != nil && path != abs && !dirHasReachableContent(path, reachable) {
+			if path == root {
+				return nil
+			}
+			// Subdirectory: if it's a kustomize package, switch to
+			// graph walk and SkipDir to keep filepath.WalkDir from
+			// descending again.
+			if k := readKustomization(path); k != nil {
+				if k.Kind == "Component" {
+					return filepath.SkipDir
+				}
+				w.visited[path] = struct{}{}
+				n, err := w.walkKustomize(ctx, path, k)
+				if err != nil {
+					return err
+				}
+				count += n
 				return filepath.SkipDir
 			}
 			return nil
@@ -139,47 +280,18 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 		if !isManifestFile(path) {
 			return nil
 		}
-		if ignore.matches(path, abs) {
+		if w.ignore.matches(path, root) {
 			return nil
 		}
-		if _, isData := scan.DataFiles[path]; isData {
-			slog.Debug("loader: skipping generator data file", "path", path)
-			return nil
-		}
-		if reachable != nil {
-			// Graph-walk filter: only files reachable from the entry's
-			// kustomize resource graph are loaded. The kustomization.yaml
-			// itself is always in the reachable set (per scan.reachable).
-			if _, ok := reachable[path]; !ok {
-				slog.Debug("loader: skipping YAML unreachable from entry kustomize graph", "path", path)
-				return nil
-			}
-		} else if isOrphanYAML(path, scan) {
-			// Legacy walk (entry has no kustomization.yaml) — fall
-			// back to the same-dir orphan-skip from #346.
-			slog.Debug("loader: skipping orphan YAML not referenced in parent kustomization.yaml", "path", path)
-			return nil
-		}
-		n, err := l.loadFile(path)
+		n, err := w.loader.loadFile(path)
 		if err != nil {
-			// `templates/`, `crds/`, and ignore-matched paths never
-			// reach here — they're SkipDir'd in shouldSkipDir. A YAML
-			// syntax error at a path the loader DID try to parse is a
-			// real user-side problem (typo'd manifest, half-edited
-			// CRD); promote to WARN so it isn't invisible at default
-			// log level. The per-doc kind-mismatch case below stays at
-			// Debug because raw k8s manifests interspersed with Flux
-			// CRs are a legitimate pattern.
 			slog.Warn("loader: file failed to parse", "path", path, "err", err)
 			return nil
 		}
 		count += n
 		return nil
 	})
-	if err != nil {
-		return count, err
-	}
-	return count, nil
+	return count, err
 }
 
 func (l *Loader) loadFile(path string) (int, error) {
@@ -275,6 +387,9 @@ func isManifestFile(path string) bool {
 	return ok
 }
 
+// shouldSkipDir applies the ad-hoc walk's directory-prune rules.
+// Not used by walkKustomize — that path follows explicit resource
+// entries and trusts the user's kustomize manifests.
 func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 	switch name {
 	case ".git", "node_modules", ".cache":
@@ -290,70 +405,18 @@ func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 	if ignore.matchesDir(full, root) {
 		return true
 	}
-	// A `kind: Component` kustomization.yaml means everything below is a
-	// template fragment that real Flux only materializes via a parent
-	// Kustomization's spec.components reference. Standalone-loading the
-	// children would surface literal `${APP}` placeholders in metadata
-	// names as bogus Kustomization / HelmRelease objects. The parent's
-	// kustomize render still picks them up — it follows spec.components
-	// directly without going through flate's standalone loader.
-	return isKustomizeComponent(full)
-}
-
-// isKustomizeComponent reports whether dir contains a kustomization
-// file declaring `kind: Component`. Catches YAML, JSON, and terse
-// no-space-after-colon shapes that a substring check would miss.
-func isKustomizeComponent(dir string) bool {
-	k := readKustomization(dir)
-	return k != nil && k.Kind == "Component"
-}
-
-// dirHasReachableContent reports whether dir contains (recursively)
-// at least one path in reachable. Used by graph-walk to prune
-// SkipDir on directories with no reachable descendants — avoids
-// walking subtrees that the kustomize graph never enters.
-//
-// Linear scan over reachable. Reachable is bounded by the resource
-// graph size (at most one entry per kustomization.yaml + claimed
-// resource path), so cost stays small; turning this into a trie
-// would help for very deep graphs but isn't warranted today.
-func dirHasReachableContent(dir string, reachable map[string]struct{}) bool {
-	prefix := dir + string(filepath.Separator)
-	for r := range reachable {
-		if r == dir || strings.HasPrefix(r, prefix) {
-			return true
-		}
-	}
 	return false
 }
 
-// isOrphanYAML reports whether path should be skipped by the main
-// loader walk because it's an unreferenced YAML in a directory
-// governed by a kustomization.yaml. The rule:
-//
-//   - If the path's directory does NOT have a kustomization.yaml,
-//     the file is loaded normally (e.g. --path entry points, the
-//     bootstrap dir before the first overlay).
-//   - The kustomization.yaml file itself always loads.
-//   - Files explicitly listed in the kustomization.yaml's
-//     `resources:` always load.
-//   - Everything else in the same directory is "orphan" — toggle
-//     stubs, kustomize patches, `replacements:` payloads — and is
-//     skipped. Patches/replacements would parse as RawObject and
-//     get filtered downstream anyway; toggle stubs (the #342 case)
-//     would parse as a Flux Kustomization and reconcile against
-//     the wrong overlay state.
-//
-// Mirrors kustomize build's graph traversal: only the transitive
-// closure of `resources:` (+ generators) ends up rendered.
-func isOrphanYAML(path string, scan *kustomizationScan) bool {
-	dir := filepath.Dir(path)
-	if _, ok := scan.KustomizationDirs[dir]; !ok {
-		return false
+// kustomizationFilePath returns the absolute path of dir's
+// kustomization.{yaml,yml,json} (first match wins, matching kustomize's
+// own filename precedence). Returns ("", false) when none exists.
+func kustomizationFilePath(dir string) (string, bool) {
+	for _, name := range kustomizationFileNames {
+		p := filepath.Join(dir, name)
+		if info, err := os.Stat(p); err == nil && info.Mode().IsRegular() {
+			return p, true
+		}
 	}
-	if slices.Contains(kustomizationFileNames, filepath.Base(path)) {
-		return false
-	}
-	_, claimed := scan.ClaimedResources[path]
-	return !claimed
+	return "", false
 }

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -90,26 +90,31 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 		return 0, err
 	}
 
-	// Pre-pass: decode every kustomization.yaml in the tree and
-	// collect (a) data files declared as generator inputs, (b) files
-	// declared as `resources:`, and (c) the directories that have a
-	// kustomization.yaml at all. The main walk applies three rules
-	// from this scan:
-	//
-	//   - skip generator data files (issue #192)
-	//   - skip "orphan" YAML files: a YAML in a directory governed by
-	//     a kustomization.yaml is loaded only when explicitly
-	//     referenced via `resources:`. Closes #342 — toggle stubs
-	//     left lying around next to a kustomization.yaml (a common
-	//     pattern: comment a `./vrising.yaml` line in resources to
-	//     disable that wrapper) were being discovered and reconciled
-	//     against the wrong namespace, since the parent overlay's
-	//     transforms never applied. kustomize build follows the
-	//     same graph; flate now matches that behavior.
+	// Pre-pass: decode every kustomization.yaml in the tree to
+	// (a) identify generator data files (issue #192), (b) collect
+	// per-kustomization-dir resource edges (file + directory), and
+	// (c) record which directories are kustomize packages. The
+	// main walk uses either the kustomize-graph reachability or
+	// the orphan-aware legacy walk depending on the entry-point
+	// shape — see entryReachable below.
 	scan, err := collectKustomizationScan(ctx, abs, ignore)
 	if err != nil {
 		return 0, err
 	}
+
+	// When the entry-point IS a kustomize package, restrict the
+	// load set to files transitively reachable through the
+	// `resources:` graph. This matches `kustomize build` (and
+	// flux-local) semantics: toggle stubs commented out of
+	// kustomization.yaml stay absent, and a HelmRelease in a
+	// subtree whose only kustomize-graph reach is through an
+	// orphan wrapper KS is also absent. Closes the orphan-tree
+	// regression from #342 / buroa/k8s-gitops report.
+	//
+	// When the entry has no kustomization.yaml (an ad-hoc directory
+	// of YAMLs, the legacy --path entry shape), fall back to the
+	// recursive walk + same-dir orphan-skip from #346.
+	reachable := scan.reachable(abs)
 
 	count := 0
 	err = filepath.WalkDir(abs, func(path string, d fs.DirEntry, walkErr error) error {
@@ -123,6 +128,12 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 			if shouldSkipDir(d.Name(), path, abs, ignore) {
 				return filepath.SkipDir
 			}
+			// Graph-walk: skip subdirectories that contain no
+			// reachable files. Compared against ancestors of every
+			// reachable file (computed lazily via prefix check).
+			if reachable != nil && path != abs && !dirHasReachableContent(path, reachable) {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if !isManifestFile(path) {
@@ -132,20 +143,20 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 			return nil
 		}
 		if _, isData := scan.DataFiles[path]; isData {
-			// Declared as configMapGenerator/secretGenerator data by
-			// a kustomization.yaml in the tree. krusty handles the
-			// file correctly at render time; the loader's job is to
-			// stay out of the way.
 			slog.Debug("loader: skipping generator data file", "path", path)
 			return nil
 		}
-		if orphan := isOrphanYAML(path, scan); orphan {
-			// Orphan: this YAML lives in a directory governed by a
-			// kustomization.yaml but isn't referenced via the
-			// `resources:` list. kustomize build wouldn't include it;
-			// flate now matches that. Common shape: a disabled toggle
-			// stub like `./vrising.yaml` left in the directory after
-			// a maintainer commented out the line in `resources:`.
+		if reachable != nil {
+			// Graph-walk filter: only files reachable from the entry's
+			// kustomize resource graph are loaded. The kustomization.yaml
+			// itself is always in the reachable set (per scan.reachable).
+			if _, ok := reachable[path]; !ok {
+				slog.Debug("loader: skipping YAML unreachable from entry kustomize graph", "path", path)
+				return nil
+			}
+		} else if isOrphanYAML(path, scan) {
+			// Legacy walk (entry has no kustomization.yaml) — fall
+			// back to the same-dir orphan-skip from #346.
 			slog.Debug("loader: skipping orphan YAML not referenced in parent kustomization.yaml", "path", path)
 			return nil
 		}
@@ -295,6 +306,25 @@ func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 func isKustomizeComponent(dir string) bool {
 	k := readKustomization(dir)
 	return k != nil && k.Kind == "Component"
+}
+
+// dirHasReachableContent reports whether dir contains (recursively)
+// at least one path in reachable. Used by graph-walk to prune
+// SkipDir on directories with no reachable descendants — avoids
+// walking subtrees that the kustomize graph never enters.
+//
+// Linear scan over reachable. Reachable is bounded by the resource
+// graph size (at most one entry per kustomization.yaml + claimed
+// resource path), so cost stays small; turning this into a trie
+// would help for very deep graphs but isn't warranted today.
+func dirHasReachableContent(dir string, reachable map[string]struct{}) bool {
+	prefix := dir + string(filepath.Separator)
+	for r := range reachable {
+		if r == dir || strings.HasPrefix(r, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // isOrphanYAML reports whether path should be skipped by the main

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -303,6 +303,81 @@ metadata: {name: real, namespace: ns}
 	}
 }
 
+// TestLoader_OrphanNestedSubtreeSkipped pins the buroa/k8s-gitops
+// case: a commented-out wrapper KS in `default/kustomization.yaml`
+// (resources: [./valheim/ks.yaml, # ./atuin/ks.yaml]) should leave
+// BOTH the wrapper AND the deep HelmRelease under
+// `default/atuin/app/helmrelease.yaml` invisible. The wrapper lives
+// in a directory (`atuin/`) that has no kustomization.yaml of its
+// own; the HR lives in `atuin/app/` which DOES have one but is only
+// reachable via the orphan wrapper's spec.path. PR #346 fixed only
+// the same-dir orphan case; this test reproduces the deeper shape.
+func TestLoader_OrphanNestedSubtreeSkipped(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "default/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./valheim/ks.yaml
+  # - ./atuin/ks.yaml   # commented toggle stub — should be invisible
+`)
+	for _, app := range []string{"valheim", "atuin"} {
+		testutil.WriteFile(t, dir, "default/"+app+"/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: `+app+`
+spec:
+  path: ./default/`+app+`/app
+  sourceRef: { kind: GitRepository, name: flux-system, namespace: flux-system }
+`)
+		testutil.WriteFile(t, dir, "default/"+app+"/app/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+`)
+		testutil.WriteFile(t, dir, "default/"+app+"/app/helmrelease.yaml", `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: `+app+`
+spec:
+  chart:
+    spec:
+      chart: app-template
+      sourceRef: { kind: HelmRepository, name: bjw-s, namespace: flux-system }
+      version: "5.0.0"
+`)
+	}
+	s := store.New()
+	// Entry the loader at `default/` so its kustomization.yaml is the
+	// graph root. The orphan-tree skip only applies under graph-walk;
+	// see Loader.Load doc-comment.
+	if _, err := New(s).Load(context.Background(), filepath.Join(dir, "default")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Valheim (claimed) MUST be present.
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Name: "valheim"}) == nil {
+		t.Error("claimed Kustomization 'valheim' missing")
+	}
+	// Atuin (commented out) MUST be absent.
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Name: "atuin"}) != nil {
+		t.Error("orphan Kustomization 'atuin' should be skipped (#346 deep-orphan)")
+	}
+	// Atuin's deep HR MUST also be absent — its only kustomize-graph
+	// connection is via the orphan wrapper.
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "atuin"}) != nil {
+		t.Error("HelmRelease only reachable via orphan wrapper should be skipped")
+	}
+	// Valheim's HR should NOT load via the initial graph walk either
+	// — it lives in `default/valheim/app/` which is only reachable
+	// via the wrapper's spec.path, NOT via `default/kustomization.yaml`'s
+	// resource graph. The orchestrator's discovery later calls
+	// loadAt(valheim/app/) which becomes a fresh entry-point.
+	// (This test stops before that step, so the HR is absent here —
+	// which is the correct flux-local behavior.)
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "valheim"}) != nil {
+		t.Error("HelmRelease in unreachable subtree leaked into initial walk")
+	}
+}
+
 // TestLoader_OrphanYAMLSkipped pins the issue-#342 fix: a YAML
 // file in a directory governed by a kustomization.yaml is loaded
 // only when it appears in `resources:`. The unreferenced file (a

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -454,14 +454,18 @@ func TestE2E_SOPSValueWipedToPlaceholder(t *testing.T) {
 	}
 }
 
-// TestE2E_OrphanedKustomizationIsWarning verifies that a ks.yaml
+// TestE2E_OrphanedKustomizationNotDiscovered verifies that a ks.yaml
 // living under another Kustomization's spec.path but NOT listed in
-// any parent kustomization.yaml is treated as an orphan: the
-// reconcile warning is surfaced, the orphan is marked Ready, and
-// the overall test does not fail. Mirrors how Flux behaves — Flux
-// never sees orphaned files because they aren't in the kustomize
-// build output.
-func TestE2E_OrphanedKustomizationIsWarning(t *testing.T) {
+// any parent kustomization.yaml is INVISIBLE to flate — it never
+// loads, never reconciles, never appears in test output. Mirrors how
+// Flux + `kustomize build` behave: orphans aren't in the rendered
+// output, so they don't exist from the cluster's perspective.
+//
+// (Previous behavior was to load the orphan via a blind tree walk
+// then downgrade its inevitable spec.path failure to a "resource
+// orphaned" warning. The graph-driven loader replaces that
+// post-hoc rescue with structural invisibility.)
+func TestE2E_OrphanedKustomizationNotDiscovered(t *testing.T) {
 	src := testdataPath(t, "orphans")
 	root := copyTree(t, src)
 
@@ -472,14 +476,10 @@ func TestE2E_OrphanedKustomizationIsWarning(t *testing.T) {
 	if !strings.Contains(wiredLine, "PASSED") {
 		t.Errorf("wired should pass: %s", wiredLine)
 	}
-	// "orphan" should also report PASSED (downgraded), not FAILED.
-	orphanLine := mustExtractLine(t, out, "Kustomization/flux-system/orphan")
-	if !strings.Contains(orphanLine, "PASSED") {
-		t.Errorf("orphan should be downgraded to PASSED: %s", orphanLine)
-	}
-	// The orphan must surface as a warning so users see the issue.
-	if !strings.Contains(out, "resource orphaned") {
-		t.Errorf(`expected "resource orphaned" warning in log:\n%s`, out)
+	// "orphan" must not appear anywhere in the test output — it was
+	// never loaded because the kustomize graph doesn't reach it.
+	if strings.Contains(out, "flux-system/orphan") {
+		t.Errorf("orphan Kustomization should be invisible to graph-driven loader; output contained reference:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #346. The previous fix only caught orphan YAMLs whose **immediate directory** had a kustomization.yaml — it missed the common Flux pattern that buroa/k8s-gitops uses:

\`\`\`
apps/default/
  kustomization.yaml      # resources: [./atuin/ks.yaml]   ← commented out
  atuin/
    ks.yaml               ← orphan wrapper (dir has no kustomization.yaml)
    app/
      kustomization.yaml  ← claims helmrelease.yaml locally
      helmrelease.yaml    ← deep orphan; only reachable via the wrapper
\`\`\`

When \`./atuin/ks.yaml\` is commented out, PR #346 didn't catch the wrapper (its directory has no local kustomization.yaml), and the HR two levels deeper still loaded because its own kustomization.yaml claimed it locally. Both showed up in \`flate test ks\` and \`flate get\` despite being unreachable from the kustomize graph.

## Fix

Switch the loader's main walk from "tree walk + same-dir orphan filter" to **graph-driven reachability** when the entry-point IS a kustomize package. BFS through \`resources:\` from the entry's kustomization.yaml — file entries land in the reachable set, directory entries recurse. Files outside the reachable set are silently dropped. Matches \`kustomize build\` and flux-local semantics.

The orchestrator's per-KS \`loadAt()\` calls each become independent graph-roots, so the working case still works: a Flux KS's spec.path opens a new entry-point with its own graph walk.

When the entry has no kustomization.yaml (ad-hoc YAML directories), fall back to the recursive walk + same-dir orphan-skip from #346.

## Test plan

- [x] \`go test -race -count=1 ./...\` green
- [x] New \`TestLoader_OrphanNestedSubtreeSkipped\` reproduces the exact buroa/k8s-gitops shape and asserts both the wrapper AND the deep HR disappear
- [x] Existing \`TestLoader_OrphanYAMLSkipped\` and \`TestLoader_NestedKustomizationDataFile\` pass under the graph-walk path
- [x] Manual repro confirmed: \`flate get all --path /tmp/repro/apps/default\` previously showed \`atuin\` + its HR; now correctly shows only \`valheim\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)