### PR TITLE
polish: third-pass batch 6 — diff/resourceset/git bug bundle

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -167,7 +167,6 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 		outFormat = "diff"
 	}
 	diffs, err := diff.Run(origDocs, currentDocs, diff.Options{
-		Format:     diff.Format(outFormat),
 		StripAttrs: d.stripAttrs,
 	})
 	if err != nil {

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -31,8 +31,6 @@ const (
 
 // Options tunes Run behavior.
 type Options struct {
-	// Format selects the output flavor. Default FormatDiff.
-	Format Format
 	// StripAttrs lists annotation/label keys removed from each
 	// manifest's metadata (and pod-template metadata) before the diff
 	// is computed. Cuts chart-bump noise — annotations like
@@ -163,16 +161,18 @@ type pairKey struct {
 	// pPath disambiguates two KS parents with the same (kind, ns, name)
 	// but different spec.path — a real-world collision in repos where
 	// the same KS is rendered twice from different overlays.
-	pKind, pNS, pName, pPath string
-	kind, ns, name           string
+	pKind, pNS, pName, pPath  string
+	apiVersion                string
+	kind, ns, name            string
 }
 
 func pair(left, right []Doc) []pairedResource {
 	idx := make(map[pairKey]*pairedResource, len(left)+len(right))
 	add := func(side int, d Doc) {
 		kind := manifest.DocKind(d.Manifest)
+		apiVersion := manifest.DocAPIVersion(d.Manifest)
 		name, ns := manifest.DocMetadata(d.Manifest)
-		k := pairKey{d.Parent.Kind, d.Parent.Namespace, d.Parent.Name, d.Parent.Path, kind, ns, name}
+		k := pairKey{d.Parent.Kind, d.Parent.Namespace, d.Parent.Name, d.Parent.Path, apiVersion, kind, ns, name}
 		p, ok := idx[k]
 		if !ok {
 			p = &pairedResource{parent: d.Parent, kind: kind, namespace: ns, name: name}

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -52,6 +52,8 @@ func isClusterScoped(doc map[string]any) bool {
 		"PersistentVolume",
 		"StorageClass",
 		"PriorityClass",
+		"IngressClass",
+		"ClusterIssuer",
 		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
 		"APIService",
 		"Node":

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -135,7 +135,7 @@ func renderResources(raw *apix.JSON, inputs []map[string]any) ([]map[string]any,
 		if err != nil {
 			return nil, err
 		}
-		if doc == nil {
+		if doc == nil || disabledByReconcileAnnotation(doc) {
 			return nil, nil
 		}
 		return []map[string]any{doc}, nil
@@ -160,8 +160,22 @@ func renderResources(raw *apix.JSON, inputs []map[string]any) ([]map[string]any,
 // renderResourcesTemplate templates the multi-document YAML string in
 // spec.resourcesTemplate once per input set.
 func renderResourcesTemplate(tmplStr string, inputs []map[string]any) ([]map[string]any, error) {
+	filter := func(docs []map[string]any) []map[string]any {
+		out := docs[:0]
+		for _, doc := range docs {
+			if disabledByReconcileAnnotation(doc) {
+				continue
+			}
+			out = append(out, doc)
+		}
+		return out
+	}
 	if len(inputs) == 0 {
-		return splitMultiDoc(tmplStr, nil)
+		docs, err := splitMultiDoc(tmplStr, nil)
+		if err != nil {
+			return nil, err
+		}
+		return filter(docs), nil
 	}
 	var out []map[string]any
 	for _, in := range inputs {
@@ -169,12 +183,7 @@ func renderResourcesTemplate(tmplStr string, inputs []map[string]any) ([]map[str
 		if err != nil {
 			return nil, err
 		}
-		for _, doc := range docs {
-			if disabledByReconcileAnnotation(doc) {
-				continue
-			}
-			out = append(out, doc)
-		}
+		out = append(out, filter(docs)...)
 	}
 	return out, nil
 }

--- a/pkg/source/git/verify.go
+++ b/pkg/source/git/verify.go
@@ -83,25 +83,26 @@ func verifyTag(mode sourcev1.GitVerificationMode) bool {
 // --wipe-secrets run doesn't try to verify against a placeholder.
 func buildPGPKeyring(sec *manifest.Secret) (string, error) {
 	var out string
-	for k := range sec.StringData {
+	seen := map[string]struct{}{}
+	append1 := func(k string) {
+		if _, dup := seen[k]; dup {
+			return // StringData wins over Data per StringFromSecret
+		}
+		seen[k] = struct{}{}
 		v := source.StringFromSecret(sec, k)
 		if v == "" {
-			continue
+			return
 		}
 		if out != "" && out[len(out)-1] != '\n' {
 			out += "\n"
 		}
 		out += v
 	}
+	for k := range sec.StringData {
+		append1(k)
+	}
 	for k := range sec.Data {
-		v := source.StringFromSecret(sec, k)
-		if v == "" {
-			continue
-		}
-		if out != "" && out[len(out)-1] != '\n' {
-			out += "\n"
-		}
-		out += v
+		append1(k)
 	}
 	if out == "" {
 		return "", fmt.Errorf("verify secret carries no PGP public keys")


### PR DESCRIPTION
Five confirmed bugs from the third-pass audit:

- **diff pair key**: now includes apiVersion so a Deployment under `apps/v1` and a same-named legacy `extensions/v1beta1` entry don't collide.
- **diff Options.Format dead field**: removed. CLI was setting it but `Run` never read it; `Render` takes format separately.
- **resourceset disabled annotation**: `disabledByReconcileAnnotation` was only checked in the per-input loop. The no-inputs branches of both `renderResources` and `renderResourcesTemplate` now also filter, so a disabled static resource isn't silently emitted.
- **resourceset cluster scope**: `ClusterIssuer` (cert-manager) and `IngressClass` (networking) added to the catalog so they no longer get the default namespace stamped onto cluster-scoped CRs.
- **git PGP keyring**: `buildPGPKeyring` now dedups keys that appear in both `StringData` and `Data` — `StringFromSecret` already prefers `StringData`, but the double iteration was appending the same value twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)