### PR TITLE
fix: third-pass batch 2 — helm/loader/manifest correctness

### DIFF
--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -203,7 +203,10 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 	if c.registry == nil {
 		return "", errors.New("helm registry client not initialized")
 	}
-	target := filepath.Join(c.cacheDir, safeName(filepath.Base(ref))+"-"+version+".tgz")
+	// Key on the FULL trimmed ref (registry+path), not filepath.Base —
+	// two distinct registries publishing a chart with the same final
+	// path segment would otherwise collide on a single cache file.
+	target := filepath.Join(c.cacheDir, safeName(strings.TrimPrefix(ref, "oci://"))+"-"+version+".tgz")
 
 	release, err := chartCacheLocks.Acquire(ctx, target)
 	if err != nil {

--- a/pkg/helm/oci_chart_test.go
+++ b/pkg/helm/oci_chart_test.go
@@ -118,9 +118,10 @@ func TestLocateOCIChart_FallsBackWhenNoArtifact(t *testing.T) {
 	}
 
 	// Pre-populate the helm cache target so fetchOCIChart's cache-hit
-	// branch returns without network. The target naming comes from
-	// fetchOCIChart's `safeName(filepath.Base(ref))+"-"+version+".tgz"`.
-	cacheTarget := filepath.Join(cli.cacheDir, "chart-0.1.0.tgz")
+	// branch returns without network. Target naming is
+	// safeName(trimmedRef)+"-"+version+".tgz" — full ref (registry+
+	// path), not just the basename, to avoid cross-registry collisions.
+	cacheTarget := filepath.Join(cli.cacheDir, "ghcr.io-test-chart-0.1.0.tgz")
 	if err := os.WriteFile(cacheTarget, buildChartTarGz(t, "chart", "0.1.0"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -99,8 +99,16 @@ func (c *Client) locateLocalChart(hr *manifest.HelmRelease) (string, error) {
 func (c *Client) pullHelmRepoOCI(ctx context.Context, r *manifest.HelmRepository, hr *manifest.HelmRelease) (string, error) {
 	chartURL := strings.TrimSuffix(r.URL, "/") + "/" + hr.Chart.Name
 	if puller := c.ociPullerSnapshot(); puller != nil {
+		// Name the synthetic OCIRepository after the source
+		// HelmRepository's identity (NOT the chart name): the puller's
+		// internal slot/dedup/log key uses (Namespace, Name), and
+		// using the chart name would conflate two distinct
+		// HelmRepositories that happen to ship a chart with the same
+		// name. Disambiguate slot identity further by suffixing the
+		// chart name so distinct charts from the same HelmRepository
+		// also get distinct slots.
 		syn := &manifest.OCIRepository{
-			Name:      hr.Chart.Name,
+			Name:      r.Name + "-" + hr.Chart.Name,
 			Namespace: r.Namespace,
 		}
 		syn.URL = chartURL
@@ -195,7 +203,14 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 		return "", err
 	}
 
-	cacheKey := safeName(hr.Chart.Name) + "-" + cv.Version + ".tgz"
+	// Include the HelmRepository's identity in the cache key so two
+	// repos that publish the same chart name + version don't
+	// overwrite each other's tarball on disk. Without the repo
+	// prefix, `nginx:15.0.0` from repo A and a different
+	// `nginx:15.0.0` from repo B alternately overwrote each other's
+	// bytes; the in-memory chartCache (keyed by path) then served
+	// whichever bytes were last written.
+	cacheKey := safeName(r.Namespace+"-"+r.Name+"-"+hr.Chart.Name) + "-" + cv.Version + ".tgz"
 	target := filepath.Join(c.cacheDir, cacheKey)
 
 	release, err := chartCacheLocks.Acquire(ctx, target)

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -100,6 +100,14 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 		}
 		inst.KubeVersion = kv
 	}
+	// Same for APIVersions — action.Install under DryRunClient
+	// replaces cfg.Capabilities with a fresh default copy and then
+	// only re-applies inst.APIVersions onto that copy. Setting
+	// cfg.Capabilities alone leaves APIVersions empty at render
+	// time, silently dropping the user's --api-versions flag.
+	if len(caps.APIVersions) > 0 {
+		inst.APIVersions = caps.APIVersions
+	}
 	if hrValues == nil {
 		hrValues = map[string]any{}
 	}

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -18,6 +18,7 @@ type kustomization struct {
 	APIVersion         string            `json:"apiVersion"                   yaml:"apiVersion"`
 	Kind               string            `json:"kind"                         yaml:"kind"`
 	Resources          []string          `json:"resources,omitempty"          yaml:"resources,omitempty"`
+	Components         []string          `json:"components,omitempty"         yaml:"components,omitempty"`
 	ConfigMapGenerator []kvPairGenerator `json:"configMapGenerator,omitempty" yaml:"configMapGenerator,omitempty"`
 	SecretGenerator    []kvPairGenerator `json:"secretGenerator,omitempty"    yaml:"secretGenerator,omitempty"`
 }

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -240,6 +240,31 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 		}
 		count += n
 	}
+
+	// Walk `components:` entries too. A kustomize Component contributes
+	// resources (and patches) to its parent's render, and any Flux CRs
+	// inside a component's subtree must be discoverable by flate.
+	// parent.go already reads `components:` for ownership-prefix
+	// claiming; without walking them here, the loader's discovery and
+	// parent.go's claim graph disagree.
+	for _, comp := range k.Components {
+		if cerr := ctx.Err(); cerr != nil {
+			return count, cerr
+		}
+		abs, ok := resolveDataPath(dir, comp)
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		n, err := w.descend(ctx, abs)
+		if err != nil {
+			return count, err
+		}
+		count += n
+	}
 	return count, nil
 }
 

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -1,7 +1,6 @@
 package manifest
 
 import (
-	"cmp"
 	"encoding/json"
 	"slices"
 	"strings"
@@ -157,10 +156,4 @@ func requireMetadata(kind string, doc map[string]any) (name, ns string, err erro
 	}
 	ns, _ = md["namespace"].(string)
 	return name, ns, nil
-}
-
-// stringOr returns m[k] as a string, or fallback when absent/empty.
-func stringOr(m map[string]any, k, fallback string) string {
-	v, _ := m[k].(string)
-	return cmp.Or(v, fallback)
 }

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -132,7 +132,14 @@ func parseRawObject(doc map[string]any) (*RawObject, error) {
 	if name == "" {
 		return nil, inputf("missing metadata.name for %s", kind)
 	}
-	ns := stringOr(metadata, "namespace", DefaultNamespace)
+	// Pass through whatever the doc declares (empty for cluster-scoped
+	// CRs like ClusterRole / CRD / Namespace / IngressClass). DON'T
+	// default to flux-system here — that silently namespaces cluster-
+	// scoped resources and collides their identities in the store
+	// (NamespacedName() returns "flux-system/<name>" for every
+	// cluster-scoped CR with the same name). Callers that need a
+	// default for genuinely-namespaced kinds apply it at the emit site.
+	ns, _ := metadata["namespace"].(string)
 	spec, _ := doc["spec"].(map[string]any)
 	// Deep-copy the spec map so RawObject doesn't alias the loader's
 	// parsed YAML — mutating r.Spec then corrupts the multi-doc


### PR DESCRIPTION
Five audit-confirmed correctness fixes:

1. **helm cache key collision** across HelmRepositories shipping same chart name+version; OCI fallback used basename only.
2. **pullHelmRepoOCI syn.Name** used chart name → conflated repos. Now uses repo.Name + chart.
3. **--api-versions silently dropped** — action.Install resets caps under DryRun, only honors inst.APIVersions.
4. **loader components: never walked** — Flux CRs in component subtrees were invisible.
5. **parseRawObject silently namespaced cluster-scoped CRs** to flux-system, collapsing identities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)