### PR TITLE
refactor(source/atomic): one helper, four file-write sites

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/atomic"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -21,44 +22,12 @@ import (
 // chart tarball so two reconcilers don't race on the same file.
 var chartCacheLocks = keylock.New[string]()
 
-// writeAtomic writes data to path via a temp file + rename so partial
-// writes never appear at the target path to concurrent readers. Both
-// the file contents and the directory entry are fsynced so a
-// power-loss between rename and post-close can't leave a zero-byte
-// chart that the next Stat-OK path serves to loader.Load (which then
-// reports a misleading "corrupt chart" instead of just re-pulling).
+// writeAtomic delegates to pkg/source/atomic.WriteFile (with
+// syncDir=true so chart tarballs survive power loss). Kept as a
+// package-local thin wrapper so existing call sites keep their
+// hard-coded perm without each having to import atomic.
 func writeAtomic(path string, data []byte) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	defer func() { _ = os.Remove(tmpName) }() // no-op if rename succeeds
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		return err
-	}
-	// Fsync the directory so the rename's directory entry survives
-	// power loss. Without this, the contents fsync above guarantees
-	// file bytes survive but the rename can be lost — leaving the
-	// old path or no entry at all. Best-effort: fsync of a directory
-	// is not portable to every filesystem, so log+ignore on failure.
-	if d, err := os.Open(dir); err == nil { //nolint:gosec // dir = filepath.Dir(path); path is caller-controlled cache file
-		_ = d.Sync()
-		_ = d.Close()
-	}
-	return nil
+	return atomic.WriteFile(path, data, 0o600, true)
 }
 
 // ChartLoadResult is the loaded chart plus the on-disk path it came from.

--- a/pkg/source/atomic/file.go
+++ b/pkg/source/atomic/file.go
@@ -1,0 +1,75 @@
+// Package atomic carries the small "stage-then-rename" file write
+// helper every flate cache writer used to reinvent (helm.writeAtomic,
+// oci.writeCachedDigest, oci.writeVerifyMarker, blob.Refs.Put). One
+// implementation, one set of error shapes, one place to revisit if
+// the durability story needs to change.
+package atomic
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// WriteFile installs data at path via a sibling temp file + atomic
+// rename. Concurrent readers either see the previous contents or the
+// new ones — never a torn write, never a zero-byte file from a
+// power-loss between create and rename.
+//
+// perm is the final file's permission bits (umask still applies via
+// CreateTemp). On any error, the staging file is removed and path is
+// left untouched.
+//
+// When syncDir is true, the function fsyncs both the staged file's
+// contents AND the containing directory's entry after the rename so
+// the rename survives power loss. Set false for high-churn caches
+// where durability doesn't justify the I/O barrier (e.g. ref pointers
+// that are cheap to re-derive on the next reconcile).
+func WriteFile(path string, data []byte, perm os.FileMode, syncDir bool) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("atomic stage: %w", err)
+	}
+	tmpName := tmp.Name()
+	// On any error path we want the staging file gone. The double-
+	// defer with a sentinel keeps the success path's defer a no-op
+	// without the caller having to think about it.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("atomic write: %w", err)
+	}
+	if syncDir {
+		if err := tmp.Sync(); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("atomic sync: %w", err)
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("atomic close: %w", err)
+	}
+	if err := os.Chmod(tmpName, perm); err != nil {
+		return fmt.Errorf("atomic chmod: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("atomic rename: %w", err)
+	}
+	committed = true
+	if syncDir {
+		// Best-effort directory fsync — see writeAtomic's history
+		// for why this matters and why it's allowed to fail on
+		// filesystems that don't expose the operation.
+		if d, derr := os.Open(dir); derr == nil { //nolint:gosec // dir = filepath.Dir(path); caller-controlled path
+			_ = d.Sync()
+			_ = d.Close()
+		}
+	}
+	return nil
+}

--- a/pkg/source/atomic/file_test.go
+++ b/pkg/source/atomic/file_test.go
@@ -1,0 +1,74 @@
+package atomic
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFile_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	if err := WriteFile(path, []byte("hello"), 0o600, false); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	got, err := os.ReadFile(path) //nolint:gosec // path under t.TempDir
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !bytes.Equal(got, []byte("hello")) {
+		t.Errorf("content drift: got %q", got)
+	}
+}
+
+// TestWriteFile_OverwriteAtomic: a second write replaces the first
+// without ever exposing a torn intermediate state.
+func TestWriteFile_OverwriteAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	if err := WriteFile(path, []byte("v1"), 0o600, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(path, []byte("v2"), 0o600, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(path) //nolint:gosec // path under t.TempDir
+	if string(got) != "v2" {
+		t.Errorf("expected v2, got %q", got)
+	}
+}
+
+// TestWriteFile_StagingCleanedOnError: when an error occurs after the
+// temp file exists, the temp file is removed.
+func TestWriteFile_StagingCleanedOnError(t *testing.T) {
+	dir := t.TempDir()
+	// Write succeeds; on success we want NO leftover .tmp-* files.
+	if err := WriteFile(filepath.Join(dir, "data"), []byte("x"), 0o600, false); err != nil {
+		t.Fatal(err)
+	}
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() != "data" {
+			t.Errorf("leftover staging entry: %q", e.Name())
+		}
+	}
+}
+
+// TestWriteFile_PermRespected: perm is applied to the final file.
+func TestWriteFile_PermRespected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data")
+	if err := WriteFile(path, []byte("x"), 0o640, false); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Umask may strip group/world bits; perm-or-stricter is the
+	// portable contract.
+	if info.Mode().Perm()&0o600 != 0o600 {
+		t.Errorf("perm = %v, expected at least 0o600", info.Mode().Perm())
+	}
+}

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/home-operations/flate/pkg/source/atomic"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
@@ -57,11 +58,15 @@ func (r *Refs) Get(key string) (string, bool) {
 	return digest, true
 }
 
