### PR TITLE
feat(source/git): bare-mirror + tree-walk worktree materialization

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -221,7 +221,11 @@ func New(cfg Config) (*Orchestrator, error) {
 	// payload <T>" from the single adapter site rather than from
 	// four nearly-identical type assertions.
 	srcCtrl.Fetchers[manifest.KindGitRepository] = source.Wrap[*manifest.GitRepository](
-		manifest.KindGitRepository, &git.Fetcher{Cache: cache, Secrets: secretGet})
+		manifest.KindGitRepository, &git.Fetcher{
+			Cache:   cache,
+			Secrets: secretGet,
+			Mirrors: git.NewMirrorCache(filepath.Join(cacheRoot, "git-mirrors")),
+		})
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap[*manifest.ExternalArtifact](
 		manifest.KindExternalArtifact, &external.Fetcher{})
 	srcCtrl.Fetchers[manifest.KindBucket] = source.Wrap[*manifest.Bucket](

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -27,9 +27,19 @@ import (
 // It owns a shared Cache so multiple GitRepository CRs writing to the
 // same cache root serialize on slot allocation correctly. Secrets is
 // optional; required when a GitRepository sets spec.secretRef.
+//
+// Mirrors, when set, switches the default fetch path to an incremental
+// bare-mirror-plus-worktree strategy: one bare clone per upstream URL
+// (kept warm across runs and across refs), and per-slot worktrees are
+// materialized by walking the commit tree out of the mirror. The
+// legacy full PlainClone-into-slot path still runs for repos that
+// need submodule recursion or sparse checkout — neither feature is
+// expressible against a bare mirror without a separate fetch that
+// defeats the cache. Leave nil to keep the legacy path everywhere.
 type Fetcher struct {
 	Cache   *source.Cache
 	Secrets source.SecretGetter
+	Mirrors *MirrorCache
 }
 
 // httpsTransportMu is declared in tls.go (with the only caller —
@@ -139,6 +149,10 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		url = rest
 	}
 
+	if f.canUseMirror(repo, url) {
+		return f.fetchViaMirror(ctx, repo, refStr, slot, auth, proxy)
+	}
+
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
 	if proxy != nil {
 		cloneOpts.ProxyOptions = transport.ProxyOptions{
@@ -216,6 +230,66 @@ func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifa
 		_ = writeCachedRevision(art.LocalPath, art.Revision)
 	}
 	return nil
+}
+
+// canUseMirror reports whether this Fetcher can take the bare-mirror
+// path for repo. The mirror path doesn't support submodule recursion
+// or sparse checkout — both require a real worktree go-git can act on.
+// Everything else (https, ssh, file://) is mirror-eligible.
+func (f *Fetcher) canUseMirror(repo *manifest.GitRepository, _ string) bool {
+	if f.Mirrors == nil {
+		return false
+	}
+	if repo.RecurseSubmodules {
+		return false
+	}
+	if len(repo.SparseCheckout) > 0 {
+		return false
+	}
+	return true
+}
+
+// fetchViaMirror runs the bare-mirror path: open-or-update the
+// per-URL mirror, resolve the requested ref to a commit hash, then
+// materialize the tree into the slot's staging dir. PGP verification
+// runs against the mirror (which has the object store); ApplyIgnore
+// and the revision-marker write reuse the standard finalize.
+func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitRepository, refStr string, slot *source.Slot, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
+	tlsCfg, err := f.resolveTLS(repo)
+	if err != nil {
+		return nil, err
+	}
+	mirror, err := f.Mirrors.openOrFetch(ctx, repo.URL, auth, proxy, tlsCfg)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := resolveRefHash(mirror, repo.Reference)
+	if err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s ref %q: %w", repo.Namespace, repo.Name, refStr, err)
+	}
+	if err := materializeTree(mirror, hash, slot.Path); err != nil {
+		return nil, fmt.Errorf("materialize %s at %s: %w", hash, refStr, err)
+	}
+	if repo.Verification != nil {
+		if err := verifySignatures(f.Secrets, repo, mirror, hash); err != nil {
+			return nil, err
+		}
+	}
+	art := &store.SourceArtifact{
+		Kind: manifest.KindGitRepository,
+		URL:  repo.URL, LocalPath: slot.Path, Revision: hash.String(),
+	}
+	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+	}
+	if art.Revision != "" {
+		_ = writeCachedRevision(art.LocalPath, art.Revision)
+	}
+	if err := slot.Commit(); err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
+	}
+	art.LocalPath = slot.Path
+	return art, nil
 }
 
 // cachedRevisionFile holds the resolved commit SHA of a fetched slot.

