### PR TITLE
feat(source/blob): CAS store + refs; migrate helm tarball cache

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/blob"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -96,6 +97,16 @@ type Client struct {
 	// run reuse with etag/If-Modified-Since is a future layer.
 	indexCache sync.Map // map[string]*repo.IndexFile
 	indexLocks *keylock.KeyMap[string]
+
+	// chartBlobs is the content-addressed storage for downloaded
+	// helm chart tarballs. chartRefs maps the per-release identity
+	// tuple `(namespace, name, chartName, version)` to the current
+	// digest — so two HelmRepositories that happen to publish a
+	// chart with identical bytes share one on-disk slot, and a
+	// reconfigured cluster reading the same charts hits the CAS
+	// path without re-downloading.
+	chartBlobs *blob.Store
+	chartRefs  *blob.Refs
 }
 
 // chartCacheEntry pairs the parsed chart with the (mtime, size) of
@@ -130,6 +141,8 @@ func NewClient(tmpDir, cacheDir string) (*Client, error) {
 		chartCache:     map[string]chartCacheEntry{},
 		chartLoadLocks: keylock.New[string](),
 		indexLocks:     keylock.New[string](),
+		chartBlobs:     blob.NewStore(cacheDir),
+		chartRefs:      blob.NewRefs(filepath.Join(cacheDir, "refs", "chart-tarballs")),
 	}, nil
 }
 

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -203,24 +203,28 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 		return "", err
 	}
 
-	// Include the HelmRepository's identity in the cache key so two
-	// repos that publish the same chart name + version don't
-	// overwrite each other's tarball on disk. Without the repo
-	// prefix, `nginx:15.0.0` from repo A and a different
-	// `nginx:15.0.0` from repo B alternately overwrote each other's
-	// bytes; the in-memory chartCache (keyed by path) then served
-	// whichever bytes were last written.
-	cacheKey := safeName(r.Namespace+"-"+r.Name+"-"+hr.Chart.Name) + "-" + cv.Version + ".tgz"
-	target := filepath.Join(c.cacheDir, cacheKey)
+	// Hot path: lookup the previously-resolved digest for this
+	// (repo, chart, version) identity in chartRefs, then ask chartBlobs
+	// to confirm the blob still exists. Two HelmRepositories that
+	// publish a chart with identical bytes share one blob slot — the
+	// refs table is the only place the (repo, name, version) tuple
+	// shows up.
+	refKey := safeName(r.Namespace+"-"+r.Name+"-"+hr.Chart.Name) + "-" + cv.Version
+	if path, ok := c.chartTarballFromCAS(refKey); ok {
+		return path, nil
+	}
 
-	release, err := chartCacheLocks.Acquire(ctx, target)
+	// Coalesce concurrent downloads on the refKey — the digest is
+	// only knowable post-download, so the per-digest lock inside
+	// chartBlobs can't serve this duty.
+	release, err := chartCacheLocks.Acquire(ctx, refKey)
 	if err != nil {
 		return "", err
 	}
 	defer release()
 
