### PR TITLE
fix(loader): scan-root ignore + relax kustomization stat + apiVersion gate on Component

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -15,10 +15,30 @@ import (
 // declarations; we deliberately do not import the upstream type to
 // avoid pulling its full transitive dep tree into the load path.
 type kustomization struct {
+	APIVersion         string            `json:"apiVersion"                   yaml:"apiVersion"`
 	Kind               string            `json:"kind"                         yaml:"kind"`
 	Resources          []string          `json:"resources,omitempty"          yaml:"resources,omitempty"`
 	ConfigMapGenerator []kvPairGenerator `json:"configMapGenerator,omitempty" yaml:"configMapGenerator,omitempty"`
 	SecretGenerator    []kvPairGenerator `json:"secretGenerator,omitempty"    yaml:"secretGenerator,omitempty"`
+}
+
+// kustomizeAPIPrefix is the kustomize.config.k8s.io API group; both
+// regular Kustomizations and Components live here. A `kind: Component`
+// outside this prefix is a different CR that happens to share the
+// kind name (e.g. a custom operator's Component CR) and must NOT be
+// silently skipped by descend.
+const kustomizeAPIPrefix = "kustomize.config.k8s.io/"
+
+// isKustomizeComponent reports whether k is a kustomize Component
+// declaration (kind=Component AND kustomize.config.k8s.io apiVersion).
+// Kind alone isn't enough: a YAML with `kind: Component` and a
+// different apiVersion is a foreign CR and must not be treated as a
+// Component fragment.
+func (k *kustomization) isKustomizeComponent() bool {
+	if k == nil || k.Kind != "Component" {
+		return false
+	}
+	return strings.HasPrefix(k.APIVersion, kustomizeAPIPrefix)
 }
 
 // kvPairGenerator captures the file/env entries of a configMap or

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -112,9 +112,10 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 		return 0, err
 	}
 	w := walker{
-		loader:  l,
-		ignore:  ignore,
-		visited: map[string]struct{}{},
+		loader:   l,
+		ignore:   ignore,
+		visited:  map[string]struct{}{},
+		scanRoot: abs,
 	}
 	return w.descend(ctx, abs)
 }
@@ -123,9 +124,16 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 // dedup, loader back-reference — so the recursive functions don't
 // need to thread the same args through every call.
 type walker struct {
-	loader  *Loader
-	ignore  *ignoreSet
-	visited map[string]struct{}
+	loader *Loader
+	ignore *ignoreSet
+	// scanRoot is the original Load() root that ignore patterns are
+	// authored against. Every ignore.matches call must pass scanRoot
+	// (not the current sub-package dir), otherwise patterns like
+	// `apps/junk/**` silently fail to match anything inside a
+	// descended sub-package — the rel path would be sub-tree-relative
+	// instead of scan-root-relative.
+	scanRoot string
+	visited  map[string]struct{}
 }
 
 // descend dispatches on the kind of directory dir is:
