### PR TITLE
fix(diff): pair key includes Parent.Path to disambiguate same-named KSes

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -160,8 +160,11 @@ type pairedResource struct {
 }
 
 type pairKey struct {
-	pKind, pNS, pName string
-	kind, ns, name    string
+	// pPath disambiguates two KS parents with the same (kind, ns, name)
+	// but different spec.path — a real-world collision in repos where
+	// the same KS is rendered twice from different overlays.
+	pKind, pNS, pName, pPath string
+	kind, ns, name           string
 }
 
 func pair(left, right []Doc) []pairedResource {
@@ -169,7 +172,7 @@ func pair(left, right []Doc) []pairedResource {
 	add := func(side int, d Doc) {
 		kind := manifest.DocKind(d.Manifest)
 		name, ns := manifest.DocMetadata(d.Manifest)
-		k := pairKey{d.Parent.Kind, d.Parent.Namespace, d.Parent.Name, kind, ns, name}
+		k := pairKey{d.Parent.Kind, d.Parent.Namespace, d.Parent.Name, d.Parent.Path, kind, ns, name}
 		p, ok := idx[k]
 		if !ok {
 			p = &pairedResource{parent: d.Parent, kind: kind, namespace: ns, name: name}
@@ -196,6 +199,7 @@ func pair(left, right []Doc) []pairedResource {
 			cmp.Compare(a.parent.Kind, b.parent.Kind),
 			cmp.Compare(a.parent.Namespace, b.parent.Namespace),
 			cmp.Compare(a.parent.Name, b.parent.Name),
+			cmp.Compare(a.parent.Path, b.parent.Path),
 			cmp.Compare(a.kind, b.kind),
 			cmp.Compare(a.namespace, b.namespace),
 			cmp.Compare(a.name, b.name),

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -356,3 +356,43 @@ func TestRun_DistinguishesByParent(t *testing.T) {
 		t.Errorf("wrong parent: %+v", diffs[0].Parent)
 	}
 }
+
+// TestRun_PairKeyIncludesParentPath: two KS parents with identical
+// (kind, ns, name) but different spec.path render the SAME-NAMED child
+// document. Without spec.Path in the pair key, the two children would
+// merge in `pair`, producing a misleading diff.
+func TestRun_PairKeyIncludesParentPath(t *testing.T) {
+	makeKS := func(name, ns, path, val string) Doc {
+		return Doc{
+			Manifest: map[string]any{
+				"kind": "ConfigMap",
+				"metadata": map[string]any{
+					"name": "shared", "namespace": ns,
+				},
+				"data": map[string]any{"k": val},
+			},
+			Parent: Parent{Kind: "Kustomization", Namespace: ns, Name: name, Path: path},
+		}
+	}
+	// Two KS parents both named "apps" in "flux-system" but with
+	// distinct paths. Each parent renders a ConfigMap named "shared".
+	left := []Doc{
+		makeKS("apps", "flux-system", "main/apps", "from-main"),
+		makeKS("apps", "flux-system", "test/apps", "from-test"),
+	}
+	right := []Doc{
+		makeKS("apps", "flux-system", "main/apps", "from-main-CHANGED"),
+		makeKS("apps", "flux-system", "test/apps", "from-test"),
+	}
+	diffs, err := Run(left, right, Options{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Exactly one ConfigMap changed — the "main/apps" one.
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff scoped to main/apps parent, got %d: %+v", len(diffs), diffs)
+	}
+	if diffs[0].Parent.Path != "main/apps" {
+		t.Errorf("diff attributed to wrong parent path: %+v", diffs[0].Parent)
+	}
+}


### PR DESCRIPTION
Surfaced by the audit. Two KS parents with same (Kind, NS, Name) but different spec.path merged into one pairedResource. Extend pairKey + sort comparator with Parent.Path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)