### PR TITLE
refactor(source): cacheroot.Layout owns all cache paths

### DIFF
--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // newCacheCmd builds the `flate cache` subcommand tree. Today there's
@@ -50,8 +51,8 @@ Set --dry-run to see what would be removed without touching disk.`,
 			if f.maxAge < 0 {
 				return errors.New("--max-age must be non-negative")
 			}
-			root := c.resolveCacheRoot()
-			res, err := source.Sweep(root, source.SweepOpts{
+			layout := cacheroot.New(c.resolveCacheRoot())
+			res, err := source.Sweep(layout, source.SweepOpts{
 				MaxAge:         f.maxAge,
 				IncludeMirrors: f.includeMirrors,
 				DryRun:         f.dryRun,

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 type commonFlags struct {
@@ -246,7 +247,7 @@ func resolveBaseline(_ context.Context, c *commonFlags, autoFallback bool) (func
 		// default).
 		return noop, nil
 	}
-	res, err := baseline.AutoResolve(c.path, c.base, c.resolveCacheRoot())
+	res, err := baseline.AutoResolve(c.path, c.base, cacheroot.New(c.resolveCacheRoot()))
 	if err != nil {
 		return noop, err
 	}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -104,7 +105,7 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 	// (url, ref) slot can race past the mkdir/Readdirnames check and
 	// step on each other.
 	cacheRoot := cmp.Or(currentCfg.CacheDir, filepath.Join(os.TempDir(), "flate-cache"))
-	shared := source.NewCache(filepath.Join(cacheRoot, "sources"))
+	shared := source.NewCache(cacheroot.New(cacheRoot))
 	currentCfg.SourceCache = shared
 	origCfg.SourceCache = shared
 

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // Result describes a materialized baseline tree on disk.
@@ -53,15 +55,15 @@ type resolution struct {
 // explicit --base=<rev> override; otherwise the auto-detection ladder
 // runs.
 //
-// cacheRoot enables content-addressed reuse: when non-empty the
-// baseline lands at <cacheRoot>/baselines/<commit-sha>/ and Result is
-// marked Persistent — subsequent runs against the same commit skip
-// materialization entirely. When cacheRoot is "" the legacy
+// layout enables content-addressed reuse: when layout.Root is non-
+// empty the baseline lands at layout.Baseline(commitSHA) and Result
+// is marked Persistent — subsequent runs against the same commit
+// skip materialization entirely. When layout.Root is "" the legacy
 // MkdirTemp path runs and the caller is responsible for cleanup.
 //
 // Errors carry the suggested next flag so the user knows whether to
 // pass --base=<rev> or --path-orig=<dir>.
-func AutoResolve(path, base, cacheRoot string) (*Result, error) {
+func AutoResolve(path, base string, layout cacheroot.Layout) (*Result, error) {
 	repo, repoRoot, err := openRepo(path)
 	if err != nil {
 		return nil, err
@@ -76,7 +78,7 @@ func AutoResolve(path, base, cacheRoot string) (*Result, error) {
 		return nil, err
 	}
 
-	dir, persistent, err := materializeAt(repo, r.Hash, cacheRoot)
+	dir, persistent, err := materializeAt(repo, r.Hash, layout)
 	if err != nil {
 		return nil, err
 	}
@@ -97,12 +99,12 @@ func AutoResolve(path, base, cacheRoot string) (*Result, error) {
 }
 
 // materializeAt produces the baseline tree on disk for hash and
-// returns (dir, persistent, err). When cacheRoot is non-empty the
-// directory lives at <cacheRoot>/baselines/<hash>/ and is reused
-// across runs; otherwise an MkdirTemp directory is allocated.
-func materializeAt(repo *git.Repository, hash plumbing.Hash, cacheRoot string) (string, bool, error) {
-	if cacheRoot != "" {
-		slot := filepath.Join(cacheRoot, "baselines", hash.String())
+// returns (dir, persistent, err). When layout.Root is non-empty the
+// directory lives at layout.Baseline(hash) and is reused across runs;
+// otherwise an MkdirTemp directory is allocated.
+func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.Layout) (string, bool, error) {
+	if layout.Root != "" {
+		slot := layout.Baseline(hash.String())
 		if info, err := os.Stat(slot); err == nil && info.IsDir() {
 			return slot, true, nil
 		}

--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestAutoResolve_ExplicitBase pins the --base=<rev> escape hatch: an
@@ -21,7 +23,7 @@ func TestAutoResolve_ExplicitBase(t *testing.T) {
 	commitA := initRepoWithFile(t, dir, "a.yaml", "original")
 	commitB := writeAndCommit(t, dir, "a.yaml", "updated")
 
-	res, err := AutoResolve(dir, commitA.String(), "")
+	res, err := AutoResolve(dir, commitA.String(), cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestAutoResolve_UpstreamMergeBase(t *testing.T) {
 	// Move forward on the local branch.
 	writeAndCommit(t, dir, "a.yaml", "diverged")
 
-	res, err := AutoResolve(dir, "", "")
+	res, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -91,7 +93,7 @@ func TestAutoResolve_OriginHEAD(t *testing.T) {
 
 	writeAndCommit(t, dir, "a.yaml", "new")
 
-	res, err := AutoResolve(dir, "", "")
+	res, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -112,7 +114,7 @@ func TestAutoResolve_OriginMainFallback(t *testing.T) {
 
 	writeAndCommit(t, dir, "a.yaml", "new")
 
-	res, err := AutoResolve(dir, "", "")
+	res, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -142,7 +144,7 @@ func TestAutoResolve_DetachedHEAD(t *testing.T) {
 		t.Fatalf("detach HEAD: %v", err)
 	}
 
-	res, err := AutoResolve(dir, "", "")
+	res, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -159,7 +161,7 @@ func TestAutoResolve_NoGit(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte("x"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	_, err := AutoResolve(dir, "", "")
+	_, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err == nil {
 		t.Fatal("expected error for non-git path")
 	}
@@ -179,7 +181,7 @@ func TestAutoResolve_Shallow(t *testing.T) {
 	}
 	// No upstream, no origin refs → the resolution ladder falls
 	// through; the shallow detection fires last.
-	_, err := AutoResolve(dir, "", "")
+	_, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err == nil {
 		t.Fatal("expected shallow error")
 	}
@@ -196,7 +198,7 @@ func TestAutoResolve_Shallow(t *testing.T) {
 func TestAutoResolve_NoUpstream(t *testing.T) {
 	dir := t.TempDir()
 	initRepoWithFile(t, dir, "a.yaml", "x")
-	_, err := AutoResolve(dir, "", "")
+	_, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err == nil {
 		t.Fatal("expected no-upstream error")
 	}
@@ -223,7 +225,7 @@ func TestAutoResolve_PathOutsideRepo(t *testing.T) {
 	if err := os.Mkdir(sibling, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	_, err := AutoResolve(sibling, "", "")
+	_, err := AutoResolve(sibling, "", cacheroot.Layout{})
 	if err == nil {
 		t.Fatal("expected error for path outside repo")
 	}
@@ -239,7 +241,7 @@ func TestAutoResolve_PathOrigMappedToSubdir(t *testing.T) {
 	commit := writeAndCommit(t, dir, "kubernetes/flux/cluster/cluster.yaml", "y")
 
 	clusterDir := filepath.Join(dir, "kubernetes", "flux", "cluster")
-	res, err := AutoResolve(clusterDir, commit.String(), "")
+	res, err := AutoResolve(clusterDir, commit.String(), cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -264,7 +266,7 @@ func TestAutoResolve_DropsGitMarker(t *testing.T) {
 	dir := t.TempDir()
 	initRepoWithFile(t, dir, "a.yaml", "x")
 	commit := writeAndCommit(t, dir, "a.yaml", "y")
-	res, err := AutoResolve(dir, commit.String(), "")
+	res, err := AutoResolve(dir, commit.String(), cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -290,7 +292,7 @@ func TestAutoResolve_CachedReusesSlot(t *testing.T) {
 	commit := writeAndCommit(t, dir, "a.yaml", "y")
 	cacheRoot := t.TempDir()
 
-	res1, err := AutoResolve(dir, commit.String(), cacheRoot)
+	res1, err := AutoResolve(dir, commit.String(), cacheroot.New(cacheRoot))
 	if err != nil {
 		t.Fatalf("AutoResolve 1: %v", err)
 	}
@@ -308,7 +310,7 @@ func TestAutoResolve_CachedReusesSlot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res2, err := AutoResolve(dir, commit.String(), cacheRoot)
+	res2, err := AutoResolve(dir, commit.String(), cacheroot.New(cacheRoot))
 	if err != nil {
 		t.Fatalf("AutoResolve 2: %v", err)
 	}
@@ -327,7 +329,7 @@ func TestAutoResolve_NoCacheRootIsTempdir(t *testing.T) {
 	initRepoWithFile(t, dir, "a.yaml", "x")
 	commit := writeAndCommit(t, dir, "a.yaml", "y")
 
-	res, err := AutoResolve(dir, commit.String(), "")
+	res, err := AutoResolve(dir, commit.String(), cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}
@@ -367,7 +369,7 @@ func TestMaterialize_PreservesExecutableBit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := AutoResolve(dir, commit.String(), "")
+	res, err := AutoResolve(dir, commit.String(), cacheroot.Layout{})
 	if err != nil {
 		t.Fatalf("AutoResolve: %v", err)
 	}

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/task"
@@ -34,7 +35,7 @@ func newTestControllerWithOptions(t *testing.T, opts ReconcileOptions) (*Control
 	t.Helper()
 	st := store.New()
 	ts := task.New()
-	hc, err := helm.NewClient(t.TempDir(), t.TempDir())
+	hc, err := helm.NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("helm.NewClient: %v", err)
 	}

--- a/pkg/helm/auth_test.go
+++ b/pkg/helm/auth_test.go
@@ -8,10 +8,11 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 func TestHelmRepoTLS_NoCertSecretIsNoOp(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -30,7 +31,7 @@ func TestHelmRepoTLS_NoCertSecretIsNoOp(t *testing.T) {
 }
 
 func TestHelmRepoTLS_FromSecret(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestHelmRepoTLS_FromSecret(t *testing.T) {
 }
 
 func TestHelmRepoTLS_AllKeysMissing(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestHelmRepoTLS_AllKeysMissing(t *testing.T) {
 }
 
 func TestHelmRepoTLS_CertSecretNotFound(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -107,7 +108,7 @@ func TestHelmRepoTLS_CertSecretNotFound(t *testing.T) {
 }
 
 func TestHelmRepoAuth_NoSecretIsAnonymous(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -125,7 +126,7 @@ func TestHelmRepoAuth_NoSecretIsAnonymous(t *testing.T) {
 }
 
 func TestHelmRepoAuth_BasicAuthFromSecret(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -156,7 +157,7 @@ func TestHelmRepoAuth_BasicAuthFromSecret(t *testing.T) {
 }
 
 func TestHelmRepoAuth_MissingCreds(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -176,7 +177,7 @@ func TestHelmRepoAuth_MissingCreds(t *testing.T) {
 }
 
 func TestHelmRepoAuth_SecretWipedTreatedAsMissing(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -201,7 +202,7 @@ func TestHelmRepoAuth_SecretWipedTreatedAsMissing(t *testing.T) {
 }
 
 func TestHelmRepoAuth_NoGetter(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -218,7 +219,7 @@ func TestHelmRepoAuth_NoGetter(t *testing.T) {
 }
 
 func TestHelmRepoAuth_SecretNotFound(t *testing.T) {
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -17,6 +16,7 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/blob"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -119,11 +119,21 @@ type chartCacheEntry struct {
 	size  int64
 }
 
-// NewClient constructs a Client. tmpDir and cacheDir are used for
-// scratch chart downloads. Both will be created if absent.
-func NewClient(tmpDir, cacheDir string) (*Client, error) {
-	tmpDir = cmp.Or(tmpDir, filepath.Join(os.TempDir(), "flate-helm"))
-	cacheDir = cmp.Or(cacheDir, filepath.Join(os.TempDir(), "flate-helm-cache"))
+// NewClient constructs a Client backed by the supplied Layout. The
+// helm-tmp/ and helm-cache/ directories are taken from the Layout —
+// helm.Client never composes its own paths. The chart-tarball CAS is
+// rooted at the SHARED <root>/blobs/sha256/ blob store so identical
+// chart bytes deduplicate across HelmRepositories and across
+// orchestrator embedders.
+func NewClient(layout cacheroot.Layout) (*Client, error) {
+	if layout.Root == "" {
+		// Embedders that don't wire a cache root still need a working
+		// client. Anchor under the OS tempdir so the legacy default
+		// keeps working.
+		layout.Root = filepath.Join(os.TempDir(), "flate-cache")
+	}
+	tmpDir := layout.HelmTmp()
+	cacheDir := layout.HelmCache()
 	if err := os.MkdirAll(tmpDir, 0o750); err != nil {
 		return nil, err
 	}
@@ -141,8 +151,8 @@ func NewClient(tmpDir, cacheDir string) (*Client, error) {
 		chartCache:     map[string]chartCacheEntry{},
 		chartLoadLocks: keylock.New[string](),
 		indexLocks:     keylock.New[string](),
-		chartBlobs:     blob.NewStore(cacheDir),
-		chartRefs:      blob.NewRefs(filepath.Join(cacheDir, "refs", "chart-tarballs")),
+		chartBlobs:     blob.NewStore(layout),
+		chartRefs:      blob.NewRefs(layout, "chart-tarballs"),
 	}, nil
 }
 

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 func TestTemplate_LocalChart(t *testing.T) {
@@ -30,7 +31,7 @@ data:
   greeting: {{ .Values.greeting }}
 `)
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -72,7 +73,7 @@ func helmChartFixture(t *testing.T) *Client {
 	testutil.WriteFile(t, dir, "mychart/templates/test-hook.yaml",
 		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-test\n  annotations:\n    \"helm.sh/hook\": test\ndata:\n  k: v\n")
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/pkg/helm/loadchart_test.go
+++ b/pkg/helm/loadchart_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestLoadChart_CoalescesConcurrentFirstLoad verifies that N parallel
@@ -37,7 +38,7 @@ description: test
 	testutil.WriteFile(t, dir, "mychart/values.yaml", "k: v\n")
 	testutil.WriteFile(t, dir, "mychart/templates/_helpers.tpl", "")
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -124,7 +125,7 @@ description: test
 // the path, and an overwrite is invisible.
 func TestLoadChart_InvalidatesOnFileMtimeChange(t *testing.T) {
 	dir := t.TempDir()
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -222,7 +223,7 @@ dependencies:
 	testutil.WriteFile(t, dir, "mychart/values.yaml", "k: shared\n")
 	testutil.WriteFile(t, dir, "mychart/templates/_helpers.tpl", "")
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/helm/oci_chart_test.go
+++ b/pkg/helm/oci_chart_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestLocateOCIChart_PrefersSourceArtifactExtract is the headline of
@@ -89,7 +90,7 @@ func TestLocateOCIChart_PrefersSourceArtifactCopy(t *testing.T) {
 func TestLocateOCIChart_FallsBackWhenNoArtifact(t *testing.T) {
 	t.Parallel()
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestLocateOCIChart_FallsBackWhenNoArtifact(t *testing.T) {
 func TestLocateOCIChart_RoutesThroughPullerWhenWired(t *testing.T) {
 	t.Parallel()
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -295,7 +296,7 @@ func TestLocateOCIChart_AmbiguousSubdirs(t *testing.T) {
 func TestLocateOCIChart_FallbackSemverRefused(t *testing.T) {
 	t.Parallel()
 
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -351,7 +352,7 @@ func TestOCIChartPathFromArtifact_MissingLayer(t *testing.T) {
 // would have produced.
 func setupOCIChartTest(t *testing.T, slot, label string) (*Client, *manifest.HelmRelease) {
 	t.Helper()
-	cli, err := NewClient(t.TempDir(), t.TempDir())
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/pkg/helm/repo_test.go
+++ b/pkg/helm/repo_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"helm.sh/helm/v4/pkg/getter"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 const indexYAMLFixture = `apiVersion: v1
@@ -32,7 +33,7 @@ func TestFetchIndex_CachesAcrossCalls(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestFetchIndex_DistinctKeysFetchSeparately(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c, err := NewClient(t.TempDir(), t.TempDir())
+	c, err := NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/pkg/helm/resolver_test.go
+++ b/pkg/helm/resolver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -46,7 +47,7 @@ data:
 		Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir,
 	})
 
-	cli, err := helm.NewClient(t.TempDir(), t.TempDir())
+	cli, err := helm.NewClient(cacheroot.New(t.TempDir()))
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/source/bucket"
 	"github.com/home-operations/flate/pkg/source/external"
 	"github.com/home-operations/flate/pkg/source/git"
@@ -180,29 +181,26 @@ func New(cfg Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("orchestrator: path is required")
 	}
 
-	cacheRoot := cmp.Or(cfg.CacheDir, defaultCacheRoot())
-	helmClient, err := helm.NewClient(
-		filepath.Join(cacheRoot, "helm-tmp"),
-		filepath.Join(cacheRoot, "helm-cache"),
-	)
+	layout := cacheroot.New(cmp.Or(cfg.CacheDir, defaultCacheRoot()))
+	helmClient, err := helm.NewClient(layout)
 	if err != nil {
 		return nil, err
 	}
-	staging, err := kustomize.NewStagingCache(filepath.Join(cacheRoot, "stage"))
+	staging, err := kustomize.NewStagingCache(layout.Stage())
 	if err != nil {
-		// helmClient already created tmpDir + cacheDir under cacheRoot.
-		// Leaving them would leak a temp directory per failed
-		// orchestrator construction (e.g. retry-on-bad-config loops in
-		// a test harness). The helm client itself has no Close; the
-		// best-effort cleanup is to drop the cacheRoot we own.
-		_ = os.RemoveAll(filepath.Join(cacheRoot, "helm-tmp"))
-		_ = os.RemoveAll(filepath.Join(cacheRoot, "helm-cache"))
+		// helmClient already created tmpDir + cacheDir under the
+		// cache root. Leaving them would leak a temp directory per
+		// failed orchestrator construction (e.g. retry-on-bad-config
+		// loops in a test harness). The helm client itself has no
+		// Close; the best-effort cleanup is to drop the dirs we own.
+		_ = os.RemoveAll(layout.HelmTmp())
+		_ = os.RemoveAll(layout.HelmCache())
 		return nil, err
 	}
 
 	st := store.New()
 	ts := task.NewBounded(cfg.Concurrency)
-	cache := cmp.Or(cfg.SourceCache, source.NewCache(filepath.Join(cacheRoot, "sources")))
+	cache := cmp.Or(cfg.SourceCache, source.NewCache(layout))
 	secretGet := func(ns, name string) *manifest.Secret {
 		s, _ := store.GetByName[*manifest.Secret](st, manifest.KindSecret, ns, name)
 		return s
@@ -227,7 +225,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		manifest.KindGitRepository, &git.Fetcher{
 			Cache:   cache,
 			Secrets: secretGet,
-			Mirrors: git.NewMirrorCache(filepath.Join(cacheRoot, "git-mirrors")),
+			Mirrors: git.NewMirrorCache(layout),
 		})
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap[*manifest.ExternalArtifact](
 		manifest.KindExternalArtifact, &external.Fetcher{})

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // Refs is a tiny on-disk key→digest lookup table that sits beside the
@@ -26,10 +28,12 @@ type Refs struct {
 	mu  sync.Mutex
 }
 
-// NewRefs constructs a Refs table rooted at dir. The directory is
-// created lazily on first Put.
-func NewRefs(dir string) *Refs {
-	return &Refs{dir: dir}
+// NewRefs constructs a Refs table for one category under the supplied
+// Layout. category names a stable subdirectory under <root>/refs/
+// (e.g. "chart-tarballs") that GC and introspection tooling share with
+// the writer. The directory is created lazily on first Put.
+func NewRefs(layout cacheroot.Layout, category string) *Refs {
+	return &Refs{dir: layout.RefsCategory(category)}
 }
 
 // Get reads the digest stored under key, or returns ("", false) when

--- a/pkg/source/blob/refs_test.go
+++ b/pkg/source/blob/refs_test.go
@@ -1,12 +1,13 @@
 package blob
 
 import (
-	"path/filepath"
 	"testing"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 func TestRefs_RoundTrip(t *testing.T) {
-	r := NewRefs(filepath.Join(t.TempDir(), "refs"))
+	r := NewRefs(cacheroot.New(t.TempDir()), "test")
 	if _, ok := r.Get("missing"); ok {
 		t.Error("unset key should miss")
 	}
@@ -20,7 +21,7 @@ func TestRefs_RoundTrip(t *testing.T) {
 }
 
 func TestRefs_OverwritePicksUpNewDigest(t *testing.T) {
-	r := NewRefs(filepath.Join(t.TempDir(), "refs"))
+	r := NewRefs(cacheroot.New(t.TempDir()), "test")
 	_ = r.Put("k", "old")
 	_ = r.Put("k", "new")
 	got, _ := r.Get("k")

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // Store manages a content-addressed blob directory on disk. Safe for
@@ -29,22 +31,24 @@ import (
 // the same digest so two callers writing the same content don't race
 // on the rename finalize.
 type Store struct {
-	root string
+	layout cacheroot.Layout
 
 	mu    sync.Mutex
 	locks map[string]*sync.Mutex
 }
 
-// NewStore constructs a Store rooted at dir. The blobs/sha256/
-// substructure is created lazily on first write.
-func NewStore(dir string) *Store {
-	return &Store{root: dir}
+// NewStore constructs a Store backed by the supplied Layout. The
+// blob subtree is created lazily on first write; Layout's blob
+// path methods are the single source of truth for on-disk
+// positioning.
+func NewStore(layout cacheroot.Layout) *Store {
+	return &Store{layout: layout}
 }
 
 // Path returns the on-disk path for digest. Does not stat — callers
 // use Exists to check populated-ness.
 func (s *Store) Path(digest string) string {
-	return filepath.Join(s.root, "blobs", "sha256", digest)
+	return s.layout.Blob(digest)
 }
 
 // Exists reports whether a blob has been finalized for digest.

--- a/pkg/source/blob/store_test.go
+++ b/pkg/source/blob/store_test.go
@@ -9,10 +9,12 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 func TestStore_PutBytesDigestPath(t *testing.T) {
-	s := NewStore(t.TempDir())
+	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("hello world")
 	dir, digest, err := s.PutBytes(content, "data.txt")
 	if err != nil {
@@ -36,7 +38,7 @@ func TestStore_PutBytesDigestPath(t *testing.T) {
 }
 
 func TestStore_SameContentSharesSlot(t *testing.T) {
-	s := NewStore(t.TempDir())
+	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("dedup me")
 	dir1, d1, err := s.PutBytes(content, "a.txt")
 	if err != nil {
@@ -55,7 +57,7 @@ func TestStore_SameContentSharesSlot(t *testing.T) {
 }
 
 func TestStore_ConcurrentPutsCoalesce(t *testing.T) {
-	s := NewStore(t.TempDir())
+	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("racy")
 	const goroutines = 16
 	var wg sync.WaitGroup

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -1,7 +1,6 @@
 package source
 
 import (
-	"cmp"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -12,6 +11,8 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // Cache manages a content-addressed on-disk directory for fetched
@@ -25,17 +26,24 @@ import (
 // (e.g. read an empty marker, call Reset, wipe the in-progress clone).
 // Different slots proceed in parallel.
 type Cache struct {
-	root string
-	mu   sync.Mutex // guards locks
+	layout cacheroot.Layout
+	mu     sync.Mutex // guards locks
 	// locks holds a sync.Mutex per slot path. Lazily created; never
 	// reaped — the slot count is bounded by user-declared sources.
 	locks map[string]*sync.Mutex
 }
 
-// NewCache constructs a Cache rooted at dir. If dir is empty, a
-// flate-cache subdirectory under os.TempDir() is used.
-func NewCache(dir string) *Cache {
-	return &Cache{root: cmp.Or(dir, filepath.Join(os.TempDir(), "flate-cache"))}
+// NewCache constructs a Cache backed by the supplied Layout. The
+// caller-owned Layout is the single source of truth for cache paths;
+// this Cache asks it for SourceSlot positions and never composes its
+// own. When the Layout's Root is empty, a flate-cache subdirectory
+// under os.TempDir() is used so embedders that don't wire CacheDir
+// still work.
+func NewCache(layout cacheroot.Layout) *Cache {
+	if layout.Root == "" {
+		layout.Root = filepath.Join(os.TempDir(), "flate-cache")
+	}
+	return &Cache{layout: layout}
 }
 
 // slotMu returns the per-slot mutex for path, creating it on first
@@ -82,7 +90,7 @@ func (c *Cache) Slot(url, ref, authID string) (*Slot, error) {
 	// Pass "" when the fetcher has no auth bound to this slot.
 	h := sha256.Sum256([]byte(url + "@" + ref + "#" + authID))
 	hash := hex.EncodeToString(h[:])[:16]
-	final := filepath.Join(c.root, "sources", slug, hash)
+	final := c.layout.SourceSlot(slug, hash)
 
 	m := c.slotMu(final)
 	m.Lock()
@@ -303,5 +311,8 @@ func slugifyRepo(url string) string {
 	if len(url) > maxSlugLen {
 		url = url[:maxSlugLen]
 	}
-	return cmp.Or(url, "repo")
+	if url == "" {
+		return "repo"
+	}
+	return url
 }

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestCache_ResetSerializesAgainstSlot exercises the per-slot mutex
@@ -14,7 +16,7 @@ import (
 // complete without -race tripping. A regression that drops the lock
 // from Slot would fail under `go test -race`.
 func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
-	c := NewCache(t.TempDir())
+	c := NewCache(cacheroot.New(t.TempDir()))
 	const goroutines = 16
 	const iterations = 32
 	var wg sync.WaitGroup
@@ -61,7 +63,7 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 // collision the previous Cache mutex (which guarded only allocation)
 // allowed.
 func TestCache_SlotSerializesSameKey(t *testing.T) {
-	c := NewCache(t.TempDir())
+	c := NewCache(cacheroot.New(t.TempDir()))
 	var firstReleased, secondAcquired atomic.Bool
 
 	// g1Entered closes when G1 has acquired the slot lock; g2Start
@@ -125,7 +127,7 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 // must observe Exists=false. Without atomic rename, a torn fetch would
 // leak its partial directory and the next call would see it as a hit.
 func TestCache_SlotCommitAtomicRename(t *testing.T) {
-	c := NewCache(t.TempDir())
+	c := NewCache(cacheroot.New(t.TempDir()))
 
 	// First fetcher aborts after writing partial state.
 	slot, err := c.Slot("https://example.com/repo", "v1", "")
@@ -160,7 +162,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 // staging, Commit, Release, next Slot observes Exists=true with the
 // committed contents at Path.
 func TestCache_SlotCommitPersists(t *testing.T) {
-	c := NewCache(t.TempDir())
+	c := NewCache(cacheroot.New(t.TempDir()))
 
 	slot, err := c.Slot("https://example.com/repo", "v1", "")
 	if err != nil {
@@ -196,7 +198,7 @@ func TestCache_SlotCommitPersists(t *testing.T) {
 // otherwise the first fetch's clone is silently reused for the second
 // auth context, bypassing the access check.
 func TestCache_AuthIDIsolatesSlots(t *testing.T) {
-	c := NewCache(t.TempDir())
+	c := NewCache(cacheroot.New(t.TempDir()))
 	a, err := c.Slot("https://example.com/repo", "v1", "team-a/git-creds")
 	if err != nil {
 		t.Fatalf("Slot a: %v", err)
@@ -211,7 +213,7 @@ func TestCache_AuthIDIsolatesSlots(t *testing.T) {
 		t.Errorf("auth-keyed slots should differ, both got %q", a.Path)
 	}
 	// Empty authID must still collide with itself.
-	c2 := NewCache(t.TempDir())
+	c2 := NewCache(cacheroot.New(t.TempDir()))
 	x, err := c2.Slot("https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot x: %v", err)
@@ -233,7 +235,7 @@ func TestCache_AuthIDIsolatesSlots(t *testing.T) {
 // rejected the cached digest). Reset wipes the final, Stage allocates
 // a fresh staging dir, write + Commit publishes the new contents.
 func TestCache_SlotResetThenStage(t *testing.T) {
-	c := NewCache(t.TempDir())
+	c := NewCache(cacheroot.New(t.TempDir()))
 
 	// Seed a committed slot.
 	slot, err := c.Slot("https://example.com/repo", "v1", "")

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -1,0 +1,107 @@
+// Package cacheroot owns the layout of flate's on-disk cache. Every
+// other package — fetchers, baseline materialization, GC, helm — asks
+// a Layout for the path of the subtree it operates on; nothing else
+// constructs those paths by hand. The intent is that renaming a
+// subdirectory means editing one method here, not chasing string
+// literals across seven files (and silently breaking the sweeper in
+// the process).
+//
+// Layout is a zero-cost value type. Construct via Layout{Root: …} or
+// New(root); pass by value freely.
+package cacheroot
+
+import "path/filepath"
+
+// Layout describes where the various caches live under a single root.
+// All methods return absolute paths derived from Root + a constant
+// subdirectory name. Methods that take a key (slug, hash, digest, …)
+// append it; methods that return a parent directory are the GC and
+// listing entry points.
+type Layout struct {
+	// Root is the on-disk cache root (typically $XDG_CACHE_HOME/flate
+	// or the user-supplied --cache-dir override).
+	Root string
+}
+
+// New is a convenience constructor; same as Layout{Root: root}.
+func New(root string) Layout { return Layout{Root: root} }
+
+// Subdirectory names. Exported as constants so a future audit of "who
+// touches the sources directory" can grep these specifically; writers
+// and the sweeper consume them via the Layout methods, not directly.
+const (
+	SourcesDir    = "sources"
+	BaselinesDir  = "baselines"
+	BlobsDir      = "blobs"
+	BlobsAlgo     = "sha256"
+	RefsDir       = "refs"
+	GitMirrorsDir = "git-mirrors"
+	HelmTmpDir    = "helm-tmp"
+	HelmCacheDir  = "helm-cache"
+	StageDir      = "stage"
+)
+
+// Sources returns the parent directory of every source slot. Used by
+// GC's age sweep and listing tools.
+func (l Layout) Sources() string { return filepath.Join(l.Root, SourcesDir) }
+
+// SourceSlot returns the on-disk slot for a given (slug, hash) pair.
+// slug is a human-readable repo name; hash is the content-keyed
+// identifier source.Cache computes from (url, ref, authID).
+func (l Layout) SourceSlot(slug, hash string) string {
+	return filepath.Join(l.Root, SourcesDir, slug, hash)
+}
+
+// Baselines returns the parent directory of every materialized
+// baseline tree.
+func (l Layout) Baselines() string { return filepath.Join(l.Root, BaselinesDir) }
+
+// Baseline returns the on-disk path for a baseline tree keyed by its
+// commit sha.
+func (l Layout) Baseline(commitSHA string) string {
+	return filepath.Join(l.Root, BaselinesDir, commitSHA)
+}
+
+// Blobs returns the parent of every content-addressed blob.
+// Always includes the algorithm segment so blobs/sha512/ etc. can land
+// here later without rewriting the GC's walk.
+func (l Layout) Blobs() string { return filepath.Join(l.Root, BlobsDir, BlobsAlgo) }
+
+// Blob returns the on-disk directory for a single blob keyed by its
+// hex sha256 digest.
+func (l Layout) Blob(digest string) string {
+	return filepath.Join(l.Root, BlobsDir, BlobsAlgo, digest)
+}
+
+// RefsRoot returns the parent of every refs table. Walked by GC to
+// clean dangling pointers.
+func (l Layout) RefsRoot() string { return filepath.Join(l.Root, RefsDir) }
+
+// RefsCategory carves out a subdirectory under refs/ for one
+// caller's identity→digest mapping. The first arg is a stable name
+// (e.g. "chart-tarballs", "git-revisions") shared between the writer
+// and any introspection tooling.
+func (l Layout) RefsCategory(name string) string {
+	return filepath.Join(l.Root, RefsDir, name)
+}
+
+// GitMirrors returns the parent of every bare git mirror.
+func (l Layout) GitMirrors() string { return filepath.Join(l.Root, GitMirrorsDir) }
+
+// GitMirror returns the on-disk path for a bare mirror keyed by the
+// stable hash of an upstream URL.
+func (l Layout) GitMirror(urlHash string) string {
+	return filepath.Join(l.Root, GitMirrorsDir, urlHash)
+}
+
+// HelmTmp returns the scratch directory the helm client uses for
+// transient writes (index.yaml downloads, TLS cert materialization).
+func (l Layout) HelmTmp() string { return filepath.Join(l.Root, HelmTmpDir) }
+
+// HelmCache returns the helm client's cacheDir — the on-disk root the
+// chart tarball CAS and chart-tarball refs table sit under.
+func (l Layout) HelmCache() string { return filepath.Join(l.Root, HelmCacheDir) }
+
+// Stage returns the kustomize staging root. Per-render stage dirs land
+// inside as flate-stage-<rand>.
+func (l Layout) Stage() string { return filepath.Join(l.Root, StageDir) }

--- a/pkg/source/cacheroot/layout_test.go
+++ b/pkg/source/cacheroot/layout_test.go
@@ -1,0 +1,40 @@
+package cacheroot
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestLayout_Paths locks in the on-disk layout. The test is intentionally
+// strict — every relocation goes through this fixture, so the diff that
+// renames a subdir is co-located with the diff that updates the GC, the
+// writers, and this test.
+func TestLayout_Paths(t *testing.T) {
+	l := New("/cache")
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Sources", l.Sources(), "/cache/sources"},
+		{"SourceSlot", l.SourceSlot("myrepo", "deadbeef0123"), "/cache/sources/myrepo/deadbeef0123"},
+		{"Baselines", l.Baselines(), "/cache/baselines"},
+		{"Baseline", l.Baseline("abc123"), "/cache/baselines/abc123"},
+		{"Blobs", l.Blobs(), "/cache/blobs/sha256"},
+		{"Blob", l.Blob("ffff"), "/cache/blobs/sha256/ffff"},
+		{"RefsRoot", l.RefsRoot(), "/cache/refs"},
+		{"RefsCategory", l.RefsCategory("chart-tarballs"), "/cache/refs/chart-tarballs"},
+		{"GitMirrors", l.GitMirrors(), "/cache/git-mirrors"},
+		{"GitMirror", l.GitMirror("0123"), "/cache/git-mirrors/0123"},
+		{"HelmTmp", l.HelmTmp(), "/cache/helm-tmp"},
+		{"HelmCache", l.HelmCache(), "/cache/helm-cache"},
+		{"Stage", l.Stage(), "/cache/stage"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if filepath.Clean(c.got) != filepath.Clean(c.want) {
+				t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+			}
+		})
+	}
+}

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // SweepOpts tunes Sweep's behavior.
@@ -42,21 +44,21 @@ type SweepResult struct {
 	Errors []error
 }
 
-// Sweep prunes stale entries under root according to opts. Walks the
-// known per-cache subdirectories (sources/, baselines/, blobs/sha256/)
-// and removes top-level entries whose mtime is older than opts.MaxAge.
-// Dangling refs files whose digest no longer materializes in
-// blobs/sha256/ are removed regardless of age.
+// Sweep prunes stale entries from the cache root described by layout
+// according to opts. Walks the layout-managed subdirectories — sources,
+// baselines, blobs — and removes top-level entries whose mtime is older
+// than opts.MaxAge. Dangling refs files whose digest no longer
+// materializes in the blob store are removed regardless of age.
 //
-// Mirrors at <root>/git-mirrors are preserved by default; pass
+// Mirrors (layout.GitMirrors()) are preserved by default; pass
 // IncludeMirrors to age-prune them too.
 //
 // Returns a SweepResult with the (would-be-)removed paths and a count
 // of recoverable bytes. Individual I/O errors land in Result.Errors
 // rather than short-circuiting the sweep.
-func Sweep(root string, opts SweepOpts) (SweepResult, error) {
+func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 	var res SweepResult
-	if root == "" {
+	if layout.Root == "" {
 		return res, fmt.Errorf("sweep: empty cache root")
 	}
 	cutoff := time.Time{}
@@ -64,28 +66,38 @@ func Sweep(root string, opts SweepOpts) (SweepResult, error) {
 		cutoff = time.Now().Add(-opts.MaxAge)
 	}
 
-	ageRoots := []string{
-		filepath.Join(root, "sources"),
-		filepath.Join(root, "baselines"),
-		filepath.Join(root, "blobs", "sha256"),
+	// Each entry pairs a directory to sweep with the depth at which
+	// the age comparison applies. Sources land at <root>/sources/
+	// <slug>/<hash>/, so age comparison is two levels in; everything
+	// else compares mtime of the immediate child.
+	ageRoots := []struct {
+		dir   string
+		depth int
+	}{
+		{layout.Sources(), 2},
+		{layout.Baselines(), 1},
+		{layout.Blobs(), 1},
 	}
 	if opts.IncludeMirrors {
-		ageRoots = append(ageRoots, filepath.Join(root, "git-mirrors"))
+		ageRoots = append(ageRoots, struct {
+			dir   string
+			depth int
+		}{layout.GitMirrors(), 1})
 	}
-	for _, dir := range ageRoots {
-		sweepDirByAge(dir, cutoff, opts.DryRun, &res)
+	for _, ar := range ageRoots {
+		sweepDirByAge(ar.dir, ar.depth, cutoff, opts.DryRun, &res)
 	}
 
-	sweepDanglingRefs(filepath.Join(root, "refs"), root, opts.DryRun, &res)
+	sweepDanglingRefs(layout, opts.DryRun, &res)
 
 	return res, nil
 }
 
 // sweepDirByAge removes immediate-child entries of dir whose mtime is
-// older than cutoff. For sources/ this is one level deeper (slug/hash)
-// — we descend one extra level so the slug/ wrapper doesn't shield
-// stale hash slots from age comparison.
-func sweepDirByAge(dir string, cutoff time.Time, dryRun bool, res *SweepResult) {
+// older than cutoff. depth=1 compares mtime of dir's children;
+// depth=2 recurses one more level (sources/<slug>/<hash> — the slug
+// wrapper would otherwise shield stale hash slots from comparison).
+func sweepDirByAge(dir string, depth int, cutoff time.Time, dryRun bool, res *SweepResult) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -93,11 +105,9 @@ func sweepDirByAge(dir string, cutoff time.Time, dryRun bool, res *SweepResult) 
 		}
 		return
 	}
-	// sources/ has an extra slug/ level — recurse one deeper so the
-	// final hash dirs are the age targets.
-	if filepath.Base(dir) == "sources" {
+	if depth > 1 {
 		for _, e := range entries {
-			sweepDirByAge(filepath.Join(dir, e.Name()), cutoff, dryRun, res)
+			sweepDirByAge(filepath.Join(dir, e.Name()), depth-1, cutoff, dryRun, res)
 		}
 		return
 	}
@@ -126,11 +136,12 @@ func sweepDirByAge(dir string, cutoff time.Time, dryRun bool, res *SweepResult) 
 	}
 }
 
-// sweepDanglingRefs walks every file under refsRoot (recursively) and
-// removes entries whose stored digest no longer materializes a blob
-// under <cacheRoot>/blobs/sha256/. Refs files are tiny so we read
-// each one to compare.
-func sweepDanglingRefs(refsRoot, cacheRoot string, dryRun bool, res *SweepResult) {
+// sweepDanglingRefs walks every file under the layout's refs root
+// (recursively) and removes entries whose stored digest no longer
+// materializes a blob in the layout's blob store. Refs files are tiny
+// so we read each one to compare.
+func sweepDanglingRefs(layout cacheroot.Layout, dryRun bool, res *SweepResult) {
+	refsRoot := layout.RefsRoot()
 	_ = filepath.WalkDir(refsRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -171,7 +182,7 @@ func sweepDanglingRefs(refsRoot, cacheRoot string, dryRun bool, res *SweepResult
 			res.Errors = append(res.Errors, fmt.Errorf("refs %s: bogus digest %q", path, digest))
 			return nil
 		}
-		blobPath := filepath.Join(cacheRoot, "blobs", "sha256", digest)
+		blobPath := layout.Blob(digest)
 		if _, err := os.Stat(blobPath); err == nil { //nolint:gosec // digest gated by looksLikeDigest above
 			return nil
 		}

--- a/pkg/source/gc_test.go
+++ b/pkg/source/gc_test.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestSweep_AgePrunesStaleSlots: a slot whose mtime is older than
@@ -27,7 +29,7 @@ func TestSweep_AgePrunesStaleSlots(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, err := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour})
+	res, err := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour})
 	if err != nil {
 		t.Fatalf("Sweep: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestSweep_BaselinesAndBlobs(t *testing.T) {
 		}
 	}
 
-	res, _ := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour})
+	res, _ := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour})
 	if len(res.Removed) != 2 {
 		t.Errorf("Removed = %v, want 2 entries", res.Removed)
 	}
@@ -80,12 +82,12 @@ func TestSweep_MirrorsPreservedByDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, _ := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour})
+	res, _ := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour})
 	if slices.Contains(res.Removed, mirror) {
 		t.Error("mirror swept without IncludeMirrors")
 	}
 
-	res, _ = Sweep(root, SweepOpts{MaxAge: 24 * time.Hour, IncludeMirrors: true})
+	res, _ = Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour, IncludeMirrors: true})
 	if !slices.Contains(res.Removed, mirror) {
 		t.Errorf("mirror not swept with IncludeMirrors: %v", res.Removed)
 	}
@@ -116,7 +118,7 @@ func TestSweep_DanglingRefsCleaned(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, _ := Sweep(root, SweepOpts{})
+	res, _ := Sweep(cacheroot.New(root), SweepOpts{})
 	if !slices.Contains(res.Removed, dangling) {
 		t.Errorf("dangling ref not removed: %v", res.Removed)
 	}
@@ -138,7 +140,7 @@ func TestSweep_DryRunReports(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res, _ := Sweep(root, SweepOpts{MaxAge: 24 * time.Hour, DryRun: true})
+	res, _ := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour, DryRun: true})
 	if !slices.Contains(res.Removed, slot) {
 		t.Errorf("DryRun didn't report stale slot: %v", res.Removed)
 	}

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -13,13 +13,14 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 func TestFetcher_LocalFileURL(t *testing.T) {
 	src := t.TempDir()
 	mustInitRepo(t, src)
 
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
@@ -56,7 +57,7 @@ func TestFetcher_RefByName(t *testing.T) {
 	mustInitRepo(t, src)
 	tagged := mustTagHEAD(t, src, "v0.1.0")
 
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -80,7 +81,7 @@ func TestFetcher_RefByName_Unresolvable(t *testing.T) {
 	src := t.TempDir()
 	mustInitRepo(t, src)
 
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -107,7 +108,7 @@ func TestFetcher_SparseCheckout(t *testing.T) {
 		"README.md":             "top-level",
 	})
 
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -141,7 +142,7 @@ func TestFetcher_AppliesSpecIgnore(t *testing.T) {
 	})
 
 	patterns := "*.tmp\ndocs/\n"
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -173,7 +174,7 @@ func TestFetcher_CacheMarkerSurvivesIgnore(t *testing.T) {
 	src := t.TempDir()
 	mustInitRepo(t, src)
 
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	patterns := "/*\n!/hello.txt\n"
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",

--- a/pkg/source/git/mirror.go
+++ b/pkg/source/git/mirror.go
@@ -19,6 +19,7 @@ import (
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // MirrorCache holds one bare clone per unique upstream URL. The mirror
@@ -31,16 +32,17 @@ import (
 // path runs unchanged (used by tests and any caller that prefers the
 // older behavior).
 type MirrorCache struct {
-	root string
+	layout cacheroot.Layout
 
 	mu    sync.Mutex
 	locks map[string]*sync.Mutex
 }
 
-// NewMirrorCache constructs a MirrorCache rooted at dir. The directory
-// is created lazily on first openOrFetch.
-func NewMirrorCache(dir string) *MirrorCache {
-	return &MirrorCache{root: dir}
+// NewMirrorCache constructs a MirrorCache backed by the supplied
+// Layout. The git-mirrors subtree is created lazily on first
+// openOrFetch.
+func NewMirrorCache(layout cacheroot.Layout) *MirrorCache {
+	return &MirrorCache{layout: layout}
 }
 
 // urlHash returns the stable directory name for url's mirror. The hash
@@ -54,7 +56,7 @@ func urlHash(url string) string {
 }
 
 func (m *MirrorCache) pathFor(url string) string {
-	return filepath.Join(m.root, urlHash(url))
+	return m.layout.GitMirror(urlHash(url))
 }
 
 // lockFor returns the per-URL mutex, creating it on first access. Used

--- a/pkg/source/git/mirror_test.go
+++ b/pkg/source/git/mirror_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestMirror_BareClonePersistsAcrossFetches confirms that a Fetcher
@@ -22,14 +23,15 @@ func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
 	mustInitRepo(t, src)
 
 	cacheDir := t.TempDir()
-	mirrorDir := filepath.Join(cacheDir, "git-mirrors")
+	layout := cacheroot.New(cacheDir)
+	mirrorDir := layout.GitMirrors()
 
-	cache := source.NewCache(cacheDir)
+	cache := source.NewCache(layout)
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
 	}
-	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(mirrorDir)}
+	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(layout)}
 
 	art, err := f.Fetch(context.Background(), repo)
 	if err != nil {
@@ -67,7 +69,7 @@ func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
 // We don't actually wire up a submodule repo — we only assert the
 // branch decision via canUseMirror.
 func TestMirror_FallsBackForSubmodules(t *testing.T) {
-	f := &Fetcher{Mirrors: NewMirrorCache(t.TempDir())}
+	f := &Fetcher{Mirrors: NewMirrorCache(cacheroot.New(t.TempDir()))}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -102,9 +104,9 @@ func TestMirror_TagResolvesAcrossRefs(t *testing.T) {
 	mustInitRepo(t, src)
 	tagged := mustTagHEAD(t, src, "v1.0.0")
 
-	cacheDir := t.TempDir()
-	cache := source.NewCache(cacheDir)
-	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(filepath.Join(cacheDir, "git-mirrors"))}
+	layout := cacheroot.New(t.TempDir())
+	cache := source.NewCache(layout)
+	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(layout)}
 
 	// First: fetch a tag.
 	tagRepo := &manifest.GitRepository{

--- a/pkg/source/oci/fetch_test.go
+++ b/pkg/source/oci/fetch_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // TestFetcher_ExtractsLayerWithoutTitleAnnotation regresses the silent
@@ -43,7 +44,7 @@ func TestFetcher_ExtractsLayerWithoutTitleAnnotation(t *testing.T) {
 
 	srv := startFakeRegistry(t, manifestBytes, configBytes, layerBytes)
 
-	f := &Fetcher{Cache: source.NewCache(t.TempDir())}
+	f := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))}
 	repo := &manifest.OCIRepository{
 		Name:      "flux-manifests",
 		Namespace: "flux-system",
@@ -100,7 +101,7 @@ func TestFetcher_PartialSlotInvalidated(t *testing.T) {
 	)
 	srv := startFakeRegistry(t, manifestBytes, configBytes, layerBytes)
 
-	cache := source.NewCache(t.TempDir())
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	f := &Fetcher{Cache: cache}
 	repo := &manifest.OCIRepository{
 		Name:      "partial",
@@ -168,7 +169,7 @@ func TestFetcher_ExtractCollidesWithOCILayoutName(t *testing.T) {
 	)
 	srv := startFakeRegistry(t, manifestBytes, configBytes, layerBytes)
 
-	f := &Fetcher{Cache: source.NewCache(t.TempDir())}
+	f := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))}
 	repo := &manifest.OCIRepository{
 		Name:      "collider",
 		Namespace: "test",


### PR DESCRIPTION
## Cleanup PR A — eliminate cache-path coupling

`pkg/source/cacheroot.Layout` is now the single source of truth for every on-disk cache subtree. Every writer + GC asks the Layout for its paths; nothing else composes them.

## Why
Before this PR, `sources/`, `baselines/`, `blobs/sha256/`, `refs/`, `git-mirrors/`, `helm-tmp/`, `helm-cache/` were string-literals scattered across seven writers and a sweeper that rebuilt them independently. The audit found:
- `gc.go` hardcodes `blobs/sha256` *three* times.
- GC's `sources/` depth logic recognizes the directory by string compare on line 98 — rename silently breaks it.
- Helm wrote chart refs under `<cacheDir>/refs/chart-tarballs/` while GC walked `<root>/refs/` — misaligned roots before this PR.

## How
Layout exposes path methods like `SourceSlot(slug, hash)`, `Baseline(sha)`, `Blob(digest)`, `RefsCategory(name)`, `GitMirror(urlhash)`, `HelmTmp()`, `HelmCache()`. Subdirectory names are exported constants so a future audit (or refactor) can grep them.

Every constructor takes a `Layout`:
- `source.NewCache(layout)`
- `blob.NewStore(layout)`
- `blob.NewRefs(layout, category)`
- `git.NewMirrorCache(layout)`
- `baseline.AutoResolve(path, base, layout)`
- `helm.NewClient(layout)`
- `source.Sweep(layout, opts)`

GC's special-case depth logic for sources/ becomes an explicit `depth: 2` field in the age-roots table — no more `filepath.Base(dir) == "sources"` magic.

## Bonus alignment
Helm chart-tarball CAS now points at the shared `<root>/blobs/sha256/` store and `<root>/refs/chart-tarballs/`. Two HelmRepositories that publish identical chart bytes share one on-disk slot regardless of which one fetched first.

## Plan
First of 5 cleanup PRs. Next: mark-sweep GC (which can preserve referenced blobs regardless of age — the TOCTOU race the audit found).

🤖 Generated with [Claude Code](https://claude.com/claude-code)