### PR TITLE
feat(baseline): content-addressed slot at <cache>/baselines/<sha>/

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -22,19 +23,26 @@ import (
 )
 
 type commonFlags struct {
-	path               string
-	pathOrig           string
-	base               string
-	namespace          string
-	labels             map[string]string
-	skipCRDs           bool
-	skipSecrets        bool
+	path                string
+	pathOrig            string
+	base                string
+	namespace           string
+	labels              map[string]string
+	skipCRDs            bool
+	skipSecrets         bool
 	allowMissingSecrets bool
-	skipKinds          []string
-	output             string
-	enableOCI          bool
-	registryConfig     string
-	concurrency        int
+	skipKinds           []string
+	output              string
+	enableOCI           bool
+	registryConfig      string
+	concurrency         int
+	// cacheDir is resolved lazily (and only when needed) via
+	// resolveCacheRoot — it points at the shared cache root used by
+	// both the orchestrator's source/helm caches and the baseline's
+	// content-addressed slots. Surfaced as a field (not just a
+	// function) so the value remains stable across multiple lookups
+	// within one command invocation.
+	cacheDir string
 }
 
 func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
@@ -238,26 +246,49 @@ func resolveBaseline(_ context.Context, c *commonFlags, autoFallback bool) (func
 		// default).
 		return noop, nil
 	}
-	res, err := baseline.AutoResolve(c.path, c.base)
+	res, err := baseline.AutoResolve(c.path, c.base, c.resolveCacheRoot())
 	if err != nil {
 		return noop, err
 	}
 	c.pathOrig = res.PathOrig
-	slog.Debug("baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig)
+	slog.Debug("baseline", "source", res.Source, "rev", res.Rev, "pathOrig", res.PathOrig, "persistent", res.Persistent)
+	if res.Persistent {
+		return noop, nil
+	}
 	return func() { _ = os.RemoveAll(res.TempDir) }, nil
 }
 
 func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	return orchestrator.Config{
-		Path:               c.path,
-		PathOrig:           c.pathOrig,
-		HelmOptions:        c.helmOptions(h),
-		WipeSecrets:        true,
-		EnableOCI:          c.enableOCI,
-		RegistryConfig:     c.registryConfig,
-		Concurrency:        c.concurrency,
+		Path:                c.path,
+		PathOrig:            c.pathOrig,
+		HelmOptions:         c.helmOptions(h),
+		WipeSecrets:         true,
+		EnableOCI:           c.enableOCI,
+		RegistryConfig:      c.registryConfig,
+		Concurrency:         c.concurrency,
 		AllowMissingSecrets: c.allowMissingSecrets,
+		CacheDir:            c.resolveCacheRoot(),
 	}
