### PR TITLE
feat(cli): --base opts into changed-only mode on build/get/test too

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 	"slices"
@@ -13,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/home-operations/flate/internal/format"
+	"github.com/home-operations/flate/pkg/baseline"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -39,6 +41,7 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringVar(&f.path, "path", ".", "path to the Flux cluster directory")
 	fs.StringVar(&f.pathOrig, "path-orig", "",
 		"baseline path; when set, every command runs in changed-only mode")
+	bindBase(fs, f)
 	fs.StringVarP(&f.namespace, "namespace", "n", "",
 		"limit to this namespace (default: every namespace, or just the changed ones when --path-orig is set)")
 	fs.BoolVar(&f.skipCRDs, "skip-crds", true, "exclude CRD objects from rendered output")
@@ -81,16 +84,28 @@ func bindSelector(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringToStringVarP(&f.labels, "selector", "l", nil, "label selector (key=value, repeatable)")
 }
 
-// bindBase wires the `--base` flag. Scoped to diff subcommands —
-// `--base` selects the baseline git rev that the auto-baseline flow
-// materializes; only diff consumes a baseline tree, so binding it on
-// build/get/test would silently no-op. Mutually exclusive with
-// `--path-orig` (which is the absolute-path escape hatch); the check
-// is enforced at runtime in runDiff*.
+// bindBase wires the `--base` flag. Bound on every command that
+// accepts --path-orig (build, get, test, diff). Selects the baseline
+// git rev that the auto-baseline flow materializes into a tempdir
+// for changed-only mode.
+//
+// Semantics differ per verb:
+//   - diff REQUIRES a baseline; bare command auto-detects via
+//     merge-base with @{u} / origin/HEAD / origin/{main,master}.
+//   - build/get/test do NOT auto-detect — bare command tests/builds
+//     everything (preserves the existing "full tree" default).
+//     Setting --base on these verbs opts into changed-only mode
+//     against the named rev, sharing the same materialization
+//     machinery as diff.
+//
+// Mutually exclusive with --path-orig (the absolute-path escape
+// hatch); the check fires at runtime in resolveBaselineIfRequested.
 func bindBase(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringVar(&f.base, "base", "",
-		"baseline git rev (e.g. main, origin/main, HEAD~3, SHA). When unset, "+
-			"flate auto-detects via merge-base with @{u} / origin/HEAD. "+
+		"baseline git rev (e.g. main, origin/main, HEAD~3, SHA) — "+
+			"materializes the rev's tree to a tempdir and runs in changed-only mode. "+
+			"On `diff`, omitting --base auto-detects via merge-base with @{u} / origin/HEAD. "+
+			"On `build`/`get`/`test`, omitting --base keeps the default full-tree behavior. "+
 			"Mutually exclusive with --path-orig.")
 }
 
@@ -183,6 +198,44 @@ func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 	}
 }
 
