### PR TITLE
fix(orchestrator,depwait): wave-3 leftover audit findings

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -56,13 +56,16 @@ func TimeoutFromSpec(d *metav1.Duration) time.Duration {
 	return d.Duration
 }
 
-// DepStatus enumerates the per-dependency resolution result.
+// DepStatus enumerates the per-dependency resolution result. Every
+// Watch event carries one of the terminal statuses below — there is
+// no "pending" wire value because Watch only fires when the dep
+// resolves (Ready) or hits a wait-ending condition (Failed / Timeout
+// / Cancelled).
 type DepStatus int
 
 // Possible DepStatus values.
 const (
-	DepPending DepStatus = iota
-	DepReady
+	DepReady DepStatus = iota + 1
 	DepFailed
 	DepTimeout
 	DepCancelled
@@ -75,16 +78,17 @@ type Event struct {
 	Reason string
 }
 
-// Summary tallies the final state of a Waiter run.
+// Summary tallies the final state of a Waiter run. Every dep ends
+// up in Ready or Failed (Watch always emits a terminal status); a
+// Pending slot would be dead code.
 type Summary struct {
 	Ready    []manifest.NamedResource
 	Failed   []manifest.NamedResource
-	Pending  []manifest.NamedResource
 	Messages map[manifest.NamedResource]string
 }
 
 // AllReady reports whether every dependency reached DepReady.
-func (s Summary) AllReady() bool { return len(s.Failed) == 0 && len(s.Pending) == 0 }
+func (s Summary) AllReady() bool { return len(s.Failed) == 0 }
 
 // AnyFailed reports whether at least one dependency ended in failure.
 func (s Summary) AnyFailed() bool { return len(s.Failed) > 0 }
@@ -578,8 +582,6 @@ func WaitAll(ch <-chan Event) Summary {
 			s.Ready = append(s.Ready, ev.Dep)
 		case DepFailed, DepTimeout, DepCancelled:
 			s.Failed = append(s.Failed, ev.Dep)
-		default:
-			s.Pending = append(s.Pending, ev.Dep)
 		}
 	}
 	return s

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -19,7 +19,11 @@ import (
 // warning rather than gating the test on stale local files.
 func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.StatusInfo) map[manifest.NamedResource]struct{} {
 	out := make(map[manifest.NamedResource]struct{})
-	prefixes := loader.KSPathPrefixes(o.store, o.cfg.Path)
+	// Use repoRoot (not cfg.Path) so KSPathPrefixes' component
+	// lookups read from the actual repo root rather than a
+	// potentially-subdir --path. Same fix as PR #358 applied to
+	// the orchestrator side.
+	prefixes := loader.KSPathPrefixes(o.store, o.repoRoot)
 	for id := range failed {
 		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
 			continue

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/helmrelease"
@@ -92,6 +93,16 @@ type Orchestrator struct {
 	staging *kustomize.StagingCache
 	filter  *change.Filter
 
+	// repoRoot is the resolved .git ancestor of cfg.Path (or
+	// cfg.Path when no .git exists). Populated during Bootstrap from
+	// discovery.Result.RepoRoot. Consumed by finalize.detectOrphans
+	// to feed loader.KSPathPrefixes the correct filesystem root for
+	// `components:` lookups (cfg.Path is the user-supplied --path,
+	// which may be a subdir of the actual repo root and produce
+	// wrong component prefixes — same bug fixed in pkg/discovery by
+	// PR #358).
+	repoRoot string
+
 	// sourceFiles tracks which file produced each loaded resource. It
 	// is populated during loadManifests and consumed once by Bootstrap
 	// to construct the immutable change.Filter.
@@ -136,6 +147,11 @@ type Orchestrator struct {
 	// WithFetcher to refuse late fetcher swaps that would silently
 	// miss any source CR discovery already reconciled.
 	bootstrapped bool
+
+	// stopOnce guards Stop so a New+Bootstrap-then-abort caller's
+	// manual Stop and Run's deferred Stop don't double-close the
+	// staging cache / controller unsubs.
+	stopOnce sync.Once
 }
 
 // Result is the structured output of Orchestrator.Render: the rendered
@@ -288,6 +304,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	o.repoRoot = res.RepoRoot
 	o.sourceFiles = res.SourceFiles
 	o.parentOf = res.ParentOf
 	o.existence = res.Existence
@@ -296,6 +313,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	o.breakDependsOnCycles()
 	o.warnOnDisabledOCIFeatures()
 	o.warnOnUnsupportedHelmRepoSecretRef()
+	o.warnOnKSOCISourceRefWithoutOCI()
 	if err := o.buildChangeFilter(res.RepoRoot); err != nil {
 		return err
 	}
@@ -367,6 +385,29 @@ func (o *Orchestrator) warnOnUnsupportedHelmRepoSecretRef() {
 		slog.Warn("HelmRepository: SecretRef on OCI HelmRepositories is not yet implemented and will fail at render time; reference the chart via a sibling OCIRepository CR instead",
 			"helmRepository", repo.Namespace+"/"+repo.Name,
 			"url", repo.URL)
+	}
+}
+
+// warnOnKSOCISourceRefWithoutOCI surfaces the EnableOCI=false +
+// KS-sourceRef=OCIRepository combo at bootstrap. Without OCI
+// reconciliation, source/ExistenceFetcher gives the OCIRepository a
+// Ready status but NO SourceArtifact — a Kustomization that needs
+// the artifact for spec.path resolution then dies at reconcile with
+// the cryptic "artifact not found", far from where the actual
+// configuration error lives. Warn up front so the operator either
+// enables OCI (--enable-oci=true / default) or restructures the KS
+// to use a GitRepository source.
+func (o *Orchestrator) warnOnKSOCISourceRefWithoutOCI() {
+	if o.cfg.EnableOCI {
+		return
+	}
+	for _, ks := range store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization) {
+		if ks.SourceKind != manifest.KindOCIRepository {
+			continue
+		}
+		slog.Warn("Kustomization sourceRef points at OCIRepository but --enable-oci=false; the synthesized existence-only artifact has no LocalPath and spec.path resolution will fail at render time",
+			"kustomization", ks.Namespace+"/"+ks.Name,
+			"sourceRef", ks.SourceNamespace+"/"+ks.SourceName)
 	}
 }
 
@@ -702,12 +743,22 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 }
 
 // Stop shuts the controllers down in reverse-construction order and
