### PR TITLE
fix(source): close mark-sweep race between gc.Sweep and Refs.Put

### DIFF
--- a/pkg/source/blob/gclock.go
+++ b/pkg/source/blob/gclock.go
@@ -1,0 +1,38 @@
+package blob
+
+import "sync"
+
+// gcMu coordinates the GC mark↔sweep window against concurrent
+// Refs.Put.
+//
+// Without it, this interleaving deletes a freshly-referenced blob:
+//
+//  1. GC's mark walk runs over refs/<category>/ and snapshots the
+//     live digest set. A Put that lands its atomic rename after the
+//     walk reads that subdirectory is invisible to mark.
+//  2. GC's sweep then scans blobs/. For each blob older than MaxAge,
+//     it consults the live set. A blob the new ref points at is
+//     missing from live (mark didn't see it) and gets removed.
+//  3. The Put completes successfully — but its ref now points at a
+//     blob that was just deleted.
+//
+// Sweep takes the exclusive lock for the duration of mark + sweep,
+// freezing Put visibility. Put takes the shared lock so concurrent
+// Puts to different keys stay parallel — they only serialize against
+// the (rare) GC sweep.
+var gcMu sync.RWMutex
+
+// RLockGC acquires a shared lock against the GC sweep. Caller must
+// invoke the returned function to release.
+func RLockGC() func() {
+	gcMu.RLock()
+	return gcMu.RUnlock
+}
+
+// LockGC acquires the exclusive sweep lock. Held across mark + sweep
+// so no Refs.Put can finalize within the window. Caller must invoke
+// the returned function to release.
+func LockGC() func() {
+	gcMu.Lock()
+	return gcMu.Unlock
+}

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -48,7 +48,12 @@ func NewRefs(layout cacheroot.Layout, category string) *Refs {
 // torn write doesn't surface as a sentinel.
 //
 // Consults the in-memory cache first; a hit avoids the disk read
-// entirely. A miss falls through to ReadFile and populates the cache.
+// entirely. A miss falls through to ReadFile and populates the cache
+// via LoadOrStore — if a concurrent Put landed a newer digest into
+// mem between our ReadFile (which may have observed the old contents)
+// and our cache-fill, the Put's value wins. Without LoadOrStore, this
+// Get could overwrite the Put's NEW with the disk-read OLD and poison
+// the cache for the rest of the run.
 func (r *Refs) Get(key string) (string, bool) {
 	if v, ok := r.mem.Load(key); ok {
 		digest, _ := v.(string)
@@ -66,7 +71,11 @@ func (r *Refs) Get(key string) (string, bool) {
 	if digest == "" {
 		return "", false
 	}
-	r.mem.Store(key, digest)
+	if v, loaded := r.mem.LoadOrStore(key, digest); loaded {
+		if existing, _ := v.(string); existing != "" {
+			return existing, true
+		}
+	}
 	return digest, true
 }
 
@@ -76,10 +85,16 @@ func (r *Refs) Get(key string) (string, bool) {
 // supported (an upstream tag re-resolved to a new digest) — the
 // rename atomically replaces the file.
 //
+// Takes the package-level GC shared lock for the duration of the
+// write so a concurrent gc.Sweep can't observe a not-yet-written ref
+// during mark and then purge its blob during sweep (see gclock.go).
+//
 // syncDir=false on the underlying atomic write: refs files are cheap
 // to rebuild on the next reconcile, so the fsync barrier is not worth
 // the per-render I/O cost.
 func (r *Refs) Put(key, digest string) error {
+	unlockGC := RLockGC()
+	defer unlockGC()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if err := os.MkdirAll(r.dir, 0o750); err != nil {

--- a/pkg/source/blob/refs_test.go
+++ b/pkg/source/blob/refs_test.go
@@ -1,9 +1,14 @@
 package blob
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
@@ -48,6 +53,83 @@ func TestRefs_GetServesFromMemory(t *testing.T) {
 	got, ok := r.Get("k")
 	if !ok || got != "abc" {
 		t.Errorf("Get after disk wipe = (%q, %v), expected (abc, true) from cache", got, ok)
+	}
+}
+
+// TestRefs_GetMissDoesNotClobberConcurrentPut: a Get whose disk
+// ReadFile observed the OLD ref file must not overwrite the in-memory
+// entry a concurrent Put just landed with the NEW digest. The
+// pre-fix Get used mem.Store unconditionally, which poisoned the
+// cache for the rest of the run.
+//
+// We simulate the race deterministically by pre-seeding the on-disk
+// file with OLD, then in two goroutines (a) calling Put("k", "new")
+// and (b) calling Get("k") repeatedly. After both finish, the
+// in-memory cache must hold "new" — Put is authoritative.
+func TestRefs_GetMissDoesNotClobberConcurrentPut(t *testing.T) {
+	layout := cacheroot.New(t.TempDir())
+	r := NewRefs(layout, "test")
+	dir := layout.RefsCategory("test")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "k"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			_, _ = r.Get("k")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		_ = r.Put("k", "new")
+	}()
+	wg.Wait()
+	got, ok := r.Get("k")
+	if !ok || got != "new" {
+		t.Errorf("after concurrent Put, Get = (%q, %v), want (new, true) — Get clobbered Put's mem entry", got, ok)
+	}
+}
+
+// TestStore_PutBytesRefreshesMtimeOnReuse: when PutBytes returns the
+// existing-blob early path, the blob's mtime is bumped to "now" so a
+// concurrent gc.Sweep with a tight MaxAge can't purge a blob the
+// caller is about to reference. Without the chtimes, an old blob
+// reused across runs would have a stale mtime and could be swept
+// between the caller's PutBytes and Refs.Put.
+func TestStore_PutBytesRefreshesMtimeOnReuse(t *testing.T) {
+	layout := cacheroot.New(t.TempDir())
+	s := NewStore(layout)
+	content := []byte("hello world")
+	dir, digest, err := s.PutBytes(context.Background(), content, "f.bin")
+	if err != nil {
+		t.Fatalf("PutBytes initial: %v", err)
+	}
+	sum := sha256.Sum256(content)
+	if digest != hex.EncodeToString(sum[:]) {
+		t.Fatalf("digest mismatch: got %s", digest)
+	}
+	// Artificially age the blob directory.
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatal(err)
+	}
+	// Reuse the same content — should hit the Exists=true early return
+	// and refresh mtime.
+	before := time.Now().Add(-1 * time.Second)
+	if _, _, err := s.PutBytes(context.Background(), content, "f.bin"); err != nil {
+		t.Fatalf("PutBytes reuse: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.ModTime().Before(before) {
+		t.Errorf("blob mtime not refreshed on reuse: got %v, want > %v", info.ModTime(), before)
 	}
 }
 

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
@@ -64,11 +65,21 @@ func (s *Store) Exists(digest string) bool {
 // and return without rewriting. ctx cancellation aborts the lock
 // acquire (no write performed).
 //
+// Takes the package-level GC shared lock so a concurrent gc.Sweep
+// can't delete a blob between the Exists check and the caller's
+// subsequent Refs.Put. The early-return path also refreshes the
+// blob's mtime — without that bump, a reused-but-old blob whose
+// "fresh" ref lands after Sweep's mark walk would be age-pruned even
+// though a live caller just touched it.
+//
 // Returns the populated blob directory path and the computed digest.
 func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (string, string, error) {
 	sum := sha256.Sum256(content)
 	digest := hex.EncodeToString(sum[:])
 	dir := s.Path(digest)
+
+	unlockGC := RLockGC()
+	defer unlockGC()
 
 	release, err := s.locks.Acquire(ctx, digest)
 	if err != nil {
@@ -77,6 +88,8 @@ func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (
 	defer release()
 
 	if s.Exists(digest) {
+		now := time.Now()
+		_ = os.Chtimes(dir, now, now)
 		return dir, digest, nil
 	}
 	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/home-operations/flate/pkg/source/blob"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
@@ -70,6 +71,14 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 	if opts.MaxAge > 0 {
 		cutoff = time.Now().Add(-opts.MaxAge)
 	}
+
+	// Hold the exclusive GC lock for the entire mark + sweep so no
+	// blob.Refs.Put can land an atomic-rename between markLiveDigests
+	// and the blob sweep — the race would otherwise purge a freshly-
+	// referenced blob as orphan-old. Refs.Put takes the shared lock so
+	// the gate is invisible for the common case (no GC running).
+	unlockGC := blob.LockGC()
+	defer unlockGC()
 
 	live := markLiveDigests(layout, &res)
 

--- a/pkg/source/gc_test.go
+++ b/pkg/source/gc_test.go
@@ -1,12 +1,15 @@
 package source
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/home-operations/flate/pkg/source/blob"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
@@ -184,6 +187,67 @@ func TestSweep_UnreferencedOldBlobIsPruned(t *testing.T) {
 	res, _ := Sweep(cacheroot.New(root), SweepOpts{MaxAge: 24 * time.Hour})
 	if !slices.Contains(res.Removed, blob) {
 		t.Errorf("orphan blob survived: %v", res.Removed)
+	}
+}
+
+// TestSweep_PutInFlightPreservesBlob is the regression test for the
+// mark↔sweep race fix in gclock.go. The caller's PutBytes + Refs.Put
+// pair runs concurrently with Sweep; the invariant is "if the ref
+// landed, its blob still resolves" — i.e., no ref points at a freshly-
+// purged blob.
+//
+// Pre-fix: Sweep marks refs before PutBytes refreshes the (old) blob's
+// mtime, then ages-out the blob; Refs.Put then writes a ref pointing
+// at a deleted blob. Post-fix: PutBytes holds RLockGC and refreshes
+// mtime, Refs.Put holds RLockGC, Sweep holds the exclusive LockGC —
+// the three operations serialize cleanly so the invariant holds in
+// every interleaving.
+func TestSweep_PutInFlightPreservesBlob(t *testing.T) {
+	layout := cacheroot.New(t.TempDir())
+	store := blob.NewStore(layout)
+	refs := blob.NewRefs(layout, "test")
+
+	// Pre-seed an OLD blob so Sweep would age-prune it on the next pass.
+	content := []byte("payload")
+	dir, digest, err := store.PutBytes(context.Background(), content, "f.bin")
+	if err != nil {
+		t.Fatalf("seed PutBytes: %v", err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(dir, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	// Race the (PutBytes → Refs.Put) pair against Sweep with a tight
+	// MaxAge that would otherwise reap the seeded blob.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		if _, _, perr := store.PutBytes(context.Background(), content, "f.bin"); perr != nil {
+			t.Errorf("racing PutBytes: %v", perr)
+			return
+		}
+		if perr := refs.Put("k", digest); perr != nil {
+			t.Errorf("racing Refs.Put: %v", perr)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		if _, serr := Sweep(layout, SweepOpts{MaxAge: 1 * time.Nanosecond}); serr != nil {
+			t.Errorf("Sweep: %v", serr)
+		}
+	}()
+	wg.Wait()
+
+	// Invariant: if the ref landed, its blob must resolve.
+	if got, ok := refs.Get("k"); ok {
+		if got != digest {
+			t.Fatalf("ref points at unexpected digest %q (want %q)", got, digest)
+		}
+		if _, err := os.Stat(layout.Blob(got)); err != nil {
+			t.Errorf("ref → blob invariant broken: ref exists but blob is gone: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Three interleavings between `gc.Sweep` and the `blob.Store` + `blob.Refs` write path could leave the cache in a broken state — either a fresh ref pointing at a deleted blob, or a stale in-memory cache poisoning every subsequent read.

### The races

1. **Mark↔sweep window** — Sweep marks refs, then `Refs.Put` lands a new (key→digest) that the mark walk missed, then sweep prunes the (old-mtime) blob the new ref names. Freshly-written ref → deleted blob.

2. **Exists-true early return** — `Store.PutBytes` returns an existing blob's path without refreshing mtime. A Sweep that runs between `PutBytes` and the caller's `Refs.Put` can age-prune a blob the caller is one syscall away from referencing.

3. **Get cache poisoning** — `Refs.Get`'s miss path unconditionally `mem.Store`'s its disk result. A concurrent `Refs.Put` that already landed NEW in mem gets clobbered with the OLD digest the racing Get read off disk, poisoning the in-memory cache for the rest of the run.

### Fix

- New `pkg/source/blob/gclock.go` with a package-level `sync.RWMutex`. Sweep takes the exclusive lock for mark + sweep; `Refs.Put` and `Store.PutBytes` take the shared lock so concurrent writes stay parallel and only block during the (rare) GC window.
- `Store.PutBytes` refreshes the blob directory's mtime on the Exists=true early-return path.
- `Refs.Get` switches to `LoadOrStore` so a concurrent Put's newer value wins over a stale disk read.

### Regression coverage

- `TestStore_PutBytesRefreshesMtimeOnReuse`
- `TestRefs_GetMissDoesNotClobberConcurrentPut` (-race x50 clean)
- `TestSweep_PutInFlightPreservesBlob` (-race x50 clean)

## Test plan

- [x] \`go test -race ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] Race regression tests pass under \`-count 50\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)