--- a/pkg/source/git/materialize.go
+++ b/pkg/source/git/materialize.go
@@ -1,0 +1,122 @@
+package git
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// materializeTree walks the tree at hash and writes every blob into
+// root, preserving the on-disk layout the upstream commit produced.
+// Submodule entries are warn-and-skipped: the bare mirror has no
+// nested object stores, so resolving them would require a separate
+// fetch that defeats the point of the mirror cache. Callers that need
+// submodule support fall back to the legacy PlainClone path
+// (Fetcher.fetch decides on Spec.RecurseSubmodules).
+//
+// Symlinks materialize as real OS symlinks rather than being collapsed
+// to text files, so the rendered tree matches what a `git checkout`
+// would produce — important for kustomize bases that follow symlinked
+// component directories.
+func materializeTree(repo *git.Repository, hash plumbing.Hash, root string) error {
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return fmt.Errorf("load commit %s: %w", hash, err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return fmt.Errorf("load tree for %s: %w", hash, err)
+	}
+
+	walker := object.NewTreeWalker(tree, true, nil)
+	defer walker.Close()
+	for {
+		name, entry, werr := walker.Next()
+		if errors.Is(werr, io.EOF) {
+			break
+		}
+		if werr != nil {
+			return fmt.Errorf("walk tree: %w", werr)
+		}
+		if entry.Mode == filemode.Submodule {
+			slog.Warn("git mirror: skipping submodule (mirror path does not recurse)", "path", name)
+			continue
+		}
+		dst := filepath.Join(root, filepath.FromSlash(name))
+		switch entry.Mode {
+		case filemode.Symlink:
+			blob, berr := repo.BlobObject(entry.Hash)
+			if berr != nil {
+				return fmt.Errorf("load symlink blob %s for %q: %w", entry.Hash, name, berr)
+			}
+			target, terr := readBlobBytes(blob)
+			if terr != nil {
+				return fmt.Errorf("read symlink target for %q: %w", name, terr)
+			}
+			if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+				return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+			}
+			if err := os.Symlink(string(target), dst); err != nil {
+				return fmt.Errorf("symlink %s -> %s: %w", dst, target, err)
+			}
+		default:
+			if !entry.Mode.IsFile() {
+				continue
+			}
+			blob, berr := repo.BlobObject(entry.Hash)
+			if berr != nil {
+				return fmt.Errorf("load blob %s for %q: %w", entry.Hash, name, berr)
+			}
+			if err := writeBlobTo(dst, blob, entry.Mode); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// readBlobBytes returns the full contents of a blob. Used for symlink
+// targets which are bounded by PATH_MAX.
+func readBlobBytes(blob *object.Blob) ([]byte, error) {
+	r, err := blob.Reader()
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+// writeBlobTo writes a blob to dst with mode-derived permissions
+// (executable bit preserved from filemode.Executable). Creates the
+// parent dir as needed.
+func writeBlobTo(dst string, blob *object.Blob, mode filemode.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
+	}
+	perm := os.FileMode(0o600)
+	if mode == filemode.Executable {
+		perm = 0o700
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", dst, err)
+	}
+	defer out.Close()
+	r, err := blob.Reader()
+	if err != nil {
+		return fmt.Errorf("blob reader %s: %w", dst, err)
+	}
+	defer r.Close()
+	if _, err := io.Copy(out, r); err != nil {
+		return fmt.Errorf("copy %s: %w", dst, err)
+	}
+	return nil
+}

--- a/pkg/source/git/mirror.go
+++ b/pkg/source/git/mirror.go
@@ -1,0 +1,159 @@
+package git
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// MirrorCache holds one bare clone per unique upstream URL. The mirror
+// is the persistent object store that incremental Fetches update; the
+// per-(URL, ref) cache slots materialize their worktrees from it
+// without re-cloning across runs or across refs of the same repo.
+//
+// Construct via NewMirrorCache; pass to Fetcher.Mirrors. A nil
+// Fetcher.Mirrors disables mirroring — the legacy PlainClone-into-slot
+// path runs unchanged (used by tests and any caller that prefers the
+// older behavior).
+type MirrorCache struct {
+	root string
+
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+// NewMirrorCache constructs a MirrorCache rooted at dir. The directory
+// is created lazily on first openOrFetch.
+func NewMirrorCache(dir string) *MirrorCache {
+	return &MirrorCache{root: dir}
+}
+
+// urlHash returns the stable directory name for url's mirror. The hash
+// keys ONLY on the URL — not on ref or auth — so all refs of one repo
+// share one object store. Two CRs with different SecretRefs targeting
+// the same URL share the mirror; their per-slot worktrees stay isolated
+// via the cache slot's authID (see source.Cache.Slot).
+func urlHash(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return hex.EncodeToString(h[:])[:16]
+}
+
+func (m *MirrorCache) pathFor(url string) string {
+	return filepath.Join(m.root, urlHash(url))
+}
+
+// lockFor returns the per-URL mutex, creating it on first access. Used
+// by openOrFetch to serialize concurrent Fetches against the same
+// mirror — go-git's pack-file writes are not concurrent-safe.
+func (m *MirrorCache) lockFor(url string) *sync.Mutex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.locks == nil {
+		m.locks = make(map[string]*sync.Mutex)
+	}
+	k := urlHash(url)
+	mx, ok := m.locks[k]
+	if !ok {
+		mx = &sync.Mutex{}
+		m.locks[k] = mx
+	}
+	return mx
+}
+
+// openOrFetch returns the bare mirror repo for url, ensuring it carries
+// up-to-date refs. First call for a URL runs a bare clone; subsequent
+// calls incrementally Fetch. Holds the per-URL lock across the network
+// operation so two concurrent callers serialize.
+//
+// auth/proxy/tlsCfg are applied to whichever network operation runs
+// (clone or fetch). For HTTPS with a custom TLS config, the global
+// httpsTransportMu protocol-install dance is repeated to match the
+// non-mirror path's contract.
+func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*git.Repository, error) {
+	lock := m.lockFor(url)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if tlsCfg != nil {
+		httpsTransportMu.Lock()
+		defer httpsTransportMu.Unlock()
+		tr := &http.Transport{TLSClientConfig: tlsCfg}
+		if proxy != nil {
+			pfn, perr := proxy.HTTPProxyFunc()
+			if perr != nil {
+				return nil, perr
+			}
+			tr.Proxy = pfn
+		}
+		client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
+		defer client.InstallProtocol("https", githttp.DefaultClient)
+	}
+
+	path := m.pathFor(url)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return nil, fmt.Errorf("mirror parent: %w", err)
+	}
+
+	repo, openErr := git.PlainOpen(path)
+	if openErr == nil {
+		if err := m.fetchInto(ctx, repo, auth, proxy); err != nil {
+			return nil, err
+		}
+		return repo, nil
+	}
+	if !errors.Is(openErr, git.ErrRepositoryNotExists) {
+		return nil, fmt.Errorf("mirror open %s: %w", path, openErr)
+	}
+
+	cloneOpts := &git.CloneOptions{URL: url, Auth: auth}
+	if proxy != nil {
+		cloneOpts.ProxyOptions = transport.ProxyOptions{
+			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
+		}
+	}
+	repo, err := git.PlainCloneContext(ctx, path, true, cloneOpts) // bare = true
+	if err != nil {
+		// Leave nothing partial behind so the next attempt re-clones
+		// from scratch rather than tripping over a half-written mirror.
+		_ = os.RemoveAll(path)
+		return nil, fmt.Errorf("mirror clone %s: %w", url, err)
+	}
+	return repo, nil
+}
+
+// fetchInto runs an incremental Fetch against the mirror's remote with
+// the mirror refspec — every branch and tag updates in place. Treats
+// NoErrAlreadyUpToDate as a clean noop.
+func (m *MirrorCache) fetchInto(ctx context.Context, repo *git.Repository, auth transport.AuthMethod, proxy *source.ProxyConfig) error {
+	opts := &git.FetchOptions{
+		Auth: auth,
+		RefSpecs: []config.RefSpec{
+			"+refs/heads/*:refs/heads/*",
+			"+refs/tags/*:refs/tags/*",
+		},
+	}
+	if proxy != nil {
+		opts.ProxyOptions = transport.ProxyOptions{
+			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
+		}
+	}
+	if err := repo.FetchContext(ctx, opts); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+		return fmt.Errorf("mirror fetch: %w", err)
+	}
+	return nil
+}

