### PR TITLE
perf(kustomize): hardlink stage files instead of byte-copying

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -273,7 +273,16 @@ func restoreKustomizationFile(sourceRoot, stagedSub, subPath string) error {
 				rmErrs = append(rmErrs, fmt.Errorf("remove staged %s: %w", other, err))
 			}
 		}
-		if err := os.WriteFile(filepath.Join(stagedSub, name), data, info.Mode().Perm()); err != nil { //nolint:gosec // stagedSub is our own tempdir
+		// Break any hardlink to source before writing — copyFile may
+		// have linked the staged path to the source inode (so renders
+		// that don't mutate the file share storage), but an O_TRUNC
+		// write would clobber the source's bytes. os.Remove drops just
+		// the staged directory entry; the source's link survives.
+		stagedPath := filepath.Join(stagedSub, name)
+		if err := os.Remove(stagedPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			rmErrs = append(rmErrs, fmt.Errorf("unlink staged %s: %w", name, err))
+		}
+		if err := os.WriteFile(stagedPath, data, info.Mode().Perm()); err != nil { //nolint:gosec // stagedSub is our own tempdir
 			rmErrs = append(rmErrs, fmt.Errorf("write staged %s: %w", name, err))
 		}
 		return errors.Join(rmErrs...)

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -268,7 +269,28 @@ func (c *StagingCache) copyTree(src string) (string, error) {
 	return dst, nil
 }
 
+// copyFile materializes srcPath at dstPath. Hardlinks when source and
+// destination sit on the same filesystem — a stage of a monorepo would
+// otherwise duplicate gigabytes of bytes on every render. Falls back to
+// a stream copy on cross-device (EXDEV) failures so the cache continues
+// to work when a user points --cache-dir at a different volume than
+// their working tree.
+//
+// Callers that mutate the staged file MUST first os.Remove it so the
+// hardlink is broken before write — otherwise an O_TRUNC|O_WRONLY open
+// on the staged path would modify the source's underlying inode.
+// flux.go's restoreKustomizationFile follows that protocol; new write
+// sites must too.
 func copyFile(srcPath, dstPath string, mode os.FileMode) error {
+	if err := os.Link(srcPath, dstPath); err == nil {
+		return nil
+	} else if !errors.Is(err, syscall.EXDEV) {
+		// Other Link failures (permissions, source missing) fall
+		// through to the copy path so unusual filesystems still work.
+		// The cross-device case is the only one we explicitly classify
+		// to keep the fast path readable.
+		_ = err
+	}
 	src, err := os.Open(srcPath) //nolint:gosec // srcPath is a tree-walk result under our source root
 	if err != nil {
 		return err

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -209,3 +209,80 @@ func TestNewStagingCache_SweepsStaleLeftovers(t *testing.T) {
 		t.Errorf("non-flate dir was reaped (prefix check broken): %v", err)
 	}
 }
+
+// TestStagingCache_HardlinksWhenSameFilesystem confirms the perf win:
+// staged files share an inode with their source when the source and
+// the cache tempdir sit on the same filesystem (the common case). A
+// matching inode number on both sides proves we're not paying for a
+// full-tree byte copy on every render.
+func TestStagingCache_HardlinksWhenSameFilesystem(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	srcFile := filepath.Join(src, "kustomization.yaml")
+	mustWrite(t, srcFile, "resources: []\n")
+
+	cache, err := NewStagingCache(filepath.Join(root, "stage"))
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	staged, err := cache.Stage(src)
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	stagedFile := filepath.Join(staged, "kustomization.yaml")
+	si, err := os.Stat(srcFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	di, err := os.Stat(stagedFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(si, di) {
+		t.Errorf("expected staged file to share an inode with source (hardlink); same-file check failed")
+	}
+}
+
+// TestRestoreKustomization_DoesNotMutateSource is the safety net for
+// hardlink staging: even though the stage's kustomization.yaml may
+// share an inode with the source, restoreKustomizationFile must
+// os.Remove the staged link before WriteFile so the source's bytes
+// stay intact across renders.
+func TestRestoreKustomization_DoesNotMutateSource(t *testing.T) {
+	src := t.TempDir()
+	srcKust := filepath.Join(src, "kustomization.yaml")
+	mustWrite(t, srcKust, "original\n")
+
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	staged, err := cache.Stage(src)
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+	// Pretend the Generator wrote over the staged kustomization. If
+	// the staged file is still hard-linked to the source, this writes
+	// to the source's inode and corrupts it.
+	if err := restoreKustomizationFile(src, staged, ""); err != nil {
+		t.Fatalf("restoreKustomizationFile: %v", err)
+	}
+	// Overwrite the staged file simulating Generator output.
+	if err := os.WriteFile(filepath.Join(staged, "kustomization.yaml"), []byte("rewritten\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(srcKust) //nolint:gosec // srcKust under t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original\n" {
+		t.Errorf("source kustomization.yaml mutated by stage write: got %q", got)
+	}
+}


### PR DESCRIPTION
## Last deferred polish from the cache redesign

`copyTree` now `os.Link`s each regular file from the source root into the stage. On a monorepo this turns a multi-GB byte copy into a metadata-only operation — every render shares the same inodes as the working tree.

Cross-filesystem stages (`--cache-dir` on a different volume than `--path`) fall back to the existing byte copy via the EXDEV branch.

## Safety
The staged `kustomization.yaml` may now share an inode with the source, so an `O_TRUNC|O_WRONLY` open against the stage path would corrupt the source's bytes. `restoreKustomizationFile` already runs before every Generator write; it now `os.Remove`s the staged path first to break the hardlink, then `WriteFile` creates a fresh inode for the merged kustomization. The source link survives.

## Tests
- `TestStagingCache_HardlinksWhenSameFilesystem` — staged file shares an inode with source (`os.SameFile`)
- `TestRestoreKustomization_DoesNotMutateSource` — restore + stage write leaves source bytes intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)