-	if _, err := os.Stat(target); err == nil {
-		return target, nil
+	if path, ok := c.chartTarballFromCAS(refKey); ok {
+		return path, nil
 	}
 	g, err := getter.NewHTTPGetter()
 	if err != nil {
@@ -230,10 +234,25 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", chartURL, err)
 	}
-	if err := writeAtomic(target, buf.Bytes()); err != nil {
-		return "", err
+	dir, digest, err := c.chartBlobs.PutBytes(buf.Bytes(), "chart.tgz")
+	if err != nil {
+		return "", fmt.Errorf("store chart %s: %w", chartURL, err)
 	}
-	return target, nil
+	if err := c.chartRefs.Put(refKey, digest); err != nil {
+		return "", fmt.Errorf("record chart ref %s: %w", refKey, err)
+	}
+	return filepath.Join(dir, "chart.tgz"), nil
+}
+
+// chartTarballFromCAS returns the on-disk path to a previously-stored
+// chart tarball for refKey, or ("", false) when either the ref is
+// unknown or its digest is no longer materialized in the blob store.
+func (c *Client) chartTarballFromCAS(refKey string) (string, bool) {
+	digest, ok := c.chartRefs.Get(refKey)
+	if !ok || !c.chartBlobs.Exists(digest) {
+		return "", false
+	}
+	return filepath.Join(c.chartBlobs.Path(digest), "chart.tgz"), true
 }
 
 // helmRepoAuthOptions / helmRepoTLSOptions live in auth.go (paired

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -1,0 +1,101 @@
+package blob
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Refs is a tiny on-disk key→digest lookup table that sits beside the
+// CAS blob store. It exists so callers that resolve artifacts by some
+// mutable identity tuple (e.g. (repo, chart, version) for a helm
+// tarball, or (URL, ref, authID) for a source CR) can persist the
+// "this identity currently points at this content" mapping without
+// stat-walking the blob store on every lookup.
+//
+// Each entry is one tiny file at <dir>/<urlEscape(key)> containing
+// the hex digest. The choice of one-file-per-key keeps writes atomic
+// (os.Rename), avoids parsing a single index file under contention,
+// and survives partial writes — a corrupted entry just looks like a
+// cache miss.
+type Refs struct {
+	dir string
+	mu  sync.Mutex
+}
+
+// NewRefs constructs a Refs table rooted at dir. The directory is
+// created lazily on first Put.
+func NewRefs(dir string) *Refs {
+	return &Refs{dir: dir}
+}
+
+// Get reads the digest stored under key, or returns ("", false) when
+// the key is unknown. Treats partial or empty entries as misses so a
+// torn write doesn't surface as a sentinel.
+func (r *Refs) Get(key string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	path, err := r.pathFor(key)
+	if err != nil {
+		return "", false
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // path is built from dir + escaped key
+	if err != nil {
+		return "", false
+	}
+	digest := strings.TrimSpace(string(b))
+	if digest == "" {
+		return "", false
+	}
+	return digest, true
+}
+
+// Put records (key → digest) durably via atomic rename. Concurrent
+// writers to the same key serialize on the Refs mutex; different keys
+// proceed in parallel. Overwriting an existing key is supported (an
+// upstream tag re-resolved to a new digest) — the rename atomically
+// replaces the file.
+func (r *Refs) Put(key, digest string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := os.MkdirAll(r.dir, 0o750); err != nil {
+		return fmt.Errorf("refs dir: %w", err)
+	}
+	final, err := r.pathFor(key)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(r.dir, ".tmp.*")
+	if err != nil {
+		return fmt.Errorf("refs staging: %w", err)
+	}
+	if _, err := tmp.WriteString(digest); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("refs write: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("refs close: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), final); err != nil {
+		_ = os.Remove(tmp.Name())
+		return fmt.Errorf("refs finalize: %w", err)
+	}
+	return nil
+}
+
+// pathFor URL-escapes key into a single-segment filename. Refuses keys
+// that would escape the refs dir after escape — defense in depth; the
+// escape itself never produces "..", but a future encoding bug
+// shouldn't open path traversal.
+func (r *Refs) pathFor(key string) (string, error) {
+	safe := url.PathEscape(key)
+	if strings.ContainsAny(safe, "/\\") || safe == "" || safe == "." || safe == ".." {
+		return "", fmt.Errorf("refs: refusing escaped key %q", safe)
+	}
+	return filepath.Join(r.dir, safe), nil
+}

--- a/pkg/source/blob/refs_test.go
+++ b/pkg/source/blob/refs_test.go
@@ -1,0 +1,30 @@
+package blob
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRefs_RoundTrip(t *testing.T) {
+	r := NewRefs(filepath.Join(t.TempDir(), "refs"))
+	if _, ok := r.Get("missing"); ok {
+		t.Error("unset key should miss")
+	}
+	if err := r.Put("repo/chart@1.2.3", "deadbeef"); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, ok := r.Get("repo/chart@1.2.3")
+	if !ok || got != "deadbeef" {
+		t.Errorf("Get = (%q, %v), want (deadbeef, true)", got, ok)
+	}
+}
+
+func TestRefs_OverwritePicksUpNewDigest(t *testing.T) {
+	r := NewRefs(filepath.Join(t.TempDir(), "refs"))
+	_ = r.Put("k", "old")
+	_ = r.Put("k", "new")
+	got, _ := r.Get("k")
+	if got != "new" {
+		t.Errorf("Get after overwrite = %q, want new", got)
+	}
+}

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -1,0 +1,124 @@
+// Package blob is a small content-addressed storage layer for flate's
+// fetched artifacts. Blobs are indexed by sha256 digest; two artifacts
+// with identical content share the same on-disk slot regardless of
+// which CR resolved them. The store is the substrate the cache rework
+// builds on — see pkg/source for ref-keyed slots that compose with
+// this CAS via separate ref tables.
+//
+// Layout under root:
+//
+//	<root>/blobs/sha256/<hex>/
+//
+// Each blob is a directory so individual files (chart.tgz, README,
+// etc.) can sit inside it without escaping the digest namespace.
+package blob
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Store manages a content-addressed blob directory on disk. Safe for
+// concurrent use; per-digest mutexes serialize PutFile/PutBytes for
+// the same digest so two callers writing the same content don't race
+// on the rename finalize.
+type Store struct {
+	root string
+
+	mu    sync.Mutex
+	locks map[string]*sync.Mutex
+}
+
+// NewStore constructs a Store rooted at dir. The blobs/sha256/
+// substructure is created lazily on first write.
+func NewStore(dir string) *Store {
+	return &Store{root: dir}
+}
+
+// Path returns the on-disk path for digest. Does not stat — callers
+// use Exists to check populated-ness.
+func (s *Store) Path(digest string) string {
+	return filepath.Join(s.root, "blobs", "sha256", digest)
+}
+
+// Exists reports whether a blob has been finalized for digest.
+func (s *Store) Exists(digest string) bool {
+	info, err := os.Stat(s.Path(digest))
+	return err == nil && info.IsDir()
+}
+
+// PutBytes installs content as a single file named filename inside the
+// blob directory keyed by content's sha256. The digest is recomputed
+// from the bytes (never trusted from caller input). Concurrent callers
+// targeting the same digest serialize on a per-digest mutex; the first
+// finalizes via atomic rename and the rest observe ErrExists internally
+// and return without rewriting.
+//
+// Returns the populated blob directory path and the computed digest.
+func (s *Store) PutBytes(content []byte, filename string) (string, string, error) {
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+	dir := s.Path(digest)
+
+	lock := s.lockFor(digest)
+	lock.Lock()
+	defer lock.Unlock()
+
+	if s.Exists(digest) {
+		return dir, digest, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {
+		return "", "", fmt.Errorf("blob parent: %w", err)
+	}
+	staging, err := os.MkdirTemp(filepath.Dir(dir), filepath.Base(dir)+".tmp.*")
+	if err != nil {
+		return "", "", fmt.Errorf("blob staging: %w", err)
+	}
+	target := filepath.Join(staging, filename)
+	if err := os.WriteFile(target, content, 0o600); err != nil {
+		_ = os.RemoveAll(staging)
+		return "", "", fmt.Errorf("blob write: %w", err)
+	}
+	if err := os.Rename(staging, dir); err != nil {
+		_ = os.RemoveAll(staging)
+		// A racing writer may have finalized while we were composing
+		// staging. If the blob now exists with the same digest, adopt
+		// it — content-addressing guarantees identical bytes.
+		if errors.Is(err, os.ErrExist) || s.Exists(digest) {
+			return dir, digest, nil
+		}
+		return "", "", fmt.Errorf("blob finalize: %w", err)
+	}
+	return dir, digest, nil
+}
+
+// PutReader is the streaming variant of PutBytes. Useful when the
+// caller has an io.Reader but doesn't want to buffer the whole
+// artifact in memory.
+func (s *Store) PutReader(r io.Reader, filename string) (string, string, error) {
+	buf, err := io.ReadAll(r)
+	if err != nil {
+		return "", "", err
+	}
+	return s.PutBytes(buf, filename)
+}
+
+func (s *Store) lockFor(digest string) *sync.Mutex {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.locks == nil {
+		s.locks = make(map[string]*sync.Mutex)
+	}
+	mx, ok := s.locks[digest]
+	if !ok {
+		mx = &sync.Mutex{}
+		s.locks[digest] = mx
+	}
+	return mx
+}

--- a/pkg/source/blob/store_test.go
+++ b/pkg/source/blob/store_test.go
@@ -1,0 +1,86 @@
+package blob
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestStore_PutBytesDigestPath(t *testing.T) {
+	s := NewStore(t.TempDir())
+	content := []byte("hello world")
+	dir, digest, err := s.PutBytes(content, "data.txt")
+	if err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	wantDigest := hex.EncodeToString(sum[:])
+	if digest != wantDigest {
+		t.Errorf("digest = %q, want %q", digest, wantDigest)
+	}
+	if !s.Exists(digest) {
+		t.Error("Exists should be true after PutBytes")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "data.txt")) //nolint:gosec // dir is under t.TempDir()
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("content drift: got %q, want %q", got, content)
+	}
+}
+
+func TestStore_SameContentSharesSlot(t *testing.T) {
+	s := NewStore(t.TempDir())
+	content := []byte("dedup me")
+	dir1, d1, err := s.PutBytes(content, "a.txt")
+	if err != nil {
+		t.Fatalf("Put 1: %v", err)
+	}
+	dir2, d2, err := s.PutBytes(content, "a.txt")
+	if err != nil {
+		t.Fatalf("Put 2: %v", err)
+	}
+	if d1 != d2 {
+		t.Errorf("digest drift across identical-content puts: %q vs %q", d1, d2)
+	}
+	if dir1 != dir2 {
+		t.Errorf("path drift across identical-content puts: %q vs %q", dir1, dir2)
+	}
+}
+
+func TestStore_ConcurrentPutsCoalesce(t *testing.T) {
+	s := NewStore(t.TempDir())
+	content := []byte("racy")
+	const goroutines = 16
+	var wg sync.WaitGroup
+	var errs atomic.Int32
+	digests := make([]string, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, d, err := s.PutBytes(content, "data")
+			if err != nil {
+				errs.Add(1)
+				return
+			}
+			digests[i] = d
+		}()
+	}
+	wg.Wait()
+	if got := errs.Load(); got != 0 {
+		t.Errorf("expected no errors, got %d", got)
+	}
+	first := digests[0]
+	for i, d := range digests {
+		if d != first {
+			t.Errorf("goroutine %d digest %q differs from %q", i, d, first)
+		}
+	}
+}