--- a/pkg/source/git/mirror_test.go
+++ b/pkg/source/git/mirror_test.go
@@ -1,0 +1,140 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// TestMirror_BareClonePersistsAcrossFetches confirms that a Fetcher
+// with Mirrors set creates the bare mirror once and reuses it on the
+// second fetch — the per-URL mirror dir is present after run 1 and
+// still present after run 2, while the slot worktree is materialized
+// each time (the slot lives at a different path than the mirror).
+func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+
+	cacheDir := t.TempDir()
+	mirrorDir := filepath.Join(cacheDir, "git-mirrors")
+
+	cache := source.NewCache(cacheDir)
+	repo := &manifest.GitRepository{
+		Name: "t", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+	}
+	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(mirrorDir)}
+
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch 1: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "hello.txt")); err != nil {
+		t.Errorf("worktree missing hello.txt: %v", err)
+	}
+
+	// The mirror directory must exist after the first fetch.
+	entries, err := os.ReadDir(mirrorDir)
+	if err != nil {
+		t.Fatalf("mirror dir missing: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected one mirror dir, got %d: %v", len(entries), entries)
+	}
+
+	// Second fetch reuses the slot AND the mirror.
+	art2, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch 2: %v", err)
+	}
+	if art2.LocalPath != art.LocalPath {
+		t.Errorf("slot path drifted: %s vs %s", art.LocalPath, art2.LocalPath)
+	}
+	entries2, _ := os.ReadDir(mirrorDir)
+	if len(entries2) != 1 {
+		t.Errorf("mirror dir count drifted: %d → %d", len(entries), len(entries2))
+	}
+}
+
+// TestMirror_FallsBackForSubmodules confirms that RecurseSubmodules=true
+// disables the mirror path so go-git's submodule support still works.
+// We don't actually wire up a submodule repo — we only assert the
+// branch decision via canUseMirror.
+func TestMirror_FallsBackForSubmodules(t *testing.T) {
+	f := &Fetcher{Mirrors: NewMirrorCache(t.TempDir())}
+	repo := &manifest.GitRepository{
+		Name: "t", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL: "https://example.com/x", RecurseSubmodules: true,
+		},
+	}
+	if f.canUseMirror(repo, "https://example.com/x") {
+		t.Error("RecurseSubmodules should disable the mirror path")
+	}
+	repo.RecurseSubmodules = false
+	repo.SparseCheckout = []string{"sub/"}
+	if f.canUseMirror(repo, "https://example.com/x") {
+		t.Error("SparseCheckout should disable the mirror path")
+	}
+	repo.SparseCheckout = nil
+	if !f.canUseMirror(repo, "https://example.com/x") {
+		t.Error("vanilla fetch should be mirror-eligible")
+	}
+
+	// Nil Mirrors → legacy.
+	f2 := &Fetcher{}
+	if f2.canUseMirror(repo, "https://example.com/x") {
+		t.Error("nil Mirrors should disable the mirror path")
+	}
+}
+
+// TestMirror_TagResolvesAcrossRefs covers the cross-ref reuse the
+// mirror enables: a single bare clone covers both the main branch and
+// a tag, and fetching each materializes the right commit.
+func TestMirror_TagResolvesAcrossRefs(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+	tagged := mustTagHEAD(t, src, "v1.0.0")
+
+	cacheDir := t.TempDir()
+	cache := source.NewCache(cacheDir)
+	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(filepath.Join(cacheDir, "git-mirrors"))}
+
+	// First: fetch a tag.
+	tagRepo := &manifest.GitRepository{
+		Name: "t", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
+		},
+	}
+	art, err := f.Fetch(context.Background(), tagRepo)
+	if err != nil {
+		t.Fatalf("Fetch tag: %v", err)
+	}
+	if art.Revision != tagged {
+		t.Errorf("tag revision = %q, want %q", art.Revision, tagged)
+	}
+
+	// Second: fetch HEAD (same commit but different ref path).
+	headRepo := &manifest.GitRepository{
+		Name: "u", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+	}
+	art2, err := f.Fetch(context.Background(), headRepo)
+	if err != nil {
+		t.Fatalf("Fetch HEAD: %v", err)
+	}
+	if art2.Revision != tagged {
+		t.Errorf("HEAD revision = %q, want %q", art2.Revision, tagged)
+	}
+	if art.LocalPath == art2.LocalPath {
+		t.Error("different refs should land in different slots")
+	}
+}

