### PR TITLE
fix(baseline): --base main falls back to origin/main on CI checkouts

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -244,11 +245,22 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	}
 
 	if base != "" {
-		h, err := repo.ResolveRevision(plumbing.Revision(base))
-		if err != nil {
-			return nil, fmt.Errorf("could not resolve --base=%q: %w", base, err)
+		if h, err := repo.ResolveRevision(plumbing.Revision(base)); err == nil {
+			return &resolution{Hash: *h, Source: "explicit --base=" + base}, nil
 		}
-		return &resolution{Hash: *h, Source: "explicit --base=" + base}, nil
+		// CI checkouts (actions/checkout with default fetch-depth=1)
+		// land the PR's branch but not local branch refs for sibling
+		// branches — only remote-tracking ones. Retry as origin/<base>
+		// so `--base main` works without forcing CI users to type
+		// `--base origin/main`. Skip the fallback when base already
+		// looks remote-qualified to keep the error close to intent.
+		if !strings.ContainsRune(base, '/') {
+			remote := "origin/" + base
+			if h, err := repo.ResolveRevision(plumbing.Revision(remote)); err == nil {
+				return &resolution{Hash: *h, Source: "explicit --base=" + base + " (via " + remote + ")"}, nil
+			}
+		}
+		return nil, fmt.Errorf("could not resolve --base=%q: not found locally or as origin/%s", base, base)
 	}
 
 	// 1. @{u} via the branch config (go-git's ResolveRevision doesn't

--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -103,6 +103,50 @@ func TestAutoResolve_OriginHEAD(t *testing.T) {
 	}
 }
 
+// TestAutoResolve_ExplicitBaseFallsBackToOrigin locks the CI ergonomic
+// the workflow-side broke on: `--base main` on a checkout that has
+// only `origin/main` (no local main ref) must resolve via the
+// remote-tracking branch. actions/checkout with default
+// fetch-depth=1 lands the PR branch and origin/* but no sibling
+// local refs; we shouldn't force users to type `--base origin/main`.
+func TestAutoResolve_ExplicitBaseFallsBackToOrigin(t *testing.T) {
+	dir := t.TempDir()
+	mainCommit := initRepoWithFile(t, dir, "a.yaml", "base")
+	repo := openHelper(t, dir)
+	// Simulate the CI checkout: only the remote-tracking ref exists.
+	setRef(t, repo, plumbing.NewRemoteReferenceName("origin", "main"), mainCommit)
+	writeAndCommit(t, dir, "a.yaml", "pr-tip")
+
+	res, err := AutoResolve(dir, "main", cacheroot.Layout{})
+	if err != nil {
+		t.Fatalf("AutoResolve(--base=main) should fall back to origin/main: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+	if got := res.Rev; got != shortRev(mainCommit) {
+		t.Errorf("Rev = %q, want %q", got, shortRev(mainCommit))
+	}
+	if !strings.Contains(res.Source, "via origin/main") {
+		t.Errorf("Source = %q, want to mention 'via origin/main'", res.Source)
+	}
+}
+
+// TestAutoResolve_ExplicitBaseNeitherLocalNorRemote: when --base
+// resolves neither locally nor as origin/<base>, the error names
+// both lookup attempts so the user knows what to fix.
+func TestAutoResolve_ExplicitBaseNeitherLocalNorRemote(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithFile(t, dir, "a.yaml", "base")
+	writeAndCommit(t, dir, "a.yaml", "pr-tip")
+
+	_, err := AutoResolve(dir, "nonexistent", cacheroot.Layout{})
+	if err == nil {
+		t.Fatal("expected error for unresolvable --base")
+	}
+	if !strings.Contains(err.Error(), "origin/nonexistent") {
+		t.Errorf("error should mention the remote fallback was tried: %v", err)
+	}
+}
+
 // TestAutoResolve_OriginMainFallback exercises the third rung: no
 // @{u}, no origin/HEAD, but origin/main exists.
 func TestAutoResolve_OriginMainFallback(t *testing.T) {


### PR DESCRIPTION
## Fix the CI ergonomic

`actions/checkout` with the default `fetch-depth: 1` lands the PR's branch + `origin/*` remote-tracking refs, but no LOCAL refs for sibling branches. Today flate's `resolve()` asks go-git for exactly the literal `--base`, so `--base main` errors with "reference not found" — a foot-gun every CI user hits.

Reported via [buroa/k8s-gitops run #26443644878](https://github.com/buroa/k8s-gitops/actions/runs/26443644878/job/77844250223).

## Fix
When the literal `--base` lookup misses AND it doesn't already look remote-qualified (no `/`), retry as `origin/<base>`. The Source label remembers which lookup won so logs stay unambiguous (`explicit --base=main (via origin/main)`).

The error path now names both lookup attempts so users without an origin remote still get a clear hint.

## Tests
- `TestAutoResolve_ExplicitBaseFallsBackToOrigin` — simulates the CI checkout (only `origin/main`, no local main), asserts resolution succeeds and Source mentions `via origin/main`
- `TestAutoResolve_ExplicitBaseNeitherLocalNorRemote` — error names the remote fallback that was tried

🤖 Generated with [Claude Code](https://claude.com/claude-code)