### PR TITLE
refactor(manifest): dedup readKustomizeComponents

### DIFF
--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -1,13 +1,10 @@
 package change
 
 import (
-	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
-
-	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -70,7 +67,7 @@ func buildOwnership(objs ObjectLister, repoRoot string) ownershipIndex {
 		}
 		comps, ok := componentCache[base]
 		if !ok {
-			comps = readKustomizeComponents(repoRoot, base)
+			comps = manifest.ReadKustomizeComponents(repoRoot, base)
 			componentCache[base] = comps
 		}
 		for _, comp := range comps {
@@ -83,25 +80,6 @@ func buildOwnership(objs ObjectLister, repoRoot string) ownershipIndex {
 		ownersCache:    make(map[string][]manifest.NamedResource),
 		ancestorsCache: make(map[string][]manifest.NamedResource),
 	}
-}
-
-// readKustomizeComponents returns the top-level `components:` field
-// of the kustomization file at base (resolved relative to repoRoot).
-func readKustomizeComponents(repoRoot, base string) []string {
-	for _, name := range manifest.KustomizeBuilderFilenames {
-		data, err := os.ReadFile(filepath.Join(repoRoot, base, name)) //nolint:gosec // path composed from known cluster layout
-		if err != nil {
-			continue
-		}
-		var doc struct {
-			Components []string `yaml:"components"`
-		}
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			continue
-		}
-		return doc.Components
-	}
-	return nil
 }
 
 // ownersOf returns every KS that claims the longest-matching prefix

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -2,13 +2,10 @@ package loader
 
 import (
 	"cmp"
-	"os"
 	"path"
 	"path/filepath"
 	"slices"
 	"strings"
-
-	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -77,7 +74,7 @@ func KSPathPrefixes(s *store.Store, repoRoot string) []KSPathPrefix {
 			baseTrimmed := strings.TrimSuffix(base, "/")
 			comps, ok := componentCache[baseTrimmed]
 			if !ok {
-				comps = readKustomizeComponents(repoRoot, baseTrimmed)
+				comps = manifest.ReadKustomizeComponents(repoRoot, baseTrimmed)
 				componentCache[baseTrimmed] = comps
 			}
 			for _, comp := range comps {
@@ -91,27 +88,6 @@ func KSPathPrefixes(s *store.Store, repoRoot string) []KSPathPrefix {
 	return out
 }
 
-// readKustomizeComponents returns the top-level `components:` field
-// of the kustomization file at base (resolved relative to repoRoot),
-// or nil when the file is missing / unreadable / malformed. Mirrors
-// change/ownership.go's reader so the two indexes agree on which
-// component dirs to fold into the prefix set.
-func readKustomizeComponents(repoRoot, base string) []string {
-	for _, name := range manifest.KustomizeBuilderFilenames {
-		data, err := os.ReadFile(filepath.Join(repoRoot, base, name)) //nolint:gosec // path composed from known cluster layout
-		if err != nil {
-			continue
-		}
-		var doc struct {
-			Components []string `yaml:"components"`
-		}
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			continue
-		}
-		return doc.Components
-	}
-	return nil
-}
 
 // LongestParent returns the deepest KS whose spec.path covers file
 // (slash-normalized repo-relative path), excluding self. The second

--- a/pkg/manifest/kustomize_fs.go
+++ b/pkg/manifest/kustomize_fs.go
@@ -1,0 +1,36 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+
+	yaml "go.yaml.in/yaml/v4"
+)
+
+// ReadKustomizeComponents returns the top-level `components:` field of
+// the kustomization file at base (resolved relative to repoRoot).
+// Returns nil when the file is missing / unreadable / malformed —
+// pure best-effort, as the caller's claim graph is built from the
+// union of declared sources and on-disk reads.
+//
+// Lives here so loader's parent index and change's ownership index
+// share the same on-disk reader. Previously each module had its own
+// copy; behavior must agree across them or change attribution and
+// loader discovery silently disagree on which files belong to which
+// Flux Kustomization.
+func ReadKustomizeComponents(repoRoot, base string) []string {
+	for _, name := range KustomizeBuilderFilenames {
+		data, err := os.ReadFile(filepath.Join(repoRoot, base, name)) //nolint:gosec // path composed from known cluster layout
+		if err != nil {
+			continue
+		}
+		var doc struct {
+			Components []string `yaml:"components"`
+		}
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			continue
+		}
+		return doc.Components
+	}
+	return nil
+}


### PR DESCRIPTION
## Audit-B — DRY

`pkg/loader/parent.go` and `pkg/change/ownership.go` each had a private copy of the same on-disk reader (open a kustomization.yaml, return its top-level `components:` list). Identical behavior; drift was only in doc comments.

Moved to `pkg/manifest.ReadKustomizeComponents` — both packages already depend on manifest, and the helper sits next to `KustomizeBuilderFilenames` it consumes. Two private copies + their `os` / `go.yaml.in/yaml/v4` imports gone from loader and change.

## What's not in this PR

The audit also flagged the byte-identical `newWaiter` in kustomization + helmrelease controllers. Moving it to `base.Controller` would require adding `existence` + `renders` fields that source.Controller doesn't use, OR adding two parameters at every call site (making calls less readable). The 13-line duplication is the lesser cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)