--- a/pkg/source/git/resolve.go
+++ b/pkg/source/git/resolve.go
@@ -1,0 +1,127 @@
+package git
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// resolveRefHash translates a Flux GitRepositoryRef into a concrete
+// commit hash within repo (a bare mirror). Ordering matches upstream
+// source-controller:
+//
+//   - explicit Commit always wins
+//   - SemVer picks the highest tag satisfying the constraint
+//   - Tag resolves by name (annotated or lightweight)
+//   - Branch resolves by name
+//   - empty/missing → HEAD (the mirror's default branch)
+//
+// Returns a wrapped error if no match exists; the caller surfaces it
+// to the user with the originating CR's identity.
+func resolveRefHash(repo *git.Repository, ref *manifest.GitRepositoryRef) (plumbing.Hash, error) {
+	if ref == nil {
+		return resolveHEAD(repo)
+	}
+	switch {
+	case ref.Commit != "":
+		return plumbing.NewHash(ref.Commit), nil
+	case ref.SemVer != "":
+		return resolveSemver(repo, ref.SemVer)
+	case ref.Tag != "":
+		return resolveTagOrBranch(repo, ref.Tag, true)
+	case ref.Branch != "":
+		return resolveTagOrBranch(repo, ref.Branch, false)
+	}
+	return resolveHEAD(repo)
+}
+
+func resolveHEAD(repo *git.Repository) (plumbing.Hash, error) {
+	head, err := repo.Head()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("resolve HEAD: %w", err)
+	}
+	return head.Hash(), nil
+}
+
+// resolveTagOrBranch tries tag-first then branch-first depending on
+// preferTag. Annotated tags are dereferenced via TagObject when
+// present; lightweight tags resolve directly.
+func resolveTagOrBranch(repo *git.Repository, name string, preferTag bool) (plumbing.Hash, error) {
+	if preferTag {
+		if h, ok := lookupTag(repo, name); ok {
+			return h, nil
+		}
+		if h, ok := lookupBranch(repo, name); ok {
+			return h, nil
+		}
+		return plumbing.ZeroHash, fmt.Errorf("tag %q not found in mirror", name)
+	}
+	if h, ok := lookupBranch(repo, name); ok {
+		return h, nil
+	}
+	if h, ok := lookupTag(repo, name); ok {
+		return h, nil
+	}
+	return plumbing.ZeroHash, fmt.Errorf("branch %q not found in mirror", name)
+}
+
+func lookupTag(repo *git.Repository, name string) (plumbing.Hash, bool) {
+	tag, err := repo.Tag(name)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	// Annotated tags point at a tag object whose Target is the commit.
+	if obj, oerr := repo.TagObject(tag.Hash()); oerr == nil {
+		return obj.Target, true
+	}
+	return tag.Hash(), true
+}
+
+func lookupBranch(repo *git.Repository, name string) (plumbing.Hash, bool) {
+	r, err := repo.Reference(plumbing.NewBranchReferenceName(name), true)
+	if err != nil {
+		return plumbing.ZeroHash, false
+	}
+	return r.Hash(), true
+}
+
+// resolveSemver picks the highest tag in repo satisfying expr.
+func resolveSemver(repo *git.Repository, expr string) (plumbing.Hash, error) {
+	constraint, err := semver.NewConstraint(expr)
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("parse semver %q: %w", expr, err)
+	}
+	tags, err := repo.Tags()
+	if err != nil {
+		return plumbing.ZeroHash, fmt.Errorf("list tags: %w", err)
+	}
+	var best *semver.Version
+	var bestHash plumbing.Hash
+	if err := tags.ForEach(func(ref *plumbing.Reference) error {
+		name := ref.Name().Short()
+		v, verr := semver.NewVersion(name)
+		if verr != nil {
+			return nil
+		}
+		if !constraint.Check(v) {
+			return nil
+		}
+		if best == nil || v.GreaterThan(best) {
+			best = v
+			if h, ok := lookupTag(repo, name); ok {
+				bestHash = h
+			}
+		}
+		return nil
+	}); err != nil {
+		return plumbing.ZeroHash, err
+	}
+	if best == nil {
+		return plumbing.ZeroHash, fmt.Errorf("no tag satisfies semver %q", expr)
+	}
+	return bestHash, nil
+}


