### PR TITLE
fix(orchestrator): widen change.Detect to per-side .git root for sibling-checkout diffs

### DIFF
--- a/pkg/change/integration_test.go
+++ b/pkg/change/integration_test.go
@@ -219,3 +219,108 @@ data:
 // via depwait.Waiter.Existence. An orchestrator-level duplicate
 // would require a slow fake fetcher to recreate the timing window
 // in real-time, slowing CI without catching new bugs.
+
+// TestIntegration_DiffWidensToRepoRootForSiblingCheckouts pins the
+// fix for the diff-coupling footgun seen in real-world validation:
+// when the user points `--path` at a Flux cluster subdir (e.g.
+// `<repo>/kubernetes/flux/cluster`) and `--path-orig` at the same
+// subdir of a sibling checkout, edits in `<repo>/kubernetes/apps/...`
+// must still enter the keep set. The old behavior diffed the literal
+// subdirs (which were byte-identical) and produced an empty keep set,
+// silently rendering nothing. The new behavior detects that both sides
+// resolve to distinct .git roots and widens the diff to those roots.
+func TestIntegration_DiffWidensToRepoRootForSiblingCheckouts(t *testing.T) {
+	origRoot := t.TempDir()
+	currRoot := t.TempDir()
+	// Mark both as separate git checkouts so discovery.FindRepoRoot
+	// picks them up. A bare directory is enough — change.Detect's git
+	// path runs `git diff --no-index` which doesn't read .git internals.
+	mustWrite(t, filepath.Join(origRoot, ".git", "HEAD"), "ref: refs/heads/main\n")
+	mustWrite(t, filepath.Join(currRoot, ".git", "HEAD"), "ref: refs/heads/main\n")
+
+	// Identical Flux bootstrap on both sides — the cluster subdir
+	// content is byte-identical, so a literal subdir-vs-subdir diff
+	// would return zero.
+	bootstrap := `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/foo
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`
+	mustWrite(t, filepath.Join(origRoot, "kubernetes/flux/cluster.yaml"), bootstrap)
+	mustWrite(t, filepath.Join(currRoot, "kubernetes/flux/cluster.yaml"), bootstrap)
+
+	// The Kustomization spec.path tree lives under apps/foo — outside
+	// the flux/ subdir, exactly where real-world repos put their app
+	// manifests. The change is in this tree.
+	appKust := `resources:
+  - ./cm.yaml
+`
+	mustWrite(t, filepath.Join(origRoot, "kubernetes/apps/foo/kustomization.yaml"), appKust)
+	mustWrite(t, filepath.Join(currRoot, "kubernetes/apps/foo/kustomization.yaml"), appKust)
+	mustWrite(t, filepath.Join(origRoot, "kubernetes/apps/foo/cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo-config
+  namespace: flux-system
+data:
+  value: original
+`)
+	mustWrite(t, filepath.Join(currRoot, "kubernetes/apps/foo/cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: foo-config
+  namespace: flux-system
+data:
+  value: changed
+`)
+
+	// Point --path / --path-orig at the cluster subdir, NOT the repo
+	// root — this is the user-facing convention and the case the fix
+	// targets. The flux/cluster directory is byte-identical between
+	// the two checkouts; only kubernetes/apps/foo/cm.yaml differs.
+	currCluster := filepath.Join(currRoot, "kubernetes/flux")
+	origCluster := filepath.Join(origRoot, "kubernetes/flux")
+
+	o, err := orchestrator.New(orchestrator.Config{
+		Path:        currCluster,
+		PathOrig:    origCluster,
+		WipeSecrets: true,
+	})
+	if err != nil {
+		t.Fatalf("orchestrator.New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	f := o.Filter()
+	if f == nil {
+		t.Fatal("expected change.Filter to be wired (PathOrig was set), got nil — buildChangeFilter dropped the filter")
+	}
+	clusterApps := manifest.NamedResource{
+		Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps",
+	}
+	if !f.ShouldReconcile(clusterApps) {
+		t.Errorf("cluster-apps owns the changed file (apps/foo/cm.yaml) but was filtered out of the keep set; diff did not widen to repo root")
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -430,20 +430,39 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 				"resolvedPath", currAbs)
 			return nil
 		}
-		// Diff the literal user-supplied paths so subdir-vs-subdir
-		// comparisons inside one repo work. Walking up to .git would
-		// collapse both endpoints to the same root.
-		cs, err := change.Detect(origAbs, currAbs)
+		// Widen the diff scope to each side's .git root when the user
+		// pointed at sibling subdirs of separate checkouts — the
+		// canonical PR-vs-base-branch flow `flate diff ks --path
+		// pr/cluster --path-orig base/cluster` where the actual edits
+		// live in `apps/`, outside the cluster subdir. Diffing the
+		// literal subdirs would report zero changes even though the
+		// rendered output differs. We only widen when both sides resolve
+		// to .git roots that are (a) not the same root (one checkout,
+		// two subdirs is the deliberate subdir-vs-subdir case) and
+		// (b) actually distinct from the path the user passed (no .git
+		// ancestor → FindRepoRoot returns the path unchanged).
+		diffOrig, diffCurr := origAbs, currAbs
+		origRoot := discovery.FindRepoRoot(origAbs)
+		currRoot := discovery.FindRepoRoot(currAbs)
+		widened := origRoot != origAbs && currRoot != currAbs && origRoot != currRoot
+		if widened {
+			diffOrig, diffCurr = origRoot, currRoot
+		}
+		cs, err := change.Detect(diffOrig, diffCurr)
 		if err != nil {
 			return fmt.Errorf("change detect: %w", err)
 		}
-		// Detect emits paths relative to currAbs; re-root them under
-		// repoRoot so they line up with SourceFiles keys.
-		if rel, err := filepath.Rel(repoRoot, currAbs); err == nil && rel != "." {
-			cs = cs.Reroot(rel)
+		// Detect emits paths relative to diffCurr. When we widened, that
+		// already equals repoRoot and SourceFiles keys line up. When we
+		// didn't, lift the subdir-relative paths into repoRoot's
+		// coordinate system so they match SourceFiles keys.
+		if !widened {
+			if rel, err := filepath.Rel(repoRoot, currAbs); err == nil && rel != "." {
+				cs = cs.Reroot(rel)
+			}
 		}
 		slog.Info("changed-only mode",
-			"baseline", origAbs, "current", currAbs, "changedFiles", cs.Len())
+			"baseline", diffOrig, "current", diffCurr, "changedFiles", cs.Len(), "widenedToRepoRoot", widened)
 		if cs.Len() == 0 {
 			slog.Warn("no changes detected between --path and --path-orig — output will be empty; verify both paths reference distinct snapshots")
 		}


### PR DESCRIPTION
## Summary

- Surfaced during PR #347's parallel-agent validation. With `--path <pr>/kubernetes/flux/cluster --path-orig <base>/kubernetes/flux/cluster`, edits in `kubernetes/apps/...` were invisible to changed-only mode because `change.Detect` only saw the literal cluster subdirs (which were byte-identical across the two checkouts).
- `buildChangeFilter` now widens the diff to each side's `.git` root when both paths live under distinct `.git` ancestors (the PR-vs-base sibling-checkout pattern). Guarded against same-`.git`, missing-`.git`, and already-at-root cases — none of which want widening.
- New `TestIntegration_DiffWidensToRepoRootForSiblingCheckouts` exercises the path end-to-end via `orchestrator.Bootstrap` + `Filter().ShouldReconcile`. Existing e2e tests (fixture trees with no `.git`) continue to hit the literal-paths branch.

## Test plan
- [x] `go test ./...` — green
- [x] Empirical: `flate diff ks --path .../buroa/current/kubernetes/flux/cluster --path-orig .../buroa/orig/...` now logs `changedFiles=1 widenedToRepoRoot=true` and the diff body shows the commented-out wrapper KS + HR + downstream ReplicationSource as removed
- [x] Existing e2e diff tests (`TestE2E_ComponentChangePropagatesToAllConsumers`, `TestE2E_NonSharedChangeDoesNotPropagate`) still pass — they pass `--path current --path-orig orig` where both ARE the repo roots, so widening is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)