### PR DESCRIPTION
## Arc #6 of cache redesign

Introduces `pkg/source/blob` — a content-addressed storage layer the rest of the caches can rebuild on top of.

### Building blocks

- **`blob.Store`** at `<root>/blobs/sha256/<digest>/` with per-digest mutexes and atomic staging→rename finalize. Two artifacts with identical bytes share one slot, regardless of which CR resolved them.
- **`blob.Refs`**: tiny per-key file table mapping mutable identity tuples (e.g. `<repo>/<chart>-<version>`) to the current digest, so callers don't stat-walk the blob store on every lookup.

### First consumer migration: helm chart tarballs

`locateHelmRepoChart` no longer writes to `<cacheDir>/<safeName>.tgz`. It asks `chartRefs` for the previously-resolved digest, asks `chartBlobs` whether that digest is materialized, and only downloads when both miss. Concurrent HR renders against the same chart still coalesce on `chartCacheLocks` (keyed by `refKey` rather than file path — the digest is only knowable post-download).

Two HelmRepositories that publish a chart with identical bytes now share one on-disk slot. Cross-run, a chart already in the blob store skips re-download entirely.

### What's NOT in this PR

`source.Cache` slots, baseline slots, and the git bare-mirror are not yet routed through the CAS. The package is introduced, one consumer is migrated to prove the API, and follow-up PRs handle the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)