### PR DESCRIPTION
## Arc #3 of cache redesign — biggest perf win in the series

GitRepository fetches now flow through a per-URL bare mirror. First fetch clones `--bare` into `<root>/git-mirrors/<urlhash>/`; subsequent fetches against the same URL run incremental `git fetch` (refs/heads + refs/tags). Per-`(URL, ref, authID)` cache slots are materialized by **walking the commit tree directly out of the mirror** — no second clone, no `.git/` in the slot, no full re-clone when only the ref changed.

## Wins
- Multi-GB monorepos clone once per URL, ever
- A repo with `main` + `v1.0.0` + `v1.1.0` stored as three slots shares one object store; three light-weight tree walks
- `file://`, `https`, `ssh` all mirror-eligible

## Fallback path (legacy PlainClone-into-slot) retained for:
- `RecurseSubmodules` — bare mirror has no nested object stores; the separate fetch the submodule API issues would defeat the cache
- `SparseCheckout` — needs a real worktree go-git can pattern against
- `Fetcher.Mirrors == nil` — tests + embedders that prefer the older path

## PGP verification
Runs against the mirror — same code path; the mirror has every commit object the verifier needs.

## Tests
- bare clone persists across fetches; second fetch reuses the mirror dir
- RecurseSubmodules / SparseCheckout / nil Mirrors all disable the mirror path
- tag + HEAD of the same repo share the mirror; their slots are distinct

## Stack
Builds on **#377** (auth-in-key) which builds on **#376** (XDG root). Merge in that order or this PR rebases trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)