### PR TITLE
polish: selector label coverage + IsResolved Name guard + baseline rename

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -115,10 +115,12 @@ func mapToTempDir(repoRoot, tempDir, path string) (string, error) {
 	return filepath.Join(tempDir, rel), nil
 }
 
-// FindRepoRoot returns the .git ancestor of path, or "" when none
+// GitRepoRoot returns the .git ancestor of path, or "" when none
 // exists. Exposed so callers can branch on "is this a git repo" before
-// calling AutoResolve.
-func FindRepoRoot(path string) string {
+// calling AutoResolve. Renamed from FindRepoRoot to disambiguate from
+// `discovery.FindRepoRoot` which has different fallback semantics
+// (returns p unchanged when no .git exists, rather than "").
+func GitRepoRoot(path string) string {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return ""
@@ -138,7 +140,7 @@ func FindRepoRoot(path string) string {
 // openRepo opens the git repo containing path. Returns the *Repository
 // and the repo root (the directory containing .git).
 func openRepo(path string) (*git.Repository, string, error) {
-	root := FindRepoRoot(path)
+	root := GitRepoRoot(path)
 	if root == "" {
 		return nil, "", fmt.Errorf("--path %q is not inside a git working tree; pass --path-orig=<dir> or --base=<rev> with a git checkout", path)
 	}

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -44,8 +44,22 @@ func (h HelmChart) ChartName() string {
 // that read h.Name / h.Version must either run after Prepare /
 // ResolveChartRef, or check IsResolved first — see also the empty
 // Name guarantee in chartFromHelmRelease.
+//
+// chartRef → Bucket / GitRepository / OCIRepository also lands with
+// Name="" intentionally (the underlying source's content determines
+// the chart layout, not the ref name). IsResolved keys on both
+// "RepoKind has a real name" AND "the bytes-determining field —
+// Name for HelmRepository, Version for chartRef-HelmChart — is
+// non-empty" so a caller that branches on IsResolved to safely
+// dereference Name doesn't get an empty subpath silently.
 func (h HelmChart) IsResolved() bool {
-	return h.RepoKind != KindHelmChart || h.Version != ""
+	if h.Name == "" {
+		return false
+	}
+	if h.RepoKind == KindHelmChart && h.Version == "" {
+		return false
+	}
+	return true
 }
 
 // chartFromHelmRelease projects the chart reference out of a typed

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -37,6 +37,10 @@ func labelsOf(obj manifest.BaseManifest) map[string]string {
 		return o.Labels
 	case *manifest.HelmRelease:
 		return o.Labels
+	case *manifest.ResourceSet:
+		return o.Labels
+	case *manifest.ResourceSetInputProvider:
+		return o.Labels
 	}
 	return nil
 }


### PR DESCRIPTION
Three small audit-surfaced cleanups:

1. **selector.labelsOf** extended to cover ResourceSet + ResourceSetInputProvider — `flate get -l foo=bar` was silently filtering them out.
2. **HelmChart.IsResolved()** now requires Name != "" so chartRef→{Bucket,Git,OCI} (which intentionally leave Name empty) doesn't claim resolved.
3. **baseline.FindRepoRoot → GitRepoRoot** to disambiguate from discovery.FindRepoRoot which has different fallback semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)