### PR TITLE
fix(cli): get -o yaml/json output now deterministic

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -480,24 +480,6 @@ func TestCompareDocs_OrdersByKindNamespaceName(t *testing.T) {
 	}
 }
 
-// TestSortRows_Deterministic covers helpers.sortRows: rows must
-// land in (namespace, name) order regardless of input order.
-func TestSortRows_Deterministic(t *testing.T) {
-	rows := []map[string]string{
-		{"namespace": "b", "name": "z"},
-		{"namespace": "a", "name": "y"},
-		{"namespace": "a", "name": "x"},
-	}
-	sortRows(rows)
-	want := []string{"a/x", "a/y", "b/z"}
-	for i, r := range rows {
-		got := r["namespace"] + "/" + r["name"]
-		if got != want[i] {
-			t.Errorf("rows[%d] = %s, want %s", i, got, want[i])
-		}
-	}
-}
-
 // TestFilterCRDsOnly drops every non-CRD doc.
 func TestFilterCRDsOnly(t *testing.T) {
 	docs := []map[string]any{

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -219,8 +219,11 @@ func printResources[T manifest.BaseManifest](
 	cols []format.Column, mapper func(*orchestrator.Orchestrator, T) (map[string]string, map[string]any),
 ) error {
 	objs := o.Store().ListObjects(kind)
-	rows := make([]map[string]string, 0, len(objs))
-	docs := make([]map[string]any, 0, len(objs))
+	type pair struct {
+		row map[string]string
+		doc map[string]any
+	}
+	pairs := make([]pair, 0, len(objs))
 	for _, obj := range objs {
 		if !sel.Matches(obj) {
 			continue
@@ -234,10 +237,23 @@ func printResources[T manifest.BaseManifest](
 			continue
 		}
 		row, doc := mapper(o, t)
-		rows = append(rows, row)
-		docs = append(docs, doc)
+		pairs = append(pairs, pair{row, doc})
 	}
-	sortRows(rows)
+	// Store.ListObjects iterates a Go map (random order); sort the
+	// (row, doc) tuple so every output flavor — including yaml/json —
+	// is deterministic across runs.
+	slices.SortFunc(pairs, func(a, b pair) int {
+		return cmp.Or(
+			cmp.Compare(a.row["namespace"], b.row["namespace"]),
+			cmp.Compare(a.row["name"], b.row["name"]),
+		)
+	})
+	rows := make([]map[string]string, len(pairs))
+	docs := make([]map[string]any, len(pairs))
+	for i, p := range pairs {
+		rows[i] = p.row
+		docs[i] = p.doc
+	}
 
 	switch format.Output(out) {
 	case format.OutputYAML:

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -27,17 +26,6 @@ func firstArg(args []string) string {
 		return ""
 	}
 	return args[0]
-}
-
-// sortRows orders rows by (namespace, name) so table output is
-// deterministic across runs.
-func sortRows(rows []map[string]string) {
-	slices.SortFunc(rows, func(a, b map[string]string) int {
-		return cmp.Or(
-			cmp.Compare(a["namespace"], b["namespace"]),
-			cmp.Compare(a["name"], b["name"]),
-		)
-	})
 }
 
 // collectImages returns the union of images extracted from every


### PR DESCRIPTION
## Summary

`printResources` sorted `rows` but not `docs`, so table mode was deterministic while `-o yaml` / `-o json` shipped whatever map-iteration order `Store.ListObjects` happened to return. Different runs of the same command produced documents in different orders.

Pair rows and docs together, sort once on `(namespace, name)`, then split out. The free-standing `sortRows` helper (and its isolated unit test) is gone — `printResources` was its only caller, and the sort is now inline alongside the pairing where it can't fall out of sync with `docs` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)