### PR TITLE
refactor(source): collapse fetcher authIdentity helpers into AuthIdentityFromRefs

### DIFF
--- a/pkg/source/authid.go
+++ b/pkg/source/authid.go
@@ -1,5 +1,7 @@
 package source
 
+import "github.com/home-operations/flate/pkg/manifest"
+
 // AuthIdentity returns a deterministic, opaque tag identifying the
 // auth context bound to a source fetch. It is appended to the cache
 // key so two source CRs that target the same (URL, ref) but reference
@@ -12,6 +14,11 @@ package source
 // Returns "" when every input is empty — the caller passes "" to
 // Cache.Slot in that case, and slots match the legacy unauthenticated
 // layout so existing caches survive.
+//
+// Fetchers should prefer AuthIdentityFromRefs when their inputs are
+// already *manifest.LocalObjectReference values; reach for this
+// lower-level entry point only when a non-secret-ref dimension (e.g.
+// a hashed cert thumbprint) needs to participate in the key.
 func AuthIdentity(parts ...string) string {
 	out := ""
 	for _, p := range parts {
@@ -26,12 +33,29 @@ func AuthIdentity(parts ...string) string {
 	return out
 }
 
-// SecretRefID renders a Flux LocalObjectReference into the
-// `<namespace>/<name>` shape AuthIdentity expects. ns is the owning
-// CR's namespace (SecretRefs are LocalObjectReferences — they inherit
-// it). Returns "" when name is empty so optional refs slot in as
-// no-op zero values.
-func SecretRefID(ns, name string) string {
+// AuthIdentityFromRefs is the typed entry point fetchers use to build
+// a cache auth identity from their namespaced SecretRefs. Each fetcher
+// (git, oci, bucket) used to reimplement the same nil-check + format +
+// AuthIdentity call sequence; collapsing them here keeps the format
+// stable as new ref dimensions get added.
+//
+// Refs are consumed in caller-defined order; nil entries slot in as
+// "" so AuthIdentity strips them. ns is the owning CR's namespace
+// (SecretRefs are LocalObjectReferences — they inherit it).
+func AuthIdentityFromRefs(ns string, refs ...*manifest.LocalObjectReference) string {
+	parts := make([]string, len(refs))
+	for i, ref := range refs {
+		if ref != nil {
+			parts[i] = secretRefID(ns, ref.Name)
+		}
+	}
+	return AuthIdentity(parts...)
+}
+
+// secretRefID renders a Flux LocalObjectReference into the
+// `<namespace>/<name>` shape AuthIdentity expects. Returns "" when
+// name is empty so optional refs slot in as no-op zero values.
+func secretRefID(ns, name string) string {
 	if name == "" {
 		return ""
 	}

--- a/pkg/source/authid_test.go
+++ b/pkg/source/authid_test.go
@@ -1,0 +1,98 @@
+package source
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func TestAuthIdentity(t *testing.T) {
+	cases := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"all empty", []string{"", "", ""}, ""},
+		{"single", []string{"a"}, "a"},
+		{"strips empties", []string{"a", "", "b"}, "a\x00b"},
+		{"order matters", []string{"b", "a"}, "b\x00a"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := AuthIdentity(c.parts...); got != c.want {
+				t.Errorf("AuthIdentity(%q) = %q, want %q", c.parts, got, c.want)
+			}
+		})
+	}
+}
+
+func TestAuthIdentityFromRefs(t *testing.T) {
+	mk := func(name string) *manifest.LocalObjectReference {
+		return &manifest.LocalObjectReference{Name: name}
+	}
+	cases := []struct {
+		name string
+		ns   string
+		refs []*manifest.LocalObjectReference
+		want string
+	}{
+		{"no refs", "ns", nil, ""},
+		{"all nil", "ns", []*manifest.LocalObjectReference{nil, nil}, ""},
+		{"single secret", "ns", []*manifest.LocalObjectReference{mk("creds")}, "ns/creds"},
+		{
+			name: "matches positional AuthIdentity",
+			ns:   "ns",
+			refs: []*manifest.LocalObjectReference{mk("a"), nil, mk("b")},
+			want: AuthIdentity("ns/a", "", "ns/b"),
+		},
+		{
+			name: "namespace prefix isolates colliding names",
+			ns:   "team-a",
+			refs: []*manifest.LocalObjectReference{mk("shared")},
+			want: "team-a/shared",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := AuthIdentityFromRefs(c.ns, c.refs...); got != c.want {
+				t.Errorf("AuthIdentityFromRefs(%q, %v) = %q, want %q", c.ns, c.refs, got, c.want)
+			}
+		})
+	}
+}
+
+// TestAuthIdentityFromRefs_BackwardCompat: the typed helper must produce
+// the same identities the three fetchers used to compute by hand —
+// otherwise existing on-disk cache slots would orphan on upgrade.
+func TestAuthIdentityFromRefs_BackwardCompat(t *testing.T) {
+	mk := func(name string) *manifest.LocalObjectReference {
+		return &manifest.LocalObjectReference{Name: name}
+	}
+	ns := "demo"
+
+	// Git: (Secret, Proxy)
+	gitWant := AuthIdentity(secretRefID(ns, "g-secret"), secretRefID(ns, "g-proxy"))
+	if got := AuthIdentityFromRefs(ns, mk("g-secret"), mk("g-proxy")); got != gitWant {
+		t.Errorf("git shape: %q vs legacy %q", got, gitWant)
+	}
+
+	// Bucket: (Secret, Cert, Proxy)
+	bucketWant := AuthIdentity(
+		secretRefID(ns, "b-secret"),
+		secretRefID(ns, "b-cert"),
+		secretRefID(ns, "b-proxy"))
+	if got := AuthIdentityFromRefs(ns, mk("b-secret"), mk("b-cert"), mk("b-proxy")); got != bucketWant {
+		t.Errorf("bucket shape: %q vs legacy %q", got, bucketWant)
+	}
+
+	// OCI: (Secret, Cert, Proxy, Verify)
+	ociWant := AuthIdentity(
+		secretRefID(ns, "o-secret"),
+		secretRefID(ns, "o-cert"),
+		secretRefID(ns, "o-proxy"),
+		secretRefID(ns, "o-verify"))
+	if got := AuthIdentityFromRefs(ns, mk("o-secret"), mk("o-cert"), mk("o-proxy"), mk("o-verify")); got != ociWant {
+		t.Errorf("oci shape: %q vs legacy %q", got, ociWant)
+	}
+}

