### PR TITLE
fix: third-pass regressions from PR #349 / #361 / #365

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -210,30 +210,41 @@ func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 //
 // Mutual exclusion with --path-orig is enforced here so every caller
 // gets the same error message.
-func resolveBaseline(ctx context.Context, c *commonFlags, autoFallback bool) error {
+//
+// Returns a cleanup func that callers MUST defer — it removes the
+// materialized baseline tempdir. Previously cleanup was bound to
+// `context.AfterFunc(ctx, ...)`, but ctx cancels on SIGINT
+// concurrently with orchestrator goroutines that may still be
+// reading under PathOrig (helm/kustomize/go-git filesystem reads
+// aren't all ctx-aware), producing ENOENT noise in the shutdown
+// error tail. Caller-defer'd cleanup runs after the orchestrator
+// has finished (or panicked through) the read path, eliminating
+// the race.
+//
+// Callers receive a no-op when no materialization happened (no
+// --base / no autoFallback / explicit --path-orig).
+func resolveBaseline(_ context.Context, c *commonFlags, autoFallback bool) (func(), error) {
+	noop := func() {}
 	if c.pathOrig != "" && c.base != "" {
-		return errors.New("--path-orig and --base are mutually exclusive")
+		return noop, errors.New("--path-orig and --base are mutually exclusive")
 	}
 	if c.pathOrig != "" {
 		// Explicit --path-orig — caller already specified the baseline.
-		return nil
+		return noop, nil
 	}
 	if c.base == "" && !autoFallback {
 		// No opt-in and no fallback semantics — leave c.pathOrig empty
 		// so the orchestrator runs in full-tree mode (the build/get/test
 		// default).
-		return nil
+		return noop, nil
 	}
 	res, err := baseline.AutoResolve(c.path, c.base)
 	if err != nil {
-		return err
+		return noop, err
 	}
 	c.pathOrig = res.PathOrig
-	// Schedule cleanup against ctx — fires when the CLI's root context
-	// cancels at RunE return.
-	context.AfterFunc(ctx, func() { _ = os.RemoveAll(res.TempDir) })
 	slog.Debug("baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
-	return nil
+	return func() { _ = os.RemoveAll(res.TempDir) }, nil
 }
 
 func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
@@ -267,9 +278,14 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 	// Opt-in baseline materialization: build/get/test only fires
 	// resolveBaseline when the user explicitly set --base (or
 	// --path-orig). Bare command keeps the full-tree default.
-	if err := resolveBaseline(ctx, &c, false); err != nil {
+	// Cleanup is deferred (not bound to ctx) so the tempdir survives
+	// SIGINT until the orchestrator's read paths have actually
+	// unwound.
+	cleanup, err := resolveBaseline(ctx, &c, false)
+	if err != nil {
 		return nil, nil, err
 	}
+	defer cleanup()
 	return runOrchestratorCfg(ctx, buildOrchCfg(c, h))
 }
 

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -98,10 +98,14 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 	// diff REQUIRES a baseline — when neither --path-orig nor --base
 	// is set, auto-detect via the merge-base ladder. resolveBaseline
 	// with autoFallback=true preserves the existing "bare diff
-	// figures it out" UX.
-	if err := resolveBaseline(ctx, c, true); err != nil {
+	// figures it out" UX. Cleanup is deferred (not bound to ctx) so
+	// the tempdir survives SIGINT until both orchestrators' read
+	// paths have actually unwound.
+	cleanup, err := resolveBaseline(ctx, c, true)
+	if err != nil {
 		return diffSide{}, diffSide{}, err
 	}
+	defer cleanup()
 	currentCfg := buildOrchCfg(*c, *h)
 	origCfg := currentCfg
 	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -245,6 +245,34 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return err
 	}
 
+	// Wait for chart source (HelmRepository / OCIRepository / GitRepository)
+	// to be ready BEFORE the fingerprint dedup gate. A re-emit that
+	// finds the prior fingerprint cached must not replay stale docs
+	// when the upstream source has since transitioned to Failed or
+	// soft-skipped (--allow-missing-secrets newly applied) — the
+	// dedup-replay path otherwise publishes outputs the fresh path
+	// would have refused with ErrSourceSkipped.
+	srcID := manifest.NamedResource{
+		Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
+	}
+	if err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout),
+		[]manifest.DependencyRef{{NamedResource: srcID}},
+		"", // status already set above
+		func(sum depwait.Summary) error {
+			return fmt.Errorf("%w: chart source %s not ready: %s",
+				manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
+		}); err != nil {
+		return err
+	}
+	// A chart source that soft-skipped (--allow-missing-secrets on its
+	// auth) marks Ready but writes no artifact and almost certainly
+	// can't be pulled anonymously either. Propagate the skip instead
+	// of letting TemplateDocs fail at the registry.
+	if info, ok := c.Store.GetStatus(srcID); ok && store.IsSkipped(info) {
+		return fmt.Errorf("%w: chart source %s %s",
+			manifest.ErrSourceSkipped, srcID.String(), info.Message)
+	}
+
 	// Fingerprint dedup: when the same HR id gets re-AddObject'd with
 	// the same effective spec (e.g. the parent KS render stamps
 	// kustomize.toolkit.fluxcd.io/{name,namespace} labels onto a
@@ -265,30 +293,6 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		// KS-side dedup-replay pattern.
 		c.dispatchRendered(id, existing.Manifests)
 		return nil
-	}
-
-	// Wait for chart source (HelmRepository / OCIRepository / GitRepository)
-	// to be ready. For HelmRepository we wait by existence rather than
-	// status — there's no controller updating HelmRepository status.
-	srcID := manifest.NamedResource{
-		Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
-	}
-	if err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout),
-		[]manifest.DependencyRef{{NamedResource: srcID}},
-		"", // status already set above
-		func(sum depwait.Summary) error {
-			return fmt.Errorf("%w: chart source %s not ready: %s",
-				manifest.ErrObjectNotFound, srcID.String(), sum.Messages[srcID])
-		}); err != nil {
-		return err
-	}
-	// A chart source that soft-skipped (--allow-missing-secrets on its
-	// auth) marks Ready but writes no artifact and almost certainly
-	// can't be pulled anonymously either. Propagate the skip instead
-	// of letting TemplateDocs fail at the registry.
-	if info, ok := c.Store.GetStatus(srcID); ok && store.IsSkipped(info) {
-		return fmt.Errorf("%w: chart source %s %s",
-			manifest.ErrSourceSkipped, srcID.String(), info.Message)
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering chart")

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -644,21 +644,22 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		Existence: existence,
 		Renders:   renders,
 	})