@@ -149,7 +157,7 @@ func (w *walker) descend(ctx context.Context, dir string) (int, error) {
 
 	k := readKustomization(dir)
 	if k != nil {
-		if k.Kind == "Component" {
+		if k.isKustomizeComponent() {
 			slog.Debug("loader: skipping kustomize Component directory", "dir", dir)
 			return 0, nil
 		}
@@ -182,7 +190,7 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 	// lets parseFile recognize a Flux Kustomization that happens to
 	// be authored at the `kustomization.yaml` filename (rare but
 	// permitted).
-	if kpath, ok := kustomizationFilePath(dir); ok && !w.ignore.matches(kpath, dir) {
+	if kpath, ok := kustomizationFilePath(dir); ok && !w.ignore.matches(kpath, w.scanRoot) {
 		n, err := w.loader.loadFile(kpath)
 		if err != nil {
 			slog.Warn("loader: kustomization file failed to parse", "path", kpath, "err", err)
@@ -222,7 +230,7 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 		if _, isData := dataFiles[abs]; isData {
 			continue
 		}
-		if w.ignore.matches(abs, dir) {
+		if w.ignore.matches(abs, w.scanRoot) {
 			continue
 		}
 		n, err := w.loader.loadFile(abs)
@@ -254,7 +262,7 @@ func (w *walker) walkAdHoc(ctx context.Context, root string) (int, error) {
 			return walkErr
 		}
 		if d.IsDir() {
-			if shouldSkipDir(d.Name(), path, root, w.ignore) {
+			if shouldSkipDir(d.Name(), path, w.scanRoot, w.ignore) {
 				return filepath.SkipDir
 			}
 			if path == root {
@@ -264,7 +272,7 @@ func (w *walker) walkAdHoc(ctx context.Context, root string) (int, error) {
 			// graph walk and SkipDir to keep filepath.WalkDir from
 			// descending again.
 			if k := readKustomization(path); k != nil {
-				if k.Kind == "Component" {
+				if k.isKustomizeComponent() {
 					return filepath.SkipDir
 				}
 				w.visited[path] = struct{}{}
@@ -280,7 +288,7 @@ func (w *walker) walkAdHoc(ctx context.Context, root string) (int, error) {
 		if !isManifestFile(path) {
 			return nil
 		}
-		if w.ignore.matches(path, root) {
+		if w.ignore.matches(path, w.scanRoot) {
 			return nil
 		}
 		n, err := w.loader.loadFile(path)
@@ -411,12 +419,25 @@ func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 // kustomizationFilePath returns the absolute path of dir's
 // kustomization.{yaml,yml,json} (first match wins, matching kustomize's
 // own filename precedence). Returns ("", false) when none exists.
+//
+// Uses os.Stat (follows symlinks) rather than restricting to regular
+// files via Lstat-IsRegular: readKustomization (which actually parses
+// the file) reads through symlinks happily, so the two need to agree
+// or descend silently classifies the dir as a kustomize package via
+// readKustomization but walkKustomize skips loading the file itself.
 func kustomizationFilePath(dir string) (string, bool) {
 	for _, name := range kustomizationFileNames {
 		p := filepath.Join(dir, name)
-		if info, err := os.Stat(p); err == nil && info.Mode().IsRegular() {
-			return p, true
+		info, err := os.Stat(p)
+		if err != nil {
+			continue
 		}
+		if info.IsDir() {
+			// `kustomization.yaml/` is nonsense — refuse and let the
+			// next candidate filename try.
+			continue
+		}
+		return p, true
 	}
 	return "", false
 }

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -127,6 +127,41 @@ spec:
 	}
 }
 
+// TestLoader_ForeignComponentKindIsNotSkipped pins the apiVersion
+// gate on the Component detection: a CR with `kind: Component` but a
+// non-kustomize apiVersion (e.g. someone's operator's custom CR) MUST
+// NOT be treated as a kustomize Component fragment — the subtree
+// would silently be skipped and any Flux resources inside vanish from
+// the load. Use a kustomization.yaml as the carrier so descend's
+// readKustomization picks it up.
+func TestLoader_ForeignComponentKindIsNotSkipped(t *testing.T) {
+	dir := t.TempDir()
+	// Foreign Component CR shaped exactly like the kustomize one
+	// except for apiVersion. With the kind-only check, descend would
+	// short-circuit and the sibling KS would never load.
+	testutil.WriteFile(t, dir, "addons/kustomization.yaml", `apiVersion: example.com/v1alpha1
+kind: Component
+resources:
+  - ./ks.yaml
+`)
+	testutil.WriteFile(t, dir, "addons/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: addons, namespace: flux-system}
+spec:
+  path: ./addons
+  sourceRef: {kind: GitRepository, name: flux-system}
+  interval: 1h
+`)
+	s := store.New()
+	if _, err := New(s).Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "addons"})
+	if got == nil {
+		t.Error("foreign 'kind: Component' (non-kustomize apiVersion) silently skipped sibling KS — Component gate fired without apiVersion check")
+	}
+}
+
 // TestLoader_SkipsConfigMapGeneratorDataFile mirrors the home-ops
 // repo shape that triggered #192: a `kustomization.yaml` declares a
 // `configMapGenerator.files` entry pointing at a YAML data file


### PR DESCRIPTION
Three loader correctness fixes from the second-pass audit:

1. **ignore patterns scan-root mismatch** — threaded scanRoot through the walker so ignore.matches always sees scan-root-relative rels.
2. **kustomizationFilePath rejected symlinked kustomization.yaml** while readKustomization read through symlinks — asymmetric. Use os.Stat and only reject dirs.
3. **Component detection was kind-only** — added apiVersion prefix check on kustomize.config.k8s.io so foreign 'kind: Component' CRs don't get their subtree skipped.

Regression test for #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)