--- a/pkg/source/bucket/bucket.go
+++ b/pkg/source/bucket/bucket.go
@@ -241,15 +241,6 @@ func downloadObject(ctx context.Context, client *minio.Client, bucket, key, dst 
 // SecretRef (S3 access creds), CertSecretRef (TLS), and
 // ProxySecretRef. Returns "" when all are unset.
 func authIdentity(b *manifest.Bucket) string {
-	var secret, cert, proxy string
-	if b.SecretRef != nil {
-		secret = source.SecretRefID(b.Namespace, b.SecretRef.Name)
-	}
-	if b.CertSecretRef != nil {
-		cert = source.SecretRefID(b.Namespace, b.CertSecretRef.Name)
-	}
-	if b.ProxySecretRef != nil {
-		proxy = source.SecretRefID(b.Namespace, b.ProxySecretRef.Name)
-	}
-	return source.AuthIdentity(secret, cert, proxy)
+	return source.AuthIdentityFromRefs(b.Namespace,
+		b.SecretRef, b.CertSecretRef, b.ProxySecretRef)
 }

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -391,14 +391,8 @@ func updateSubmodules(repo *git.Repository, auth transport.AuthMethod) error {
 // fetcher binds. Returns "" for anonymous clones so they share slots
 // with the legacy un-auth-keyed layout.
 func authIdentity(repo *manifest.GitRepository) string {
-	var secret, proxy string
-	if repo.SecretRef != nil {
-		secret = source.SecretRefID(repo.Namespace, repo.SecretRef.Name)
-	}
-	if repo.ProxySecretRef != nil {
-		proxy = source.SecretRefID(repo.Namespace, repo.ProxySecretRef.Name)
-	}
-	return source.AuthIdentity(secret, proxy)
+	return source.AuthIdentityFromRefs(repo.Namespace,
+		repo.SecretRef, repo.ProxySecretRef)
 }
 
 // readResolvedRevision returns the current commit SHA at the worktree.

--- a/pkg/source/oci/oci.go
+++ b/pkg/source/oci/oci.go
@@ -632,18 +632,10 @@ func versionTag(ref manifest.OCIRepositoryRef) string {
 // ProxySecretRef, and verify.SecretRef (cosign keys) since each can
 // change which artifact bytes a reconcile resolves to.
 func authIdentity(repo *manifest.OCIRepository) string {
-	var secret, cert, proxy, verify string
-	if repo.SecretRef != nil {
-		secret = source.SecretRefID(repo.Namespace, repo.SecretRef.Name)
+	var verifyRef *manifest.LocalObjectReference
+	if repo.Verify != nil {
+		verifyRef = repo.Verify.SecretRef
 	}
-	if repo.CertSecretRef != nil {
-		cert = source.SecretRefID(repo.Namespace, repo.CertSecretRef.Name)
-	}
-	if repo.ProxySecretRef != nil {
-		proxy = source.SecretRefID(repo.Namespace, repo.ProxySecretRef.Name)
-	}
-	if repo.Verify != nil && repo.Verify.SecretRef != nil {
-		verify = source.SecretRefID(repo.Namespace, repo.Verify.SecretRef.Name)
-	}
-	return source.AuthIdentity(secret, cert, proxy, verify)
+	return source.AuthIdentityFromRefs(repo.Namespace,
+		repo.SecretRef, repo.CertSecretRef, repo.ProxySecretRef, verifyRef)
 }


### PR DESCRIPTION
## Summary

\`git\`, \`oci\`, and \`bucket\` each carried a near-identical helper that nil-checked its SecretRefs, called \`source.SecretRefID\`, and joined with \`source.AuthIdentity\`. The shape was identical; only which refs each passed differed.

Move the loop into a single typed entry point in \`pkg/source/authid.go\`:

\`\`\`go
func AuthIdentityFromRefs(ns string, refs ...*manifest.LocalObjectReference) string
\`\`\`

Each fetcher now calls this with its own ref order. \`SecretRefID\` is demoted to package-private (\`secretRefID\`) since the typed entry point is the only caller.

## Backward compatibility

Output is byte-for-byte identical to the previous per-fetcher logic — see \`TestAuthIdentityFromRefs_BackwardCompat\` — so existing on-disk cache slots remain valid.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)