-	o.src.Start(ctx)
-	o.ksc.Start(ctx)
-	o.hrc.Start(ctx)
-	defer o.Stop()
-
-	// Re-detect dependsOn cycles when render-emitted children
-	// land. Bootstrap's one-shot pass only sees file-loaded
-	// resources; a parent KS render that emits a child with a
-	// dependsOn pointing at another freshly-emitted (or pre-existing)
-	// peer can introduce a cycle invisible to the Bootstrap pass.
-	// breakDependsOnCycles short-circuits when no cycle is present
-	// (O(N+E) DFS, then early-return), so re-running on every
-	// KS/HR add is cheap even on render-heavy passes. The
-	// listener unsubs at orchestrator Stop via the closure
-	// captured here.
+	// Re-detect dependsOn cycles when render-emitted children land.
+	// Bootstrap's one-shot pass only sees file-loaded resources; a
+	// parent KS render that emits a child with a dependsOn pointing
+	// at another freshly-emitted (or pre-existing) peer can introduce
+	// a cycle invisible to the Bootstrap pass. breakDependsOnCycles
+	// short-circuits when no cycle is present (O(N+E) DFS, then
+	// early-return), so re-running on every KS/HR add is cheap even
+	// on render-heavy passes.
+	//
+	// REGISTERED BEFORE the controllers: listeners fire in
+	// registration order, so this strips cycle edges via store.Mutate
+	// synchronously BEFORE the controllers' listeners spawn their
+	// reconcile goroutines. Without the ordering the controller
+	// goroutine could read the un-stripped DependsOn from the store
+	// concurrently with cycle-stripping and burn its full per-dep
+	// Timeout waiting on a peer that's also waiting on it.
 	unsubCycles := o.store.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
 		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
 			return
