### PR TITLE
fix(discovery): repo-root threading + bootstrap GR survival + worktree detect + OCI alias ns

### DIFF
--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -18,18 +18,32 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 		return "", err
 	}
 	root := FindRepoRoot(abs)
-
-	repo := &manifest.GitRepository{
-		Name: manifest.BootstrapSourceID.Name, Namespace: manifest.BootstrapSourceID.Namespace,
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
-	}
-	id := repo.Named()
-	d.cfg.Store.AddObject(repo)
+	id := manifest.BootstrapSourceID
+	// Always seed the artifact + status: even if the user authored a
+	// GitRepository at this id (the `flux bootstrap` pattern), the
+	// canonical reference for spec.path resolution is the local
+	// working tree, not whatever URL the manifest declares. The
+	// artifact is the load-bearing piece — downstream consumers read
+	// LocalPath, not spec.url.
 	d.cfg.Store.SetArtifact(id, &store.SourceArtifact{
 		Kind: manifest.KindGitRepository,
-		URL:  repo.URL, LocalPath: root,
+		URL:  "file://" + root, LocalPath: root,
 	})
 	d.cfg.Store.UpdateStatus(id, store.StatusReady, "bootstrap")
+	// Only publish the synthetic object when no user-authored
+	// equivalent exists. If the user has their own
+	// GitRepository/flux-system/flux-system in the tree, the loader's
+	// first pass (PreferExisting=false at this point) would otherwise
+	// overwrite this synthetic immediately and leave object↔artifact
+	// out of sync when overrideSelfReferentialGitRepositories doesn't
+	// fire (no remote URL match).
+	if d.cfg.Store.GetObject(id) == nil {
+		repo := &manifest.GitRepository{
+			Name: id.Name, Namespace: id.Namespace,
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
+		}
+		d.cfg.Store.AddObject(repo)
+	}
 	return root, nil
 }
 
@@ -168,8 +182,9 @@ func newBootstrapAlias(id manifest.NamedResource, repoRoot string) (manifest.Bas
 		// Synthetic oci:// URL — never resolved, only present so the
 		// store has something to return for spec.url reads. The
 		// SourceArtifact's LocalPath is what downstream consumers
-		// actually use.
-		url := "oci://flate-bootstrap-alias/" + id.Name
+		// actually use. Embed namespace so two distinct-namespace
+		// OCIRepositories with the same name don't collide on URL.
+		url := "oci://flate-bootstrap-alias/" + id.Namespace + "/" + id.Name
 		return &manifest.OCIRepository{
 			Name: id.Name, Namespace: id.Namespace,
 			OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: url},

--- a/pkg/discovery/bootstrap_internal_test.go
+++ b/pkg/discovery/bootstrap_internal_test.go
@@ -31,7 +31,7 @@ func TestNewBootstrapAlias(t *testing.T) {
 			name:    "OCIRepository → synthetic oci:// alias",
 			id:      manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "flux-manifests"},
 			wantOK:  true,
-			wantURL: "oci://flate-bootstrap-alias/flux-manifests",
+			wantURL: "oci://flate-bootstrap-alias/flux-system/flux-manifests",
 			wantNS:  "flux-system",
 		},
 		{

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -92,6 +92,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	d.repoRoot = repoRoot
 	if err := d.loadManifests(ctx, repoRoot); err != nil {
 		return nil, err
 	}
@@ -100,10 +101,13 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	// Unified parent index over every reconcilable kind that uses a
 	// parent gate. KS and HR keys never collide because NamedResource
 	// includes Kind; downstream controllers look up by their own id
-	// and naturally filter to their own kind.
+	// and naturally filter to their own kind. Pass repoRoot — the
+	// helpers read each KS's spec.path joined under this root to
+	// follow `components:` entries; cfg.Path would misread when the
+	// user pointed --path at a subdir below the actual repo root.
 	parentOf := mergeParents(
-		loader.BuildParentIndexForKind(d.cfg.Store, d.cfg.Path, d.sourceFiles, manifest.KindKustomization),
-		loader.BuildParentIndexForKind(d.cfg.Store, d.cfg.Path, d.sourceFiles, manifest.KindHelmRelease),
+		loader.BuildParentIndexForKind(d.cfg.Store, repoRoot, d.sourceFiles, manifest.KindKustomization),
+		loader.BuildParentIndexForKind(d.cfg.Store, repoRoot, d.sourceFiles, manifest.KindHelmRelease),
 	)
 	// Orphan promotion: every Existence entry whose file path is NOT
 	// under any KS spec.path will never reach the Store through KS
@@ -141,6 +145,13 @@ type discoverer struct {
 	cfg         Config
 	loader      *loader.Loader
 	sourceFiles map[manifest.NamedResource]string
+	// repoRoot is the resolved .git ancestor of cfg.Path (or cfg.Path
+	// when no .git exists). Stored here because every consumer of
+	// loader.BuildParentIndexForKind / loader.KSPathPrefixes needs the
+	// repo-relative root used to resolve KS spec.path entries, and
+	// passing cfg.Path silently misreads `components:` lookups when
+	// the user pointed --path at a subdir.
+	repoRoot string
 }
 
 // loadManifests scans cfg.Path, then iteratively follows each loaded

--- a/pkg/discovery/orphans.go
+++ b/pkg/discovery/orphans.go
@@ -31,7 +31,10 @@ func (d *discoverer) promoteOrphans() {
 	if d.loader.Existence == nil {
 		return
 	}
-	prefixes := loader.KSPathPrefixes(d.cfg.Store, d.cfg.Path)
+	// Same repoRoot argument as BuildParentIndexForKind — passing
+	// cfg.Path would misread component lookups when --path is a
+	// subdir below the actual repo root.
+	prefixes := loader.KSPathPrefixes(d.cfg.Store, d.repoRoot)
 	for id := range d.loader.Existence.All() {
 		if d.cfg.Store.GetObject(id) != nil {
 			continue

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -22,7 +22,12 @@ import (
 // fail due to SOPS-wiped credentials. Aliasing the GitRepository to
 // the working tree avoids both pitfalls.
 func readWorkingTreeRemotes(repoRoot string) map[string]struct{} {
-	repo, err := gogit.PlainOpen(repoRoot)
+	// DetectDotGit follows a `.git` file pointer (git worktrees,
+	// submodules), so the URL-match aliasing still works when flate
+	// is run inside a `git worktree add`'d checkout. Without it,
+	// PlainOpen errors out and the self-referential override silently
+	// no-ops.
+	repo, err := gogit.PlainOpenWithOptions(repoRoot, &gogit.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return nil
 	}


### PR DESCRIPTION
Four small discovery fixes from the second-pass audit. Each is independently justified but they share the file footprint:

1. **repoRoot vs cfg.Path** — BuildParentIndexForKind/KSPathPrefixes received cfg.Path but use it as the filesystem root for component-lookup joins. Pass repoRoot.
2. **bootstrap GR survival** — synthetic GR was overwritten by user-authored equivalent on first scan, leaving artifact↔object inconsistent. Always seed the artifact; only publish the object when none exists.
3. **git worktree detection** — readWorkingTreeRemotes failed on .git-pointer layouts. Use DetectDotGit.
4. **OCI alias URL** — synthetic oci:// URL didn't include namespace, colliding across namespaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)