### PR TITLE
feat(helm): OCI pulls yield the worker-pool slot

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -58,6 +58,12 @@ type Client struct {
 	// path: no auth/TLS surface, anonymous pulls only).
 	ociPuller OCIPuller
 
+	// taskYield, when set, wraps long-running network I/O (OCI
+	// pulls) so the worker-pool slot is released for the duration.
+	// nil = no yield (legacy behavior for embedders without a task
+	// pool). See SetTaskYield.
+	taskYield func(fn func())
+
 	// chartCache memoizes parsed *chart.Chart by on-disk path. Helm's
 	// loader.Load reparses the entire tgz on every call — for repos
 	// where many HelmReleases share a base chart (e.g. bjw-s
@@ -160,6 +166,37 @@ func (c *Client) SetSourceResolver(r SourceResolver) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.resolver = r
+}
+
+// SetTaskYield installs a callback that the helm client uses to
+// release its worker-pool slot during long-running network I/O
+// (OCI pulls). The orchestrator wires this to
+// task.Service.YieldSlot so concurrent helm renders don't block
+// the pool while one of them is mid-pull. nil disables the yield
+// (the I/O runs while still holding the slot — the legacy
+// behavior for embedders without a task pool).
+//
+// Kept as a callback rather than a direct task.Service dependency to
+// avoid importing pkg/task into pkg/helm — the orchestrator wires
+// the function reference and helm stays dependency-free.
+func (c *Client) SetTaskYield(yield func(fn func())) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.taskYield = yield
+}
+
+// yieldDuring invokes fn under the configured task-slot yield, or
+// directly when no yield is wired. fn typically wraps a long
+// network round-trip.
+func (c *Client) yieldDuring(fn func()) {
+	c.mu.RLock()
+	y := c.taskYield
+	c.mu.RUnlock()
+	if y == nil {
+		fn()
+		return
+	}
+	y(fn)
 }
 
 // Resolver returns the configured SourceResolver, or nil when none

--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"helm.sh/helm/v4/pkg/registry"
+
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -215,9 +217,18 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 
 	pullRef := ociPullRef(ref, version)
 	_ = ctx // reserved for future per-pull cancellation when helm supports it
-	result, err := c.registry.Pull(pullRef)
-	if err != nil {
-		return "", fmt.Errorf("oci pull %s: %w", pullRef, err)
+	// Yield the worker-pool slot for the duration of the network
+	// pull so concurrent helm renders don't block the pool. No-op
+	// when SetTaskYield wasn't wired (legacy embedders).
+	var (
+		result  *registry.PullResult
+		pullErr error
+	)
+	c.yieldDuring(func() {
+		result, pullErr = c.registry.Pull(pullRef)
+	})
+	if pullErr != nil {
+		return "", fmt.Errorf("oci pull %s: %w", pullRef, pullErr)
 	}
 	if result == nil || result.Chart == nil {
 		return "", fmt.Errorf("oci pull %s: empty result", pullRef)

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // chartCacheLocks serializes concurrent fetches of the same cached
@@ -117,7 +118,13 @@ func (c *Client) pullHelmRepoOCI(ctx context.Context, r *manifest.HelmRepository
 		syn.SecretRef = r.SecretRef
 		syn.CertSecretRef = r.CertSecretRef
 		syn.Insecure = r.Insecure
-		art, err := puller.Fetch(ctx, syn)
+		var (
+			art *store.SourceArtifact
+			err error
+		)
+		c.yieldDuring(func() {
+			art, err = puller.Fetch(ctx, syn)
+		})
 		if err != nil {
 			return "", err
 		}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -209,6 +209,10 @@ func New(cfg Config) (*Orchestrator, error) {
 	// Store rather than maintaining a duplicate registry the HR controller
 	// would otherwise have to keep in sync via Add* push-API calls.
 	helmClient.SetSourceResolver(helm.NewStoreSourceResolver(st))
+	// Yield the worker-pool slot during OCI pulls so concurrent helm
+	// renders don't starve. Passes task.Service.YieldSlot through as
+	// a callback so pkg/helm doesn't have to import pkg/task.
+	helmClient.SetTaskYield(ts.YieldSlot)
 	srcCtrl := sourcectrl.New(st, ts)
 	// Every kind-specific fetcher is wired through source.Wrap so the
 	// concrete Fetch signature stays typed (no per-impl type


### PR DESCRIPTION
Both helm.Client OCI pull paths (`fetchOCIChart` registry-client fallback and `pullHelmRepoOCI`'s `puller.Fetch`) held the task.Service slot through the network round-trip. With concurrent helm renders sharing a chart source, the pool serialized behind one slow pull while idle slots stayed reserved.

New `SetTaskYield` callback on helm.Client; orchestrator wires it to `task.Service.YieldSlot`. Both pull sites wrap their network calls in `yieldDuring` so the slot is released for the I/O duration.

Callback shape (not a direct task.Service field) keeps pkg/helm dependency-free of pkg/task — one function-value seam, no import cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)