@@ -666,6 +667,11 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		o.breakDependsOnCycles()
 	}, false)
 	defer unsubCycles()
+
+	o.src.Start(ctx)
+	o.ksc.Start(ctx)
+	o.hrc.Start(ctx)
+	defer o.Stop()
 
 	// Race ctx.Done() against task drain so a Ctrl-C during a stuck
 	// fetch / render is observable within one task's natural

--- a/pkg/orchestrator/rendered.go
+++ b/pkg/orchestrator/rendered.go
@@ -53,8 +53,18 @@ func (r *renderedSet) MarkRendered(parent, child manifest.NamedResource) {
 		return
 	}
 	r.mu.Lock()
+	defer r.mu.Unlock()
+	// First-write-wins: a child emitted by multiple parents (rare —
+	// kustomize replacements/components patterns) keeps its initial
+	// attribution. Without this guard, PR #361's fingerprint-dedup
+	// replay re-runs MarkRendered on every reconcile of every parent
+	// and silently swaps attribution to whichever parent reconciled
+	// most recently — breaking detectOrphans / ParentOf / RS-extension
+	// queries that subsequently read the wrong parent.
+	if _, exists := r.parents[child]; exists {
+		return
+	}
 	r.parents[child] = parent
-	r.mu.Unlock()
 }
 
 // has reports whether id was ever marked rendered.

--- a/pkg/orchestrator/rendered_test.go
+++ b/pkg/orchestrator/rendered_test.go
@@ -37,13 +37,16 @@ func TestRenderedSet_RecordsAndQueriesParent(t *testing.T) {
 	}
 }
 
-// TestRenderedSet_LastWriterWins documents the overwrite semantic:
+// TestRenderedSet_FirstWriterWins pins the attribution semantic:
 // when a child id is rendered by two parents in the same run (rare,
-// but theoretically possible if a child KS is referenced from
-// multiple parent paths), the most recent emission wins. This
-// matches kustomize's semantics and the AddObject DeepEqual gate's
-// "last write wins" pattern.
-func TestRenderedSet_LastWriterWins(t *testing.T) {
+// but possible if a child KS is referenced from multiple parent
+// paths), the FIRST emitter owns the child. The first-write-wins
+// guard exists so PR #361's fingerprint-dedup replay — which
+// re-runs MarkRendered on every reconcile of every parent — doesn't
+// silently swap attribution to whichever parent reconciled most
+// recently (breaking detectOrphans / ParentOf / RS-extension queries
+// downstream).
+func TestRenderedSet_FirstWriterWins(t *testing.T) {
 	r := newRenderedSet()
 	child := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "n", Name: "demo"}
 	parentA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "a"}
@@ -53,7 +56,7 @@ func TestRenderedSet_LastWriterWins(t *testing.T) {
 	r.MarkRendered(parentB, child)
 
 	got, _ := r.ParentOf(child)
-	if got != parentB {
-		t.Errorf("ParentOf = %v, want last writer %v", got, parentB)
+	if got != parentA {
+		t.Errorf("ParentOf = %v, want first writer %v", got, parentA)
 	}
 }


### PR DESCRIPTION
Four follow-up regressions surfaced by the third-pass audit:

1. **#365 cycle listener order**: Listener was registered after controllers → reconcile goroutine could race the cycle-strip. Register BEFORE controllers so stripping completes synchronously.
2. **#349 AfterFunc cleanup race**: ctx-bound cleanup fired on SIGINT while orchestrator was still reading the tempdir. Switch to caller-defer.
3. **#361 KS dedup MarkRendered overwrite**: Replay re-ran MarkRendered on every reconcile, swapping parent attribution. Switch to first-writer-wins.
4. **#361 HR dedup bypassed chart-source check**: Replay published stale docs even when source had since soft-skipped. Hoist chart-source Await + skip check above dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)