### PR TITLE
fix(controllers): Recover re-raises + Refire type-miss writes terminal + depwait cap sentinel

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -189,11 +189,20 @@ func (c *Controller) Await(
 // surfaces it. Intended for use as `defer base.Recover(store, id, "kind")`
 // in controllers that don't go through RunWithStatus (e.g. source
 // fetchers that own their own status writes).
+//
+// After recording status, re-raises the panic so the enclosing
+// task.Service.Go increments its failures counter — a panicked
+// reconcile MUST count against the orchestrator's failure gate, not
+// silently masquerade as success when Service.Failures() is consulted
+// for the final exit-code decision.
 func Recover(s *store.Store, id manifest.NamedResource, logKind string) {
-	if r := recover(); r != nil {
-		slog.Error(logKind+": panic during reconcile", "id", id.String(), "panic", r)
-		s.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
+	r := recover()
+	if r == nil {
+		return
 	}
+	slog.Error(logKind+": panic during reconcile", "id", id.String(), "panic", r)
+	s.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
+	panic(r)
 }
 
 // RunWithStatus is the standard reconcile body for controllers that
@@ -222,6 +231,17 @@ func RunWithStatus[T manifest.BaseManifest](
 	defer Recover(s, id, logKind)
 	obj, ok := s.GetObject(id).(T)
 	if !ok {
+		// Object deleted (or wrong type) between coalescer enqueue and
+		// run. A Refire-driven re-run that previously wrote
+		// StatusPending/MsgRefetching would otherwise stick at Pending
+		// forever — every depwait blocking on this id rides its full
+		// per-dep timeout. Write a terminal Ready with a brief reason
+		// so dep checks unblock and the testrunner reports cleanly.
+		// Use Ready (not Failed) because a vanished resource is the
+		// same outcome real Flux would see when the CR is deleted.
+		if info, has := s.GetStatus(id); has && info.Status != store.StatusReady {
+			s.UpdateStatus(id, store.StatusReady, "skipped: object not in store at reconcile time")
+		}
 		return
 	}
 	if err := fn(ctx, obj); err != nil {

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -57,12 +57,22 @@ func TestRunWithStatus_Panic(t *testing.T) {
 	s.AddObject(hr)
 	id := hr.Named()
 
-	// Panic must be caught and converted into StatusFailed; no re-panic.
-	base.RunWithStatus(t.Context(), s, id, "helmrelease",
-		func(_ context.Context, _ *manifest.HelmRelease) error {
-			panic("kaboom")
-		},
-	)
+	// Contract: panic is converted into StatusFailed AND re-raised
+	// so the enclosing task.Service.Go's recover increments failures
+	// (Service.Failures() must count panicked reconciles). Recover
+	// the re-raise at the test boundary and assert both pieces.
+	var rec any
+	func() {
+		defer func() { rec = recover() }()
+		base.RunWithStatus(t.Context(), s, id, "helmrelease",
+			func(_ context.Context, _ *manifest.HelmRelease) error {
+				panic("kaboom")
+			},
+		)
+	}()
+	if rec == nil {
+		t.Fatal("expected panic to be re-raised so task.Service.Go's recover counts it; got nil")
+	}
 	got, _ := s.GetStatus(id)
 	if got.Status != store.StatusFailed {
 		t.Errorf("status = %v, want Failed", got.Status)

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -318,7 +318,15 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 					switch {
 					case errors.Is(ctx.Err(), context.Canceled):
 						return classify(id, ctx.Err(), "")
-					case errors.Is(err, context.DeadlineExceeded), errors.Is(err, errRenderDrained):
+					case errors.Is(err, errRenderCapExceeded),
+						errors.Is(err, context.DeadlineExceeded),
+						errors.Is(err, errRenderDrained):
+						// The render-emission cap fired (or the pool
+						// drained without producing, or the wait was
+						// bounded by the per-dep Timeout) — the dep
+						// isn't going to appear. Fast-fail with
+						// "dependency not found" rather than the
+						// ambiguous "timeout" label.
 						return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
 					default:
 						return Event{Dep: id, Status: DepFailed, Reason: err.Error()}
@@ -452,6 +460,13 @@ func (w *Waiter) depExists(dep manifest.NamedResource) bool {
 	return ok
 }
 
+// errRenderCapExceeded is returned by waitRenderEmission when the
+// inner RenderProducingTimeout fires (with or without parent ctx
+// also dying). Distinguishes "cap-fired no-show" from a genuine
+// caller-cancellation, both of which would otherwise look like
+// `context.DeadlineExceeded` on the wire.
+var errRenderCapExceeded = errors.New("render-producing-timeout cap reached")
+
 // errRenderDrained is the sentinel waitRenderEmission returns when
 // the orchestrator's task pool drains while step-2 is still waiting
 // — no future emission can produce the missing dep, so the wait
@@ -520,7 +535,17 @@ func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResour
 			}
 			return errRenderDrained
 		case <-renderCtx.Done():
-			return renderCtx.Err()
+			// Distinguish parent-canceled (caller wants to abort)
+			// from "deadline elapsed without the dep arriving"
+			// (whether the deadline came from the per-dep Timeout
+			// wrapper or from the inner RenderProducingTimeout cap).
+			// Caller-driven Cancel must propagate so the wait
+			// classifies as DepCancelled; any deadline becomes a
+			// "render couldn't produce" fast-fail.
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return ctx.Err()
+			}
+			return errRenderCapExceeded
 		}
 	}
 }


### PR DESCRIPTION
Three controller-correctness fixes:

1. **base.Recover** re-raises after writing status, so task.Service.Go's outer recover increments Failures().
2. **RunWithStatus type-miss** writes a terminal Ready instead of returning silently — unblocks depwait on objects deleted between coalescer enqueue and run.
3. **depwait waitRenderEmission** distinguishes caller-Cancel propagation from deadline-elapsed via a new errRenderCapExceeded sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)