### PR TITLE
refactor(source): unify per-key locks via internal/keylock

### DIFF
--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -234,7 +234,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	if err != nil {
 		return "", fmt.Errorf("download %s: %w", chartURL, err)
 	}
-	dir, digest, err := c.chartBlobs.PutBytes(buf.Bytes(), "chart.tgz")
+	dir, digest, err := c.chartBlobs.PutBytes(ctx, buf.Bytes(), "chart.tgz")
 	if err != nil {
 		return "", fmt.Errorf("store chart %s: %w", chartURL, err)
 	}

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -14,6 +14,7 @@
 package blob
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -21,20 +22,18 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
 // Store manages a content-addressed blob directory on disk. Safe for
-// concurrent use; per-digest mutexes serialize PutFile/PutBytes for
-// the same digest so two callers writing the same content don't race
-// on the rename finalize.
+// concurrent use; the keylock.KeyMap serializes Put for the same digest
+// so two callers writing the same content don't race on rename
+// finalize.
 type Store struct {
 	layout cacheroot.Layout
-
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks  *keylock.KeyMap[string]
 }
 
 // NewStore constructs a Store backed by the supplied Layout. The
@@ -42,7 +41,7 @@ type Store struct {
 // path methods are the single source of truth for on-disk
 // positioning.
 func NewStore(layout cacheroot.Layout) *Store {
-	return &Store{layout: layout}
+	return &Store{layout: layout, locks: keylock.New[string]()}
 }
 
 // Path returns the on-disk path for digest. Does not stat — callers
@@ -60,19 +59,22 @@ func (s *Store) Exists(digest string) bool {
 // PutBytes installs content as a single file named filename inside the
 // blob directory keyed by content's sha256. The digest is recomputed
 // from the bytes (never trusted from caller input). Concurrent callers
-// targeting the same digest serialize on a per-digest mutex; the first
+// targeting the same digest serialize on a per-digest lock; the first
 // finalizes via atomic rename and the rest observe ErrExists internally
-// and return without rewriting.
+// and return without rewriting. ctx cancellation aborts the lock
+// acquire (no write performed).
 //
 // Returns the populated blob directory path and the computed digest.
-func (s *Store) PutBytes(content []byte, filename string) (string, string, error) {
+func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (string, string, error) {
 	sum := sha256.Sum256(content)
 	digest := hex.EncodeToString(sum[:])
 	dir := s.Path(digest)
 
-	lock := s.lockFor(digest)
-	lock.Lock()
-	defer lock.Unlock()
+	release, err := s.locks.Acquire(ctx, digest)
+	if err != nil {
+		return "", "", err
+	}
+	defer release()
 
 	if s.Exists(digest) {
 		return dir, digest, nil
@@ -105,24 +107,11 @@ func (s *Store) PutBytes(content []byte, filename string) (string, string, error
 // PutReader is the streaming variant of PutBytes. Useful when the
 // caller has an io.Reader but doesn't want to buffer the whole
 // artifact in memory.
-func (s *Store) PutReader(r io.Reader, filename string) (string, string, error) {
+func (s *Store) PutReader(ctx context.Context, r io.Reader, filename string) (string, string, error) {
 	buf, err := io.ReadAll(r)
 	if err != nil {
 		return "", "", err
 	}
-	return s.PutBytes(buf, filename)
+	return s.PutBytes(ctx, buf, filename)
 }
 
-func (s *Store) lockFor(digest string) *sync.Mutex {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.locks == nil {
-		s.locks = make(map[string]*sync.Mutex)
-	}
-	mx, ok := s.locks[digest]
-	if !ok {
-		mx = &sync.Mutex{}
-		s.locks[digest] = mx
-	}
-	return mx
-}

--- a/pkg/source/blob/store_test.go
+++ b/pkg/source/blob/store_test.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"os"
@@ -16,7 +17,7 @@ import (
 func TestStore_PutBytesDigestPath(t *testing.T) {
 	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("hello world")
-	dir, digest, err := s.PutBytes(content, "data.txt")
+	dir, digest, err := s.PutBytes(context.Background(), content, "data.txt")
 	if err != nil {
 		t.Fatalf("PutBytes: %v", err)
 	}
@@ -40,11 +41,11 @@ func TestStore_PutBytesDigestPath(t *testing.T) {
 func TestStore_SameContentSharesSlot(t *testing.T) {
 	s := NewStore(cacheroot.New(t.TempDir()))
 	content := []byte("dedup me")
-	dir1, d1, err := s.PutBytes(content, "a.txt")
+	dir1, d1, err := s.PutBytes(context.Background(), content, "a.txt")
 	if err != nil {
 		t.Fatalf("Put 1: %v", err)
 	}
-	dir2, d2, err := s.PutBytes(content, "a.txt")
+	dir2, d2, err := s.PutBytes(context.Background(), content, "a.txt")
 	if err != nil {
 		t.Fatalf("Put 2: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestStore_ConcurrentPutsCoalesce(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, d, err := s.PutBytes(content, "data")
+			_, d, err := s.PutBytes(context.Background(), content, "data")
 			if err != nil {
 				errs.Add(1)
 				return

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -78,7 +78,7 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 	// still holds the dead file. We treat every fetch as a miss:
 	// write to a fresh staging dir, then atomic-rename into the final
 	// slot on success.
-	slot, err := f.Cache.Slot(endpoint+"/"+b.BucketName, b.Prefix, authIdentity(b))
+	slot, err := f.Cache.Slot(ctx, endpoint+"/"+b.BucketName, b.Prefix, authIdentity(b))
 	if err != nil {
 		return nil, fmt.Errorf("bucket %s/%s cache slot: %w", b.Namespace, b.Name, err)
 	}

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -10,8 +11,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
@@ -27,10 +28,10 @@ import (
 // Different slots proceed in parallel.
 type Cache struct {
 	layout cacheroot.Layout
-	mu     sync.Mutex // guards locks
-	// locks holds a sync.Mutex per slot path. Lazily created; never
-	// reaped — the slot count is bounded by user-declared sources.
-	locks map[string]*sync.Mutex
+	// locks is the canonical per-slot mutex provider. Sharing the
+	// keylock.KeyMap implementation with helm + blob keeps cancellation
+	// semantics and lifetime management consistent across the cache.
+	locks *keylock.KeyMap[string]
 }
 
 // NewCache constructs a Cache backed by the supplied Layout. The
@@ -43,23 +44,7 @@ func NewCache(layout cacheroot.Layout) *Cache {
 	if layout.Root == "" {
 		layout.Root = filepath.Join(os.TempDir(), "flate-cache")
 	}
-	return &Cache{layout: layout}
-}
-
-// slotMu returns the per-slot mutex for path, creating it on first
-// access. Caller must NOT hold c.mu.
-func (c *Cache) slotMu(path string) *sync.Mutex {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.locks == nil {
-		c.locks = make(map[string]*sync.Mutex)
-	}
-	m, ok := c.locks[path]
-	if !ok {
-		m = &sync.Mutex{}
-		c.locks[path] = m
-	}
-	return m
+	return &Cache{layout: layout, locks: keylock.New[string]()}
 }
 
 // Slot allocates a per-(url, ref) slot under the cache root with
@@ -81,7 +66,7 @@ func (c *Cache) slotMu(path string) *sync.Mutex {
 // next fetch starts clean. This atomicity replaces the older
 // "write in place + .flate-* sentinels" pattern: the final slot is
 // either complete or doesn't exist, never torn.
-func (c *Cache) Slot(url, ref, authID string) (*Slot, error) {
+func (c *Cache) Slot(ctx context.Context, url, ref, authID string) (*Slot, error) {
 	slug := slugifyRepo(url)
 	// authID participates in the cache key so two source CRs with the
 	// same (URL, ref) but different SecretRef / RegistryConfig don't
@@ -92,9 +77,11 @@ func (c *Cache) Slot(url, ref, authID string) (*Slot, error) {
 	hash := hex.EncodeToString(h[:])[:16]
 	final := c.layout.SourceSlot(slug, hash)
 
-	m := c.slotMu(final)
-	m.Lock()
-	s := &Slot{final: final, mu: m}
+	release, err := c.locks.Acquire(ctx, final)
+	if err != nil {
+		return nil, err
+	}
+	s := &Slot{final: final, release: release}
 
 	info, statErr := os.Stat(final)
 	switch {
@@ -171,7 +158,7 @@ type Slot struct {
 
 	final     string
 	staging   string
-	mu        *sync.Mutex
+	release   func() // keylock release; populated by Cache.Slot
 	committed bool
 	unlocked  bool
 }
@@ -251,7 +238,7 @@ func (s *Slot) unlock() {
 		return
 	}
 	s.unlocked = true
-	s.mu.Unlock()
+	s.release()
 }
 
 // nonAlnum collapses non-alphanumeric (plus `.-_`) runs into a single

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -1,6 +1,7 @@
 package source
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -26,7 +27,7 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range iterations {
-				slot, err := c.Slot("https://shared.example/repo", "main", "")
+				slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
@@ -37,7 +38,7 @@ func TestCache_ResetSerializesAgainstSlot(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for range iterations {
-				slot, err := c.Slot("https://shared.example/repo", "main", "")
+				slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 				if err != nil {
 					t.Errorf("Slot: %v", err)
 					return
@@ -74,7 +75,7 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 	g2Start := make(chan struct{})
 	done := make(chan struct{}, 2)
 	go func() {
-		slot, err := c.Slot("https://shared.example/repo", "main", "")
+		slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 		if err != nil {
 			t.Errorf("Slot: %v", err)
 			done <- struct{}{}
@@ -94,7 +95,7 @@ func TestCache_SlotSerializesSameKey(t *testing.T) {
 	}()
 	<-g1Entered // G1 holds the lock.
 	go func() {
-		slot, err := c.Slot("https://shared.example/repo", "main", "")
+		slot, err := c.Slot(context.Background(), "https://shared.example/repo", "main", "")
 		if err != nil {
 			t.Errorf("Slot: %v", err)
 			done <- struct{}{}
@@ -130,7 +131,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
 
 	// First fetcher aborts after writing partial state.
-	slot, err := c.Slot("https://example.com/repo", "v1", "")
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot: %v", err)
 	}
@@ -148,7 +149,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 	}
 
 	// Next caller must see Exists=false.
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 2: %v", err)
 	}
@@ -164,7 +165,7 @@ func TestCache_SlotCommitAtomicRename(t *testing.T) {
 func TestCache_SlotCommitPersists(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
 
-	slot, err := c.Slot("https://example.com/repo", "v1", "")
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot: %v", err)
 	}
@@ -177,7 +178,7 @@ func TestCache_SlotCommitPersists(t *testing.T) {
 	committed := slot.Path
 	slot.Release()
 
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 2: %v", err)
 	}
@@ -199,12 +200,12 @@ func TestCache_SlotCommitPersists(t *testing.T) {
 // auth context, bypassing the access check.
 func TestCache_AuthIDIsolatesSlots(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
-	a, err := c.Slot("https://example.com/repo", "v1", "team-a/git-creds")
+	a, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "team-a/git-creds")
 	if err != nil {
 		t.Fatalf("Slot a: %v", err)
 	}
 	defer a.Release()
-	b, err := c.Slot("https://example.com/repo", "v1", "team-b/git-creds")
+	b, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "team-b/git-creds")
 	if err != nil {
 		t.Fatalf("Slot b: %v", err)
 	}
@@ -214,13 +215,13 @@ func TestCache_AuthIDIsolatesSlots(t *testing.T) {
 	}
 	// Empty authID must still collide with itself.
 	c2 := NewCache(cacheroot.New(t.TempDir()))
-	x, err := c2.Slot("https://example.com/repo", "v1", "")
+	x, err := c2.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot x: %v", err)
 	}
 	y := filepath.Dir(x.Path)
 	x.Release()
-	z, err := c2.Slot("https://example.com/repo", "v1", "")
+	z, err := c2.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot z: %v", err)
 	}
@@ -238,7 +239,7 @@ func TestCache_SlotResetThenStage(t *testing.T) {
 	c := NewCache(cacheroot.New(t.TempDir()))
 
 	// Seed a committed slot.
-	slot, err := c.Slot("https://example.com/repo", "v1", "")
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot: %v", err)
 	}
@@ -251,7 +252,7 @@ func TestCache_SlotResetThenStage(t *testing.T) {
 	slot.Release()
 
 	// Acquire again, detect stale, reset-and-restage.
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 2: %v", err)
 	}
@@ -272,7 +273,7 @@ func TestCache_SlotResetThenStage(t *testing.T) {
 	}
 	slot.Release()
 
-	slot, err = c.Slot("https://example.com/repo", "v1", "")
+	slot, err = c.Slot(context.Background(), "https://example.com/repo", "v1", "")
 	if err != nil {
 		t.Fatalf("Slot 3: %v", err)
 	}

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -116,7 +116,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	}
 
 	authID := authIdentity(repo)
-	slot, err := cache.Slot(repo.URL, refStr, authID)
+	slot, err := cache.Slot(ctx, repo.URL, refStr, authID)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", repo.URL, err)
 	}

--- a/pkg/source/git/mirror.go
+++ b/pkg/source/git/mirror.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -18,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/client"
 	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 
+	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
@@ -33,16 +33,14 @@ import (
 // older behavior).
 type MirrorCache struct {
 	layout cacheroot.Layout
-
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	locks  *keylock.KeyMap[string]
 }
 
 // NewMirrorCache constructs a MirrorCache backed by the supplied
 // Layout. The git-mirrors subtree is created lazily on first
 // openOrFetch.
 func NewMirrorCache(layout cacheroot.Layout) *MirrorCache {
-	return &MirrorCache{layout: layout}
+	return &MirrorCache{layout: layout, locks: keylock.New[string]()}
 }
 
 // urlHash returns the stable directory name for url's mirror. The hash
@@ -59,24 +57,6 @@ func (m *MirrorCache) pathFor(url string) string {
 	return m.layout.GitMirror(urlHash(url))
 }
 
-// lockFor returns the per-URL mutex, creating it on first access. Used
-// by openOrFetch to serialize concurrent Fetches against the same
-// mirror — go-git's pack-file writes are not concurrent-safe.
-func (m *MirrorCache) lockFor(url string) *sync.Mutex {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.locks == nil {
-		m.locks = make(map[string]*sync.Mutex)
-	}
-	k := urlHash(url)
-	mx, ok := m.locks[k]
-	if !ok {
-		mx = &sync.Mutex{}
-		m.locks[k] = mx
-	}
-	return mx
-}
-
 // openOrFetch returns the bare mirror repo for url, ensuring it carries
 // up-to-date refs. First call for a URL runs a bare clone; subsequent
 // calls incrementally Fetch. Holds the per-URL lock across the network
@@ -87,9 +67,11 @@ func (m *MirrorCache) lockFor(url string) *sync.Mutex {
 // httpsTransportMu protocol-install dance is repeated to match the
 // non-mirror path's contract.
 func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*git.Repository, error) {
-	lock := m.lockFor(url)
-	lock.Lock()
-	defer lock.Unlock()
+	release, err := m.locks.Acquire(ctx, urlHash(url))
+	if err != nil {
+		return nil, err
+	}
+	defer release()
 
 	if tlsCfg != nil {
 		httpsTransportMu.Lock()
@@ -128,7 +110,7 @@ func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transpor
 			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
 		}
 	}
-	repo, err := git.PlainCloneContext(ctx, path, true, cloneOpts) // bare = true
+	repo, err = git.PlainCloneContext(ctx, path, true, cloneOpts) // bare = true
 	if err != nil {
 		// Leave nothing partial behind so the next attempt re-clones
 		// from scratch rather than tripping over a half-written mirror.

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -217,7 +217,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	}
 
 	versioned := versionedURL(repo.URL, ref)
-	slot, err := cache.Slot(versioned, "", authIdentity(repo))
+	slot, err := cache.Slot(ctx, versioned, "", authIdentity(repo))
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}


### PR DESCRIPTION
Reopening #388 (base branch was deleted when #391 squash-merged). Code unchanged; rebased onto main.

`source.Cache`, `blob.Store`, and `git.MirrorCache` each rolled their own `sync.Map-of-mutex` with an inline `lockFor` helper. `internal/keylock.KeyMap` already implements the pattern with context-cancel support — helm uses it. Migrate all three.

Slot now stores the keylock release fn instead of a `*sync.Mutex`; `Cache.Slot` and `blob.Store.PutBytes` gain `ctx` as their first parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)