### PR TITLE
fix(loader): materialize Component configMapGenerator/secretGenerator

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -98,6 +98,13 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}
 	d.aliasBootstrapSources(repoRoot)
 	loader.ApplyNamespaceInheritance(d.cfg.Store, d.sourceFiles, repoRoot)
+	// Materialize configMapGenerator / secretGenerator entries the
+	// file walker collected. The effective namespace comes from the
+	// enclosing Flux Kustomization, which is only known now that
+	// the full KS tree is loaded. Resolves the depwait gap where a
+	// substituteFrom references a CM produced by a Component's
+	// generator (issue #396).
+	l.FinalizeGenerators(repoRoot)
 	// Unified parent index over every reconcilable kind that uses a
 	// parent gate. KS and HR keys never collide because NamedResource
 	// includes Kind; downstream controllers look up by their own id

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -444,3 +444,64 @@ spec:
 		t.Errorf("non-matching upstream GitRepository must NOT receive a working-tree alias artifact")
 	}
 }
+
+// TestRun_ComponentGeneratorMaterializesCM mirrors home-operations/flate
+// issue #396: a Flux Kustomization references a kustomize Component
+// whose configMapGenerator produces cluster-settings. Without the
+// generator-discovery pass, depwait can't find the CM (no on-disk
+// YAML to walk to) and every downstream KS with `substituteFrom:
+// [cluster-settings]` fails. The fix synthesizes the CM at the
+// Flux KS's namespace and registers it in the store + ExistenceIndex.
+func TestRun_ComponentGeneratorMaterializesCM(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Flux Kustomization in flux-system pointing at ./cluster
+	mustWrite(t, filepath.Join(dir, "flux", "ks.yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-config
+  namespace: flux-system
+spec:
+  path: ./cluster
+  sourceRef: {kind: GitRepository, name: flux-system}
+  interval: 10m
+`)
+	// cluster/kustomization.yaml references the Component
+	mustWrite(t, filepath.Join(dir, "cluster", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1
+kind: Kustomization
+components:
+  - ../components/cluster-settings
+`)
+	// Component declares the configMapGenerator
+	mustWrite(t, filepath.Join(dir, "components", "cluster-settings", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+configMapGenerator:
+  - name: cluster-settings
+    literals:
+      - DOMAIN=example.com
+      - TIMEZONE=UTC
+`)
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	cmID := manifest.NamedResource{
+		Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings",
+	}
+	cm, _ := store.GetByName[*manifest.ConfigMap](st, manifest.KindConfigMap, "flux-system", "cluster-settings")
+	if cm == nil {
+		t.Fatalf("ConfigMap %s not synthesized from configMapGenerator", cmID)
+	}
+	if got, _ := cm.Data["DOMAIN"].(string); got != "example.com" {
+		t.Errorf("DOMAIN = %q, want example.com", got)
+	}
+	if got, _ := cm.Data["TIMEZONE"].(string); got != "UTC" {
+		t.Errorf("TIMEZONE = %q, want UTC", got)
+	}
+}

--- a/pkg/loader/generators.go
+++ b/pkg/loader/generators.go
@@ -1,0 +1,107 @@
+package loader
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// generatorRecord captures one configMapGenerator or secretGenerator
+// entry found in a kustomization.yaml during discovery, plus enough
+// context to resolve the effective namespace post-walk (kustomize
+// inherits namespace from the calling Flux Kustomization when neither
+// the generator nor the surrounding kustomization.yaml sets one).
+//
+// Tracking these records lets flate's depwait resolve dependencies
+// like `substituteFrom: [ConfigMap/<ns>/cluster-settings]` even when
+// the CM is produced by a configMapGenerator inside a Component —
+// the CM has no on-disk YAML, so the file-walker would otherwise
+// miss it.
+type generatorRecord struct {
+	// file is the absolute path to the kustomization.yaml that
+	// declared the generator. Used by the post-walk finalizer to
+	// look up the enclosing Flux Kustomization via KSPathPrefixes.
+	file string
+	// kustomizationNS is the kustomization.yaml's own `namespace:`
+	// field. Empty means "inherit from the enclosing Flux KS."
+	kustomizationNS string
+	// entryNS is the generator entry's own `namespace:`. Overrides
+	// kustomizationNS when set.
+	entryNS string
+
+	isConfigMap bool
+	name        string
+	literals    []string
+}
+
+// collectGeneratorRecords harvests every configMapGenerator and
+// secretGenerator declaration in k. Files/Envs entries are NOT
+// materialized (kustomize parses those at render time against the
+// caller's file system); literals are enough to make depwait happy
+// for the common cluster-settings pattern.
+func collectGeneratorRecords(k *kustomization, file string) []generatorRecord {
+	if k == nil {
+		return nil
+	}
+	var out []generatorRecord
+	for _, g := range k.ConfigMapGenerator {
+		if g.Name == "" {
+			continue
+		}
+		out = append(out, generatorRecord{
+			file: file, kustomizationNS: k.Namespace, entryNS: g.Namespace,
+			isConfigMap: true, name: g.Name, literals: g.Literals,
+		})
+	}
+	for _, g := range k.SecretGenerator {
+		if g.Name == "" {
+			continue
+		}
+		out = append(out, generatorRecord{
+			file: file, kustomizationNS: k.Namespace, entryNS: g.Namespace,
+			isConfigMap: false, name: g.Name, literals: g.Literals,
+		})
+	}
+	return out
+}
+
+// materialize builds the synthesized manifest from r. parentNS is the
+// namespace inherited from the enclosing Flux Kustomization; the
+// caller looks it up via KSPathPrefixes against r.file. Precedence
+// matches kustomize: entry.namespace > kustomization.namespace >
+// parent (Flux KS) namespace.
+//
+// Data fidelity: literals are split on the first `=` per kustomize's
+// own KvSources conventions. Secrets land in Data (base64-encoded)
+// to match what a real k8s Secret carries; ConfigMaps land in Data
+// as strings.
+func (r generatorRecord) materialize(parentNS string) manifest.BaseManifest {
+	ns := parentNS
+	if r.kustomizationNS != "" {
+		ns = r.kustomizationNS
+	}
+	if r.entryNS != "" {
+		ns = r.entryNS
+	}
+	if r.isConfigMap {
+		data := make(map[string]any, len(r.literals))
+		for _, lit := range r.literals {
+			k, v, ok := strings.Cut(lit, "=")
+			if !ok {
+				continue
+			}
+			data[k] = v
+		}
+		return &manifest.ConfigMap{Name: r.name, Namespace: ns, Data: data}
+	}
+	data := make(map[string]any, len(r.literals))
+	for _, lit := range r.literals {
+		k, v, ok := strings.Cut(lit, "=")
+		if !ok {
+			continue
+		}
+		data[k] = base64.StdEncoding.EncodeToString([]byte(v))
+	}
+	return &manifest.Secret{Name: r.name, Namespace: ns, Data: data}
+}

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -17,6 +17,7 @@ import (
 type kustomization struct {
 	APIVersion         string            `json:"apiVersion"                   yaml:"apiVersion"`
 	Kind               string            `json:"kind"                         yaml:"kind"`
+	Namespace          string            `json:"namespace,omitempty"          yaml:"namespace,omitempty"`
 	Resources          []string          `json:"resources,omitempty"          yaml:"resources,omitempty"`
 	Components         []string          `json:"components,omitempty"         yaml:"components,omitempty"`
 	ConfigMapGenerator []kvPairGenerator `json:"configMapGenerator,omitempty" yaml:"configMapGenerator,omitempty"`
@@ -42,11 +43,16 @@ func (k *kustomization) isKustomizeComponent() bool {
 	return strings.HasPrefix(k.APIVersion, kustomizeAPIPrefix)
 }
 
-// kvPairGenerator captures the file/env entries of a configMap or
-// secret generator. Literals are inline strings and stay out of scope.
+// kvPairGenerator captures one configMap or secret generator entry.
+// Name + Namespace + Literals participate in flate's generator
+// discovery (see generators.go); Files / Envs are tracked so the
+// outer kustomization can exclude them from resource scans.
 type kvPairGenerator struct {
-	Files []string `json:"files,omitempty" yaml:"files,omitempty"`
-	Envs  []string `json:"envs,omitempty"  yaml:"envs,omitempty"`
+	Name      string   `json:"name,omitempty"      yaml:"name,omitempty"`
+	Namespace string   `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Literals  []string `json:"literals,omitempty"  yaml:"literals,omitempty"`
+	Files     []string `json:"files,omitempty"     yaml:"files,omitempty"`
+	Envs      []string `json:"envs,omitempty"      yaml:"envs,omitempty"`
 }
 
 // kustomizationFileNames is the ordered list kustomize checks; first
@@ -161,5 +167,19 @@ func resolveDataPath(base, rel string) (string, bool) {
 		return "", false
 	}
 	return abs, true
+}
+
+// resolveComponentPath is the components: counterpart to
+// resolveDataPath. kustomize's `components:` legitimately escapes the
+// calling kustomization's directory (e.g. `../components/cluster-
+// settings` is the canonical Flux pattern), so the in-base
+// constraint resolveDataPath enforces is too strict for this field.
+// We still reject URLs and absolute paths — flate's loader only
+// follows local relative components.
+func resolveComponentPath(base, rel string) (string, bool) {
+	if rel == "" || filepath.IsAbs(rel) || strings.Contains(rel, "://") {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(base, rel)), true
 }
 

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -85,6 +86,15 @@ type Loader struct {
 	// keeps out of the Store. Nil disables the bookkeeping (the
 	// default for non-DiscoveryOnly callers).
 	Existence *ExistenceIndex
+
+	// generators accumulates configMapGenerator/secretGenerator
+	// entries observed during the walk. After Load returns, the
+	// orchestrator finalizes them via FinalizeGenerators — the
+	// effective namespace depends on which Flux Kustomization
+	// encloses each kustomization.yaml, and that's only known once
+	// the full walk completes.
+	generatorsMu sync.Mutex
+	generators   []generatorRecord
 }
 
 // New returns a Loader configured to wipe secrets.
@@ -157,6 +167,14 @@ func (w *walker) descend(ctx context.Context, dir string) (int, error) {
 
 	k := readKustomization(dir)
 	if k != nil {
+		// Harvest configMapGenerator/secretGenerator entries
+		// regardless of whether this is a Kustomization or Component
+		// — both can declare generators, and downstream depwait
+		// lookups for substituteFrom CMs need the synthesized
+		// records either way.
+		if kpath, ok := kustomizationFilePath(dir); ok {
+			w.loader.recordGenerators(collectGeneratorRecords(k, kpath))
+		}
 		if k.isKustomizeComponent() {
 			slog.Debug("loader: skipping kustomize Component directory", "dir", dir)
 			return 0, nil
@@ -251,7 +269,7 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 		if cerr := ctx.Err(); cerr != nil {
 			return count, cerr
 		}
-		abs, ok := resolveDataPath(dir, comp)
+		abs, ok := resolveComponentPath(dir, comp)
 		if !ok {
 			continue
 		}
@@ -356,6 +374,94 @@ func (l *Loader) loadFile(path string) (int, error) {
 		count++
 	}
 	return count, nil
+}
+
+// recordGenerators appends generator records observed during a walk.
+// The orchestrator's Bootstrap calls FinalizeGenerators after Load
+// returns to resolve effective namespaces and inject the synthesized
+// CMs/Secrets into the store.
+func (l *Loader) recordGenerators(records []generatorRecord) {
+	if len(records) == 0 {
+		return
+	}
+	l.generatorsMu.Lock()
+	defer l.generatorsMu.Unlock()
+	l.generators = append(l.generators, records...)
+}
+
+// FinalizeGenerators materializes every harvested configMapGenerator/
+// secretGenerator entry into the store. Effective namespace is
+// resolved per kustomize precedence: the entry's own namespace wins,
+// then the kustomization.yaml's namespace, then the enclosing Flux
+// Kustomization's namespace (looked up via KSPathPrefixes against
+// the source file).
+//
+// Synthesized objects honor PreferExisting: if an explicit CM/Secret
+// with the same id already came from a real on-disk YAML, we don't
+// overwrite it with the generated placeholder.
+//
+// repoRoot is the filesystem root used to compute slash-relative
+// paths for the parent lookup; pass the same root the change filter
+// is keyed against (the Flux KS spec.path prefixes are
+// repoRoot-relative).
+func (l *Loader) FinalizeGenerators(repoRoot string) {
+	l.generatorsMu.Lock()
+	records := l.generators
+	l.generators = nil
+	l.generatorsMu.Unlock()
+	if len(records) == 0 {
+		return
+	}
+	prefixes := KSPathPrefixes(l.Store, repoRoot)
+	seen := make(map[manifest.NamedResource]struct{}, len(records))
+	for _, r := range records {
+		parentNS := parentNamespaceFor(prefixes, l.Store, r.file, repoRoot)
+		obj := r.materialize(parentNS)
+		id := obj.Named()
+		if _, dup := seen[id]; dup {
+			// Iterative discovery re-walks the same kustomization.yaml
+			// across passes; the second occurrence is a duplicate.
+			continue
+		}
+		seen[id] = struct{}{}
+		if l.Store.GetObject(id) != nil {
+			// Real CM/Secret YAML already won; don't overwrite.
+			continue
+		}
+		l.Store.AddObject(obj)
+		l.recordSource(id, r.file)
+		if l.Existence != nil {
+			l.Existence.Record(id, r.file)
+		}
+	}
+}
+
+// parentNamespaceFor resolves the enclosing Flux Kustomization's
+// namespace for the file at absPath. Falls back to "" when the file
+// sits outside any KS spec.path / component — depwait's name-only
+// fallback may still match in that case.
+func parentNamespaceFor(prefixes []KSPathPrefix, s *store.Store, absPath, repoRoot string) string {
+	rel, err := filepath.Rel(repoRoot, absPath)
+	if err != nil {
+		return ""
+	}
+	owner, ok := LongestParent(prefixes, rel, manifest.NamedResource{})
+	if !ok {
+		return ""
+	}
+	ks, _ := store.GetByName[*manifest.Kustomization](s, manifest.KindKustomization, owner.Namespace, owner.Name)
+	if ks == nil {
+		return ""
+	}
+	// Flux's render-time namespace precedence: spec.targetNamespace
+	// (the resource's effective namespace post-render) wins over the
+	// KS's own namespace (where the KS CR lives). For generated CMs
+	// we want the post-render namespace because that's what
+	// substituteFrom in downstream KSes references.
+	if ks.TargetNamespace != "" {
+		return ks.TargetNamespace
+	}
+	return ks.Namespace
 }
 
 // recordSource maps a resource id back to the on-disk file it was


### PR DESCRIPTION
Fixes #396.

## Two compounding bugs

### 1. `resolveDataPath` rejected components that escape the package

The path resolver used by both data files AND component descent refused any `..` segment. That's right for `resources:` (data files shouldn't escape the kustomization package) but wrong for `components:` — `components: [../foo]` is the canonical Flux pattern. Added a separate `resolveComponentPath` so the descent in `walkKustomize` can follow sibling/parent directory references.

### 2. Generated CMs/Secrets have no on-disk YAML

A configMapGenerator inside a Component produces no file the walker can pick up. `depwait` then fails when a downstream Kustomization's `substituteFrom` references that CM — the exact symptom in #396:

> dependencies failed: ConfigMap/flux-system/cluster-settings: dependency not found

The loader now harvests `configMapGenerator` + `secretGenerator` entries during walk. After every Flux KS is loaded (in `discovery.Run`), `FinalizeGenerators` synthesizes each one as a real `manifest.ConfigMap`/`Secret` and AddObjects to the store.

## Namespace precedence

Matches kustomize at render time:

1. Generator entry's own `namespace:` (rare)
2. The kustomization.yaml's `namespace:` field
3. The enclosing Flux Kustomization's `spec.targetNamespace`
4. The enclosing Flux Kustomization's own namespace

The enclosing KS is found via `KSPathPrefixes` — the same machinery that already routes Components into the right parent for orphan attribution.

## Coverage limits

`literals:` are decoded directly. `files:` and `envs:` entries aren't yet supported; the cluster-settings idiom in real-world Flux repos overwhelmingly uses literals, so this covers the reporter's case. Synthesized CMs land in the store with the resolved namespace and the parsed key/value pairs; substituteFrom against them works.

## Test
`TestRun_ComponentGeneratorMaterializesCM` plants the exact shape from #396 (Flux KS in flux-system → kustomization.yaml with `components: [../components/cluster-settings]` → Component with literals) and asserts the synthesized CM lands at `flux-system/cluster-settings` with the right keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)