+// resolveBaseline runs baseline.AutoResolve when the user opted into
+// changed-only mode via --base, mutates c.pathOrig to the synthetic
+// materialized path, and schedules tempdir cleanup against ctx.
+//
+// autoFallback toggles the "fire even when both flags are empty" case
+// — true for `flate diff` (which always needs a baseline; bare
+// command auto-detects via the merge-base ladder); false for
+// build/get/test (where bare command means "no baseline, full tree",
+// and changed-only mode is opt-in via --base or --path-orig).
+//
+// Mutual exclusion with --path-orig is enforced here so every caller
+// gets the same error message.
+func resolveBaseline(ctx context.Context, c *commonFlags, autoFallback bool) error {
+	if c.pathOrig != "" && c.base != "" {
+		return errors.New("--path-orig and --base are mutually exclusive")
+	}
+	if c.pathOrig != "" {
+		// Explicit --path-orig — caller already specified the baseline.
+		return nil
+	}
+	if c.base == "" && !autoFallback {
+		// No opt-in and no fallback semantics — leave c.pathOrig empty
+		// so the orchestrator runs in full-tree mode (the build/get/test
+		// default).
+		return nil
+	}
+	res, err := baseline.AutoResolve(c.path, c.base)
+	if err != nil {
+		return err
+	}
+	c.pathOrig = res.PathOrig
+	// Schedule cleanup against ctx — fires when the CLI's root context
+	// cancels at RunE return.
+	context.AfterFunc(ctx, func() { _ = os.RemoveAll(res.TempDir) })
+	slog.Debug("baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
+	return nil
+}
+
 func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	return orchestrator.Config{
 		Path:               c.path,
@@ -209,6 +262,12 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 		}
 	}
 	if _, err := format.ParseOutput(c.output); err != nil {
+		return nil, nil, err
+	}
+	// Opt-in baseline materialization: build/get/test only fires
+	// resolveBaseline when the user explicitly set --base (or
+	// --path-orig). Bare command keeps the full-tree default.
+	if err := resolveBaseline(ctx, &c, false); err != nil {
 		return nil, nil, err
 	}
 	return runOrchestratorCfg(ctx, buildOrchCfg(c, h))

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -74,7 +74,6 @@ func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	bindBase(cmd.Flags(), c)
 	// `diff all` renders HRs as part of its scope, so always bind
 	// helm flags (matches `build all` / `test all` / `get all`).
 	if kind == "" || kind == manifest.KindHelmRelease {
@@ -96,7 +95,6 @@ func newDiffImagesCmd() *cobra.Command {
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	bindBase(cmd.Flags(), c)
 	bindHelmFlags(cmd.Flags(), h)
 	cmd.Flags().BoolVar(&includeRemoved, "include-removed", false,
 		"also emit images present only in --path-orig (default: only newly added images)")

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -3,10 +3,8 @@ package cli
 import (
 	"cmp"
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -15,7 +13,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/home-operations/flate/internal/format"
-	"github.com/home-operations/flate/pkg/baseline"
 	"github.com/home-operations/flate/pkg/diff"
 	"github.com/home-operations/flate/pkg/image"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -98,30 +95,12 @@ type diffSide struct {
 }
 
 func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (diffSide, diffSide, error) {
-	if c.pathOrig != "" && c.base != "" {
-		return diffSide{}, diffSide{}, errors.New("--path-orig and --base are mutually exclusive")
-	}
-	if c.pathOrig == "" {
-		// Auto-baseline: materialize a baseline tree from git (either
-		// --base=<rev> or the auto-detect ladder) and point
-		// c.pathOrig at it for the remainder of the diff. The tempdir
-		// gets cleaned up via the context's cancel — Bootstrap reads
-		// the path-orig once and never reopens it (see PR #348's
-		// orchestrator surface mapping), so removing the tempdir
-		// after both orchestrators return is safe.
-		res, err := baseline.AutoResolve(c.path, c.base)
-		if err != nil {
-			return diffSide{}, diffSide{}, err
-		}
-		c.pathOrig = res.PathOrig
-		// Schedule cleanup via the parent context. context.AfterFunc
-		// fires when ctx is canceled OR when we explicitly call its
-		// returned stop-and-run helper at the end of the diff. The
-		// CLI cancels its root context on RunE return, so cleanup
-		// happens deterministically without each diff verb needing
-		// its own defer.
-		context.AfterFunc(ctx, func() { _ = os.RemoveAll(res.TempDir) })
-		slog.Debug("diff baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
+	// diff REQUIRES a baseline — when neither --path-orig nor --base
+	// is set, auto-detect via the merge-base ladder. resolveBaseline
+	// with autoFallback=true preserves the existing "bare diff
+	// figures it out" UX.
+	if err := resolveBaseline(ctx, c, true); err != nil {
+		return diffSide{}, diffSide{}, err
 	}
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg


### PR DESCRIPTION
## Summary

PR #349 introduced \`--base\` for \`flate diff\`. Extend it to every command that accepts \`--path-orig\`: \`build\`, \`get\`, \`test\`.

The mechanics are identical (\`pkg/baseline.AutoResolve\` materializes the rev's tree to a tempdir; synthetic \`--path-orig\` points at it). The default behavior differs by verb:

- **diff** REQUIRES a baseline — bare command auto-detects via the merge-base ladder (existing behavior).
- **build/get/test** do NOT auto-detect — bare command keeps the full-tree default. Setting \`--base\` opts into changed-only mode.

```
flate test ks --path X              # tests everything (unchanged)
flate test ks --path X --base main  # changed-only mode vs main
flate diff ks --path X              # auto-detects against @{u}
flate diff ks --path X --base main  # explicit baseline
```

Mechanically: extract \`resolveBaseline\` helper from \`runDiffOrchestrators\`; \`runOrchestrator\` (build/get/test funnel) calls it with \`autoFallback=false\` so the bare command stays full-tree. Mutual exclusion with \`--path-orig\` enforced in one place.

## Test plan
- [x] \`go test ./...\` green
- [x] Empirical: \`flate test ks --path X\` → 72 passed (full tree); \`flate test ks --path X --base HEAD\` → 71 passed, 1 skipped (changed-only mode picks up only the modified kustomization.yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)