### PR TITLE
fix(depwait): CEL eval errors are transient, not terminal

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -59,22 +59,51 @@ func mustCELEnv() *cel.Env {
 
 // evaluateReadyExpr compiles (memoized) and evaluates expr against the
 // projected views of self (consumer) and dep (dependency). Returns true
-// iff the program produces a bool true. Any compile, eval, or type-
-// shape error is returned verbatim.
+// iff the program produces a bool true.
+//
+// Errors are split: a compile/program error is wrapped in *celCompileErr
+// (terminal — the expression itself is broken); an eval error against
+// the projected object is wrapped in *celEvalErr (transient — the dep's
+// status may not yet be populated, so callers polling on store events
+// should keep waiting).
 func evaluateReadyExpr(expr string, s *store.Store, self, dep manifest.NamedResource) (bool, error) {
 	prog, err := compileReadyExpr(expr)
 	if err != nil {
-		return false, err
+		return false, &celCompileErr{err}
 	}
 	val, _, err := prog.Eval(map[string]any{
 		"self": projectObject(s, self),
 		"dep":  projectObject(s, dep),
 	})
 	if err != nil {
-		return false, fmt.Errorf("eval: %w", err)
+		return false, &celEvalErr{fmt.Errorf("eval: %w", err)}
 	}
-	return asBool(val)
+	// asBool errors are type-shape problems with the expression itself
+	// (e.g. `dep.metadata.name` returns a string). The user's expr is
+	// broken regardless of dep state, so surface as terminal.
+	ok, err := asBool(val)
+	if err != nil {
+		return false, &celCompileErr{err}
+	}
+	return ok, nil
 }
+
+// celCompileErr signals an unrecoverable expression problem (parse,
+// type-check, or program assembly failure). Treated as terminal by
+// every caller.
+type celCompileErr struct{ err error }
+
+func (e *celCompileErr) Error() string { return e.err.Error() }
+func (e *celCompileErr) Unwrap() error { return e.err }
+
+// celEvalErr signals a runtime evaluation failure against the current
+// projection — typically a "no such attribute" because the dep's
+// status hasn't landed yet. Polling callers should treat this as
+// transient and re-evaluate on the next store event.
+type celEvalErr struct{ err error }
+
+func (e *celEvalErr) Error() string { return e.err.Error() }
+func (e *celEvalErr) Unwrap() error { return e.err }
 
 func compileReadyExpr(expr string) (cel.Program, error) {
 	if v, ok := celCache.Load(expr); ok {

--- a/pkg/depwait/cel_test.go
+++ b/pkg/depwait/cel_test.go
@@ -183,6 +183,35 @@ func TestReadyExpr_NonBoolResult(t *testing.T) {
 	}
 }
 
+// TestReadyExpr_TransientEvalErrorPolls covers the "eval error against
+// the projection is transient" contract: cel-go's runtime can fail
+// when the expression touches a field that isn't yet present
+// (e.g. an empty conditions slice). The waiter must re-poll on the
+// next store event instead of failing terminally, so a dep that
+// becomes ready a moment later still goes Ready.
+func TestReadyExpr_TransientEvalErrorPolls(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "infra"}
+	// Status is set but conditions is empty — `conditions[0]` triggers
+	// a runtime eval error inside cel-go.
+	s.UpdateStatus(dep, store.StatusReady, "")
+
+	w := &Waiter{Store: s, Timeout: time.Second}
+	ch := w.Watch(context.Background(), []manifest.DependencyRef{{
+		NamedResource: dep,
+		ReadyExpr:     `dep.status.conditions[0].type == "Ready"`,
+	}})
+	// Now land the condition the expr is looking for — this should
+	// wake the polling loop.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		s.SetCondition(dep, store.Condition{Type: "Ready", Status: metav1.ConditionTrue})
+	}()
+	if sum := WaitAll(ch); !sum.AllReady() {
+		t.Errorf("dep should go Ready once conditions[0] populates: %+v", sum)
+	}
+}
+
 // TestReadyExpr_ReadsLabelsAndAnnotations locks the upstream Flux
 // contract that readyExpr can read dep.metadata.{labels,annotations}.
 // The HR/KS manifest types now carry these maps and the CEL projection

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -440,13 +440,21 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 }
 
 // tryReadyExpr evaluates expr once and translates the outcome into
-// the per-dep Event. Returns (event, true) on a definitive result
-// (Ready or eval error); returns (zero, false) when the expression
-// produced a clean false and the caller should keep waiting.
+// the per-dep Event. Returns (event, true) on a definitive result —
+// Ready, or a compile error that no amount of polling will fix.
+// Returns (zero, false) when the expression produced a clean false
+// OR a transient runtime eval error (typically a missing attribute
+// because the dep's status hasn't been populated yet) — the caller
+// should keep waiting on store events.
 func (w *Waiter) tryReadyExpr(expr string, id manifest.NamedResource) (Event, bool) {
 	ok, err := evaluateReadyExpr(expr, w.Store, w.Parent, id)
 	if err != nil {
-		return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}, true
+		var compileErr *celCompileErr
+		if errors.As(err, &compileErr) {
+			return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}, true
+		}
+		// Eval error: transient, re-poll on next event.
+		return Event{}, false
 	}
 	if ok {
 		return Event{Dep: id, Status: DepReady, Reason: "readyExpr satisfied"}, true


### PR DESCRIPTION
## Summary
- Split `evaluateReadyExpr` error surface: compile/program failures (and non-bool returns) stay terminal; cel-go runtime failures against the current projection are now flagged transient.
- The polling watcher re-evaluates on the next store event instead of failing the dep outright when the expression touches a not-yet-populated attribute (e.g. `dep.status.conditions[0]` before any condition lands).
- Adds a regression test that locks the new behavior.

## Why
A common Flux readyExpr like `dep.status.conditions[0].type == "Ready"` would previously fail terminally the first time it ran against an empty conditions slice — even though the very next store event would have populated it. The new split matches upstream Flux semantics where readiness checks are intended to be eventually consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)