### PR TITLE
perf: drop unnecessary syscalls and narrow the AddObject lock

### DIFF
--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -259,6 +259,19 @@ func (c *StagingCache) copyTree(src string) (string, error) {
 			}
 			return os.MkdirAll(filepath.Join(dst, rel), 0o750)
 		}
+		// Only stat when we need to follow a symlink — DirEntry already
+		// carries the file-type bits for regular entries. Skipping the
+		// stat on 50k regular files in a monorepo eliminates the same
+		// number of syscalls; hardlinks inherit mode from source so the
+		// fallback-copy's mode field is only consulted on cross-FS
+		// stages (EXDEV), where 0o600 is acceptable for kustomize input.
+		if d.Type()&fs.ModeSymlink == 0 {
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			tasks = append(tasks, task{path, filepath.Join(dst, rel), 0o600})
+			return nil
+		}
 		info, err := os.Stat(path)
 		if err != nil {
 			// A dangling symlink in the user's working tree (a common
@@ -268,7 +281,7 @@ func (c *StagingCache) copyTree(src string) (string, error) {
 			// reconcile wouldn't either — so skip silently when the
 			// target is missing. Other Stat errors (permissions, I/O)
 			// still surface.
-			if d.Type()&fs.ModeSymlink != 0 && errors.Is(err, fs.ErrNotExist) {
+			if errors.Is(err, fs.ErrNotExist) {
 				return nil
 			}
 			return err

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -90,10 +90,20 @@ func Materialize(ctx context.Context, repo *git.Repository, hash plumbing.Hash, 
 				opts.OnSubmodule(name)
 				continue
 			}
+			if entry.Mode == filemode.Dir {
+				// Pre-create the directory once on the walker. Without
+				// this, every worker that writes a blob into the dir
+				// would re-call MkdirAll for the same parent — on a
+				// 50k-file monorepo with 5k unique dirs, that's 10×
+				// the syscalls. Walker is single-threaded so each
+				// unique dir is created once.
+				dir := filepath.Join(root, filepath.FromSlash(name))
+				if err := os.MkdirAll(dir, 0o750); err != nil {
+					return fmt.Errorf("mkdir %s: %w", dir, err)
+				}
+				continue
+			}
 			if entry.Mode != filemode.Symlink && !entry.Mode.IsFile() {
-				// Tree entries; NewTreeWalker recurses into subtrees
-				// automatically. The per-blob writer MkdirAll's its
-				// parent on demand, so we don't need to mkdir here.
 				continue
 			}
 			select {
@@ -117,7 +127,8 @@ func Materialize(ctx context.Context, repo *git.Repository, hash plumbing.Hash, 
 }
 
 // writeEntry materializes one tree entry — a symlink or a blob — at
-// root/name. Caller has already gated by mode (symlink or IsFile).
+// root/name. The walker pre-created the parent dir, so we don't
+// MkdirAll here.
 func writeEntry(repo *git.Repository, entry object.TreeEntry, root, name string) error {
 	dst := filepath.Join(root, filepath.FromSlash(name))
 	if entry.Mode == filemode.Symlink {
@@ -128,9 +139,6 @@ func writeEntry(repo *git.Repository, entry object.TreeEntry, root, name string)
 		target, err := readBlobBytes(blob)
 		if err != nil {
 			return fmt.Errorf("read symlink target for %q: %w", name, err)
-		}
-		if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
-			return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
 		}
 		if err := os.Symlink(string(target), dst); err != nil {
 			return fmt.Errorf("symlink %s -> %s: %w", dst, target, err)
@@ -157,12 +165,8 @@ func readBlobBytes(blob *object.Blob) ([]byte, error) {
 
 // writeBlobTo streams blob's content to dst with mode-derived
 // permissions (executable bit preserved from filemode.Executable).
-// Creates the parent dir as needed; concurrent calls to the same
-// parent are safe because os.MkdirAll is idempotent.
+// Caller (Materialize's walker) has already created the parent dir.
 func writeBlobTo(dst string, blob *object.Blob, mode filemode.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(dst), err)
-	}
 	perm := os.FileMode(0o600)
 	if mode == filemode.Executable {
 		perm = 0o700

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -70,11 +70,26 @@ func nameKey(namespace, name string) string { return namespace + "/" + name }
 // AddObject inserts a manifest. Re-adding an equal object is a no-op.
 // Re-adding a different object overwrites the existing entry AND still
 // dispatches an ObjectAdded event (so newer values propagate).
+//
+// The equal-prev fast path reads under RLock and runs reflect.DeepEqual
+// outside the write lock. Reflection on a typed CR is the slowest
+// operation in this method; keeping it off the write path means
+// re-emits (a common pattern when a parent KS re-renders unchanged
+// children) don't block concurrent readers.
 func (s *Store) AddObject(obj manifest.BaseManifest) {
 	id := obj.Named()
-	s.mu.Lock()
+	s.mu.RLock()
 	prev, exists := s.objects[id]
+	s.mu.RUnlock()
 	if exists && reflect.DeepEqual(prev, obj) {
+		return
+	}
+	s.mu.Lock()
+	// Re-check under the write lock: a concurrent AddObject may have
+	// landed the same object between our RUnlock and Lock. Without the
+	// re-check we'd dispatch a redundant event for a write the previous
+	// goroutine already did.
+	if cur, ok := s.objects[id]; ok && reflect.DeepEqual(cur, obj) {
 		s.mu.Unlock()
 		return
 	}


### PR DESCRIPTION
Three small wins on the render hot path, each backed by file:line evidence from the perf review.

## 1. `kustomize/stage.go`: skip `os.Stat` for non-symlink entries
`filepath.WalkDir` already carries the file-type bits on each `DirEntry`. For 50k regular files in a monorepo, that's 50k fewer syscalls per stage copy. Symlinks still Stat (need target type + dangling-link detection).

The 0o600 fallback applies only to the EXDEV cross-FS copy path; hardlinks (the common case) inherit mode from source.

## 2. `source/gittree/materialize.go`: have the walker pre-create directories
The walker visits tree (`filemode.Dir`) entries before the files inside them. With `NumCPU` workers each previously re-`MkdirAll`'d the same parent. Now the walker mkdir's each Dir entry once; workers write blobs/symlinks assuming the parent exists.

~10× fewer mkdir syscalls on a 50k-file / 5k-dir monorepo.

## 3. `store.AddObject`: run `reflect.DeepEqual` outside the write lock
Re-emits (parent KS re-rendering unchanged children) are the common case and previously held the write lock across reflection. RLock the prev, compare, then promote to write only when different. Double-check under the write lock prevents racing a redundant dispatch.

## What I'm skipping from the perf agents (and why)

- **Cycle DFS per AddObject** (orchestrator.go:668): real cost but no easy fix without graph fingerprinting. Defer.
- **JSON round-trip in parseTyped**: unavoidable without writing a custom CR decoder.
- **GetStatus RLock contention**: RLock acquisition is an atomic CAS; not a hotspot.
- **`applyStrip` DeepCopyMap**: ~25ms on 500 docs. Not worth the complexity of a surgical-copy refactor.
- **`emitRenderedChildren` two-pass**: both passes are pointer-walks. Partitioning yields the same operation count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)