### PR TITLE
feat(helm): in-process HelmRepository index cache

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -82,6 +82,20 @@ type Client struct {
 	chartMu        sync.Mutex
 	chartCache     map[string]chartCacheEntry
 	chartLoadLocks *keylock.KeyMap[string]
+
+	// indexCache holds parsed HelmRepository index.yaml documents for
+	// the lifetime of this Client. The same Client serves every
+	// HelmRelease in one orchestrator run, so N HRs pointing at the
+	// same HelmRepository now share a single index fetch instead of
+	// re-downloading it N times. Keyed by `<ns>/<name>@<indexURL>`
+	// so two HelmRepository CRs that happen to share a URL still get
+	// distinct entries (their auth contexts may differ, and a private
+	// feed can serve different bytes per credential set).
+	//
+	// In-process only — there is no on-disk index cache yet; cross-
+	// run reuse with etag/If-Modified-Since is a future layer.
+	indexCache sync.Map // map[string]*repo.IndexFile
+	indexLocks *keylock.KeyMap[string]
 }
 
 // chartCacheEntry pairs the parsed chart with the (mtime, size) of
@@ -115,6 +129,7 @@ func NewClient(tmpDir, cacheDir string) (*Client, error) {
 		registry:       reg,
 		chartCache:     map[string]chartCacheEntry{},
 		chartLoadLocks: keylock.New[string](),
+		indexLocks:     keylock.New[string](),
 	}, nil
 }
 

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -185,7 +185,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	allOpts := append(authOpts, tlsOpts...)
 
 	indexURL := strings.TrimSuffix(r.URL, "/") + "/index.yaml"
-	idx, err := c.fetchIndex(indexURL, allOpts)
+	idx, err := c.fetchIndex(ctx, r.Namespace+"/"+r.Name+"@"+indexURL, indexURL, allOpts)
 	if err != nil {
 		return "", err
 	}
@@ -239,8 +239,30 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 // helmRepoAuthOptions / helmRepoTLSOptions live in auth.go (paired
 // with auth_test.go).
 
-// fetchIndex downloads and parses a HelmRepository index.yaml.
-func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexFile, error) {
+// fetchIndex returns the parsed index.yaml for a HelmRepository. The
+// parsed *repo.IndexFile is memoized on Client.indexCache for the
+// process lifetime, keyed by `<ns>/<name>@<indexURL>`. N concurrent
+// HelmReleases pointing at the same repo coalesce on indexLocks so
+// exactly one HTTP fetch runs and the rest hit the populated cache.
+//
+// cacheKey is derived by the caller (locateHelmRepoChart) so the
+// cache distinguishes two HelmRepository CRs that share a URL but
+// may carry different auth contexts. The HTTP fetch itself uses opts
+// (auth, TLS) the caller resolved against the CR's SecretRef.
+func (c *Client) fetchIndex(ctx context.Context, cacheKey, indexURL string, opts []getter.Option) (*repo.IndexFile, error) {
+	if v, ok := c.indexCache.Load(cacheKey); ok {
+		return v.(*repo.IndexFile), nil
+	}
+	release, err := c.indexLocks.Acquire(ctx, cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	// Re-check after acquiring the lock: a sibling that beat us into
+	// the critical section populated the entry while we waited.
+	if v, ok := c.indexCache.Load(cacheKey); ok {
+		return v.(*repo.IndexFile), nil
+	}
 	g, err := getter.NewHTTPGetter()
 	if err != nil {
 		return nil, err
@@ -266,6 +288,7 @@ func (c *Client) fetchIndex(indexURL string, opts []getter.Option) (*repo.IndexF
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", indexURL, err)
 	}
+	c.indexCache.Store(cacheKey, idx)
 	return idx, nil
 }
 

--- a/pkg/helm/repo_test.go
+++ b/pkg/helm/repo_test.go
@@ -1,6 +1,88 @@
 package helm
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"helm.sh/helm/v4/pkg/getter"
+)
+
+const indexYAMLFixture = `apiVersion: v1
+entries:
+  app-template:
+    - name: app-template
+      version: 5.0.0
+      urls:
+        - app-template-5.0.0.tgz
+`
+
+// TestFetchIndex_CachesAcrossCalls confirms that the index.yaml is
+// downloaded once across N calls with the same cache key. Two HRs
+// pointing at the same HelmRepository previously each downloaded
+// the full index — now the second call hits the in-memory cache.
+func TestFetchIndex_CachesAcrossCalls(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(indexYAMLFixture))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	url := srv.URL + "/index.yaml"
+	key := "default/test-repo@" + url
+
+	idx1, err := c.fetchIndex(context.Background(), key, url, []getter.Option{})
+	if err != nil {
+		t.Fatalf("fetchIndex 1: %v", err)
+	}
+	idx2, err := c.fetchIndex(context.Background(), key, url, []getter.Option{})
+	if err != nil {
+		t.Fatalf("fetchIndex 2: %v", err)
+	}
+	if idx1 != idx2 {
+		t.Errorf("expected same *IndexFile pointer on cache hit; got distinct")
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 HTTP fetch, got %d", got)
+	}
+}
+
+// TestFetchIndex_DistinctKeysFetchSeparately: two HelmRepository CRs
+// with different (ns, name) keys are kept separate even if they
+// happen to point at the same URL — the cache is keyed by CR
+// identity so private feeds with different credentials don't share
+// a cached index that was fetched under another auth context.
+func TestFetchIndex_DistinctKeysFetchSeparately(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(indexYAMLFixture))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	url := srv.URL + "/index.yaml"
+	if _, err := c.fetchIndex(context.Background(), "team-a/repo@"+url, url, nil); err != nil {
+		t.Fatalf("fetchIndex A: %v", err)
+	}
+	if _, err := c.fetchIndex(context.Background(), "team-b/repo@"+url, url, nil); err != nil {
+		t.Fatalf("fetchIndex B: %v", err)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Errorf("expected 2 HTTP fetches (one per CR identity), got %d", got)
+	}
+}
 
 func TestOCIPullRef(t *testing.T) {
 	const repo = "oci://ghcr.io/bjw-s-labs/helm/app-template"


### PR DESCRIPTION
## Arc #5 of cache redesign

`fetchIndex` previously downloaded and re-parsed `index.yaml` on every HelmRelease render — N HRs against one repo paid N round trips. The parsed `*repo.IndexFile` now memoizes on `Client.indexCache` for the process lifetime, keyed by `<ns>/<name>@<indexURL>`. N concurrent HRs coalesce on `indexLocks` (per-key keylock) so exactly one HTTP fetch runs and the rest hit the populated cache.

## Cache key
Includes the HelmRepository's `(namespace, name)` — two CRs sharing a URL but bound to different SecretRefs may receive different index bytes from a private feed, so their cached entries stay isolated. Mirrors the same correctness fix as arc #2 (auth-in-key) for the source cache.

## What's NOT in this PR
Cross-run reuse with `etag` / `If-Modified-Since` is a future layer — the helm getter doesn't expose response headers, so the on-disk variant needs a custom HTTP transport. The in-process win already eliminates the dominant cost: a single `flate build` with 50 HRs against one repo drops from 50 index downloads to one.

## Tests
- `TestFetchIndex_CachesAcrossCalls` — second call returns same pointer; only 1 HTTP hit
- `TestFetchIndex_DistinctKeysFetchSeparately` — same URL with different CR identity → 2 fetches

## Stack
Builds on **#379** (baseline) → **#378** (git mirror) → **#377** (auth-in-key) → **#376** (XDG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)