### PR TITLE
refactor(source): unify per-key locks via internal/keylock

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -234,7 +234,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", chartURL, err)
 	}
-	dir, digest, err := c.chartBlobs.PutBytes(buf.Bytes(), "chart.tgz")
+	dir, digest, err := c.chartBlobs.PutBytes(ctx, buf.Bytes(), "chart.tgz")
 	if err != nil {
 		return "", fmt.Errorf("store chart %s: %w", chartURL, err)
 	}

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -14,6 +14,7 @@
 package blob
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -21,20 +22,18 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // Store manages a content-addressed blob directory on disk. Safe for
-// concurrent use; per-digest mutexes serialize PutFile/PutBytes for
-// the same digest so two callers writing the same content don't race
-// on the rename finalize.
+// concurrent use; the keylock.KeyMap serializes Put for the same digest
+// so two callers writing the same content don't race on rename
+// finalize.
 type Store struct {
 	layout cacheroot.Layout
-
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks  *keylock.KeyMap[string]
 }
 
 // NewStore constructs a Store backed by the supplied Layout. The
@@ -42,7 +41,7 @@ type Store struct {
 // path methods are the single source of truth for on-disk
 // positioning.
 func NewStore(layout cacheroot.Layout) *Store {
-	return &Store{layout: layout}
+	return &Store{layout: layout, locks: keylock.New[string]()}
 }
 
 // Path returns the on-disk path for digest. Does not stat — callers
@@ -60,19 +59,22 @@ func (s *Store) Exists(digest string) bool {
 // PutBytes installs content as a single file named filename inside the
 // blob directory keyed by content's sha256. The digest is recomputed
 // from the bytes (never trusted from caller input). Concurrent callers
-// targeting the same digest serialize on a per-digest mutex; the first
+// targeting the same digest serialize on a per-digest lock; the first
 // finalizes via atomic rename and the rest observe ErrExists internally
-// and return without rewriting.
+// and return without rewriting. ctx cancellation aborts the lock
+// acquire (no write performed).
 //
 // Returns the populated blob directory path and the computed digest.
-func (s *Store) PutBytes(content []byte, filename string) (string, string, error) {
+func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (string, string, error) {
 	sum := sha256.Sum256(content)
 	digest := hex.EncodeToString(sum[:])
 	dir := s.Path(digest)
 
-	lock := s.lockFor(digest)
-	lock.Lock()
-	defer lock.Unlock()
+	release, err := s.locks.Acquire(ctx, digest)
+	if err != nil {
+		return "", "", err
+	}
+	defer release()
 
 	if s.Exists(digest) {
 		return dir, digest, nil
@@ -105,24 +107,11 @@ func (s *Store) PutBytes(content []byte, filename string) (string, string, error
 // PutReader is the streaming variant of PutBytes. Useful when the
 // caller has an io.Reader but doesn't want to buffer the whole
 // artifact in memory.
-func (s *Store) PutReader(r io.Reader, filename string) (string, string, error) {
+func (s *Store) PutReader(ctx context.Context, r io.Reader, filename string) (string, string, error) {
 	buf, err := io.ReadAll(r)
 	if err != nil {
 		return "", "", err
 	}
-	return s.PutBytes(buf, filename)
+	return s.PutBytes(ctx, buf, filename)
 }
 
-func (s *Store) lockFor(digest string) *sync.Mutex {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.locks == nil {
-		s.locks = make(map[string]*sync.Mutex)
-	}
-	mx, ok := s.locks[digest]
-	if !ok {
-		mx = &sync.Mutex{}
-		s.locks[digest] = mx
-	}
-	return mx
-}

--- a/pkg/source/blob/store_test.go
+++ b/pkg/source/blob/store_test.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -16,7 +17,7 @@ import (
 func TestStore_PutBytesDigestPath(t *testing.T) {
 	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("hello world")
-	dir, digest, err := s.PutBytes(content, "data.txt")
+	dir, digest, err := s.PutBytes(context.Background(), content, "data.txt")
 	if err != nil {
 		t.Fatalf("PutBytes: %v", err)
 	}
@@ -40,11 +41,11 @@ func TestStore_PutBytesDigestPath(t *testing.T) {
 func TestStore_SameContentSharesSlot(t *testing.T) {
 	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("dedup me")
-	dir1, d1, err := s.PutBytes(content, "a.txt")
+	dir1, d1, err := s.PutBytes(context.Background(), content, "a.txt")
 	if err != nil {
 		t.Fatalf("Put 1: %v", err)
 	}
-	dir2, d2, err := s.PutBytes(content, "a.txt")
+	dir2, d2, err := s.PutBytes(context.Background(), content, "a.txt")
 	if err != nil {
 		t.Fatalf("Put 2: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestStore_ConcurrentPutsCoalesce(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, d, err := s.PutBytes(content, "data")
+			_, d, err := s.PutBytes(context.Background(), content, "data")
 			if err != nil {
 				errs.Add(1)
 				return

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -78,7 +78,7 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 	// still holds the dead file. We treat every fetch as a miss:
 	// write to a fresh staging dir, then atomic-rename into the final
 	// slot on success.
-	slot, err := f.Cache.Slot(endpoint+"/"+b.BucketName, b.Prefix, authIdentity(b))
+	slot, err := f.Cache.Slot(ctx, endpoint+"/"+b.BucketName, b.Prefix, authIdentity(b))
 	if err != nil {
 		return nil, fmt.Errorf("bucket %s/%s cache slot: %w", b.Namespace, b.Name, err)
 	}

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -10,8 +11,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
@@ -27,10 +28,10 @@ import (
 // Different slots proceed in parallel.
 type Cache struct {
 	layout cacheroot.Layout
-	mu     sync.Mutex // guards locks
-	// locks holds a sync.Mutex per slot path. Lazily created; never
-	// reaped — the slot count is bounded by user-declared sources.
-	locks map[string]*sync.Mutex
+	// locks is the canonical per-slot mutex provider. Sharing the
+	// keylock.KeyMap implementation with helm + blob keeps cancellation
+	// semantics and lifetime management consistent across the cache.
+	locks *keylock.KeyMap[string]
 }
 
 // NewCache constructs a Cache backed by the supplied Layout. The
@@ -43,23 +44,7 @@ func NewCache(layout cacheroot.Layout) *Cache {
 	if layout.Root == "" {
 		layout.Root = filepath.Join(os.TempDir(), "flate-cache")
 	}
-	return &Cache{layout: layout}
-}
-
-// slotMu returns the per-slot mutex for path, creating it on first
-// access. Caller must NOT hold c.mu.
-func (c *Cache) slotMu(path string) *sync.Mutex {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.locks == nil {
-		c.locks = make(map[string]*sync.Mutex)
-	}
-	m, ok := c.locks[path]
-	if !ok {
-		m = &sync.Mutex{}
-		c.locks[path] = m
-	}
-	return m
+	return &Cache{layout: layout, locks: keylock.New[string]()}
 }
 
 // Slot allocates a per-(url, ref) slot under the cache root with
@@ -81,7 +66,7 @@ func (c *Cache) slotMu(path string) *sync.Mutex {
 // next fetch starts clean. This atomicity replaces the older
 // "write in place + .flate-* sentinels" pattern: the final slot is
 // either complete or doesn't exist, never torn.
-func (c *Cache) Slot(url, ref, authID string) (*Slot, error) {
+func (c *Cache) Slot(ctx context.Context, url, ref, authID string) (*Slot, error) {
 	slug := slugifyRepo(url)
 	// authID participates in the cache key so two source CRs with the
 	// same (URL, ref) but different SecretRef / RegistryConfig don't
@@ -92,9 +77,11 @@ func (c *Cache) Slot(url, ref, authID string) (*Slot, error) {
 	hash := hex.EncodeToString(h[:])[:16]
 	final := c.layout.SourceSlot(slug, hash)
 
-	m := c.slotMu(final)
-	m.Lock()
-	s := &Slot{final: final, mu: m}
+	release, err := c.locks.Acquire(ctx, final)
+	if err != nil {
+		return nil, err
+	}
+	s := &Slot{final: final, release: release}
 
 	info, statErr := os.Stat(final)
 	switch {
@@ -171,7 +158,7 @@ type Slot struct {
 
 	final     string
 	staging   string
-	mu        *sync.Mutex
+	release   func() // keylock release; populated by Cache.Slot
 	committed bool
 	unlocked  bool
 }
@@ -251,7 +238,7 @@ func (s *Slot) unlock() {
 		return
 	}
 	s.unlocked = true
-	s.mu.Unlock()
+	s.release()
 }
 
 // nonAlnum collapses non-alphanumeric (plus `.-_`) runs into a single

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -26,7 +27,7 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range iterations {
-				slot, err := c.Slot("https://shared.example/repo", "main", "")
+				slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
@@ -37,7 +38,7 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range iterations {
-				slot, err := c.Slot("https://shared.example/repo", "main", "")
+				slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
@@ -74,7 +75,7 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 	g2Start := make(chan struct{})
 	done := make(chan struct{}, 2)
 	go func() {
-		slot, err := c.Slot("https://shared.example/repo", "main", "")
+		slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 		if err != nil {
 			t.Errorf("Slot: %v", err)
 			done <- struct{}{}
@@ -94,7 +95,7 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 	}()
 	<-g1Entered // G1 holds the lock.
 	go func() {
-		slot, err := c.Slot("https://shared.example/repo", "main", "")
+		slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 		if err != nil {
 			t.Errorf("Slot: %v", err)
 			done <- struct{}{}
@@ -130,7 +131,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
 
 	// First fetcher aborts after writing partial state.
-	slot, err := c.Slot("https://example.com/repo", "v1", "")
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot: %v", err)
 	}
@@ -148,7 +149,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 	}
 
 	// Next caller must see Exists=false.
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 2: %v", err)
 	}
@@ -164,7 +165,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 func TestCache_SlotCommitPersists(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
 
-	slot, err := c.Slot("https://example.com/repo", "v1", "")
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestCache_SlotCommitPersists(t *testing.T) {
 	committed := slot.Path
 	slot.Release()
 
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 2: %v", err)
 	}
@@ -199,12 +200,12 @@ func TestCache_SlotCommitPersists(t *testing.T) {
 // auth context, bypassing the access check.
 func TestCache_AuthIDIsolatesSlots(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
-	a, err := c.Slot("https://example.com/repo", "v1", "team-a/git-creds")
+	a, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "team-a/git-creds")
 	if err != nil {
 		t.Fatalf("Slot a: %v", err)
 	}
 	defer a.Release()
-	b, err := c.Slot("https://example.com/repo", "v1", "team-b/git-creds")
+	b, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "team-b/git-creds")
 	if err != nil {
 		t.Fatalf("Slot b: %v", err)
 	}
@@ -214,13 +215,13 @@ func TestCache_AuthIDIsolatesSlots(t *testing.T) {
 	}
 	// Empty authID must still collide with itself.
 	c2 := NewCache(cacheroot.New(t.TempDir()))
-	x, err := c2.Slot("https://example.com/repo", "v1", "")
+	x, err := c2.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot x: %v", err)
 	}
 	y := filepath.Dir(x.Path)
 	x.Release()
-	z, err := c2.Slot("https://example.com/repo", "v1", "")
+	z, err := c2.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot z: %v", err)
 	}
@@ -238,7 +239,7 @@ func TestCache_SlotResetThenStage(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
 
 	// Seed a committed slot.
-	slot, err := c.Slot("https://example.com/repo", "v1", "")
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot: %v", err)
 	}
@@ -251,7 +252,7 @@ func TestCache_SlotResetThenStage(t *testing.T) {
 	slot.Release()
 
 	// Acquire again, detect stale, reset-and-restage.
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 2: %v", err)
 	}
@@ -272,7 +273,7 @@ func TestCache_SlotResetThenStage(t *testing.T) {
 	}
 	slot.Release()
 
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 3: %v", err)
 	}

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -36,7 +36,8 @@ type SweepResult struct {
 	// "kind" of cache that lost the entry — sources/, baselines/, etc.
 	Removed []string
 	// Bytes is the cumulative size of removed entries before deletion.
-	// Approximate — du-style recursive walk per entry.
+	// Computed during the same walk that decides removal so the sweep
+	// stays O(files) overall.
 	Bytes int64
 	// Errors aggregates per-entry I/O errors. Sweep continues past
 	// individual failures and reports them here so a single permissions
@@ -45,17 +46,21 @@ type SweepResult struct {
 }
 
 // Sweep prunes stale entries from the cache root described by layout
-// according to opts. Walks the layout-managed subdirectories — sources,
-// baselines, blobs — and removes top-level entries whose mtime is older
-// than opts.MaxAge. Dangling refs files whose digest no longer
-// materializes in the blob store are removed regardless of age.
+// using a mark-sweep strategy:
 //
-// Mirrors (layout.GitMirrors()) are preserved by default; pass
-// IncludeMirrors to age-prune them too.
+//  1. MARK — read every refs/<category>/<key> file, build the set of
+//     digests still referenced from disk.
+//  2. SWEEP — walk the layout-managed subtrees (sources, baselines,
+//     blobs, optionally git-mirrors) and remove entries older than
+//     MaxAge. Blobs whose digest is in the live set survive
+//     regardless of age — a fresh ref must always resolve.
+//  3. ORPHAN refs — drop refs whose digest no longer materializes a
+//     blob. Runs regardless of MaxAge; these are dead pointers and
+//     refs cost nothing on disk anyway.
 //
-// Returns a SweepResult with the (would-be-)removed paths and a count
-// of recoverable bytes. Individual I/O errors land in Result.Errors
-// rather than short-circuiting the sweep.
+// Mirrors are preserved by default; pass IncludeMirrors to age-prune
+// them too. Individual I/O errors land in Result.Errors rather than
+// short-circuiting the sweep.
 func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 	var res SweepResult
 	if layout.Root == "" {
@@ -66,26 +71,32 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 		cutoff = time.Now().Add(-opts.MaxAge)
 	}
 
+	live := markLiveDigests(layout, &res)
+
 	// Each entry pairs a directory to sweep with the depth at which
-	// the age comparison applies. Sources land at <root>/sources/
-	// <slug>/<hash>/, so age comparison is two levels in; everything
-	// else compares mtime of the immediate child.
+	// the age comparison applies and whether the leaf's basename is
+	// a content digest to consult the live set with. Sources land at
+	// <root>/sources/<slug>/<hash>/ so age comparison is two levels
+	// in; blobs sit one level below the algo segment and are gated
+	// by mark.
 	ageRoots := []struct {
 		dir   string
 		depth int
+		gate  func(name string) bool // skip when gate returns true
 	}{
-		{layout.Sources(), 2},
-		{layout.Baselines(), 1},
-		{layout.Blobs(), 1},
+		{layout.Sources(), 2, nil},
+		{layout.Baselines(), 1, nil},
+		{layout.Blobs(), 1, func(name string) bool { _, ok := live[name]; return ok }},
 	}
 	if opts.IncludeMirrors {
 		ageRoots = append(ageRoots, struct {
 			dir   string
 			depth int
-		}{layout.GitMirrors(), 1})
+			gate  func(name string) bool
+		}{layout.GitMirrors(), 1, nil})
 	}
 	for _, ar := range ageRoots {
-		sweepDirByAge(ar.dir, ar.depth, cutoff, opts.DryRun, &res)
+		sweepDirByAge(ar.dir, ar.depth, cutoff, ar.gate, opts.DryRun, &res)
 	}
 
 	sweepDanglingRefs(layout, opts.DryRun, &res)
@@ -93,11 +104,48 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 	return res, nil
 }
 
+// markLiveDigests walks every refs/<category>/<key> file and returns
+// the set of digests they point at. Used to gate blob sweep: a fresh
+// ref must always be able to resolve, even if its blob is "old".
+// Malformed or missing refs land in res.Errors but don't abort.
+func markLiveDigests(layout cacheroot.Layout, res *SweepResult) map[string]struct{} {
+	live := map[string]struct{}{}
+	refsRoot := layout.RefsRoot()
+	_ = filepath.WalkDir(refsRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fs.SkipDir
+			}
+			res.Errors = append(res.Errors, fmt.Errorf("mark refs %s: %w", path, err))
+			return nil
+		}
+		if d.IsDir() || strings.HasPrefix(d.Name(), ".tmp.") {
+			return nil
+		}
+		b, rerr := os.ReadFile(path) //nolint:gosec // path is a WalkDir result under refsRoot
+		if rerr != nil {
+			res.Errors = append(res.Errors, fmt.Errorf("mark read %s: %w", path, rerr))
+			return nil
+		}
+		digest := strings.TrimSpace(string(b))
+		if looksLikeDigest(digest) {
+			live[digest] = struct{}{}
+		}
+		return nil
+	})
+	return live
+}
+
 // sweepDirByAge removes immediate-child entries of dir whose mtime is
-// older than cutoff. depth=1 compares mtime of dir's children;
-// depth=2 recurses one more level (sources/<slug>/<hash> — the slug
-// wrapper would otherwise shield stale hash slots from comparison).
-func sweepDirByAge(dir string, depth int, cutoff time.Time, dryRun bool, res *SweepResult) {
+// older than cutoff. depth>1 recurses (sources/<slug>/<hash> — the
+// slug wrapper would otherwise shield stale hash slots from
+// comparison). gate, when non-nil, is consulted with the leaf name
+// before age is checked; returning true preserves the entry.
+//
+// Sizes accumulate during this single walk; entries that survive the
+// age check don't contribute to res.Bytes, but neither do they get
+// re-walked elsewhere — the sweep stays O(files) overall.
+func sweepDirByAge(dir string, depth int, cutoff time.Time, gate func(string) bool, dryRun bool, res *SweepResult) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -107,26 +155,25 @@ func sweepDirByAge(dir string, depth int, cutoff time.Time, dryRun bool, res *Sw
 	}
 	if depth > 1 {
 		for _, e := range entries {
-			sweepDirByAge(filepath.Join(dir, e.Name()), depth-1, cutoff, dryRun, res)
+			sweepDirByAge(filepath.Join(dir, e.Name()), depth-1, cutoff, gate, dryRun, res)
 		}
 		return
 	}
 	for _, e := range entries {
 		path := filepath.Join(dir, e.Name())
+		if gate != nil && gate(e.Name()) {
+			continue
+		}
 		info, err := e.Info()
 		if err != nil {
 			res.Errors = append(res.Errors, fmt.Errorf("stat %s: %w", path, err))
 			continue
 		}
-		if cutoff.IsZero() {
+		if cutoff.IsZero() || info.ModTime().After(cutoff) {
 			continue
 		}
-		if info.ModTime().After(cutoff) {
-			continue
-		}
-		size := entrySize(path)
+		res.Bytes += entrySize(path)
 		res.Removed = append(res.Removed, path)
-		res.Bytes += size
 		if dryRun {
 			continue
 		}
@@ -140,6 +187,10 @@ func sweepDirByAge(dir string, depth int, cutoff time.Time, dryRun bool, res *Sw
 // (recursively) and removes entries whose stored digest no longer
 // materializes a blob in the layout's blob store. Refs files are tiny
 // so we read each one to compare.
+//
+// This runs AFTER the blob age sweep — if the mark phase preserved
+// blobs that live refs point at, only genuinely-dead pointers (or
+// orphaned .tmp.* staging files from torn writes) remain here.
 func sweepDanglingRefs(layout cacheroot.Layout, dryRun bool, res *SweepResult) {
 	refsRoot := layout.RefsRoot()
 	_ = filepath.WalkDir(refsRoot, func(path string, d fs.DirEntry, err error) error {
@@ -174,10 +225,6 @@ func sweepDanglingRefs(layout cacheroot.Layout, dryRun bool, res *SweepResult) {
 			}
 			return nil
 		}
-		// Reject anything that doesn't look like a sha256 hex — defense
-		// against a hostile or corrupt refs file injecting a traversal
-		// path. The filepath.Join below would normalize "../..", but
-		// rejecting upfront keeps the blame closer to the source.
 		if !looksLikeDigest(digest) {
 			res.Errors = append(res.Errors, fmt.Errorf("refs %s: bogus digest %q", path, digest))
 			return nil
@@ -186,9 +233,6 @@ func sweepDanglingRefs(layout cacheroot.Layout, dryRun bool, res *SweepResult) {
 		if _, err := os.Stat(blobPath); err == nil { //nolint:gosec // digest gated by looksLikeDigest above
 			return nil
 		}
-		// The digest this ref points at has been swept away — drop the
-		// pointer so future lookups don't keep claiming "we know about
-		// this digest, but it's gone".
 		res.Removed = append(res.Removed, path)
 		if !dryRun {
 			if err := os.Remove(path); err != nil { //nolint:gosec // path is a WalkDir result under refsRoot

--- a/pkg/source/gc_test.go
+++ b/pkg/source/gc_test.go
@@ -127,6 +127,66 @@ func TestSweep_DanglingRefsCleaned(t *testing.T) {
 	}
 }
 
+// TestSweep_LiveRefPreservesOldBlob is the mark-sweep contract: a
+// blob whose digest is referenced by a live ref must survive the age
+// sweep, even when its mtime is older than MaxAge. Without mark, the
+// fresh ref would silently point at a deleted blob and the next
+// render would hit ENOENT.
+func TestSweep_LiveRefPreservesOldBlob(t *testing.T) {
+	root := t.TempDir()
+	const digest = "2222222222222222222222222222222222222222222222222222222222222222"
+
+	blob := filepath.Join(root, "blobs", "sha256", digest)
+	if err := os.MkdirAll(blob, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Stamp the blob old so the age sweep would otherwise grab it.
+	old := time.Now().Add(-365 * 24 * time.Hour)
+	if err := os.Chtimes(blob, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh ref points at this digest — the chart we just resolved.
+	if err := os.MkdirAll(filepath.Join(root, "refs", "charts"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	ref := filepath.Join(root, "refs", "charts", "live-chart")
+	if err := os.WriteFile(ref, []byte(digest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, _ := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour})
+	if slices.Contains(res.Removed, blob) {
+		t.Error("live-referenced blob was swept by age — mark phase broken")
+	}
+	if _, err := os.Stat(blob); err != nil {
+		t.Errorf("live blob removed from disk: %v", err)
+	}
+	if slices.Contains(res.Removed, ref) {
+		t.Error("live ref removed; should have survived (blob exists)")
+	}
+}
+
+// TestSweep_UnreferencedOldBlobIsPruned proves the inverse — an old
+// blob with NO ref still pointing at it gets swept.
+func TestSweep_UnreferencedOldBlobIsPruned(t *testing.T) {
+	root := t.TempDir()
+	const digest = "3333333333333333333333333333333333333333333333333333333333333333"
+	blob := filepath.Join(root, "blobs", "sha256", digest)
+	if err := os.MkdirAll(blob, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(blob, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	res, _ := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour})
+	if !slices.Contains(res.Removed, blob) {
+		t.Errorf("orphan blob survived: %v", res.Removed)
+	}
+}
+
 // TestSweep_DryRunReports: DryRun emits the would-be-removed list
 // without touching disk.
 func TestSweep_DryRunReports(t *testing.T) {

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -116,7 +116,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	}
 
 	authID := authIdentity(repo)
-	slot, err := cache.Slot(repo.URL, refStr, authID)
+	slot, err := cache.Slot(ctx, repo.URL, refStr, authID)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", repo.URL, err)
 	}

--- a/pkg/source/git/mirror.go
+++ b/pkg/source/git/mirror.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -18,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
@@ -33,16 +33,14 @@ import (
 // older behavior).
 type MirrorCache struct {
 	layout cacheroot.Layout
-
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks  *keylock.KeyMap[string]
 }
 
 // NewMirrorCache constructs a MirrorCache backed by the supplied
 // Layout. The git-mirrors subtree is created lazily on first
 // openOrFetch.
 func NewMirrorCache(layout cacheroot.Layout) *MirrorCache {
-	return &MirrorCache{layout: layout}
+	return &MirrorCache{layout: layout, locks: keylock.New[string]()}
 }
 
 // urlHash returns the stable directory name for url's mirror. The hash
@@ -59,24 +57,6 @@ func (m *MirrorCache) pathFor(url string) string {
 	return m.layout.GitMirror(urlHash(url))
 }
 
-// lockFor returns the per-URL mutex, creating it on first access. Used
-// by openOrFetch to serialize concurrent Fetches against the same
-// mirror — go-git's pack-file writes are not concurrent-safe.
-func (m *MirrorCache) lockFor(url string) *sync.Mutex {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.locks == nil {
-		m.locks = make(map[string]*sync.Mutex)
-	}
-	k := urlHash(url)
-	mx, ok := m.locks[k]
-	if !ok {
-		mx = &sync.Mutex{}
-		m.locks[k] = mx
-	}
-	return mx
-}
-
 // openOrFetch returns the bare mirror repo for url, ensuring it carries
 // up-to-date refs. First call for a URL runs a bare clone; subsequent
 // calls incrementally Fetch. Holds the per-URL lock across the network
@@ -87,9 +67,11 @@ func (m *MirrorCache) lockFor(url string) *sync.Mutex {
 // httpsTransportMu protocol-install dance is repeated to match the
 // non-mirror path's contract.
 func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*git.Repository, error) {
-	lock := m.lockFor(url)
-	lock.Lock()
-	defer lock.Unlock()
+	release, err := m.locks.Acquire(ctx, urlHash(url))
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	if tlsCfg != nil {
 		httpsTransportMu.Lock()
@@ -128,7 +110,7 @@ func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transpor
 			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
 		}
 	}
-	repo, err := git.PlainCloneContext(ctx, path, true, cloneOpts) // bare = true
+	repo, err = git.PlainCloneContext(ctx, path, true, cloneOpts) // bare = true
 	if err != nil {
 		// Leave nothing partial behind so the next attempt re-clones
 		// from scratch rather than tripping over a half-written mirror.

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -217,7 +217,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	}
 
 	versioned := versionedURL(repo.URL, ref)
-	slot, err := cache.Slot(versioned, "", authIdentity(repo))
+	slot, err := cache.Slot(ctx, versioned, "", authIdentity(repo))
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}


### PR DESCRIPTION
## Cleanup PR C — kill the per-key mutex reinvention

`source.Cache`, `blob.Store`, and `git.MirrorCache` each rolled their own `sync.Map-of-mutex` with an inline `lockFor` helper. `internal/keylock.KeyMap` already implements the same pattern with context-cancel support; helm has used it the whole time.

This PR migrates all three to keylock. Net loss of ~40 lines + the four-way duplication. Wins:

- Slot acquisition (`Cache.Slot`, `blob.Store.PutBytes`, `MirrorCache.openOrFetch`) now respects ctx — a cancelled fetcher unwinds immediately instead of blocking on a stale mutex.
- One implementation to test, one error shape to handle.

`Slot` now stores the keylock release fn instead of a `*sync.Mutex`; `Slot.unlock` calls `release()` the same way it used to call `mu.Unlock`.

`Cache.Slot` and `blob.Store.PutBytes` gain `ctx` as their first parameter — all callers already have ctx in scope.

## Stack
Builds on **#387** (mark-sweep GC) → **#386** (Layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)