### PR TITLE
feat(source,cli): cache GC + flate cache gc command

### DIFF
--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// newCacheCmd builds the `flate cache` subcommand tree. Today there's
+// one verb (gc); the parent exists so future cache-maintenance
+// commands (size, locate, prune-by-key, etc.) plug in alongside.
+func newCacheCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Inspect and prune flate's on-disk cache",
+	}
+	cmd.AddCommand(newCacheGCCmd())
+	return cmd
+}
+
+// cacheGCFlags captures the GC verb's input.
+type cacheGCFlags struct {
+	maxAge         time.Duration
+	includeMirrors bool
+	dryRun         bool
+}
+
+// newCacheGCCmd wires `flate cache gc` — age-prunes per-cache subdirs
+// (sources/, baselines/, blobs/sha256/), removes dangling refs, and
+// optionally extends the prune to git mirrors.
+func newCacheGCCmd() *cobra.Command {
+	f := &cacheGCFlags{}
+	c := &commonFlags{}
+	cmd := &cobra.Command{
+		Use:   "gc",
+		Short: "Prune stale entries from flate's on-disk cache",
+		Long: `Walks the cache root, removing entries whose mtime is older than
+--max-age. Sources, baseline trees, and CAS blobs are pruned by age.
+Dangling refs (digest pointers whose blob has been swept) are
+removed regardless of age. Bare git mirrors are preserved by default
+because re-hydrating them is expensive; pass --include-mirrors to
+age-prune them too.
+
+Set --dry-run to see what would be removed without touching disk.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if f.maxAge < 0 {
+				return errors.New("--max-age must be non-negative")
+			}
+			root := c.resolveCacheRoot()
+			res, err := source.Sweep(root, source.SweepOpts{
+				MaxAge:         f.maxAge,
+				IncludeMirrors: f.includeMirrors,
+				DryRun:         f.dryRun,
+			})
+			if err != nil {
+				return err
+			}
+			w := cmd.OutOrStdout()
+			prefix := ""
+			if f.dryRun {
+				prefix = "[dry-run] "
+			}
+			for _, p := range res.Removed {
+				_, _ = fmt.Fprintln(w, prefix+p)
+			}
+			_, _ = fmt.Fprintf(w, "%s%d entries, %s reclaimed",
+				prefix, len(res.Removed), formatBytes(res.Bytes))
+			if len(res.Errors) > 0 {
+				_, _ = fmt.Fprintf(w, ", %d errors", len(res.Errors))
+			}
+			_, _ = fmt.Fprintln(w)
+			for _, e := range res.Errors {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warn: %v\n", e)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().DurationVar(&f.maxAge, "max-age", 30*24*time.Hour,
+		"prune entries with mtime older than this duration (default 30d); 0 disables age pruning")
+	cmd.Flags().BoolVar(&f.includeMirrors, "include-mirrors", false,
+		"also age-prune git mirrors (default off — mirrors are expensive to rebuild)")
+	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false,
+		"report what would be removed without touching disk")
+	cmd.Flags().StringVar(&c.cacheDir, "cache-dir", "",
+		"cache root to sweep (defaults to the same path flate uses for fetched artifacts)")
+	return cmd
+}
+
+// formatBytes renders byte counts as KiB/MiB/GiB strings. Approximate;
+// suited for human-facing summaries.
+func formatBytes(n int64) string {
+	const (
+		KiB = 1024
+		MiB = 1024 * KiB
+		GiB = 1024 * MiB
+	)
+	switch {
+	case n >= GiB:
+		return fmt.Sprintf("%.2f GiB", float64(n)/float64(GiB))
+	case n >= MiB:
+		return fmt.Sprintf("%.2f MiB", float64(n)/float64(MiB))
+	case n >= KiB:
+		return fmt.Sprintf("%.2f KiB", float64(n)/float64(KiB))
+	}
+	return fmt.Sprintf("%d B", n)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -47,6 +47,7 @@ func New(version string) *cobra.Command {
 		newBuildCmd(),
 		newDiffCmd(),
 		newTestCmd(),
+		newCacheCmd(),
 	)
 	return root
 }

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -1,0 +1,237 @@
+package source
+
+import (
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// SweepOpts tunes Sweep's behavior.
+type SweepOpts struct {
+	// MaxAge marks an entry stale when its mtime is older than now-MaxAge.
+	// Stale entries are removed unless DryRun. Zero disables age-based
+	// pruning (only orphan refs are cleaned).
+	MaxAge time.Duration
+
+	// IncludeMirrors enables age-based pruning of bare git mirrors at
+	// <root>/git-mirrors. Mirrors are otherwise preserved because re-
+	// hydrating them is expensive (a full clone over the network).
+	// Set true when running an explicit "wipe stale state" pass.
+	IncludeMirrors bool
+
+	// DryRun reports what would be removed without touching disk.
+	DryRun bool
+}
+
+// SweepResult summarizes what Sweep did (or would have done under DryRun).
+type SweepResult struct {
+	// Removed lists every entry that was deleted (or would be under
+	// DryRun). Paths are absolute. Group by parent dir to recover the
+	// "kind" of cache that lost the entry — sources/, baselines/, etc.
+	Removed []string
+	// Bytes is the cumulative size of removed entries before deletion.
+	// Approximate — du-style recursive walk per entry.
+	Bytes int64
+	// Errors aggregates per-entry I/O errors. Sweep continues past
+	// individual failures and reports them here so a single permissions
+	// error on one slot doesn't abort the whole sweep.
+	Errors []error
+}
+
+// Sweep prunes stale entries under root according to opts. Walks the
+// known per-cache subdirectories (sources/, baselines/, blobs/sha256/)
+// and removes top-level entries whose mtime is older than opts.MaxAge.
+// Dangling refs files whose digest no longer materializes in
+// blobs/sha256/ are removed regardless of age.
+//
+// Mirrors at <root>/git-mirrors are preserved by default; pass
+// IncludeMirrors to age-prune them too.
+//
+// Returns a SweepResult with the (would-be-)removed paths and a count
+// of recoverable bytes. Individual I/O errors land in Result.Errors
+// rather than short-circuiting the sweep.
+func Sweep(root string, opts SweepOpts) (SweepResult, error) {
+	var res SweepResult
+	if root == "" {
+		return res, fmt.Errorf("sweep: empty cache root")
+	}
+	cutoff := time.Time{}
+	if opts.MaxAge > 0 {
+		cutoff = time.Now().Add(-opts.MaxAge)
+	}
+
+	ageRoots := []string{
+		filepath.Join(root, "sources"),
+		filepath.Join(root, "baselines"),
+		filepath.Join(root, "blobs", "sha256"),
+	}
+	if opts.IncludeMirrors {
+		ageRoots = append(ageRoots, filepath.Join(root, "git-mirrors"))
+	}
+	for _, dir := range ageRoots {
+		sweepDirByAge(dir, cutoff, opts.DryRun, &res)
+	}
+
+	sweepDanglingRefs(filepath.Join(root, "refs"), root, opts.DryRun, &res)
+
+	return res, nil
+}
+
+// sweepDirByAge removes immediate-child entries of dir whose mtime is
+// older than cutoff. For sources/ this is one level deeper (slug/hash)
+// — we descend one extra level so the slug/ wrapper doesn't shield
+// stale hash slots from age comparison.
+func sweepDirByAge(dir string, cutoff time.Time, dryRun bool, res *SweepResult) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			res.Errors = append(res.Errors, fmt.Errorf("read %s: %w", dir, err))
+		}
+		return
+	}
+	// sources/ has an extra slug/ level — recurse one deeper so the
+	// final hash dirs are the age targets.
+	if filepath.Base(dir) == "sources" {
+		for _, e := range entries {
+			sweepDirByAge(filepath.Join(dir, e.Name()), cutoff, dryRun, res)
+		}
+		return
+	}
+	for _, e := range entries {
+		path := filepath.Join(dir, e.Name())
+		info, err := e.Info()
+		if err != nil {
+			res.Errors = append(res.Errors, fmt.Errorf("stat %s: %w", path, err))
+			continue
+		}
+		if cutoff.IsZero() {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			continue
+		}
+		size := entrySize(path)
+		res.Removed = append(res.Removed, path)
+		res.Bytes += size
+		if dryRun {
+			continue
+		}
+		if err := os.RemoveAll(path); err != nil {
+			res.Errors = append(res.Errors, fmt.Errorf("remove %s: %w", path, err))
+		}
+	}
+}
+
+// sweepDanglingRefs walks every file under refsRoot (recursively) and
+// removes entries whose stored digest no longer materializes a blob
+// under <cacheRoot>/blobs/sha256/. Refs files are tiny so we read
+// each one to compare.
+func sweepDanglingRefs(refsRoot, cacheRoot string, dryRun bool, res *SweepResult) {
+	_ = filepath.WalkDir(refsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fs.SkipDir
+			}
+			res.Errors = append(res.Errors, fmt.Errorf("walk %s: %w", path, err))
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.HasPrefix(d.Name(), ".tmp.") {
+			// Orphaned staging file from a torn Refs.Put — clean.
+			res.Removed = append(res.Removed, path)
+			if !dryRun {
+				_ = os.Remove(path) //nolint:gosec // path is a WalkDir result under refsRoot
+			}
+			return nil
+		}
+		b, rerr := os.ReadFile(path) //nolint:gosec // path is a WalkDir result under refsRoot
+		if rerr != nil {
+			res.Errors = append(res.Errors, fmt.Errorf("read %s: %w", path, rerr))
+			return nil
+		}
+		digest := strings.TrimSpace(string(b))
+		if digest == "" {
+			res.Removed = append(res.Removed, path)
+			if !dryRun {
+				_ = os.Remove(path) //nolint:gosec // path is a WalkDir result under refsRoot
+			}
+			return nil
+		}
+		// Reject anything that doesn't look like a sha256 hex — defense
+		// against a hostile or corrupt refs file injecting a traversal
+		// path. The filepath.Join below would normalize "../..", but
+		// rejecting upfront keeps the blame closer to the source.
+		if !looksLikeDigest(digest) {
+			res.Errors = append(res.Errors, fmt.Errorf("refs %s: bogus digest %q", path, digest))
+			return nil
+		}
+		blobPath := filepath.Join(cacheRoot, "blobs", "sha256", digest)
+		if _, err := os.Stat(blobPath); err == nil { //nolint:gosec // digest gated by looksLikeDigest above
+			return nil
+		}
+		// The digest this ref points at has been swept away — drop the
+		// pointer so future lookups don't keep claiming "we know about
+		// this digest, but it's gone".
+		res.Removed = append(res.Removed, path)
+		if !dryRun {
+			if err := os.Remove(path); err != nil { //nolint:gosec // path is a WalkDir result under refsRoot
+				res.Errors = append(res.Errors, fmt.Errorf("remove %s: %w", path, err))
+			}
+		}
+		return nil
+	})
+}
+
+// looksLikeDigest reports whether s plausibly is a sha256 hex string.
+// Used to gate refs files before we treat their contents as a path
+// component — a corrupt file containing "../../etc/passwd" should fail
+// closed rather than feed into filepath.Join.
+func looksLikeDigest(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, r := range s {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// entrySize returns the cumulative byte size under path. Best-effort —
+// returns 0 on any walk error rather than failing the sweep over a
+// missing-file race.
+func entrySize(path string) int64 {
+	var total int64
+	_ = filepath.WalkDir(path, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return nil
+		}
+		total += info.Size()
+		return nil
+	})
+	return total
+}
+
+// Log emits a structured summary of res at slog.LevelInfo. Convenience
+// for CLI / orchestrator callers that don't want to format the result
+// inline.
+func (res *SweepResult) Log() {
+	slog.Info("cache sweep",
+		"removed", len(res.Removed),
+		"bytes", res.Bytes,
+		"errors", len(res.Errors))
+}

--- a/pkg/source/gc_test.go
+++ b/pkg/source/gc_test.go
@@ -1,0 +1,148 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+// TestSweep_AgePrunesStaleSlots: a slot whose mtime is older than
+// MaxAge is removed; a fresh one is preserved.
+func TestSweep_AgePrunesStaleSlots(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, "sources", "old-repo", "deadbeef")
+	fresh := filepath.Join(root, "sources", "new-repo", "cafefeed")
+	for _, d := range []string{stale, fresh} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "marker"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-7 * 24 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Removed) != 1 || res.Removed[0] != stale {
+		t.Errorf("Removed = %v, want [%q]", res.Removed, stale)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale slot still exists: %v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Errorf("fresh slot removed: %v", err)
+	}
+}
+
+// TestSweep_BaselinesAndBlobs: age applies to baselines/<sha>/ and
+// blobs/sha256/<digest>/ exactly the same way as sources.
+func TestSweep_BaselinesAndBlobs(t *testing.T) {
+	root := t.TempDir()
+	baseline := filepath.Join(root, "baselines", "abc123")
+	blob := filepath.Join(root, "blobs", "sha256", "def456")
+	for _, d := range []string{baseline, blob} {
+		if err := os.MkdirAll(d, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	for _, d := range []string{baseline, blob} {
+		if err := os.Chtimes(d, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res, _ := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour})
+	if len(res.Removed) != 2 {
+		t.Errorf("Removed = %v, want 2 entries", res.Removed)
+	}
+}
+
+// TestSweep_MirrorsPreservedByDefault: bare git mirrors are kept
+// across sweeps unless IncludeMirrors is set — they're expensive to
+// rebuild.
+func TestSweep_MirrorsPreservedByDefault(t *testing.T) {
+	root := t.TempDir()
+	mirror := filepath.Join(root, "git-mirrors", "abc123")
+	if err := os.MkdirAll(mirror, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-365 * 24 * time.Hour)
+	if err := os.Chtimes(mirror, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	res, _ := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour})
+	if slices.Contains(res.Removed, mirror) {
+		t.Error("mirror swept without IncludeMirrors")
+	}
+
+	res, _ = Sweep(root, SweepOpts{MaxAge: 24 * time.Hour, IncludeMirrors: true})
+	if !slices.Contains(res.Removed, mirror) {
+		t.Errorf("mirror not swept with IncludeMirrors: %v", res.Removed)
+	}
+}
+
+// TestSweep_DanglingRefsCleaned: a ref pointing at a digest that
+// doesn't exist in blobs/ is removed regardless of age.
+func TestSweep_DanglingRefsCleaned(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "refs", "charts"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	const (
+		missingDigest = "0000000000000000000000000000000000000000000000000000000000000000"
+		liveDigest    = "1111111111111111111111111111111111111111111111111111111111111111"
+	)
+	dangling := filepath.Join(root, "refs", "charts", "missing-chart")
+	if err := os.WriteFile(dangling, []byte(missingDigest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second ref points at a real blob — must survive.
+	live := filepath.Join(root, "refs", "charts", "real-chart")
+	if err := os.WriteFile(live, []byte(liveDigest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "blobs", "sha256", liveDigest), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	res, _ := Sweep(root, SweepOpts{})
+	if !slices.Contains(res.Removed, dangling) {
+		t.Errorf("dangling ref not removed: %v", res.Removed)
+	}
+	if slices.Contains(res.Removed, live) {
+		t.Errorf("live ref removed: %v", res.Removed)
+	}
+}
+
+// TestSweep_DryRunReports: DryRun emits the would-be-removed list
+// without touching disk.
+func TestSweep_DryRunReports(t *testing.T) {
+	root := t.TempDir()
+	slot := filepath.Join(root, "sources", "repo", "hash")
+	if err := os.MkdirAll(slot, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(slot, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	res, _ := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour, DryRun: true})
+	if !slices.Contains(res.Removed, slot) {
+		t.Errorf("DryRun didn't report stale slot: %v", res.Removed)
+	}
+	if _, err := os.Stat(slot); err != nil {
+		t.Errorf("DryRun removed slot on disk: %v", err)
+	}
+}


### PR DESCRIPTION
## Arc #7 of cache redesign — final piece

Adds `source.Sweep` for prune-by-age and dangling-ref cleanup, plus a `flate cache gc` CLI surface.

## What gets pruned
- `sources/<slug>/<hash>/` — slot dirs older than `--max-age`
- `baselines/<sha>/` — baseline trees older than `--max-age`
- `blobs/sha256/<digest>/` — CAS blobs older than `--max-age`
- `refs/<key>` — pointers whose digest no longer materializes (regardless of age — pure cleanup)

## What's preserved
Bare git mirrors at `git-mirrors/<urlhash>/` are kept by default — re-hydrating one is expensive (full clone over the network). `--include-mirrors` extends the age prune to cover them.

## CLI
```
flate cache gc [--max-age=30d] [--include-mirrors] [--dry-run] [--cache-dir=PATH]
```

`--dry-run` reports the would-be-removed list without touching disk. Per-entry I/O errors surface as warnings rather than aborting the sweep — a single permissions failure doesn't block reclaiming everything else.

## Tests
- age prunes stale slots, keeps fresh ones
- baselines + blobs prune symmetrically with sources
- mirrors survive by default, swept with `--include-mirrors`
- dangling refs cleaned regardless of age
- `--dry-run` reports but doesn't touch disk

## Stack
This is the last arc. With #381, #379, #380, #382 (arc #6, currently open) merged, the cache redesign is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)