-// releases the staging cache.
+// releases the staging cache. Safe to call multiple times: each
+// controller's Close is idempotent (drains the unsub slice once and
+// nils it), and StagingCache.Close zeroes its stages map after the
+// first cleanup. Wrapped in sync.Once so the bookkeeping reads
+// cleanly even if a caller's defer runs after Run's defer.
+//
+// Embedders who call only New + Bootstrap (without Run) MUST call
+// Stop themselves — the staging cache holds a tempdir that would
+// otherwise leak until process exit.
 func (o *Orchestrator) Stop() {
-	o.hrc.Close()
-	o.ksc.Close()
-	o.src.Close()
-	if o.staging != nil {
-		_ = o.staging.Close()
-	}
+	o.stopOnce.Do(func() {
+		o.hrc.Close()
+		o.ksc.Close()
+		o.src.Close()
+		if o.staging != nil {
+			_ = o.staging.Close()
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Four small audit-confirmed bugs that didn't make it into the original 12-PR batch:

1. **\`orchestrator/finalize.go\` repoRoot threading** — \`detectOrphans\` called \`loader.KSPathPrefixes\` with \`cfg.Path\` instead of \`repoRoot\`. Same fix PR #358 applied to \`pkg/discovery\`, now extended to the orchestrator (which now stores \`repoRoot\` from \`discovery.Result\`).
2. **\`Stop()\` idempotency made explicit** via \`sync.Once\` so embedders calling \`New+Bootstrap-then-abort\` (no Run) can safely Stop manually without racing a later deferred Stop.
3. **New \`warnOnKSOCISourceRefWithoutOCI\`** — KS referencing an OCIRepository when \`--enable-oci=false\` dies cryptically at reconcile. Warn at bootstrap.
4. **Drop dead \`DepPending\` + \`Summary.Pending\`** from depwait. Watch only emits terminal statuses; the Pending slot was unreachable code.

## Test plan
- [x] \`go test ./...\` green
- [x] No callers of \`DepPending\` / \`Summary.Pending\` outside the dead code itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)