### PR TITLE
feat(diff): auto-detect baseline via git so --path-orig is optional

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -22,6 +22,7 @@ import (
 type commonFlags struct {
 	path               string
 	pathOrig           string
+	base               string
 	namespace          string
 	labels             map[string]string
 	skipCRDs           bool
@@ -78,6 +79,19 @@ func (c *commonFlags) skipResourceKinds() []string {
 // `-l foo=bar` and do nothing.
 func bindSelector(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringToStringVarP(&f.labels, "selector", "l", nil, "label selector (key=value, repeatable)")
+}
+
+// bindBase wires the `--base` flag. Scoped to diff subcommands —
+// `--base` selects the baseline git rev that the auto-baseline flow
+// materializes; only diff consumes a baseline tree, so binding it on
+// build/get/test would silently no-op. Mutually exclusive with
+// `--path-orig` (which is the absolute-path escape hatch); the check
+// is enforced at runtime in runDiff*.
+func bindBase(fs *pflag.FlagSet, f *commonFlags) {
+	fs.StringVar(&f.base, "base", "",
+		"baseline git rev (e.g. main, origin/main, HEAD~3, SHA). When unset, "+
+			"flate auto-detects via merge-base with @{u} / origin/HEAD. "+
+			"Mutually exclusive with --path-orig.")
 }
 
 // scopedNamespaces returns the namespace filter the command should

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -74,6 +74,7 @@ func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
+	bindBase(cmd.Flags(), c)
 	// `diff all` renders HRs as part of its scope, so always bind
 	// helm flags (matches `build all` / `test all` / `get all`).
 	if kind == "" || kind == manifest.KindHelmRelease {
@@ -95,6 +96,7 @@ func newDiffImagesCmd() *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
+	bindBase(cmd.Flags(), c)
 	bindHelmFlags(cmd.Flags(), h)
 	cmd.Flags().BoolVar(&includeRemoved, "include-removed", false,
 		"also emit images present only in --path-orig (default: only newly added images)")

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -121,7 +121,7 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 		// happens deterministically without each diff verb needing
 		// its own defer.
 		context.AfterFunc(ctx, func() { _ = os.RemoveAll(res.TempDir) })
-		slog.Info("diff baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
+		slog.Debug("diff baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
 	}
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -14,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/home-operations/flate/internal/format"
+	"github.com/home-operations/flate/pkg/baseline"
 	"github.com/home-operations/flate/pkg/diff"
 	"github.com/home-operations/flate/pkg/image"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -96,8 +98,30 @@ type diffSide struct {
 }
 
 func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (diffSide, diffSide, error) {
+	if c.pathOrig != "" && c.base != "" {
+		return diffSide{}, diffSide{}, errors.New("--path-orig and --base are mutually exclusive")
+	}
 	if c.pathOrig == "" {
-		return diffSide{}, diffSide{}, errors.New("diff requires --path-orig")
+		// Auto-baseline: materialize a baseline tree from git (either
+		// --base=<rev> or the auto-detect ladder) and point
+		// c.pathOrig at it for the remainder of the diff. The tempdir
+		// gets cleaned up via the context's cancel — Bootstrap reads
+		// the path-orig once and never reopens it (see PR #348's
+		// orchestrator surface mapping), so removing the tempdir
+		// after both orchestrators return is safe.
+		res, err := baseline.AutoResolve(c.path, c.base)
+		if err != nil {
+			return diffSide{}, diffSide{}, err
+		}
+		c.pathOrig = res.PathOrig
+		// Schedule cleanup via the parent context. context.AfterFunc
+		// fires when ctx is canceled OR when we explicitly call its
+		// returned stop-and-run helper at the end of the diff. The
+		// CLI cancels its root context on RunE return, so cleanup
+		// happens deterministically without each diff verb needing
+		// its own defer.
+		context.AfterFunc(ctx, func() { _ = os.RemoveAll(res.TempDir) })
+		slog.Info("diff baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
 	}
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -1,0 +1,410 @@
+package baseline
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// Result describes a materialized baseline tree on disk.
+type Result struct {
+	// PathOrig is the path the caller should use as the synthetic
+	// --path-orig: <TempDir>/<rel> where rel is the user's --path
+	// relative to the git repo root.
+	PathOrig string
+	// TempDir is the root of the materialized tree. Caller is
+	// responsible for os.RemoveAll once the diff is done.
+	TempDir string
+	// Rev is the resolved short SHA of the baseline commit, for
+	// logging and error context.
+	Rev string
+	// Source is a human-readable description of how the rev was
+	// picked (e.g. "merge-base with origin/HEAD", "explicit
+	// --base=main"), surfaced in the startup log line.
+	Source string
+}
+
+// resolution carries the result of picking a baseline rev: the commit
+// hash plus a Source label naming how it was found.
+type resolution struct {
+	Hash   plumbing.Hash
+	Source string
+}
+
+// AutoResolve picks a baseline for path, materializes it to a tempdir,
+// and returns a Result with the synthetic --path-orig already mapped
+// into the baseline tree's coordinate system. When base is non-empty
+// it is the explicit --base=<rev> override; otherwise the
+// auto-detection ladder runs.
+//
+// Caller must os.RemoveAll Result.TempDir when the diff is done.
+// Errors carry the suggested next flag so the user knows whether to
+// pass --base=<rev> or --path-orig=<dir>.
+func AutoResolve(path, base string) (*Result, error) {
+	repo, repoRoot, err := openRepo(path)
+	if err != nil {
+		return nil, err
+	}
+	pathOrig, err := mapToTempDir(repoRoot, "", path) // sanity-check the relpath BEFORE we materialize
+	if err != nil {
+		return nil, err
+	}
+	_ = pathOrig // computed only to surface "outside the repo" early
+	r, err := resolve(repo, base)
+	if err != nil {
+		return nil, err
+	}
+	tmp, err := os.MkdirTemp("", "flate-baseline-*")
+	if err != nil {
+		return nil, fmt.Errorf("baseline tempdir: %w", err)
+	}
+	if err := materialize(repo, r.Hash, tmp); err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, err
+	}
+	// Drop a .git marker so discovery.FindRepoRoot (called by
+	// orchestrator.buildChangeFilter's repo-root widening, PR #348)
+	// lifts the synthetic --path-orig to tmp, lining up with the
+	// current side's repoRoot. Without it, the per-side .git roots
+	// match (both fall back to the passed path) and the widening
+	// short-circuits.
+	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0o700); err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, fmt.Errorf("baseline .git marker: %w", err)
+	}
+	pathOrig, err = mapToTempDir(repoRoot, tmp, path)
+	if err != nil {
+		_ = os.RemoveAll(tmp)
+		return nil, err
+	}
+	return &Result{
+		PathOrig: pathOrig,
+		TempDir:  tmp,
+		Rev:      shortRev(r.Hash),
+		Source:   r.Source,
+	}, nil
+}
+
+// mapToTempDir mirrors path's relative location under repoRoot into
+// tempDir. Used twice: once with an empty tempDir to validate the
+// path is inside the repo before we do anything expensive, and once
+// with the real tempDir after materialization.
+func mapToTempDir(repoRoot, tempDir, path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(repoRoot, abs)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." {
+		return tempDir, nil
+	}
+	if rel == ".." || filepath.IsAbs(rel) || len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator) {
+		return "", fmt.Errorf("--path %q is outside the git repo at %q; pass --path-orig explicitly", path, repoRoot)
+	}
+	return filepath.Join(tempDir, rel), nil
+}
+
+// FindRepoRoot returns the .git ancestor of path, or "" when none
+// exists. Exposed so callers can branch on "is this a git repo" before
+// calling AutoResolve.
+func FindRepoRoot(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	for cur := abs; ; {
+		if _, err := os.Stat(filepath.Join(cur, ".git")); err == nil {
+			return cur
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return ""
+		}
+		cur = parent
+	}
+}
+
+// openRepo opens the git repo containing path. Returns the *Repository
+// and the repo root (the directory containing .git).
+func openRepo(path string) (*git.Repository, string, error) {
+	root := FindRepoRoot(path)
+	if root == "" {
+		return nil, "", fmt.Errorf("--path %q is not inside a git working tree; pass --path-orig=<dir> or --base=<rev> with a git checkout", path)
+	}
+	repo, err := git.PlainOpen(root)
+	if err != nil {
+		return nil, "", fmt.Errorf("open git repo at %q: %w", root, err)
+	}
+	return repo, root, nil
+}
+
+// resolve picks the baseline commit for the given repo. When base is
+// non-empty it's an explicit rev (passed via --base=<rev>); otherwise
+// the auto-detection ladder runs:
+//
+//  1. @{u} — current branch's configured upstream — merge-base with HEAD
+//  2. origin/HEAD — the default remote's default-branch symref — merge-base with HEAD
+//  3. origin/main / origin/master — merge-base with HEAD
+//
+// Each rung is tried in order; the first that resolves AND has a
+// reachable merge-base wins. Falling off the end is an error (no silent
+// fallback to HEAD — that would silently change "preview my PR" into
+// "preview my dirty edits"). Shallow clones can't compute a merge-base
+// against any of these refs because the necessary commits are absent;
+// detect .git/shallow and emit a CI-friendly error.
+func resolve(repo *git.Repository, base string) (*resolution, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("resolve HEAD: %w", err)
+	}
+	headCommit, err := repo.CommitObject(head.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("load HEAD commit: %w", err)
+	}
+
+	if base != "" {
+		h, err := repo.ResolveRevision(plumbing.Revision(base))
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve --base=%q: %w", base, err)
+		}
+		return &resolution{Hash: *h, Source: "explicit --base=" + base}, nil
+	}
+
+	// 1. @{u} via the branch config (go-git's ResolveRevision doesn't
+	//    accept @{u}; read branch.<name>.remote/.merge directly).
+	if up, ok := upstreamHash(repo, head); ok {
+		if base, err := mergeBase(repo, headCommit, up); err == nil {
+			return &resolution{Hash: base, Source: "merge-base with @{u}"}, nil
+		}
+	}
+
+	// 2. origin/HEAD: a symbolic ref under refs/remotes/origin/HEAD
+	//    pointing at e.g. refs/remotes/origin/main. Resolve through
+	//    the symref to the underlying branch tip.
+	if h, ok := resolveRef(repo, plumbing.NewRemoteHEADReferenceName("origin")); ok {
+		if base, err := mergeBase(repo, headCommit, h); err == nil {
+			return &resolution{Hash: base, Source: "merge-base with origin/HEAD"}, nil
+		}
+	}
+
+	// 3. Common defaults when origin/HEAD isn't set (older clones,
+	//    some self-hosted setups).
+	for _, name := range []string{"main", "master"} {
+		ref := plumbing.NewRemoteReferenceName("origin", name)
+		if h, ok := resolveRef(repo, ref); ok {
+			if base, err := mergeBase(repo, headCommit, h); err == nil {
+				return &resolution{Hash: base, Source: "merge-base with origin/" + name}, nil
+			}
+		}
+	}
+
+	// Distinguish "shallow clone, can't see the merge-base" from "no
+	// upstream configured at all" — the first is a CI fix (fetch-depth),
+	// the second is a flag fix (--base=<rev>).
+	if isShallow(repo) {
+		return nil, errors.New(
+			"baseline: cannot compute merge-base — repo appears shallow (.git/shallow present). " +
+				"In actions/checkout, set 'fetch-depth: 0'. Locally, run 'git fetch --unshallow'. " +
+				"Or pass --base=<ref> / --path-orig=<dir> explicitly.")
+	}
+	return nil, errors.New(
+		"baseline: could not auto-detect — HEAD has no upstream, origin/HEAD is unset, " +
+			"and origin/{main,master} are absent. Pass --base=<ref> or --path-orig=<dir>.")
+}
+
+// upstreamHash reads the current branch's upstream from the repo
+// config (branch.<name>.remote + branch.<name>.merge) and resolves it
+// to a commit. Returns ok=false when HEAD isn't on a branch (detached)
+// or no upstream is configured.
+func upstreamHash(repo *git.Repository, head *plumbing.Reference) (plumbing.Hash, bool) {
+	if head.Name() == "" || !head.Name().IsBranch() {
+		return plumbing.ZeroHash, false
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	branch, ok := cfg.Branches[head.Name().Short()]
+	if !ok || branch.Remote == "" || branch.Merge == "" {
+		return plumbing.ZeroHash, false
+	}
+	// branch.Merge is a local-style ref (refs/heads/<name>); map it to
+	// the remote-tracking equivalent (refs/remotes/<remote>/<name>) so
+	// we read the fetched copy, not the (possibly stale or absent)
+	// local branch.
+	remote := branchMergeToRemoteTracking(branch.Remote, string(branch.Merge))
+	if h, ok := resolveRef(repo, remote); ok {
+		return h, true
+	}
+	// Fall back to the literal Merge ref in case the user has a
+	// non-standard layout (no remote-tracking refs).
+	if h, err := repo.ResolveRevision(plumbing.Revision(branch.Merge)); err == nil {
+		return *h, true
+	}
+	return plumbing.ZeroHash, false
+}
+
+// branchMergeToRemoteTracking maps "refs/heads/<name>" to
+// "refs/remotes/<remote>/<name>". Pass-through for any other shape so
+// non-standard configs don't get mangled.
+func branchMergeToRemoteTracking(remote, merge string) plumbing.ReferenceName {
+	const prefix = "refs/heads/"
+	if len(merge) > len(prefix) && merge[:len(prefix)] == prefix {
+		return plumbing.NewRemoteReferenceName(remote, merge[len(prefix):])
+	}
+	return plumbing.ReferenceName(merge)
+}
+
+// resolveRef looks up a ref by name and returns its hash. ok=false on
+// any failure (ref missing, symref chain broken, etc.).
+func resolveRef(repo *git.Repository, name plumbing.ReferenceName) (plumbing.Hash, bool) {
+	ref, err := repo.Reference(name, true)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	return ref.Hash(), true
+}
+
+// mergeBase returns the merge-base of headCommit and other (a hash).
+// Errors out when the two commits share no common ancestor (disjoint
+// histories) — propagated up so the resolution ladder falls through to
+// the next rung.
+func mergeBase(repo *git.Repository, headCommit *object.Commit, other plumbing.Hash) (plumbing.Hash, error) {
+	otherCommit, err := repo.CommitObject(other)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	bases, err := headCommit.MergeBase(otherCommit)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+	if len(bases) == 0 {
+		return plumbing.ZeroHash, errors.New("no merge-base (disjoint histories)")
+	}
+	return bases[0].Hash, nil
+}
+
+// isShallow reports whether the repo is a shallow clone (presence of
+// .git/shallow). Used to distinguish "merge-base unreachable because
+// CI shallow-cloned" from "merge-base unreachable because no upstream".
+func isShallow(repo *git.Repository) bool {
+	root, err := repoStorerPath(repo)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(root, "shallow"))
+	return err == nil
+}
+
+// repoStorerPath returns the on-disk .git directory for repo. go-git
+// hides this behind the Storer interface, but every repo opened via
+// PlainOpen uses a filesystem-backed Storer pointing at .git/. Walk up
+// from cwd via the same FindRepoRoot we use elsewhere — simpler and
+// avoids reflection on go-git's internals.
+func repoStorerPath(repo *git.Repository) (string, error) {
+	// repo.Worktree().Filesystem.Root() returns the worktree root;
+	// .git lives at <root>/.git for non-bare repos. go-git's
+	// Worktree.Filesystem is the worktree's billy.FS, so Root() is
+	// guaranteed to point at the working tree.
+	wt, err := repo.Worktree()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(wt.Filesystem.Root(), ".git"), nil
+}
+
+// materialize extracts every blob in commit's tree to root, mirroring
+// the original directory structure. Submodules are warn-and-skipped —
+// flate's GitRepository fetcher handles submodules via go-git's
+// submodule API, but for a baseline diff the submodule's state is
+// rarely what the user wants to compare against, and the extra fetch
+// would couple `flate diff` to network availability.
+func materialize(repo *git.Repository, hash plumbing.Hash, root string) error {
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return fmt.Errorf("load baseline commit %s: %w", hash, err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return fmt.Errorf("load baseline tree: %w", err)
+	}
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+	for {
+		name, entry, err := walker.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("walk baseline tree: %w", err)
+		}
+		if entry.Mode == filemode.Submodule {
+			slog.Warn("baseline: skipping submodule", "path", name)
+			continue
+		}
+		if !entry.Mode.IsFile() {
+			// Trees and other non-file modes — NewTreeWalker recurses
+			// into subtrees automatically, so we don't mkdir here; the
+			// per-file write below MkdirAll's the parent on demand.
+			continue
+		}
+		blob, err := repo.BlobObject(entry.Hash)
+		if err != nil {
+			return fmt.Errorf("load baseline blob %s for %q: %w", entry.Hash, name, err)
+		}
+		if err := writeBlob(filepath.Join(root, name), blob, entry.Mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeBlob streams blob's content to path, creating parent dirs and
+// preserving the executable bit. All other mode bits are normalized to
+// 0o600 — the materialized tree is read-only for the diff and never
+// promoted to a real working tree.
+func writeBlob(path string, blob *object.Blob, mode filemode.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	perm := os.FileMode(0o600)
+	if mode == filemode.Executable {
+		perm = 0o700
+	}
+	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // path is composed under a tempdir we own
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
+	}
+	defer func() { _ = out.Close() }()
+	reader, err := blob.Reader()
+	if err != nil {
+		return fmt.Errorf("read blob for %s: %w", path, err)
+	}
+	defer func() { _ = reader.Close() }()
+	if _, err := io.Copy(out, reader); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// shortRev formats a hash as the conventional 7-char prefix used in
+// log lines.
+func shortRev(h plumbing.Hash) string {
+	s := h.String()
+	if len(s) <= 7 {
+		return s
+	}
+	return s[:7]
+}
+

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -214,13 +214,13 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	// the second is a flag fix (--base=<rev>).
 	if isShallow(repo) {
 		return nil, errors.New(
-			"baseline: cannot compute merge-base — repo appears shallow (.git/shallow present). " +
-				"In actions/checkout, set 'fetch-depth: 0'. Locally, run 'git fetch --unshallow'. " +
-				"Or pass --base=<ref> / --path-orig=<dir> explicitly.")
+			"baseline: cannot compute merge-base — repo appears shallow (.git/shallow present); " +
+				"in actions/checkout, set 'fetch-depth: 0', or locally run 'git fetch --unshallow', " +
+				"or pass --base=<ref> / --path-orig=<dir> explicitly")
 	}
 	return nil, errors.New(
 		"baseline: could not auto-detect — HEAD has no upstream, origin/HEAD is unset, " +
-			"and origin/{main,master} are absent. Pass --base=<ref> or --path-orig=<dir>.")
+			"and origin/{main,master} are absent; pass --base=<ref> or --path-orig=<dir>")
 }
 
 // upstreamHash reads the current branch's upstream from the repo

