### PR TITLE
fix(change): chartRef→HelmChart BFS + git/walker symlink parity

### DIFF
--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -240,14 +240,21 @@ func detectViaWalker(before, after string) (*Set, error) {
 
 	paths := make(map[string]struct{}, len(afterFS)/8)
 	type hashJob struct {
-		rel              string
-		beforeAbs, after string
+		rel                          string
+		beforeAbs, after             string
+		beforeSymlink, afterSymlink  bool
 	}
 	var hashJobs []hashJob
 
 	for rel, after := range afterFS {
 		bef, ok := beforeFS[rel]
 		if !ok {
+			paths[rel] = struct{}{}
+			continue
+		}
+		// A type swap (regular ↔ symlink) is a content change in git's
+		// --no-index view; flag it without bothering to hash.
+		if bef.symlink != after.symlink {
 			paths[rel] = struct{}{}
 			continue
 		}
@@ -258,7 +265,10 @@ func detectViaWalker(before, after string) (*Set, error) {
 		// Same size, unknown mtime trustworthiness — hash both sides.
 		// The pre-removal mtime fast-path silently dropped real edits
 		// on coarse-mtime filesystems; correctness over speed here.
-		hashJobs = append(hashJobs, hashJob{rel: rel, beforeAbs: bef.abs, after: after.abs})
+		hashJobs = append(hashJobs, hashJob{
+			rel: rel, beforeAbs: bef.abs, after: after.abs,
+			beforeSymlink: bef.symlink, afterSymlink: after.symlink,
+		})
 	}
 	for rel := range beforeFS {
 		if _, ok := afterFS[rel]; !ok {
@@ -274,11 +284,11 @@ func detectViaWalker(before, after string) (*Set, error) {
 		for range hashWorkers {
 			hg.Go(func() error {
 				for j := range jobs {
-					b, err := hashFile(j.beforeAbs)
+					b, err := hashEntry(j.beforeAbs, j.beforeSymlink)
 					if err != nil {
 						return err
 					}
-					a, err := hashFile(j.after)
+					a, err := hashEntry(j.after, j.afterSymlink)
 					if err != nil {
 						return err
 					}
@@ -303,17 +313,20 @@ func detectViaWalker(before, after string) (*Set, error) {
 	return &Set{paths: paths}, nil
 }
 
-// fileMeta is the (size, abs) tuple collected by scanTree. The
-// previous (size, mtime) shape supported a same-mtime-skip fast path
-// that was removed because coarse-granularity filesystems made it
-// drop real changes.
+// fileMeta is the per-entry metadata scanTree collects. symlink is
+// true when the entry is a symbolic link rather than a regular file —
+// git's --no-index diff treats symlinks as files whose "content" is
+// the link target text and reports type-swaps (symlink↔regular) as
+// content changes, so the walker mirrors that.
 type fileMeta struct {
-	size int64
-	abs  string
+	size    int64
+	abs     string
+	symlink bool
 }
 
-// scanTree walks root collecting per-file (size, abs). Mirrors
-// the directory pruning that hashTree previously did.
+// scanTree walks root collecting per-file metadata. Mirrors the
+// directory pruning that hashTree previously did, and records symlinks
+// alongside regular files so the diff matches git's --no-index view.
 func scanTree(root string) (map[string]fileMeta, error) {
 	out := map[string]fileMeta{}
 	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
@@ -327,7 +340,12 @@ func scanTree(root string) (map[string]fileMeta, error) {
 			}
 			return nil
 		}
-		if !d.Type().IsRegular() {
+		typ := d.Type()
+		// Regular files and symlinks both participate in the diff;
+		// other entry kinds (sockets, devices, named pipes) don't
+		// land in a Flux tree and would confuse the comparison.
+		isLink := typ&fs.ModeSymlink != 0
+		if !typ.IsRegular() && !isLink {
 			return nil
 		}
 		rel, err := filepath.Rel(root, p)
@@ -338,9 +356,12 @@ func scanTree(root string) (map[string]fileMeta, error) {
 		if err != nil {
 			return err
 		}
+		// For symlinks Info() reports the link's own size (the target
+		// path length) — exactly the bytes we'll hash via readlink.
 		out[filepath.ToSlash(rel)] = fileMeta{
-			size: info.Size(),
-			abs:  p,
+			size:    info.Size(),
+			abs:     p,
+			symlink: isLink,
 		}
 		return nil
 	})
@@ -348,6 +369,22 @@ func scanTree(root string) (map[string]fileMeta, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// hashEntry returns the SHA-256 hex digest of an entry's content. For
+// regular files this is the file body; for symlinks it's the link
+// target text (matching git --no-index's content view of a symlink),
+// so a target-rewrite is detected without following the link.
+func hashEntry(path string, isSymlink bool) (string, error) {
+	if isSymlink {
+		target, err := os.Readlink(path)
+		if err != nil {
+			return "", err
+		}
+		sum := sha256.Sum256([]byte(target))
+		return hex.EncodeToString(sum[:]), nil
+	}
+	return hashFile(path)
 }
 
 func hashFile(path string) (string, error) {

--- a/pkg/change/detect_test.go
+++ b/pkg/change/detect_test.go
@@ -236,3 +236,47 @@ func TestSet_RerootPrependsPrefix(t *testing.T) {
 		t.Errorf("Reroot(\".\") returned a new set, want same")
 	}
 }
+
+// TestDetect_SymlinkTargetRewrite pins parity with git --no-index for
+// symlink-target changes. Pre-fix, the Go walker dropped symlinks via
+// `!d.Type().IsRegular()`, so a symlink whose target was rewritten on
+// only one side produced an empty change set on systems without git
+// on PATH (where the slow path is the only path).
+func TestDetect_SymlinkTargetRewrite(t *testing.T) {
+	before := t.TempDir()
+	after := t.TempDir()
+	// Both sides have a "link" pointing somewhere; only after's
+	// changes the target.
+	if err := os.Symlink("target-A", filepath.Join(before, "link")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if err := os.Symlink("target-B", filepath.Join(after, "link")); err != nil {
+		t.Fatal(err)
+	}
+	set, err := detectViaWalker(before, after)
+	if err != nil {
+		t.Fatalf("detectViaWalker: %v", err)
+	}
+	if !set.Contains("link") {
+		t.Errorf("walker missed symlink-target rewrite: %v", set.Paths())
+	}
+}
+
+// TestDetect_SymlinkVsRegular pins type-swap detection — a symlink on
+// one side and a regular file on the other are different "things" in
+// git's --no-index view and the walker must agree.
+func TestDetect_SymlinkVsRegular(t *testing.T) {
+	before := t.TempDir()
+	after := t.TempDir()
+	if err := os.Symlink("some-target", filepath.Join(before, "x")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	writeFile(t, after, "x", "some-target") // same byte content as target text
+	set, err := detectViaWalker(before, after)
+	if err != nil {
+		t.Fatalf("detectViaWalker: %v", err)
+	}
+	if !set.Contains("x") {
+		t.Errorf("walker missed symlink↔regular type swap: %v", set.Paths())
+	}
+}

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -517,6 +517,26 @@ func transitiveDeps(objs ObjectLister, id manifest.NamedResource) []manifest.Nam
 		return []manifest.NamedResource{{
 			Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
 		}}
+
+	case manifest.KindHelmChart:
+		// A HelmRelease chartRef pointing at a HelmChart CRD lands the
+		// HelmChart in the BFS via the HR's RepoKind=KindHelmChart edge
+		// above. The chart's actual bytes come from the HelmChart's own
+		// sourceRef (OCIRepository/HelmRepository/GitRepository/Bucket)
+		// — follow that edge so changed-only mode keeps the backing
+		// source alive. Without this, the HelmChart sits in keep but
+		// the source artifact is PreGate-skipped and render fails
+		// "artifact not found."
+		hc, _ := objs.GetObject(id).(*manifest.HelmChartSource)
+		if hc == nil {
+			return nil
+		}
+		if hc.SourceRef.Name == "" {
+			return nil
+		}
+		return []manifest.NamedResource{{
+			Kind: hc.SourceRef.Kind, Namespace: hc.Namespace, Name: hc.SourceRef.Name,
+		}}
 	}
 	return nil
 }

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -6,6 +6,7 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -612,5 +613,45 @@ func TestFilter_KeepByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
 	f.addUngated(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "cert-manager"})
 	if f.ShouldReconcile(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "monitoring-system", Name: "cert-manager"}) {
 		t.Errorf("Add() leaked across namespaces: monitoring-system/cert-manager matched on name alone; keep=%v", f.KeepNames())
+	}
+}
+
+// TestFilter_TransitiveDepsHelmReleaseViaHelmChartCRD pins the BFS
+// through a chartRef→HelmChart CRD: the HelmChart's own sourceRef
+// must land in keep so changed-only mode doesn't PreGate-skip the
+// backing artifact. Pre-fix, transitiveDeps had no KindHelmChart
+// branch — the HelmChart joined keep but its source artifact did
+// not, and render failed "artifact not found."
+func TestFilter_TransitiveDepsHelmReleaseViaHelmChartCRD(t *testing.T) {
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "apps",
+		Chart: manifest.HelmChart{
+			RepoKind: manifest.KindHelmChart, RepoName: "demo-chart", RepoNamespace: "apps",
+		},
+	}
+	hc := &manifest.HelmChartSource{
+		Name: "demo-chart", Namespace: "apps",
+		HelmChartSpec: sourcev1.HelmChartSpec{
+			SourceRef: sourcev1.LocalHelmChartSourceReference{
+				Kind: manifest.KindOCIRepository, Name: "backing-oci",
+			},
+		},
+	}
+	hrID := hr.Named()
+	hcID := hc.Named()
+	ociID := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "apps", Name: "backing-oci"}
+
+	f := NewFilter(
+		NewSet([]string{"hr.yaml"}),
+		map[manifest.NamedResource]string{hrID: "hr.yaml"},
+		"",
+		mapLister{hrID: hr, hcID: hc},
+	)
+
+	if !f.ShouldReconcile(hcID) {
+		t.Errorf("chartRef-HelmChart not pulled in by HR; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(ociID) {
+		t.Errorf("HelmChart's sourceRef OCIRepository not pulled in; keep=%v", f.KeepNames())
 	}
 }


### PR DESCRIPTION
Two correctness fixes from the second-pass audit:

1. **transitiveDeps missing HelmChart edge** — chartRef→HelmChart-CRD HRs left the HelmChart's backing source out of keep under changed-only mode; render failed 'artifact not found'.
2. **walker dropped symlinks** — Go fallback skipped symlinks via IsRegular while git --no-index reports symlink-target changes. CI/laptop divergence.

Regression tests for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)