### PR TITLE
refactor(source): final cache polish

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -281,13 +280,8 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 // %LocalAppData% on Windows) with a "flate" subdir; falls back to
 // $TMPDIR/flate-cache when UserCacheDir errors.
 func (c *commonFlags) resolveCacheRoot() string {
-	if c.cacheDir != "" {
-		return c.cacheDir
-	}
-	if d, err := os.UserCacheDir(); err == nil && d != "" {
-		c.cacheDir = filepath.Join(d, "flate")
-	} else {
-		c.cacheDir = filepath.Join(os.TempDir(), "flate-cache")
+	if c.cacheDir == "" {
+		c.cacheDir = cacheroot.Default()
 	}
 	return c.cacheDir
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -181,7 +181,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("orchestrator: path is required")
 	}
 
-	layout := cacheroot.New(cmp.Or(cfg.CacheDir, defaultCacheRoot()))
+	layout := cacheroot.New(cmp.Or(cfg.CacheDir, cacheroot.Default()))
 	helmClient, err := helm.NewClient(layout)
 	if err != nil {
 		return nil, err
@@ -796,14 +796,3 @@ func (o *Orchestrator) Stop() {
 	})
 }
 
-// defaultCacheRoot picks the on-disk cache root when Config.CacheDir
-// is unset. Prefers the OS user cache dir — $XDG_CACHE_HOME on Linux,
-// ~/Library/Caches on macOS, %LocalAppData% on Windows — so caches
-// survive reboots and OS tmpfs cleanups. Falls back to
-// $TMPDIR/flate-cache only when UserCacheDir errors (HOME unset, etc).
-func defaultCacheRoot() string {
-	if d, err := os.UserCacheDir(); err == nil && d != "" {
-		return filepath.Join(d, "flate")
-	}
-	return filepath.Join(os.TempDir(), "flate-cache")
-}

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -24,9 +24,15 @@ import (
 // (os.Rename), avoids parsing a single index file under contention,
 // and survives partial writes — a corrupted entry just looks like a
 // cache miss.
+//
+// An in-memory cache (sync.Map) sits in front of the disk reads so
+// the hot path — a render with N HelmReleases against the same repo
+// — doesn't pay a syscall per lookup. The cache is populated by
+// every successful Get/Put and invalidated by Put.
 type Refs struct {
 	dir string
-	mu  sync.Mutex
+	mu  sync.Mutex // serializes disk-writing Puts
+	mem sync.Map   // map[string]string — key → digest
 }
 
 // NewRefs constructs a Refs table for one category under the supplied
@@ -40,9 +46,14 @@ func NewRefs(layout cacheroot.Layout, category string) *Refs {
 // Get reads the digest stored under key, or returns ("", false) when
 // the key is unknown. Treats partial or empty entries as misses so a
 // torn write doesn't surface as a sentinel.
+//
+// Consults the in-memory cache first; a hit avoids the disk read
+// entirely. A miss falls through to ReadFile and populates the cache.
 func (r *Refs) Get(key string) (string, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	if v, ok := r.mem.Load(key); ok {
+		digest, _ := v.(string)
+		return digest, digest != ""
+	}
 	path, err := r.pathFor(key)
 	if err != nil {
 		return "", false
@@ -55,6 +66,7 @@ func (r *Refs) Get(key string) (string, bool) {
 	if digest == "" {
 		return "", false
 	}
+	r.mem.Store(key, digest)
 	return digest, true
 }
 
@@ -64,9 +76,9 @@ func (r *Refs) Get(key string) (string, bool) {
 // supported (an upstream tag re-resolved to a new digest) — the
 // rename atomically replaces the file.
 //
-// syncDir=false: refs files are cheap to rebuild on the next
-// reconcile (they're just digest lookups), so the fsync barrier is
-// not worth the per-render I/O cost.
+// syncDir=false on the underlying atomic write: refs files are cheap
+// to rebuild on the next reconcile, so the fsync barrier is not worth
+// the per-render I/O cost.
 func (r *Refs) Put(key, digest string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -77,7 +89,11 @@ func (r *Refs) Put(key, digest string) error {
 	if err != nil {
 		return err
 	}
-	return atomic.WriteFile(final, []byte(digest), 0o600, false)
+	if err := atomic.WriteFile(final, []byte(digest), 0o600, false); err != nil {
+		return err
+	}
+	r.mem.Store(key, digest)
+	return nil
 }
 
 // pathFor URL-escapes key into a single-segment filename. Refuses keys

--- a/pkg/source/blob/refs_test.go
+++ b/pkg/source/blob/refs_test.go
@@ -1,6 +1,8 @@
 package blob
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/home-operations/flate/pkg/source/cacheroot"
@@ -27,5 +29,43 @@ func TestRefs_OverwritePicksUpNewDigest(t *testing.T) {
 	got, _ := r.Get("k")
 	if got != "new" {
 		t.Errorf("Get after overwrite = %q, want new", got)
+	}
+}
+
+// TestRefs_GetServesFromMemory: after Put the in-memory cache is
+// populated, so a subsequent Get must not hit disk even if the
+// backing file is deleted. Proves the hot-path optimization is
+// load-bearing.
+func TestRefs_GetServesFromMemory(t *testing.T) {
+	layout := cacheroot.New(t.TempDir())
+	r := NewRefs(layout, "test")
+	if err := r.Put("k", "abc"); err != nil {
+		t.Fatal(err)
+	}
+	// Wipe the on-disk file behind Put's back; only the in-memory
+	// entry remains.
+	_ = os.RemoveAll(layout.RefsCategory("test"))
+	got, ok := r.Get("k")
+	if !ok || got != "abc" {
+		t.Errorf("Get after disk wipe = (%q, %v), expected (abc, true) from cache", got, ok)
+	}
+}
+
+// TestRefs_GetSkipsCorruptFile: a torn ref file (empty or whitespace)
+// surfaces as a miss, not as a sentinel digest.
+func TestRefs_GetSkipsCorruptFile(t *testing.T) {
+	layout := cacheroot.New(t.TempDir())
+	r := NewRefs(layout, "test")
+	dir := layout.RefsCategory("test")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Drop a file with just whitespace under the escaped key path.
+	corruptPath := filepath.Join(dir, "corrupt")
+	if err := os.WriteFile(corruptPath, []byte("   \n   "), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := r.Get("corrupt"); ok {
+		t.Error("corrupt ref should miss, not surface whitespace as digest")
 	}
 }

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -10,7 +10,27 @@
 // New(root); pass by value freely.
 package cacheroot
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
+
+// Default returns the on-disk cache root for embedders that don't
+// override it. Prefers the OS user cache dir ($XDG_CACHE_HOME on
+// Linux, ~/Library/Caches on macOS, %LocalAppData% on Windows) with
+// a "flate" subdir, so caches survive reboots and OS tmpfs cleanups.
+// Falls back to $TMPDIR/flate-cache only when UserCacheDir errors
+// (HOME unset, etc.).
+//
+// One canonical implementation here; the CLI and the orchestrator
+// both consume it, and tests that want a determinic root pass an
+// explicit Root via Layout{Root: …} or New(...).
+func Default() string {
+	if d, err := os.UserCacheDir(); err == nil && d != "" {
+		return filepath.Join(d, "flate")
+	}
+	return filepath.Join(os.TempDir(), "flate-cache")
+}
 
 // Layout describes where the various caches live under a single root.
 // All methods return absolute paths derived from Root + a constant


### PR DESCRIPTION
## Cleanup PR E — final polish (deferred items consolidated)

Three small but real cleanups:

### `cacheroot.Default()`
`orchestrator.defaultCacheRoot` and `cli.resolveCacheRoot` were two copies of the same `os.UserCacheDir / TempDir` logic. Move it to the cacheroot package; both consume it.

### Refs in-memory cache
`blob.Refs.Get` hit the disk per chart lookup — N HelmReleases against one repo = N tiny `ReadFile`s per render. Added a `sync.Map` in front; first read populates, subsequent reads return from memory. Put writes through to disk AND populates the cache.

Process-lifetime; next run rebuilds it from disk on demand.

### Tests for invariants the audit flagged
- `TestRefs_GetServesFromMemory`: wipe disk, Get still works → proves cache is load-bearing
- `TestRefs_GetSkipsCorruptFile`: whitespace-only file ⇒ miss, not sentinel digest

## What I skipped from the audit (and why)
- `git.authIdentity` wrapper: it's NOT a wrapper around `source.AuthIdentity` — it derives per-CR auth tags from `SecretRef + ProxySecretRef`. Lives correctly in each fetcher package.
- Parallel tree walks (baseline, materializeTree, copyTree): would help monorepos but adds real complexity and is a perf optimization, not a correctness fix. Defer.
- Directory atomic-stage helper extraction: `Cache.Slot.Commit` and `baseline.materializeAt` have caller-specific state mid-stage; extracting yields cleaner-on-paper code but loses readability.

## Stack
Builds on **#389** (atomic file) → **#388** (keylock) → **#387** (mark-sweep) → **#386** (Layout). End of the cleanup arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)