### PR TITLE
fix(helm): OCI fallback cache key includes tag/digest

### DIFF
--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -203,10 +203,14 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 	if c.registry == nil {
 		return "", errors.New("helm registry client not initialized")
 	}
-	// Key on the FULL trimmed ref (registry+path), not filepath.Base —
-	// two distinct registries publishing a chart with the same final
-	// path segment would otherwise collide on a single cache file.
-	target := filepath.Join(c.cacheDir, safeName(strings.TrimPrefix(ref, "oci://"))+"-"+version+".tgz")
+	pullRef := ociPullRef(ref, version)
+	// Key on the FULL pull reference (registry+path PLUS the tag or
+	// `@sha256:…` digest) so a tag-pulled artifact and a digest-pulled
+	// one for the same chart don't collide on a single cache file.
+	// The previous `safeName(ref) + "-" + version` shape collided
+	// `chart:1.2.3` with `chart@sha256:1.2.3-shaped-string` and let
+	// a tag re-push silently serve stale bytes to a digest reference.
+	target := filepath.Join(c.cacheDir, safeName(strings.TrimPrefix(pullRef, "oci://"))+".tgz")
 
 	release, err := chartCacheLocks.Acquire(ctx, target)
 	if err != nil {
@@ -218,7 +222,6 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 		return target, nil
 	}
 
-	pullRef := ociPullRef(ref, version)
 	_ = ctx // reserved for future per-pull cancellation when helm supports it
 	// Yield the worker-pool slot for the duration of the network
 	// pull so concurrent helm renders don't block the pool. No-op


### PR DESCRIPTION
## Deferred polish from the cache redesign

The EnableOCI=false fallback path of `fetchOCIChart` keyed its on-disk cache file on `safeName(ref) + "-" + version`. The `version` dimension is the user-supplied `chart.Version` — either a tag (`"1.2.3"`) or a digest (`"sha256:abc…"`). Both shapes hashed to the same cache file when the digest happened to round-trip `safeName` to the same token, and a tag re-pushed under the same name silently served stale bytes to a sibling HR that pinned the digest.

Switch the key to `safeName(pullRef)` where `pullRef` is the full OCI reference go-git would pull (registry+path with either `:tag` or `@sha256:digest`). Distinct tag and digest forms now land in distinct cache files; a tag re-push invalidates correctly.

`EnableOCI=true` was already correct via the source/oci.Fetcher CAS slot; this aligns the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)