### PR TITLE
fix: third-pass batch 3 — store/values/baseline correctness

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -294,7 +294,17 @@ func mergeBase(repo *git.Repository, headCommit *object.Commit, other plumbing.H
 	if len(bases) == 0 {
 		return plumbing.ZeroHash, errors.New("no merge-base (disjoint histories)")
 	}
-	return bases[0].Hash, nil
+	// Criss-cross merges produce >1 candidate base; go-git doesn't
+	// guarantee a stable order. Pick the lexicographically-smallest
+	// hash so two `flate diff` runs against the same repo pick the
+	// same baseline — reproducibility is a stated guarantee.
+	best := bases[0].Hash
+	for _, b := range bases[1:] {
+		if b.Hash.String() < best.String() {
+			best = b.Hash
+		}
+	}
+	return best, nil
 }
 
 // isShallow reports whether the repo is a shallow clone (presence of
@@ -355,6 +365,29 @@ func materialize(repo *git.Repository, hash plumbing.Hash, root string) error {
 			slog.Warn("baseline: skipping submodule", "path", name)
 			continue
 		}
+		if entry.Mode == filemode.Symlink {
+			// go-git's filemode.IsFile() returns true for symlinks
+			// too, but writing the link-target string as a regular
+			// file would produce false diffs vs the working tree
+			// (which has actual symlinks). Materialize symlinks as
+			// real symlinks.
+			blob, err := repo.BlobObject(entry.Hash)
+			if err != nil {
+				return fmt.Errorf("load baseline symlink blob %s for %q: %w", entry.Hash, name, err)
+			}
+			target, err := readBlob(blob)
+			if err != nil {
+				return fmt.Errorf("read baseline symlink target for %q: %w", name, err)
+			}
+			path := filepath.Join(root, filepath.FromSlash(name))
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+			}
+			if err := os.Symlink(string(target), path); err != nil {
+				return fmt.Errorf("symlink %s -> %s: %w", path, target, err)
+			}
+			continue
+		}
 		if !entry.Mode.IsFile() {
 			// Trees and other non-file modes — NewTreeWalker recurses
 			// into subtrees automatically, so we don't mkdir here; the
@@ -365,11 +398,25 @@ func materialize(repo *git.Repository, hash plumbing.Hash, root string) error {
 		if err != nil {
 			return fmt.Errorf("load baseline blob %s for %q: %w", entry.Hash, name, err)
 		}
-		if err := writeBlob(filepath.Join(root, name), blob, entry.Mode); err != nil {
+		// Convert slash-separated tree path to filesystem separator
+		// for Windows portability (no-op on Linux/macOS).
+		if err := writeBlob(filepath.Join(root, filepath.FromSlash(name)), blob, entry.Mode); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// readBlob slurps the entire contents of a blob (used for symlink
+// targets, which are bounded by PATH_MAX so the in-memory cost is
+// trivial).
+func readBlob(blob *object.Blob) ([]byte, error) {
+	r, err := blob.Reader()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	return io.ReadAll(r)
 }
 
 // writeBlob streams blob's content to path, creating parent dirs and

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -179,14 +179,32 @@ func Mutate[T interface {
 	manifest.BaseManifest
 	Cloneable[T]
 }](s *Store, id manifest.NamedResource, mutate func(T)) bool {
-	obj, ok := s.GetObject(id).(T)
-	if !ok {
-		return false
+	// Hold s.mu across the whole clone-mutate-write so a concurrent
+	// DeleteObject(id) or AddObject(newer) between Get and Add can't
+	// resurrect deleted state or clobber a newer write with the
+	// mutation of the previously-observed object.
+	var dispatch func()
+	ok := func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		obj, isT := s.objects[id].(T)
+		if !isT {
+			return false
+		}
+		cloned := obj.Clone()
+		mutate(cloned)
+		// Dedup parallel to AddObject — equal mutations no-op.
+		if reflect.DeepEqual(s.objects[id], cloned) {
+			return true
+		}
+		s.setLocked(id, cloned)
+		dispatch = s.fireUnderLock(EventObjectAdded, id, cloned)
+		return true
+	}()
+	if dispatch != nil {
+		dispatch()
 	}
-	cloned := obj.Clone()
-	mutate(cloned)
-	s.AddObject(cloned)
-	return true
+	return ok
 }
 
 // AddRendered records a manifest produced by helm/kustomize rendering.

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -104,6 +105,21 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource) (Stat
 				Resource: id.String(), Reason: currentFailed.Message,
 			}
 		case <-ctx.Done():
+			// Propagate ctx.Err() ONLY when the caller explicitly
+			// cancelled (context.Canceled) — otherwise (per-dep
+			// Timeout expired with a Failed observed), preserve the
+			// established "surface ResourceFailedError so dep
+			// summaries carry the real reason" semantic. Without
+			// this distinction, clean Ctrl-C on a depwait stuck on a
+			// genuinely-failed dep silently masqueraded the
+			// shutdown as a dep-failure downstream.
+			if errors.Is(ctx.Err(), context.Canceled) {
+				info := StatusInfo{}
+				if currentFailed != nil {
+					info = *currentFailed
+				}
+				return info, ctx.Err()
+			}
 			if currentFailed != nil {
 				return *currentFailed, &manifest.ResourceFailedError{
 					Resource: id.String(), Reason: currentFailed.Message,

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -448,22 +448,25 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 }
 
 // VarsMap returns the substitution variables for use with
-// kustomize.Substitute. Non-string values are stringified. Newline
-// characters are stripped from every value — upstream kustomize-
-// controller does the same so multi-line entries can't break inline
-// substitution into single-line YAML fields.
+// kustomize.Substitute. Non-string scalar values are stringified;
+// nested maps/slices and other unsupported shapes are silently
+// dropped with a Debug log rather than rendered as Go's default
+// `map[k:v]` / `[1 2 3]` representation, which produced literal
+// garbage substitutions diverging from upstream kustomize-controller
+// (whose LoadVariables only accepts flat string→string). Newline
+// characters are stripped from every value — upstream does the same
+// so multi-line entries can't break inline substitution into
+// single-line YAML fields.
 func VarsMap(in map[string]any) map[string]string {
 	if len(in) == 0 {
 		return nil
 	}
 	out := make(map[string]string, len(in))
 	for k, v := range in {
-		var s string
-		switch tv := v.(type) {
-		case string:
-			s = tv
-		default:
-			s = fmt.Sprint(v)
+		s, err := bagValueAsString(v)
+		if err != nil {
+			slog.Debug("values: dropping non-scalar substitute var", "key", k, "err", err)
+			continue
 		}
 		out[k] = strings.ReplaceAll(s, "\n", "")
 	}


### PR DESCRIPTION
Five audit-confirmed correctness fixes:

1. **store.Mutate TOCTOU** — hold s.mu across the whole clone-mutate-write.
2. **store.WatchReady ctx.Done propagation** — propagate ctx.Err() only on Canceled; preserve ResourceFailedError on per-dep Timeout.
3. **baseline.materialize symlinks** as actual symlinks (not text files containing the target).
4. **baseline.mergeBase determinism** — pick lex-smallest hash on multi-base criss-cross merges.
5. **values.VarsMap nested-value handling** — route through bagValueAsString instead of fmt.Sprint garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)