### PR TITLE
fix(source): wrap missing-secret errors + don't silence cosign keyless warning

### DIFF
--- a/pkg/helm/auth_test.go
+++ b/pkg/helm/auth_test.go
@@ -1,6 +1,7 @@
 package helm
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -94,8 +95,14 @@ func TestHelmRepoTLS_CertSecretNotFound(t *testing.T) {
 	}
 	_, cleanup, err := c.helmRepoTLSOptions(r)
 	cleanup()
-	if err == nil || !strings.Contains(err.Error(), "cert secret ns/missing not found") {
-		t.Errorf("expected secret-not-found error; got %v", err)
+	if err == nil {
+		t.Fatal("expected secret-not-found error; got nil")
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("expected error wrapped with manifest.ErrMissingSecret; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Errorf("expected error to name the secret 'missing'; got %v", err)
 	}
 }
 

--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -205,8 +205,8 @@ func (f *Fetcher) loadCosignPublicKeys(repo *manifest.OCIRepository) ([]crypto.P
 	}
 	sec := f.Secrets(repo.Namespace, repo.Verify.SecretRef.Name)
 	if sec == nil {
-		return nil, fmt.Errorf("OCIRepository %s/%s: verify secret %s/%s not found",
-			repo.Namespace, repo.Name, repo.Namespace, repo.Verify.SecretRef.Name)
+		return nil, source.MissingSecretErr("OCIRepository",
+			repo.Namespace, repo.Name, repo.Verify.SecretRef.Name, "verify secret not found")
 	}
 	var keys []crypto.PublicKey
 	// Iterate the union of StringData + Data keys so PEM blocks stored

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -296,7 +296,13 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	// Best-effort: a write failure costs us the next cache hit's
 	// offline win (re-verify falls back to the network) but the slot
 	// remains correct and the next pull will retry.
-	if repo.Verify != nil {
+	// Persist the marker ONLY for actual verification (SecretRef set).
+	// The keyless path returns success from verifyCosignSignature with
+	// just a WARN — writing the marker there would silence the WARN on
+	// every subsequent cache hit, because checkCacheHit sees the marker
+	// match and skips re-verifyCosignSignature entirely. Leave the
+	// marker absent for keyless so the WARN re-fires every reconcile.
+	if repo.Verify != nil && repo.Verify.SecretRef != nil {
 		if err := writeVerifyMarker(slot.Path, verifyFingerprint(repo.Verify)); err != nil {
 			slog.Warn("oci: failed to persist verify marker; cache hits will re-verify online",
 				"ociRepository", repo.Namespace+"/"+repo.Name, "err", err)
@@ -365,14 +371,23 @@ func (f *Fetcher) checkCacheHit(ctx context.Context, repoClient *remote.Reposito
 			// material and validate. This is the only path that
 			// hits the registry on a cache hit; with a stable verify
 			// policy and intact marker the cache hit is fully offline.
+			//
+			// Keyless verify (SecretRef==nil) intentionally leaves the
+			// marker absent (see the post-pull write site), so cache
+			// hits ALWAYS land here and verifyCosignSignature re-emits
+			// its WARN — surface the unverified-render status on every
+			// reconcile rather than once-per-process.
 			if err := f.verifyCosignSignature(ctx, repoClient, repo, cachedDigest); err != nil {
 				return nil, false, err
 			}
-			// Persist the new fingerprint so subsequent hits skip
-			// the network. Best-effort.
-			if err := writeVerifyMarker(slotPath, want); err != nil {
-				slog.Warn("oci: failed to persist verify marker after re-verify; future hits will re-verify online",
-					"slot", slotPath, "err", err)
+			// Persist the new fingerprint so subsequent hits skip the
+			// network — but only for keyed verification. Keyless skips
+			// the marker for the WARN-re-fire reason above.
+			if repo.Verify.SecretRef != nil {
+				if err := writeVerifyMarker(slotPath, want); err != nil {
+					slog.Warn("oci: failed to persist verify marker after re-verify; future hits will re-verify online",
+						"slot", slotPath, "err", err)
+				}
 			}
 		}
 	}

--- a/pkg/source/proxy.go
+++ b/pkg/source/proxy.go
@@ -56,8 +56,7 @@ func ResolveProxy(secrets SecretGetter, ns, ownerKind, ownerID string, ref *mani
 	}
 	sec := secrets(ns, ref.Name)
 	if sec == nil {
-		return nil, fmt.Errorf("%s %s: proxy secret %s/%s not found",
-			ownerKind, ownerID, ns, ref.Name)
+		return nil, MissingSecretErr(ownerKind, ns, ownerID, ref.Name, "not found")
 	}
 	addr := StringFromSecret(sec, "address")
 	if addr == "" {

--- a/pkg/source/proxy_test.go
+++ b/pkg/source/proxy_test.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -30,8 +31,14 @@ func TestResolveProxy_SecretNotFound(t *testing.T) {
 		func(_, _ string) *manifest.Secret { return nil },
 		"ns", "OCIRepository", "ns/r",
 		&manifest.LocalObjectReference{Name: "px"})
-	if err == nil || !strings.Contains(err.Error(), "proxy secret ns/px not found") {
-		t.Errorf("expected not-found error; got %v", err)
+	if err == nil {
+		t.Fatal("expected not-found error; got nil")
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("expected error wrapped with manifest.ErrMissingSecret so --allow-missing-secrets soft-skips; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "px") {
+		t.Errorf("error should name the secret; got %v", err)
 	}
 }
 

--- a/pkg/source/tls.go
+++ b/pkg/source/tls.go
@@ -26,8 +26,7 @@ func ResolveCertSecret(secrets SecretGetter, ns, ownerKind, ownerID string, ref 
 	}
 	sec := secrets(ns, ref.Name)
 	if sec == nil {
-		return nil, fmt.Errorf("%s %s: cert secret %s/%s not found",
-			ownerKind, ownerID, ns, ref.Name)
+		return nil, MissingSecretErr(ownerKind, ns, ownerID, ref.Name, "not found")
 	}
 	cfg, err := BuildTLSConfig(
 		StringFromSecret(sec, "tls.crt"),


### PR DESCRIPTION
## Summary

Two related skip-semantics fixes from the second-pass audit:

1. **`--allow-missing-secrets` was incomplete**: `ResolveProxy`, `ResolveCertSecret`, and cosign `loadCosignPublicKeys` returned plain `fmt.Errorf` for missing-Secret cases, bypassing the source controller's `errors.Is(err, ErrMissingSecret)` check. The flag soft-skipped Git/OCI auth Secrets but hard-failed for proxy / TLS cert / cosign verify Secrets — inconsistent skin of the same surface. Route the not-found paths through `MissingSecretErr`. Parse failures and "no SecretGetter wired" stay fail-loud.
2. **Cosign keyless verify WARN was a one-shot**: keyless `spec.verify` (no `SecretRef`) returned nil from `verifyCosignSignature` after a WARN, then the caller wrote a verify marker. Every cache hit afterward matched the marker, skipped `verifyCosignSignature`, and silenced the WARN forever. Skip the marker write on the keyless path so the WARN re-fires on every reconcile — operators see the unverified-render status persistently.

## Test plan
- [x] Updated `TestResolveProxy_SecretNotFound` and `TestHelmRepoTLS_CertSecretNotFound` to assert `errors.Is(err, manifest.ErrMissingSecret)`
- [x] Full `go test ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)