+}
+
+// resolveCacheRoot picks the on-disk cache root used by every persistent
+// cache (orchestrator sources, baseline slots, helm tarballs). Lazy and
+// cached on commonFlags so multiple lookups within one invocation
+// return the same value. Prefers the OS user cache dir
+// ($XDG_CACHE_HOME on Linux, ~/Library/Caches on macOS,
+// %LocalAppData% on Windows) with a "flate" subdir; falls back to
+// $TMPDIR/flate-cache when UserCacheDir errors.
+func (c *commonFlags) resolveCacheRoot() string {
+	if c.cacheDir != "" {
+		return c.cacheDir
+	}
+	if d, err := os.UserCacheDir(); err == nil && d != "" {
+		c.cacheDir = filepath.Join(d, "flate")
+	} else {
+		c.cacheDir = filepath.Join(os.TempDir(), "flate-cache")
+	}
+	return c.cacheDir
 }
 
 func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, *orchestrator.Result, error) {

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -20,9 +20,17 @@ type Result struct {
 	// --path-orig: <TempDir>/<rel> where rel is the user's --path
 	// relative to the git repo root.
 	PathOrig string
-	// TempDir is the root of the materialized tree. Caller is
-	// responsible for os.RemoveAll once the diff is done.
+	// TempDir is the root of the materialized tree. When Persistent
+	// is false, caller is responsible for os.RemoveAll once the diff
+	// is done. When Persistent is true, the directory lives under the
+	// cache root and is meant to be reused across runs — caller MUST
+	// NOT remove it.
 	TempDir string
+	// Persistent reports whether TempDir lives under a content-
+	// addressed cache root (and so survives across runs) or is a
+	// disposable MkdirTemp directory (legacy behavior). Callers wire
+	// cleanup conditionally on this flag.
+	Persistent bool
 	// Rev is the resolved short SHA of the baseline commit, for
 	// logging and error context.
 	Rev string
@@ -39,16 +47,21 @@ type resolution struct {
 	Source string
 }
 
-// AutoResolve picks a baseline for path, materializes it to a tempdir,
-// and returns a Result with the synthetic --path-orig already mapped
-// into the baseline tree's coordinate system. When base is non-empty
-// it is the explicit --base=<rev> override; otherwise the
-// auto-detection ladder runs.
+// AutoResolve picks a baseline for path, materializes it, and returns
+// a Result with the synthetic --path-orig already mapped into the
+// baseline tree's coordinate system. When base is non-empty it is the
+// explicit --base=<rev> override; otherwise the auto-detection ladder
+// runs.
 //
-// Caller must os.RemoveAll Result.TempDir when the diff is done.
+// cacheRoot enables content-addressed reuse: when non-empty the
+// baseline lands at <cacheRoot>/baselines/<commit-sha>/ and Result is
+// marked Persistent — subsequent runs against the same commit skip
+// materialization entirely. When cacheRoot is "" the legacy
+// MkdirTemp path runs and the caller is responsible for cleanup.
+//
 // Errors carry the suggested next flag so the user knows whether to
 // pass --base=<rev> or --path-orig=<dir>.
-func AutoResolve(path, base string) (*Result, error) {
+func AutoResolve(path, base, cacheRoot string) (*Result, error) {
 	repo, repoRoot, err := openRepo(path)
 	if err != nil {
 		return nil, err
@@ -62,13 +75,76 @@ func AutoResolve(path, base string) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	dir, persistent, err := materializeAt(repo, r.Hash, cacheRoot)
+	if err != nil {
+		return nil, err
+	}
+	pathOrig, err = mapToTempDir(repoRoot, dir, path)
+	if err != nil {
+		if !persistent {
+			_ = os.RemoveAll(dir)
+		}
+		return nil, err
+	}
+	return &Result{
+		PathOrig:   pathOrig,
+		TempDir:    dir,
+		Persistent: persistent,
+		Rev:        shortRev(r.Hash),
+		Source:     r.Source,
+	}, nil
+}
+
+// materializeAt produces the baseline tree on disk for hash and
+// returns (dir, persistent, err). When cacheRoot is non-empty the
+// directory lives at <cacheRoot>/baselines/<hash>/ and is reused
+// across runs; otherwise an MkdirTemp directory is allocated.
+func materializeAt(repo *git.Repository, hash plumbing.Hash, cacheRoot string) (string, bool, error) {
+	if cacheRoot != "" {
+		slot := filepath.Join(cacheRoot, "baselines", hash.String())
+		if info, err := os.Stat(slot); err == nil && info.IsDir() {
+			return slot, true, nil
+		}
+		if err := os.MkdirAll(filepath.Dir(slot), 0o750); err != nil {
+			return "", false, fmt.Errorf("baseline cache parent: %w", err)
+		}
+		// Stage in a sibling temp dir on the same filesystem so the
+		// finalize is an atomic rename — concurrent diffs against the
+		// same commit will either share the finished slot or fall
+		// through to their own stage (one wins the rename, the rest
+		// see ErrExist and clean up).
+		staging, err := os.MkdirTemp(filepath.Dir(slot), filepath.Base(slot)+".tmp.*")
+		if err != nil {
+			return "", false, fmt.Errorf("baseline staging: %w", err)
+		}
+		if err := materialize(repo, hash, staging); err != nil {
+			_ = os.RemoveAll(staging)
+			return "", false, err
+		}
+		if err := os.Mkdir(filepath.Join(staging, ".git"), 0o700); err != nil {
+			_ = os.RemoveAll(staging)
+			return "", false, fmt.Errorf("baseline .git marker: %w", err)
+		}
+		if err := os.Rename(staging, slot); err != nil {
+			_ = os.RemoveAll(staging)
+			// A racing diff may have finalized first; if the slot now
+			// exists we can adopt it without re-materializing.
+			if info, statErr := os.Stat(slot); statErr == nil && info.IsDir() {
+				return slot, true, nil
+			}
+			return "", false, fmt.Errorf("baseline finalize: %w", err)
+		}
+		return slot, true, nil
+	}
+
 	tmp, err := os.MkdirTemp("", "flate-baseline-*")
 	if err != nil {
-		return nil, fmt.Errorf("baseline tempdir: %w", err)
+		return "", false, fmt.Errorf("baseline tempdir: %w", err)
 	}
-	if err := materialize(repo, r.Hash, tmp); err != nil {
+	if err := materialize(repo, hash, tmp); err != nil {
 		_ = os.RemoveAll(tmp)
-		return nil, err
+		return "", false, err
 	}
 	// Drop a .git marker so discovery.FindRepoRoot (called by
 	// orchestrator.buildChangeFilter's repo-root widening, PR #348)
@@ -78,19 +154,9 @@ func AutoResolve(path, base string) (*Result, error) {
 	// short-circuits.
 	if err := os.Mkdir(filepath.Join(tmp, ".git"), 0o700); err != nil {
 		_ = os.RemoveAll(tmp)
-		return nil, fmt.Errorf("baseline .git marker: %w", err)
+		return "", false, fmt.Errorf("baseline .git marker: %w", err)
 	}
-	pathOrig, err = mapToTempDir(repoRoot, tmp, path)
-	if err != nil {
-		_ = os.RemoveAll(tmp)
-		return nil, err
-	}
-	return &Result{
-		PathOrig: pathOrig,
-		TempDir:  tmp,
-		Rev:      shortRev(r.Hash),
-		Source:   r.Source,
-	}, nil
+	return tmp, false, nil
 }
 
 // mapToTempDir mirrors path's relative location under repoRoot into

--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -21,7 +21,7 @@ func TestAutoResolve_ExplicitBase(t *testing.T) {
 	commitA := initRepoWithFile(t, dir, "a.yaml", "original")
 	commitB := writeAndCommit(t, dir, "a.yaml", "updated")
 
-	res, err := AutoResolve(dir, commitA.String())
+	res, err := AutoResolve(dir, commitA.String(), "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -60,7 +60,7 @@ func TestAutoResolve_UpstreamMergeBase(t *testing.T) {
 	// Move forward on the local branch.
 	writeAndCommit(t, dir, "a.yaml", "diverged")
 
-	res, err := AutoResolve(dir, "")
+	res, err := AutoResolve(dir, "", "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestAutoResolve_OriginHEAD(t *testing.T) {
 
 	writeAndCommit(t, dir, "a.yaml", "new")
 
-	res, err := AutoResolve(dir, "")
+	res, err := AutoResolve(dir, "", "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestAutoResolve_OriginMainFallback(t *testing.T) {
 
 	writeAndCommit(t, dir, "a.yaml", "new")
 
-	res, err := AutoResolve(dir, "")
+	res, err := AutoResolve(dir, "", "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestAutoResolve_DetachedHEAD(t *testing.T) {
 		t.Fatalf("detach HEAD: %v", err)
 	}
 
-	res, err := AutoResolve(dir, "")
+	res, err := AutoResolve(dir, "", "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestAutoResolve_NoGit(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err := AutoResolve(dir, "")
+	_, err := AutoResolve(dir, "", "")
 	if err == nil {
 		t.Fatal("expected error for non-git path")
 	}
@@ -179,7 +179,7 @@ func TestAutoResolve_Shallow(t *testing.T) {
 	}
 	// No upstream, no origin refs → the resolution ladder falls
 	// through; the shallow detection fires last.
-	_, err := AutoResolve(dir, "")
+	_, err := AutoResolve(dir, "", "")
 	if err == nil {
 		t.Fatal("expected shallow error")
 	}
@@ -196,7 +196,7 @@ func TestAutoResolve_Shallow(t *testing.T) {
 func TestAutoResolve_NoUpstream(t *testing.T) {
 	dir := t.TempDir()
 	initRepoWithFile(t, dir, "a.yaml", "x")
-	_, err := AutoResolve(dir, "")
+	_, err := AutoResolve(dir, "", "")
 	if err == nil {
 		t.Fatal("expected no-upstream error")
 	}
@@ -223,7 +223,7 @@ func TestAutoResolve_PathOutsideRepo(t *testing.T) {
 	if err := os.Mkdir(sibling, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	_, err := AutoResolve(sibling, "")
+	_, err := AutoResolve(sibling, "", "")
 	if err == nil {
 		t.Fatal("expected error for path outside repo")
 	}
@@ -239,7 +239,7 @@ func TestAutoResolve_PathOrigMappedToSubdir(t *testing.T) {
 	commit := writeAndCommit(t, dir, "kubernetes/flux/cluster/cluster.yaml", "y")
 
 	clusterDir := filepath.Join(dir, "kubernetes", "flux", "cluster")
-	res, err := AutoResolve(clusterDir, commit.String())
+	res, err := AutoResolve(clusterDir, commit.String(), "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestAutoResolve_DropsGitMarker(t *testing.T) {
 	dir := t.TempDir()
 	initRepoWithFile(t, dir, "a.yaml", "x")
 	commit := writeAndCommit(t, dir, "a.yaml", "y")
-	res, err := AutoResolve(dir, commit.String())
+	res, err := AutoResolve(dir, commit.String(), "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -275,6 +275,68 @@ func TestAutoResolve_DropsGitMarker(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Errorf(".git marker should be a directory")
+	}
+}
+
+// TestAutoResolve_CachedReusesSlot: when cacheRoot is non-empty, the
+// baseline lands at <cacheRoot>/baselines/<sha>/. A second AutoResolve
+// against the same commit returns Persistent=true with the same dir
+// and skips re-materialization. Removing a file from the materialized
+// tree before the second call would normally be a no-op since we don't
+// re-walk — locking that contract here.
+func TestAutoResolve_CachedReusesSlot(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "a.yaml", "x")
+	commit := writeAndCommit(t, dir, "a.yaml", "y")
+	cacheRoot := t.TempDir()
+
+	res1, err := AutoResolve(dir, commit.String(), cacheRoot)
+	if err != nil {
+		t.Fatalf("AutoResolve 1: %v", err)
+	}
+	if !res1.Persistent {
+		t.Error("cached AutoResolve should report Persistent=true")
+	}
+	want := filepath.Join(cacheRoot, "baselines", commit.String())
+	if res1.TempDir != want {
+		t.Errorf("TempDir = %q, want %q", res1.TempDir, want)
+	}
+	// Stamp a sentinel so we can prove run 2 didn't re-materialize
+	// (which would replace the stamp).
+	sentinel := filepath.Join(res1.TempDir, ".flate-test-stamp")
+	if err := os.WriteFile(sentinel, []byte("kept"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res2, err := AutoResolve(dir, commit.String(), cacheRoot)
+	if err != nil {
+		t.Fatalf("AutoResolve 2: %v", err)
+	}
+	if res2.TempDir != res1.TempDir {
+		t.Errorf("second call drifted: %q vs %q", res2.TempDir, res1.TempDir)
+	}
+	if got, _ := os.ReadFile(sentinel); string(got) != "kept" { //nolint:gosec // sentinel built under t.TempDir
+		t.Errorf("second call re-materialized; sentinel = %q", got)
+	}
+}
+
+// TestAutoResolve_NoCacheRootIsTempdir confirms the legacy path still
+// works: empty cacheRoot → MkdirTemp directory, Persistent=false.
+func TestAutoResolve_NoCacheRootIsTempdir(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "a.yaml", "x")
+	commit := writeAndCommit(t, dir, "a.yaml", "y")
+
+	res, err := AutoResolve(dir, commit.String(), "")
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if res.Persistent {
+		t.Error("uncached AutoResolve should report Persistent=false")
+	}
+	if !strings.HasPrefix(filepath.Base(res.TempDir), "flate-baseline-") {
+		t.Errorf("uncached TempDir = %q, want flate-baseline-* basename", res.TempDir)
 	}
 }
 
@@ -305,7 +367,7 @@ func TestMaterialize_PreservesExecutableBit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := AutoResolve(dir, commit.String())
+	res, err := AutoResolve(dir, commit.String(), "")
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}


### PR DESCRIPTION
## Arc #4 of cache redesign

`flate diff` no longer re-materializes the baseline tree on every invocation. `AutoResolve` takes a `cacheRoot`; when set, the baseline lands at `<cacheRoot>/baselines/<commit-sha>/` via an atomic staging→rename and `Result.Persistent` flips true. Subsequent diffs against the same baseline commit stat the slot and return immediately — a multi-hundred-MB tree walk becomes a no-op.

## Cleanup
The legacy MkdirTemp path runs when `cacheRoot` is `""` so callers that don't want the persistent cache (tests, embedders) keep working. `Result.Persistent` tells the CLI cleanup to skip `RemoveAll` when the slot is part of the cache.

## CLI wiring
`resolveCacheRoot()` on `commonFlags` picks the cache root via `os.UserCacheDir` (with tempdir fallback). The same value flows into both `baseline.AutoResolve` AND `orchestrator.Config.CacheDir` so the two systems share one on-disk root. Once #376 (XDG) lands the orchestrator's internal `defaultCacheRoot` becomes redundant — the CLI's value already takes precedence via `Config.CacheDir`.

## Tests
- `TestAutoResolve_CachedReusesSlot`: second call returns the same slot without re-materializing (sentinel survives)
- `TestAutoResolve_NoCacheRootIsTempdir`: legacy path still gives `flate-baseline-*`

## Stack
Builds on **#378** (git bare-mirror) → **#377** (auth-in-key) → **#376** (XDG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)