--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -1,0 +1,416 @@
+package baseline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// TestAutoResolve_ExplicitBase pins the --base=<rev> escape hatch: an
+// explicit rev bypasses the auto-detection ladder and the named commit
+// becomes the baseline.
+func TestAutoResolve_ExplicitBase(t *testing.T) {
+	dir := t.TempDir()
+	commitA := initRepoWithFile(t, dir, "a.yaml", "original")
+	commitB := writeAndCommit(t, dir, "a.yaml", "updated")
+
+	res, err := AutoResolve(dir, commitA.String())
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if !strings.HasPrefix(res.Source, "explicit --base=") {
+		t.Errorf("Source = %q, want prefix 'explicit --base='", res.Source)
+	}
+	got, err := os.ReadFile(filepath.Join(res.TempDir, "a.yaml"))
+	if err != nil {
+		t.Fatalf("read materialized: %v", err)
+	}
+	if string(got) != "original" {
+		t.Errorf("materialized a.yaml = %q, want %q (should be commitA's tree, not HEAD's)", got, "original")
+	}
+	_ = commitB
+}
+
+// TestAutoResolve_UpstreamMergeBase exercises the @{u} rung: HEAD is on
+// a branch whose config points at a remote-tracking ref, and the
+// merge-base resolves correctly.
+func TestAutoResolve_UpstreamMergeBase(t *testing.T) {
+	dir := t.TempDir()
+	mainCommit := initRepoWithFile(t, dir, "a.yaml", "main")
+	// Set up a remote-tracking ref that points at mainCommit (simulates
+	// origin/main without an actual remote). Use the actual init branch
+	// name (go-git's default may be master, not main).
+	repo := openHelper(t, dir)
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	branchName := head.Name().Short()
+	setRef(t, repo, plumbing.NewRemoteReferenceName("origin", branchName), mainCommit)
+	configureBranch(t, repo, branchName, "origin", "refs/heads/"+branchName)
+
+	// Move forward on the local branch.
+	writeAndCommit(t, dir, "a.yaml", "diverged")
+
+	res, err := AutoResolve(dir, "")
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if res.Source != "merge-base with @{u}" {
+		t.Errorf("Source = %q, want 'merge-base with @{u}'", res.Source)
+	}
+	got, err := os.ReadFile(filepath.Join(res.TempDir, "a.yaml"))
+	if err != nil {
+		t.Fatalf("read materialized: %v", err)
+	}
+	if string(got) != "main" {
+		t.Errorf("materialized = %q, want %q (should be merge-base contents)", got, "main")
+	}
+}
+
+// TestAutoResolve_OriginHEAD: no @{u}, but origin/HEAD symref present.
+// Verifies the second rung fires.
+func TestAutoResolve_OriginHEAD(t *testing.T) {
+	dir := t.TempDir()
+	mainCommit := initRepoWithFile(t, dir, "a.yaml", "base")
+	repo := openHelper(t, dir)
+	// Simulate the remote-tracking branch and origin/HEAD symref
+	// pointing at it. No branch config — so @{u} is unset.
+	setRef(t, repo, plumbing.NewRemoteReferenceName("origin", "main"), mainCommit)
+	setSymRef(t, repo, plumbing.NewRemoteHEADReferenceName("origin"),
+		plumbing.NewRemoteReferenceName("origin", "main"))
+
+	writeAndCommit(t, dir, "a.yaml", "new")
+
+	res, err := AutoResolve(dir, "")
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if res.Source != "merge-base with origin/HEAD" {
+		t.Errorf("Source = %q, want 'merge-base with origin/HEAD'", res.Source)
+	}
+}
+
+// TestAutoResolve_OriginMainFallback exercises the third rung: no
+// @{u}, no origin/HEAD, but origin/main exists.
+func TestAutoResolve_OriginMainFallback(t *testing.T) {
+	dir := t.TempDir()
+	mainCommit := initRepoWithFile(t, dir, "a.yaml", "base")
+	repo := openHelper(t, dir)
+	setRef(t, repo, plumbing.NewRemoteReferenceName("origin", "main"), mainCommit)
+	// Deliberately no origin/HEAD symref and no branch config.
+
+	writeAndCommit(t, dir, "a.yaml", "new")
+
+	res, err := AutoResolve(dir, "")
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if res.Source != "merge-base with origin/main" {
+		t.Errorf("Source = %q, want 'merge-base with origin/main'", res.Source)
+	}
+}
+
+// TestAutoResolve_DetachedHEAD: HEAD is at a SHA, not a branch. The
+// @{u} rung is unreachable (no branch → no config); the algorithm
+// must fall through to origin/HEAD. This is the GH Actions PR case.
+func TestAutoResolve_DetachedHEAD(t *testing.T) {
+	dir := t.TempDir()
+	mainCommit := initRepoWithFile(t, dir, "a.yaml", "base")
+	writeAndCommit(t, dir, "a.yaml", "pr-tip")
+	repo := openHelper(t, dir)
+	setRef(t, repo, plumbing.NewRemoteReferenceName("origin", "main"), mainCommit)
+	setSymRef(t, repo, plumbing.NewRemoteHEADReferenceName("origin"),
+		plumbing.NewRemoteReferenceName("origin", "main"))
+	// Detach HEAD: write a non-symbolic HEAD pointing at the current commit.
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.HEAD, head.Hash())); err != nil {
+		t.Fatalf("detach HEAD: %v", err)
+	}
+
+	res, err := AutoResolve(dir, "")
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if res.Source != "merge-base with origin/HEAD" {
+		t.Errorf("Source = %q, want 'merge-base with origin/HEAD' (detached HEAD should skip @{u})", res.Source)
+	}
+}
+
+// TestAutoResolve_NoGit: a path that isn't inside a .git ancestor must
+// error with a message naming the alternative flags.
+func TestAutoResolve_NoGit(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := AutoResolve(dir, "")
+	if err == nil {
+		t.Fatal("expected error for non-git path")
+	}
+	if !strings.Contains(err.Error(), "not inside a git working tree") {
+		t.Errorf("error %q: should explain why and suggest --path-orig / --base", err)
+	}
+}
+
+// TestAutoResolve_Shallow: presence of .git/shallow is the CI shallow-
+// clone signal and must produce a distinct error from "no upstream"
+// so users know to set fetch-depth: 0.
+func TestAutoResolve_Shallow(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "a.yaml", "x")
+	if err := os.WriteFile(filepath.Join(dir, ".git", "shallow"), []byte("deadbeef\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// No upstream, no origin refs → the resolution ladder falls
+	// through; the shallow detection fires last.
+	_, err := AutoResolve(dir, "")
+	if err == nil {
+		t.Fatal("expected shallow error")
+	}
+	if !strings.Contains(err.Error(), "shallow") {
+		t.Errorf("error %q should mention shallow", err)
+	}
+	if !strings.Contains(err.Error(), "fetch-depth: 0") {
+		t.Errorf("error %q should suggest fetch-depth: 0 fix", err)
+	}
+}
+
+// TestAutoResolve_NoUpstream: real (non-shallow) repo with no upstream
+// and no origin refs at all. Errors cleanly suggesting --base.
+func TestAutoResolve_NoUpstream(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "a.yaml", "x")
+	_, err := AutoResolve(dir, "")
+	if err == nil {
+		t.Fatal("expected no-upstream error")
+	}
+	if strings.Contains(err.Error(), "shallow") {
+		t.Errorf("error %q should not mention shallow on non-shallow repo", err)
+	}
+	if !strings.Contains(err.Error(), "--base") {
+		t.Errorf("error %q should suggest --base flag", err)
+	}
+}
+
+// TestAutoResolve_PathOutsideRepo: --path resolves outside the .git
+// ancestor → refuse early with a clear suggestion.
+func TestAutoResolve_PathOutsideRepo(t *testing.T) {
+	outerDir := t.TempDir()
+	repoDir := filepath.Join(outerDir, "repo")
+	if err := os.Mkdir(repoDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	initRepoWithFile(t, repoDir, "a.yaml", "x")
+	// Sibling directory, outside the repo. We expect openRepo to find
+	// no .git ancestor for outerDir/sibling, and surface a clear error.
+	sibling := filepath.Join(outerDir, "sibling")
+	if err := os.Mkdir(sibling, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	_, err := AutoResolve(sibling, "")
+	if err == nil {
+		t.Fatal("expected error for path outside repo")
+	}
+}
+
+// TestAutoResolve_PathOrigMappedToSubdir: when --path is a subdir,
+// the synthetic PathOrig must be <tempdir>/<rel>, not just tempdir.
+// This is the load-bearing case the agents flagged in PR #348's
+// validation: real users point at cluster/, not the repo root.
+func TestAutoResolve_PathOrigMappedToSubdir(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "kubernetes/flux/cluster/cluster.yaml", "x")
+	commit := writeAndCommit(t, dir, "kubernetes/flux/cluster/cluster.yaml", "y")
+
+	clusterDir := filepath.Join(dir, "kubernetes", "flux", "cluster")
+	res, err := AutoResolve(clusterDir, commit.String())
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	wantSuffix := filepath.Join("kubernetes", "flux", "cluster")
+	if !strings.HasSuffix(res.PathOrig, wantSuffix) {
+		t.Errorf("PathOrig = %q, want suffix %q", res.PathOrig, wantSuffix)
+	}
+	if !strings.HasPrefix(res.PathOrig, res.TempDir) {
+		t.Errorf("PathOrig = %q, want prefix %q", res.PathOrig, res.TempDir)
+	}
+	// The mapped file must exist at the synthetic --path-orig.
+	if _, err := os.Stat(filepath.Join(res.PathOrig, "cluster.yaml")); err != nil {
+		t.Errorf("expected materialized file at PathOrig: %v", err)
+	}
+}
+
+// TestAutoResolve_DropsGitMarker confirms the .git marker is present
+// in TempDir so discovery.FindRepoRoot (used by PR #348's repo-root
+// widening) lifts up correctly when --path-orig is a subdir.
+func TestAutoResolve_DropsGitMarker(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "a.yaml", "x")
+	commit := writeAndCommit(t, dir, "a.yaml", "y")
+	res, err := AutoResolve(dir, commit.String())
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	info, err := os.Stat(filepath.Join(res.TempDir, ".git"))
+	if err != nil {
+		t.Fatalf("expected .git marker in TempDir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf(".git marker should be a directory")
+	}
+}
+
+// TestMaterialize_PreservesExecutableBit: blobs stored as executable
+// must be written with the exec bit set so downstream consumers (e.g.,
+// scripts referenced by configMapGenerator with envs:) behave the
+// same against the baseline as against the working tree.
+func TestMaterialize_PreservesExecutableBit(t *testing.T) {
+	dir := t.TempDir()
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := filepath.Join(dir, "run.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\necho hi\n"), 0o755); err != nil { //nolint:gosec // test fixture
+		t.Fatal(err)
+	}
+	wt, err := r.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("run.sh"); err != nil {
+		t.Fatal(err)
+	}
+	commit, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := AutoResolve(dir, commit.String())
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	info, err := os.Stat(filepath.Join(res.TempDir, "run.sh"))
+	if err != nil {
+		t.Fatalf("stat materialized run.sh: %v", err)
+	}
+	if info.Mode().Perm()&0o100 == 0 {
+		t.Errorf("exec bit lost in materialization: mode = %v", info.Mode().Perm())
+	}
+}
+
+// --- helpers --------------------------------------------------------
+
+func initRepoWithFile(t *testing.T, dir, path, content string) plumbing.Hash {
+	t.Helper()
+	r, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	full := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wt, err := r.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(path); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
+}
+
+func writeAndCommit(t *testing.T, dir, path, content string) plumbing.Hash {
+	t.Helper()
+	full := filepath.Join(dir, path)
+	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := openHelper(t, dir)
+	wt, err := r.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(path); err != nil {
+		t.Fatal(err)
+	}
+	hash, err := wt.Commit("update", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hash
+}
+
+func openHelper(t *testing.T, dir string) *git.Repository {
+	t.Helper()
+	r, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+func setRef(t *testing.T, repo *git.Repository, name plumbing.ReferenceName, hash plumbing.Hash) {
+	t.Helper()
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(name, hash)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setSymRef(t *testing.T, repo *git.Repository, name, target plumbing.ReferenceName) {
+	t.Helper()
+	if err := repo.Storer.SetReference(plumbing.NewSymbolicReference(name, target)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func configureBranch(t *testing.T, repo *git.Repository, branch, remote, merge string) {
+	t.Helper()
+	cfg, err := repo.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Branches == nil {
+		cfg.Branches = map[string]*config.Branch{}
+	}
+	cfg.Branches[branch] = &config.Branch{
+		Name:   branch,
+		Remote: remote,
+		Merge:  plumbing.ReferenceName(merge),
+	}
+	if err := repo.SetConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/baseline/doc.go
+++ b/pkg/baseline/doc.go
@@ -1,0 +1,16 @@
+// Package baseline resolves and materializes a git revision into a
+// tempdir so `flate diff` can run without an explicit --path-orig.
+//
+// The user-facing flow: when --path-orig isn't supplied, the CLI
+// asks baseline.Resolve for the commit to diff against (either the
+// explicit --base=<rev>, or auto-detected via merge-base with the
+// branch's upstream / origin/HEAD / origin/{main,master}) and then
+// asks Materialize to extract that commit's tree into a fresh
+// tempdir. The CLI sets --path-orig to that tempdir for the
+// remainder of the diff run, then deletes it on exit.
+//
+// This package treats the user's checkout as read-only — it opens
+// the existing repo via go-git's object store and does not mutate
+// the working tree, the index, or refs. The materialized tempdir is
+// the only side effect, and it lives only for the diff invocation.
+package baseline

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -87,7 +87,7 @@ func (o *Orchestrator) demoteOrphans(failed map[manifest.NamedResource]store.Sta
 func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.StatusInfo) {
 	ksCount := len(o.store.ListObjects(manifest.KindKustomization))
 	hrCount := len(o.store.ListObjects(manifest.KindHelmRelease))
-	slog.Info("reconcile complete",
+	slog.Debug("reconcile complete",
 		"kustomizations", ksCount,
 		"helmReleases", hrCount,
 		"failed", len(failed))

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -461,7 +461,7 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 				cs = cs.Reroot(rel)
 			}
 		}
-		slog.Info("changed-only mode",
+		slog.Debug("changed-only mode",
 			"baseline", diffOrig, "current", diffCurr, "changedFiles", cs.Len(), "widenedToRepoRoot", widened)
 		if cs.Len() == 0 {
 			slog.Warn("no changes detected between --path and --path-orig — output will be empty; verify both paths reference distinct snapshots")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -12,6 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/home-operations/flate/internal/cli"
 )
@@ -217,13 +221,57 @@ func TestE2E_DiffImagesNoChange(t *testing.T) {
 	}
 }
 
-func TestE2E_DiffImagesRequiresPathOrig(t *testing.T) {
-	out, code := runCLIExpectErr(t, "diff", "images", "--path", testdataPath(t, "simple"))
+// TestE2E_DiffAutoBaseline_Base pins the --base=<rev> escape hatch
+// end-to-end through the CLI: init a real git repo, commit a fixture,
+// modify the working tree, then `flate diff ks --path <dir> --base
+// HEAD` and assert the diff surfaces the edit. Exercises the full
+// auto-baseline plumbing (materialize → synthetic --path-orig →
+// orchestrator → diff) without needing a configured upstream.
+func TestE2E_DiffAutoBaseline_Base(t *testing.T) {
+	clusterPath, repoRoot := initGitFixture(t)
+	// Edit cm.yaml in the working tree; HEAD still has the original.
+	cm := filepath.Join(repoRoot, "kubernetes", "apps", "cm.yaml")
+	body, err := os.ReadFile(cm) //nolint:gosec // dir is t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := strings.Replace(string(body), "value: original", "value: changed", 1)
+	if mutated == string(body) {
+		t.Fatal("sentinel 'value: original' not found in fixture")
+	}
+	if err := os.WriteFile(cm, []byte(mutated), 0o600); err != nil { //nolint:gosec // dir is t.TempDir()
+		t.Fatal(err)
+	}
+	out := runCLI(t, "diff", "ks", "--path", clusterPath, "--base", "HEAD")
+	if !strings.Contains(out, "changed") {
+		t.Errorf("expected 'changed' to surface in diff body:\n%s", out)
+	}
+	if !strings.Contains(out, "original") {
+		t.Errorf("expected baseline 'original' to surface in diff body:\n%s", out)
+	}
+}
+
+// TestE2E_DiffImagesRequiresBaselineWhenNoGit pins the error UX when
+// no baseline can be auto-detected: --path lives outside a git repo
+// AND --path-orig / --base are unset. The error must name both
+// alternative flags so the user knows their options. Pre-auto-baseline
+// this test asserted "diff requires --path-orig"; with auto-baseline
+// the failure mode shifts to "no git repo" — but the suggestion in
+// the message still mentions --path-orig so the test contract is
+// upgraded, not replaced.
+func TestE2E_DiffImagesRequiresBaselineWhenNoGit(t *testing.T) {
+	// copyTree to a tempdir with no .git ancestor (t.TempDir's parent
+	// chain stops at the OS temp root, which has no .git).
+	dir := copyTree(t, testdataPath(t, "simple"))
+	out, code := runCLIExpectErr(t, "diff", "images", "--path", dir)
 	if code == 0 {
-		t.Fatalf("expected non-zero exit when --path-orig is missing, got 0:\n%s", out)
+		t.Fatalf("expected non-zero exit with no baseline source, got 0:\n%s", out)
 	}
 	if !strings.Contains(out, "--path-orig") {
-		t.Errorf("error should mention --path-orig:\n%s", out)
+		t.Errorf("error should mention --path-orig as an option:\n%s", out)
+	}
+	if !strings.Contains(out, "--base") {
+		t.Errorf("error should mention --base as an option:\n%s", out)
 	}
 }
 
@@ -514,6 +562,64 @@ func mustExtractLine(t *testing.T, haystack, needle string) string {
 	}
 	t.Fatalf("status line for %q not found in:\n%s", needle, haystack)
 	return ""
+}
+
+// initGitFixture creates a tempdir with a real git repo, commits a
+// minimal Flux fixture (one KS + one ConfigMap with a sentinel value),
+// and returns (clusterPath, repoRoot). clusterPath is the directory
+// callers pass as --path; repoRoot is the .git ancestor (so the test
+// can locate fixture files relative to it after committing).
+func initGitFixture(t *testing.T) (clusterPath, repoRoot string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile := func(rel, body string) {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil { //nolint:gosec // dir is t.TempDir()
+			t.Fatal(err)
+		}
+	}
+	writeFile("kubernetes/flux/cluster.yaml", `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: flux-system, namespace: flux-system}
+spec: {url: "https://example.test/x.git"}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  interval: 10m
+  path: ./kubernetes/apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	writeFile("kubernetes/apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	writeFile("kubernetes/apps/cm.yaml", `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: apps}
+data:
+  value: original
+`)
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "kubernetes", "flux"), dir
 }
 
 // copyTree shallow-copies src into a fresh tempdir, preserving the


### PR DESCRIPTION
## Summary

- `flate diff ks --path <cluster>` now Just Works inside a git checkout. No more `cp -a` + manual `--path-orig`.
- New `pkg/baseline/` package opens the repo via go-git (already a dep), picks a baseline commit via merge-base with `@{u}` → `origin/HEAD` → `origin/{main,master}`, and materializes that commit's tree into a tempdir.
- New `--base=<rev>` flag for explicit baseline selection (branch / tag / SHA / `HEAD~3`). Mutually exclusive with `--path-orig`.
- Scoped to `diff` subcommands only — build/get/test keep their literal `--path-orig` semantics.

## Design choices

- **No silent fallback to HEAD** — would change "preview my PR" into "preview my dirty edits" without warning.
- **Shallow detection** distinguishes CI shallow clones (suggest `fetch-depth: 0`) from absent upstream (suggest `--base=<rev>`).
- **Synthetic `.git` marker** in the tempdir so PR #348's repo-root widening lifts correctly when `--path` is a cluster subdir.
- **Submodules warn-and-skip** — an offline-render tool shouldn't couple `diff` to a submodule fetch.
- **Cleanup via `context.AfterFunc`** — no per-verb defer; tempdir cleared when the diff context cancels.

## Test plan
- [x] 12 new unit tests in `pkg/baseline/baseline_test.go` — explicit base, `@{u}` merge-base, `origin/HEAD`, `origin/main` fallback, detached HEAD, no-git, shallow, no-upstream, path-outside-repo, subdir mapping, .git marker, exec-bit preservation
- [x] `TestE2E_DiffAutoBaseline_Base` — real git repo via `PlainInit`, working-tree edit, full CLI exercise
- [x] `TestE2E_DiffImagesRequiresPathOrig` → `TestE2E_DiffImagesRequiresBaselineWhenNoGit` — inverted to assert error names both alternative flags
- [x] Empirically validated against buroa/k8s-gitops:
  ```
  $ flate diff ks --path kubernetes/flux/cluster
  diff baseline source="merge-base with @{u}" rev=926d2bf
  changed-only mode changedFiles=1 widenedToRepoRoot=true
  ```
- [x] Full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)