### PR TITLE
polish: third-pass batch 5 — UTF-8 widths, selector strictness, image API, panic accounting

### DIFF
--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -54,7 +54,7 @@ func collectImages(o *orchestrator.Orchestrator, res *orchestrator.Result, c *co
 			continue
 		}
 		for _, doc := range docs {
-			imgs, _ := image.Extract(doc)
+			imgs := image.Extract(doc)
 			for _, img := range imgs {
 				set[img] = struct{}{}
 			}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"unicode/utf8"
 
 	"sigs.k8s.io/yaml"
 )
@@ -46,15 +47,19 @@ type Column struct {
 }
 
 // Table renders rows of map[string]string into a fixed-width table.
-// Columns are sized to the widest cell + a 4-char gutter.
+// Columns are sized to the widest cell + a 4-char gutter. Widths
+// are measured in runes (not bytes) so cells with multi-byte UTF-8
+// (paths with non-ASCII, chart names with unicode) align correctly.
+// Doesn't account for double-width CJK glyphs — adding a runewidth
+// dependency is out of scope; bring it in when CJK output matters.
 func Table(w io.Writer, cols []Column, rows []map[string]string) error {
 	widths := make([]int, len(cols))
 	for i, c := range cols {
-		widths[i] = len(c.Header)
+		widths[i] = utf8.RuneCountInString(c.Header)
 	}
 	for _, r := range rows {
 		for i, c := range cols {
-			if l := len(r[c.Key]); l > widths[i] {
+			if l := utf8.RuneCountInString(r[c.Key]); l > widths[i] {
 				widths[i] = l
 			}
 		}
@@ -79,7 +84,7 @@ func writeCol(b *bytes.Buffer, value string, width int, last bool) {
 	if last {
 		return
 	}
-	b.WriteString(strings.Repeat(" ", max(width-len(value)+4, 1)))
+	b.WriteString(strings.Repeat(" ", max(width-utf8.RuneCountInString(value)+4, 1)))
 }
 
 // YAMLMulti emits a multi-document YAML stream.

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -24,14 +24,14 @@ import (
 
 // Extract returns the unique sorted image references found anywhere
 // inside doc. Non-string values are ignored. Returns nil when no
-// images are found — never an error.
-func Extract(doc map[string]any) ([]string, error) {
+// images are found.
+func Extract(doc map[string]any) []string {
 	set := map[string]struct{}{}
 	walk(doc, set)
 	if len(set) == 0 {
-		return nil, nil
+		return nil
 	}
-	return slices.Sorted(maps.Keys(set)), nil
+	return slices.Sorted(maps.Keys(set))
 }
 
 // walk recursively descends into v collecting strings that look like

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -22,10 +22,7 @@ func TestExtract_Deployment(t *testing.T) {
 			},
 		},
 	}
-	got, err := Extract(doc)
-	if err != nil {
-		t.Fatalf("Extract: %v", err)
-	}
+	got := Extract(doc)
 	want := []string{
 		"docker.io/library/redis:7",
 		"ghcr.io/library/nginx:1.27",
@@ -43,7 +40,7 @@ func TestExtract_FindsImageInArbitraryFieldName(t *testing.T) {
 		"kind": "Cluster",
 		"spec": map[string]any{"imageName": "ghcr.io/cloudnative-pg/postgresql:16.4"},
 	}
-	got, _ := Extract(doc)
+	got := Extract(doc)
 	if !slices.Equal(got, []string{"ghcr.io/cloudnative-pg/postgresql:16.4"}) {
 		t.Errorf("got %v", got)
 	}
@@ -61,7 +58,7 @@ func TestExtract_FindsImageInUnknownKind(t *testing.T) {
 			},
 		},
 	}
-	got, _ := Extract(doc)
+	got := Extract(doc)
 	if len(got) != 1 {
 		t.Errorf("expected 1 image, got %v", got)
 	}
@@ -73,7 +70,7 @@ func TestExtract_DigestOnly(t *testing.T) {
 			"image": "ghcr.io/owner/foo@sha256:" + sha256(),
 		},
 	}
-	got, _ := Extract(doc)
+	got := Extract(doc)
 	if len(got) != 1 {
 		t.Errorf("expected 1 image, got %v", got)
 	}
@@ -88,7 +85,7 @@ func TestExtract_Nested(t *testing.T) {
 			},
 		},
 	}
-	got, _ := Extract(doc)
+	got := Extract(doc)
 	if !slices.Equal(got, []string{"ghcr.io/x:1.0"}) {
 		t.Errorf("got %v", got)
 	}
@@ -114,10 +111,7 @@ func TestExtract_RejectsNonImages(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			doc := map[string]any{"x": tc.value}
-			got, err := Extract(doc)
-			if err != nil {
-				t.Fatalf("Extract: %v", err)
-			}
+			got := Extract(doc)
 			if len(got) != 0 {
 				t.Errorf("expected nothing, got %v", got)
 			}

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -54,15 +55,21 @@ func (o *Orchestrator) finalize() error {
 	o.logSummary(failed)
 	o.logResourceFailures(failed)
 
+	// Compose any unattributed panic count with the aggregated
+	// per-resource failures so the panic signal isn't dropped when
+	// other resources also failed. Pre-fix, the panic counter was
+	// only consulted on the clean-aggregate path; a panicked task
+	// running alongside any normal failure looked indistinguishable
+	// from a clean reconcile to Service.Failures()-driven callers.
+	var panicErr error
+	if n := o.tasks.Failures(); n > 0 {
+		panicErr = fmt.Errorf("%d task(s) panicked without per-resource attribution; check logs", n)
+	}
 	if len(failed) == 0 {
-		// Controllers attribute panics by marking the resource StatusFailed
-		// (see kustomization/helmrelease/source controllers). This catches
-		// any panic that escaped attribution — e.g. inside a future task
-		// dispatched outside the per-resource recover.
-		if n := o.tasks.Failures(); n > 0 {
-			return fmt.Errorf("%d task(s) panicked without per-resource attribution; check logs", n)
-		}
-		return nil
+		return panicErr
+	}
+	if panicErr != nil {
+		return errors.Join(o.aggregateFailures(failed), panicErr)
 	}
 	return o.aggregateFailures(failed)
 }

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -23,7 +23,14 @@ func (m Metadata) Matches(obj manifest.BaseManifest) bool {
 	if len(m.Labels) > 0 {
 		labels := labelsOf(obj)
 		for k, v := range m.Labels {
-			if labels[k] != v {
+			// Use comma-ok so a selector entry like `-l env=`
+			// (empty filter value) doesn't silently match every
+			// object that lacks the `env` label entirely — map
+			// lookup of a missing key returns the zero value `""`
+			// which would equal v=="" and broaden the result set
+			// well beyond intent.
+			got, ok := labels[k]
+			if !ok || got != v {
 				return false
 			}
 		}


### PR DESCRIPTION
Five long-tail audit fixes:

1. **format.Table** widths in runes (was bytes) — fixes ragged columns for non-ASCII paths/names.
2. **selector empty-value** now uses comma-ok so `-l env=` doesn't match every object missing the label.
3. **image.Extract** sheds its always-nil error return; callers can stop discarding it.
4. **orchestrator unattributed-panic counter** folded into aggregateFailures so panics alongside per-resource failures aren't dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)