-// Put records (key → digest) durably via atomic rename. Concurrent
-// writers to the same key serialize on the Refs mutex; different keys
-// proceed in parallel. Overwriting an existing key is supported (an
-// upstream tag re-resolved to a new digest) — the rename atomically
-// replaces the file.
+// Put records (key → digest) durably via atomic.WriteFile.
+// Concurrent writers to the same key serialize on the Refs mutex;
+// different keys proceed in parallel. Overwriting an existing key is
+// supported (an upstream tag re-resolved to a new digest) — the
+// rename atomically replaces the file.
+//
+// syncDir=false: refs files are cheap to rebuild on the next
+// reconcile (they're just digest lookups), so the fsync barrier is
+// not worth the per-render I/O cost.
 func (r *Refs) Put(key, digest string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -72,24 +77,7 @@ func (r *Refs) Put(key, digest string) error {
 	if err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(r.dir, ".tmp.*")
-	if err != nil {
-		return fmt.Errorf("refs staging: %w", err)
-	}
-	if _, err := tmp.WriteString(digest); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("refs write: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("refs close: %w", err)
-	}
-	if err := os.Rename(tmp.Name(), final); err != nil {
-		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("refs finalize: %w", err)
-	}
-	return nil
+	return atomic.WriteFile(final, []byte(digest), 0o600, false)
 }
 
 // pathFor URL-escapes key into a single-segment filename. Refuses keys

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/atomic"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -429,36 +430,11 @@ func verifyFingerprint(v *manifest.OCIRepositoryVerify) string {
 }
 
 // writeVerifyMarker persists the verify-policy fingerprint to the
-// slot atomically. Uses the same temp-file + fsync + rename dance
-// as writeCachedDigest so a crash mid-write can't leave a partial
-// fingerprint that would falsely match.
+// slot atomically. atomic.WriteFile handles the temp-file + fsync +
+// rename dance so a crash mid-write can't leave a partial fingerprint
+// that would falsely match.
 func writeVerifyMarker(slot, fingerprint string) error {
-	dst := filepath.Join(slot, verifyMarkerFile)
-	tmp, err := os.CreateTemp(slot, ".flate-verified-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpPath) }
-	if _, err := tmp.WriteString(fingerprint); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpPath, dst); err != nil {
-		cleanup()
-		return err
-	}
-	return nil
+	return atomic.WriteFile(filepath.Join(slot, verifyMarkerFile), []byte(fingerprint), 0o600, true)
 }
 
 // readVerifyMarker returns the cached fingerprint or "" when the
@@ -480,38 +456,12 @@ func readVerifyMarker(slot string) string {
 // "signature not found" error, treat it as a missing marker.
 var digestRE = regexp.MustCompile(`^[a-z0-9]+:[a-fA-F0-9]{32,}$`)
 
-// writeCachedDigest persists digest atomically: write to a sibling
-// temp file, fsync, then rename into place. Without atomicity, a
-// crash mid-write could leave a partial digest string that would
-// later mis-read on cache hit and trigger a misleading cosign
-// failure on the next reconcile.
+// writeCachedDigest persists digest atomically via atomic.WriteFile.
+// Without atomicity, a crash mid-write could leave a partial digest
+// string that would later mis-read on cache hit and trigger a
+// misleading cosign failure on the next reconcile.
 func writeCachedDigest(slot, digest string) error {
-	dst := filepath.Join(slot, cachedDigestFile)
-	tmp, err := os.CreateTemp(slot, ".flate-digest-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	cleanup := func() { _ = os.Remove(tmpPath) }
-	if _, err := tmp.WriteString(digest); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		_ = tmp.Close()
-		cleanup()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpPath, dst); err != nil {
-		cleanup()
-		return err
-	}
-	return nil
+	return atomic.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(digest), 0o600, true)
 }
 
 // readCachedDigest returns the cached digest only when it parses as a


### PR DESCRIPTION
## Cleanup PR D — unify atomic file writes

Four sites had their own variant of "create temp + write + maybe fsync + rename + cleanup on error":

- `helm.writeAtomic` (chart tarballs)
- `oci.writeCachedDigest`
- `oci.writeVerifyMarker`
- `blob.Refs.Put`

The four implementations disagreed on subtleties — one fsync'd contents+dir, one only the file, one neither; cleanup semantics differed.

## One helper

`pkg/source/atomic.WriteFile(path, data, perm, syncDir)`. `syncDir` selects durability vs throughput:

- Chart tarballs / OCI digest markers: `syncDir=true` — readers depend on the bytes being present and well-formed; a partial write would surface as "corrupt chart" or silent cosign mismatch.
- `Refs.Put`: `syncDir=false` — refs cost nothing to rebuild on the next reconcile; spending an fsync per ref is wasted I/O.

Net loss ~70 lines, four shapes → one.

## Stack
Builds on **#388** (keylock unify) → **#387** (mark-sweep) → **#386** (Layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)