### PR TITLE
fix(helm): chart cache returns per-render clone to avoid ProcessDependencies race

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -232,7 +232,7 @@ func (c *Client) LoadChart(ctx context.Context, hr *manifest.HelmRelease) (Chart
 	// path is a stable string but the underlying bytes may have
 	// changed; without the stat check we'd serve the stale chart.
 	if ch, ok := c.lookupCachedChart(path); ok {
-		return ChartLoadResult{Path: path, Chart: ch}, nil
+		return ChartLoadResult{Path: path, Chart: cloneChartForRender(ch)}, nil
 	}
 
 	// Coalesce parallel first-loads of the same chart so N concurrent
@@ -248,7 +248,7 @@ func (c *Client) LoadChart(ctx context.Context, hr *manifest.HelmRelease) (Chart
 	// Re-check under the per-path lock — another goroutine may have
 	// populated the cache while we waited.
 	if ch, ok := c.lookupCachedChart(path); ok {
-		return ChartLoadResult{Path: path, Chart: ch}, nil
+		return ChartLoadResult{Path: path, Chart: cloneChartForRender(ch)}, nil
 	}
 
 	ch, err := loader.Load(path)
@@ -267,7 +267,85 @@ func (c *Client) LoadChart(ctx context.Context, hr *manifest.HelmRelease) (Chart
 		c.chartCache[path] = chartCacheEntry{chart: ch, mtime: mtime, size: size}
 		c.chartMu.Unlock()
 	}
-	return ChartLoadResult{Path: path, Chart: ch}, nil
+	// Hand the caller a clone — helm's Install.RunWithContext invokes
+	// chartutil.ProcessDependencies which mutates Chart.Values and the
+	// per-Dependency Enabled flags. Sharing the cached pointer races
+	// across concurrent renders.
+	return ChartLoadResult{Path: path, Chart: cloneChartForRender(ch)}, nil
+}
+
+// cloneChartForRender returns a shallow copy of src with the fields
+// chartutil.ProcessDependencies mutates (Values, Metadata.Dependencies,
+// and recursively each subchart's same) cloned per call. Immutable
+// fields (Templates, Raw, Files, Schema, ModTime, Lock) are aliased to
+// the cached canonical to avoid copying potentially-MBs of template
+// bytes per render.
+//
+// Mutations the helm template path performs that this guards:
+//   - `c.Values = util.MergeTables/CoalesceTables(...)` rewrites
+//     Values map on the chart and on every subchart
+//     (pkg/chart/v2/util/dependencies.go:327,334).
+//   - `processDependencyConditions` sets `dep.Enabled` on each entry
+//     of `c.Metadata.Dependencies` (line 189).
+//   - `processDependencyEnabled` rewrites the dependencies slice
+//     itself (lines 223-224).
+func cloneChartForRender(src *chart.Chart) *chart.Chart {
+	if src == nil {
+		return nil
+	}
+	out := *src
+	if src.Metadata != nil {
+		md := *src.Metadata
+		if len(src.Metadata.Dependencies) > 0 {
+			md.Dependencies = make([]*chart.Dependency, len(src.Metadata.Dependencies))
+			for i, d := range src.Metadata.Dependencies {
+				if d == nil {
+					continue
+				}
+				dc := *d
+				md.Dependencies[i] = &dc
+			}
+		}
+		out.Metadata = &md
+	}
+	out.Values = cloneValuesMap(src.Values)
+	if subs := src.Dependencies(); len(subs) > 0 {
+		clones := make([]*chart.Chart, 0, len(subs))
+		for _, sub := range subs {
+			clones = append(clones, cloneChartForRender(sub))
+		}
+		out.SetDependencies(clones...)
+	}
+	return &out
+}
+
+// cloneValuesMap deep-copies a chart.Values map (`map[string]any`).
+// Mirrors pkg/manifest.DeepCopyMap but kept local to avoid widening
+// the helm→manifest import seam for one helper.
+func cloneValuesMap(src map[string]any) map[string]any {
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = cloneValuesNode(v)
+	}
+	return out
+}
+
+func cloneValuesNode(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return cloneValuesMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = cloneValuesNode(e)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // lookupCachedChart returns the cached chart only when the on-disk

--- a/pkg/helm/loadchart_test.go
+++ b/pkg/helm/loadchart_test.go
@@ -19,12 +19,14 @@ import (
 // TestLoadChart_CoalescesConcurrentFirstLoad verifies that N parallel
 // LoadChart calls for the same chart issue exactly one loader.Load.
 // Without the per-path keylock, every concurrent first-loader saw an
-// empty cache and parsed the tgz independently — wasted CPU and (more
-// importantly) divergent *chart.Chart pointers between callers.
+// empty cache and parsed the tgz independently — wasted CPU.
 //
-// We can't directly intercept loader.Load, but we can verify the
-// post-condition: every caller ends up with the SAME *chart.Chart
-// pointer (cache wins) rather than independently-parsed copies.
+// The post-condition is that every caller's `*chart.Chart` aliases the
+// same underlying Templates/Raw/Files (which loader.Load produced
+// once), even though each caller receives a fresh outer pointer (the
+// per-render clone defended against ProcessDependencies mutation). We
+// assert the alias via Templates pointer-identity — Templates is one
+// of the immutable slices preserved across cloneChartForRender.
 func TestLoadChart_CoalescesConcurrentFirstLoad(t *testing.T) {
 	dir := t.TempDir()
 	testutil.WriteFile(t, dir, "mychart/Chart.yaml", `apiVersion: v2
@@ -92,13 +94,25 @@ description: test
 	for p := range pointers {
 		if canonical == nil {
 			canonical = p
-		} else if p != canonical {
-			t.Errorf("got divergent *chart.Chart pointers across goroutines — first-load coalesce broken")
+			continue
+		}
+		// Each goroutine receives its own outer *chart.Chart (the
+		// per-render clone), but the Templates slice header — one of
+		// the immutable, aliased fields — must point at the same
+		// backing array as the canonical's. A different backing array
+		// would mean loader.Load fired more than once.
+		if len(p.Templates) != len(canonical.Templates) {
+			t.Errorf("Templates length divergence — first-load coalesce broken (got %d, want %d)",
+				len(p.Templates), len(canonical.Templates))
+			continue
+		}
+		if len(p.Templates) > 0 && p.Templates[0] != canonical.Templates[0] {
+			t.Errorf("Templates[0] pointer divergence — first-load coalesce broken")
 		}
 		count++
 	}
-	if count != goroutines {
-		t.Errorf("collected %d pointers, want %d", count, goroutines)
+	if count != goroutines-1 { // canonical is the first one
+		t.Errorf("collected %d aliased pointers, want %d", count, goroutines-1)
 	}
 }
 
@@ -172,7 +186,86 @@ description: second-version-different-size-and-mtime
 	if err != nil {
 		t.Fatalf("second LoadChart: %v", err)
 	}
-	if second.Chart == first.Chart {
-		t.Error("cache served stale chart after on-disk overwrite; mtime/size invalidation failed")
+	// LoadChart now returns a per-call clone for ProcessDependencies
+	// safety, so pointer identity isn't the right signal — compare a
+	// content field (Description) that differs between the two
+	// on-disk versions.
+	if first.Chart.Metadata.Description == second.Chart.Metadata.Description {
+		t.Errorf("cache served stale chart after on-disk overwrite; mtime/size invalidation failed (description still %q)",
+			first.Chart.Metadata.Description)
+	}
+}
+
+// TestLoadChart_PerCallCloneIsolatesValuesAndDependencies pins that
+// each LoadChart call returns a fresh outer *chart.Chart whose
+// Values map and Metadata.Dependencies slice are independent of the
+// cached canonical AND of every other concurrent caller. Without
+// the clone, helm's ProcessDependencies (called by Install.Run)
+// mutates Chart.Values and per-Dependency Enabled flags on the
+// shared pointer, racing across reconciles.
+func TestLoadChart_PerCallCloneIsolatesValuesAndDependencies(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml", `apiVersion: v2
+name: mychart
+version: 0.1.0
+description: with deps
+dependencies:
+  - name: dep-a
+    version: 0.0.0
+    repository: ""
+    condition: dep-a.enabled
+  - name: dep-b
+    version: 0.0.0
+    repository: ""
+    condition: dep-b.enabled
+`)
+	testutil.WriteFile(t, dir, "mychart/values.yaml", "k: shared\n")
+	testutil.WriteFile(t, dir, "mychart/templates/_helpers.tpl", "")
+
+	cli, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := store.New()
+	gr := &manifest.GitRepository{Name: "chart-repo", Namespace: "flux-system"}
+	st.AddObject(gr)
+	st.SetArtifact(gr.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir,
+	})
+	cli.SetSourceResolver(NewStoreSourceResolver(st))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "mychart",
+			RepoName:      "chart-repo",
+			RepoNamespace: "flux-system",
+			RepoKind:      manifest.KindGitRepository,
+		},
+	}
+
+	a, err := cli.LoadChart(context.Background(), hr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := cli.LoadChart(context.Background(), hr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a.Chart == b.Chart {
+		t.Fatal("expected distinct outer *chart.Chart pointers across calls")
+	}
+	// Mutate a's Values + Dependencies; b must be untouched.
+	a.Chart.Values["k"] = "MUTATED-A"
+	if len(a.Chart.Metadata.Dependencies) > 0 {
+		a.Chart.Metadata.Dependencies[0].Enabled = true
+	}
+
+	if got := b.Chart.Values["k"]; got != "shared" {
+		t.Errorf("b.Values aliased a's Values map (got %q, want %q)", got, "shared")
+	}
+	if len(b.Chart.Metadata.Dependencies) > 0 && b.Chart.Metadata.Dependencies[0].Enabled {
+		t.Errorf("b.Metadata.Dependencies[0] aliased a's pointer; Enabled leaked")
 	}
 }


### PR DESCRIPTION
## Summary

- `LoadChart` cached a single `*chart.Chart` shared across concurrent renders. Helm's `action.Install.RunWithContext` → `chartutil.ProcessDependencies` mutates `Chart.Values` and per-Dependency `Enabled` flags on that pointer, racing across reconciles of the same base chart (bjw-s app-template, podinfo, common-library).
- Fix: cache the parsed chart but return a per-call clone with the mutated fields (`Values` deep, `Metadata.Dependencies` slice + per-element value-copied, recursively into subcharts) cloned. Immutable fields alias the canonical.
- Coalesce contract preserved — test now asserts `Templates` pointer-identity (the aliased slice) across N concurrent callers rather than outer `*chart.Chart` identity.

## Test plan
- [x] `TestLoadChart_CoalescesConcurrentFirstLoad` reworked to assert Templates aliasing (proves one `loader.Load` for N concurrent first-loaders)
- [x] `TestLoadChart_InvalidatesOnFileMtimeChange` adjusted to check Metadata.Description content instead of pointer identity (clone is by design now)
- [x] New `TestLoadChart_PerCallCloneIsolatesValuesAndDependencies` mutates one clone's Values/Dependencies and asserts a sibling clone stays intact
- [x] Full `go test ./... -race` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)