### PR TITLE
feat(orchestrator): incremental cycle detection on render-emit

### DIFF
--- a/pkg/orchestrator/cycles_test.go
+++ b/pkg/orchestrator/cycles_test.go
@@ -108,3 +108,46 @@ func TestBreakDependsOnCycles_StripsCycleEdges(t *testing.T) {
 		}
 	}
 }
+
+// TestBreakDependsOnCycles_RenderEmittedCycle verifies the runtime
+// cycle-detection listener: when a parent KS's render emits two
+// children whose dependsOn closes a loop, the orchestrator's
+// post-Bootstrap listener re-runs breakDependsOnCycles and strips
+// the cycle edges. Pre-fix, Bootstrap's one-shot pass never saw the
+// emitted nodes and every cycle member burned its full per-dep
+// timeout waiting on a peer that would never become Ready.
+//
+// The test invokes breakDependsOnCycles directly (mirrors what the
+// Run-time listener does) AFTER adding the emit'd children to the
+// store. End-to-end coverage of the listener wiring sits in the
+// e2e suite — but pinning the load-bearing behavior here keeps the
+// listener honest if it ever gets refactored.
+func TestBreakDependsOnCycles_RenderEmittedCycle(t *testing.T) {
+	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+
+	o := &Orchestrator{store: store.New()}
+	// Bootstrap-time graph: just one acyclic KS. No cycles to break.
+	o.store.AddObject(makeKS("acyclic", "ns"))
+	o.breakDependsOnCycles()
+
+	// Now simulate the render-emit: a parent KS adds two children
+	// whose dependsOn closes a loop. Bootstrap's pass missed these.
+	o.store.AddObject(makeKS("a", "ns", idB))
+	o.store.AddObject(makeKS("b", "ns", idA))
+	// Re-run the cycle detector (the post-Bootstrap listener fires
+	// this on every KS/HR add).
+	o.breakDependsOnCycles()
+
+	a, _ := o.store.GetObject(idA).(*manifest.Kustomization)
+	b, _ := o.store.GetObject(idB).(*manifest.Kustomization)
+	if a == nil || b == nil {
+		t.Fatal("emitted children went missing")
+	}
+	if len(a.DependsOn) != 0 {
+		t.Errorf("a's cycle edge not stripped post-emit: %+v", a.DependsOn)
+	}
+	if len(b.DependsOn) != 0 {
+		t.Errorf("b's cycle edge not stripped post-emit: %+v", b.DependsOn)
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -645,6 +645,24 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	o.hrc.Start(ctx)
 	defer o.Stop()
 
+	// Re-detect dependsOn cycles when render-emitted children
+	// land. Bootstrap's one-shot pass only sees file-loaded
+	// resources; a parent KS render that emits a child with a
+	// dependsOn pointing at another freshly-emitted (or pre-existing)
+	// peer can introduce a cycle invisible to the Bootstrap pass.
+	// breakDependsOnCycles short-circuits when no cycle is present
+	// (O(N+E) DFS, then early-return), so re-running on every
+	// KS/HR add is cheap even on render-heavy passes. The
+	// listener unsubs at orchestrator Stop via the closure
+	// captured here.
+	unsubCycles := o.store.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
+		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
+			return
+		}
+		o.breakDependsOnCycles()
+	}, false)
+	defer unsubCycles()
+
 	// Race ctx.Done() against task drain so a Ctrl-C during a stuck
 	// fetch / render is observable within one task's natural
 	// cancellation latency rather than blocking forever on


### PR DESCRIPTION
Bootstrap's one-shot `breakDependsOnCycles` pass only sees file-loaded resources. A parent KS render that emits children whose `dependsOn` closes a loop produces a cycle invisible to Bootstrap — every member then burns its full per-dep Timeout waiting on a peer that can never become Ready.

Register a post-Bootstrap listener on `EventObjectAdded` for KS/HR that re-runs `breakDependsOnCycles` after every add. The detector early-returns when no cycle is present (O(N+E) DFS), so re-running on every emit is cheap.

Listener unsubs at Stop via closure capture.

Adds regression test (`TestBreakDependsOnCycles_RenderEmittedCycle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)