### PR TITLE
refactor(source): shared NewHTTPTransport factory

### DIFF
--- a/pkg/source/bucket/transport.go
+++ b/pkg/source/bucket/transport.go
@@ -1,6 +1,7 @@
 package bucket
 
 import (
+	"crypto/tls"
 	"net/http"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -26,24 +27,13 @@ func (f *Fetcher) resolveTransport(b *manifest.Bucket) (*http.Transport, error) 
 	if err != nil {
 		return nil, err
 	}
-	if b.CertSecretRef == nil && proxy == nil {
-		return nil, nil
-	}
-	tr := http.DefaultTransport.(*http.Transport).Clone()
+	var tlsCfg *tls.Config
 	if b.CertSecretRef != nil {
-		cfg, terr := source.ResolveCertSecret(f.Secrets, b.Namespace, "Bucket",
+		tlsCfg, err = source.ResolveCertSecret(f.Secrets, b.Namespace, "Bucket",
 			b.Namespace+"/"+b.Name, b.CertSecretRef)
-		if terr != nil {
-			return nil, terr
+		if err != nil {
+			return nil, err
 		}
-		tr.TLSClientConfig = cfg
 	}
-	if proxy != nil {
-		pfn, perr := proxy.HTTPProxyFunc()
-		if perr != nil {
-			return nil, perr
-		}
-		tr.Proxy = pfn
-	}
-	return tr, nil
+	return source.NewHTTPTransport(tlsCfg, proxy)
 }

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -72,16 +72,11 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 	if tlsCfg != nil {
 		httpsTransportMu.Lock()
 		defer httpsTransportMu.Unlock()
-		tr := &http.Transport{TLSClientConfig: tlsCfg}
-		if proxy != nil {
-			pfn, perr := proxy.HTTPProxyFunc()
-			if perr != nil {
-				return nil, perr
-			}
-			tr.Proxy = pfn
+		tr, terr := source.NewHTTPTransport(tlsCfg, proxy)
+		if terr != nil {
+			return nil, terr
 		}
-		httpsClient := &http.Client{Transport: tr}
-		client.InstallProtocol("https", githttp.NewClient(httpsClient))
+		client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
 		defer client.InstallProtocol("https", githttp.DefaultClient)
 	}
 	return f.fetch(ctx, repo, auth, proxy)

--- a/pkg/source/git/mirror.go
+++ b/pkg/source/git/mirror.go
@@ -76,13 +76,9 @@ func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transpor
 	if tlsCfg != nil {
 		httpsTransportMu.Lock()
 		defer httpsTransportMu.Unlock()
-		tr := &http.Transport{TLSClientConfig: tlsCfg}
-		if proxy != nil {
-			pfn, perr := proxy.HTTPProxyFunc()
-			if perr != nil {
-				return nil, perr
-			}
-			tr.Proxy = pfn
+		tr, terr := source.NewHTTPTransport(tlsCfg, proxy)
+		if terr != nil {
+			return nil, terr
 		}
 		client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
 		defer client.InstallProtocol("https", githttp.DefaultClient)

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -177,19 +177,12 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	// Compose the http.Client transport: oras's retry transport over a
 	// customized http.Transport when TLS or proxy is configured. Without
 	// either, oras's default is used.
+	baseTransport, err := source.NewHTTPTransport(tlsCfg, proxy)
+	if err != nil {
+		return nil, err
+	}
 	var httpClient *http.Client
-	if tlsCfg != nil || proxy != nil {
-		baseTransport := http.DefaultTransport.(*http.Transport).Clone()
-		if tlsCfg != nil {
-			baseTransport.TLSClientConfig = tlsCfg
-		}
-		if proxy != nil {
-			pfn, perr := proxy.HTTPProxyFunc()
-			if perr != nil {
-				return nil, perr
-			}
-			baseTransport.Proxy = pfn
-		}
+	if baseTransport != nil {
 		httpClient = &http.Client{Transport: retry.NewTransport(baseTransport)}
 	}
 	if credStore != nil {

--- a/pkg/source/transport.go
+++ b/pkg/source/transport.go
@@ -1,0 +1,38 @@
+package source
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// NewHTTPTransport composes an *http.Transport from optional TLS and
+// proxy configuration. Returns nil when neither is set so callers can
+// substitute the runtime's default transport (and inherit its
+// keep-alive / max-idle tuning) when no customization is needed.
+//
+// When at least one of tlsCfg / proxy is non-nil, the runtime default
+// transport is cloned (NOT freshly allocated) so connection pool
+// settings, timeouts, and TLS minimum version inherit. Setting the
+// fields on a clone is the idiomatic way to override exactly the
+// dimensions the caller controls without losing the rest of net/http's
+// production-tuned defaults.
+//
+// Replaces three near-identical implementations (git, oci, bucket)
+// that had drifted on whether to clone or to allocate fresh.
+func NewHTTPTransport(tlsCfg *tls.Config, proxy *ProxyConfig) (*http.Transport, error) {
+	if tlsCfg == nil && proxy == nil {
+		return nil, nil
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if tlsCfg != nil {
+		tr.TLSClientConfig = tlsCfg
+	}
+	if proxy != nil {
+		pfn, err := proxy.HTTPProxyFunc()
+		if err != nil {
+			return nil, err
+		}
+		tr.Proxy = pfn
+	}
+	return tr, nil
+}


### PR DESCRIPTION
## Audit-C — unify HTTP transport composition

git, oci, and bucket each composed an `http.Transport` with optional TLS + proxy independently. Three implementations had drifted on whether to allocate a fresh transport or clone `http.DefaultTransport` — git allocated fresh, **losing the runtime's keep-alive / max-idle / TLS-minimum-version defaults**; oci and bucket correctly cloned.

Extract `source.NewHTTPTransport(tlsCfg, proxy)`:
- all three inherit the same net/http production-tuned defaults
- proxy-error handling centralized
- future dimensions (custom Dial, MaxIdleConnsPerHost) land in one place

Integration shapes stay where they are — git keeps its `InstallProtocol` dance, oci wraps with `retry.NewTransport`, bucket hands it to minio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)