### PR TITLE
refactor(source/git): split verify and mirror into subpackages

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/home-operations/flate/pkg/source/bucket"
 	"github.com/home-operations/flate/pkg/source/external"
 	"github.com/home-operations/flate/pkg/source/git"
+	"github.com/home-operations/flate/pkg/source/git/mirror"
 	"github.com/home-operations/flate/pkg/source/oci"
 	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/task"
@@ -225,7 +226,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		manifest.KindGitRepository, &git.Fetcher{
 			Cache:   cache,
 			Secrets: secretGet,
-			Mirrors: git.NewMirrorCache(layout),
+			Mirrors: mirror.New(layout),
 		})
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap[*manifest.ExternalArtifact](
 		manifest.KindExternalArtifact, &external.Fetcher{})

--- a/pkg/source/git/git.go
+++ b/pkg/source/git/git.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,11 +14,12 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/client"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/git/internal/gittransport"
+	"github.com/home-operations/flate/pkg/source/git/mirror"
+	"github.com/home-operations/flate/pkg/source/git/verify"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -39,11 +39,8 @@ import (
 type Fetcher struct {
 	Cache   *source.Cache
 	Secrets source.SecretGetter
-	Mirrors *MirrorCache
+	Mirrors *mirror.Cache
 }
-
-// httpsTransportMu is declared in tls.go (with the only caller —
-// the TLS-customized InstallProtocol path in Fetch below).
 
 // Fetch implements source.TypedFetcher[*manifest.GitRepository].
 // The typed signature is wrapped via source.Wrap at orchestrator
@@ -69,16 +66,11 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 	if err != nil {
 		return nil, err
 	}
-	if tlsCfg != nil {
-		httpsTransportMu.Lock()
-		defer httpsTransportMu.Unlock()
-		tr, terr := source.NewHTTPTransport(tlsCfg, proxy)
-		if terr != nil {
-			return nil, terr
-		}
-		client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
-		defer client.InstallProtocol("https", githttp.DefaultClient)
+	restore, err := gittransport.InstallHTTPS(tlsCfg, proxy)
+	if err != nil {
+		return nil, err
 	}
+	defer restore()
 	return f.fetch(ctx, repo, auth, proxy)
 }
 
@@ -210,7 +202,7 @@ func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifa
 		if herr != nil {
 			return fmt.Errorf("verify: resolve HEAD: %w", herr)
 		}
-		if err := verifySignatures(f.Secrets, repo, cloned, head.Hash()); err != nil {
+		if err := verify.Signatures(f.Secrets, repo, cloned, head.Hash()); err != nil {
 			return err
 		}
 	}
@@ -254,19 +246,19 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 	if err != nil {
 		return nil, err
 	}
-	mirror, err := f.Mirrors.openOrFetch(ctx, repo.URL, auth, proxy, tlsCfg)
+	mirrorRepo, err := f.Mirrors.OpenOrFetch(ctx, repo.URL, auth, proxy, tlsCfg)
 	if err != nil {
 		return nil, err
 	}
-	hash, err := resolveRefHash(mirror, repo.Reference)
+	hash, err := resolveRefHash(mirrorRepo, repo.Reference)
 	if err != nil {
 		return nil, fmt.Errorf("GitRepository %s/%s ref %q: %w", repo.Namespace, repo.Name, refStr, err)
 	}
-	if err := materializeTree(ctx, mirror, hash, slot.Path); err != nil {
+	if err := materializeTree(ctx, mirrorRepo, hash, slot.Path); err != nil {
 		return nil, fmt.Errorf("materialize %s at %s: %w", hash, refStr, err)
 	}
 	if repo.Verification != nil {
-		if err := verifySignatures(f.Secrets, repo, mirror, hash); err != nil {
+		if err := verify.Signatures(f.Secrets, repo, mirrorRepo, hash); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/source/git/internal/gittransport/gittransport.go
+++ b/pkg/source/git/internal/gittransport/gittransport.go
@@ -1,0 +1,48 @@
+// Package gittransport carries the shared HTTPS-transport install
+// lock that's serialized across the git.Fetcher and the bare-mirror
+// cache.
+//
+// go-git v5 has no per-CloneOptions TLS hook, so a custom-CA fetch
+// must register its transport on go-git's process-global protocol
+// map and restore the default afterward. The lock is package-global
+// because the install itself is — a per-Fetcher mutex would race
+// when two Fetchers ran concurrently and clobbered each other's
+// transport.
+package gittransport
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
+	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
+
+	"github.com/home-operations/flate/pkg/source"
+)
+
+var mu sync.Mutex
+
+// InstallHTTPS installs a TLS+proxy-customized HTTPS transport on
+// go-git's global protocol map and returns a restore function the
+// caller MUST defer. Acquires the process-global mutex on entry; the
+// restore releases it after re-installing the default client.
+//
+// When tlsCfg is nil there's nothing to customize: returns a no-op
+// restore and no error, no lock acquired.
+func InstallHTTPS(tlsCfg *tls.Config, proxy *source.ProxyConfig) (func(), error) {
+	if tlsCfg == nil {
+		return func() {}, nil
+	}
+	mu.Lock()
+	tr, err := source.NewHTTPTransport(tlsCfg, proxy)
+	if err != nil {
+		mu.Unlock()
+		return nil, err
+	}
+	client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
+	return func() {
+		client.InstallProtocol("https", githttp.DefaultClient)
+		mu.Unlock()
+	}, nil
+}

--- a/pkg/source/git/mirror/mirror.go
+++ b/pkg/source/git/mirror/mirror.go
@@ -1,4 +1,8 @@
-package git
+// Package mirror implements the bare-clone object store shared
+// across GitRepository fetches. One bare mirror per upstream URL is
+// kept warm across runs; per-(URL, ref) cache slots materialize
+// their worktrees from it without re-cloning on every reconcile.
+package mirror
 
 import (
 	"context"
@@ -7,40 +11,37 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport"
-	"github.com/go-git/go-git/v5/plumbing/transport/client"
-	githttp "github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/source/git/internal/gittransport"
 )
 
-// MirrorCache holds one bare clone per unique upstream URL. The mirror
-// is the persistent object store that incremental Fetches update; the
+// Cache holds one bare clone per unique upstream URL. The mirror is
+// the persistent object store that incremental Fetches update; the
 // per-(URL, ref) cache slots materialize their worktrees from it
 // without re-cloning across runs or across refs of the same repo.
 //
-// Construct via NewMirrorCache; pass to Fetcher.Mirrors. A nil
+// Construct via New; pass to git.Fetcher.Mirrors. A nil
 // Fetcher.Mirrors disables mirroring — the legacy PlainClone-into-slot
 // path runs unchanged (used by tests and any caller that prefers the
 // older behavior).
-type MirrorCache struct {
+type Cache struct {
 	layout cacheroot.Layout
 	locks  *keylock.KeyMap[string]
 }
 
-// NewMirrorCache constructs a MirrorCache backed by the supplied
-// Layout. The git-mirrors subtree is created lazily on first
-// openOrFetch.
-func NewMirrorCache(layout cacheroot.Layout) *MirrorCache {
-	return &MirrorCache{layout: layout, locks: keylock.New[string]()}
+// New constructs a Cache backed by the supplied Layout. The
+// git-mirrors subtree is created lazily on first OpenOrFetch.
+func New(layout cacheroot.Layout) *Cache {
+	return &Cache{layout: layout, locks: keylock.New[string]()}
 }
 
 // urlHash returns the stable directory name for url's mirror. The hash
@@ -53,36 +54,32 @@ func urlHash(url string) string {
 	return hex.EncodeToString(h[:])[:16]
 }
 
-func (m *MirrorCache) pathFor(url string) string {
+func (m *Cache) pathFor(url string) string {
 	return m.layout.GitMirror(urlHash(url))
 }
 
-// openOrFetch returns the bare mirror repo for url, ensuring it carries
-// up-to-date refs. First call for a URL runs a bare clone; subsequent
-// calls incrementally Fetch. Holds the per-URL lock across the network
-// operation so two concurrent callers serialize.
+// OpenOrFetch returns the bare mirror repo for url, ensuring it
+// carries up-to-date refs. First call for a URL runs a bare clone;
+// subsequent calls incrementally Fetch. Holds the per-URL lock across
+// the network operation so two concurrent callers serialize.
 //
 // auth/proxy/tlsCfg are applied to whichever network operation runs
 // (clone or fetch). For HTTPS with a custom TLS config, the global
-// httpsTransportMu protocol-install dance is repeated to match the
-// non-mirror path's contract.
-func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*git.Repository, error) {
+// process-level transport-install lock (gittransport.InstallHTTPS) is
+// taken so concurrent mirror Fetches don't clobber each other's
+// transport.
+func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*git.Repository, error) {
 	release, err := m.locks.Acquire(ctx, urlHash(url))
 	if err != nil {
 		return nil, err
 	}
 	defer release()
 
-	if tlsCfg != nil {
-		httpsTransportMu.Lock()
-		defer httpsTransportMu.Unlock()
-		tr, terr := source.NewHTTPTransport(tlsCfg, proxy)
-		if terr != nil {
-			return nil, terr
-		}
-		client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
-		defer client.InstallProtocol("https", githttp.DefaultClient)
+	restore, err := gittransport.InstallHTTPS(tlsCfg, proxy)
+	if err != nil {
+		return nil, err
 	}
+	defer restore()
 
 	path := m.pathFor(url)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
@@ -119,7 +116,7 @@ func (m *MirrorCache) openOrFetch(ctx context.Context, url string, auth transpor
 // fetchInto runs an incremental Fetch against the mirror's remote with
 // the mirror refspec — every branch and tag updates in place. Treats
 // NoErrAlreadyUpToDate as a clean noop.
-func (m *MirrorCache) fetchInto(ctx context.Context, repo *git.Repository, auth transport.AuthMethod, proxy *source.ProxyConfig) error {
+func (m *Cache) fetchInto(ctx context.Context, repo *git.Repository, auth transport.AuthMethod, proxy *source.ProxyConfig) error {
 	opts := &git.FetchOptions{
 		Auth: auth,
 		RefSpecs: []config.RefSpec{

--- a/pkg/source/git/mirror_test.go
+++ b/pkg/source/git/mirror_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/source/git/mirror"
 )
 
 // TestMirror_BareClonePersistsAcrossFetches confirms that a Fetcher
@@ -31,7 +32,7 @@ func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
 		Name: "t", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
 	}
-	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(layout)}
+	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
 
 	art, err := f.Fetch(context.Background(), repo)
 	if err != nil {
@@ -69,7 +70,7 @@ func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
 // We don't actually wire up a submodule repo — we only assert the
 // branch decision via canUseMirror.
 func TestMirror_FallsBackForSubmodules(t *testing.T) {
-	f := &Fetcher{Mirrors: NewMirrorCache(cacheroot.New(t.TempDir()))}
+	f := &Fetcher{Mirrors: mirror.New(cacheroot.New(t.TempDir()))}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -106,7 +107,7 @@ func TestMirror_TagResolvesAcrossRefs(t *testing.T) {
 
 	layout := cacheroot.New(t.TempDir())
 	cache := source.NewCache(layout)
-	f := &Fetcher{Cache: cache, Mirrors: NewMirrorCache(layout)}
+	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
 
 	// First: fetch a tag.
 	tagRepo := &manifest.GitRepository{

--- a/pkg/source/git/tls.go
+++ b/pkg/source/git/tls.go
@@ -4,20 +4,14 @@ import (
 	"cmp"
 	"crypto/tls"
 	"fmt"
-	"sync"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 )
 
-// httpsTransportMu serializes the brief window where a per-CR HTTPS
-// client is installed as go-git's process-global transport. go-git v5
-// has no per-CloneOptions TLS hook, so custom-CA fetches must hold
-// this lock across InstallProtocol → clone → restore. Package-global
-// because `client.InstallProtocol` is itself process-global — a
-// per-Fetcher mutex would race when two Fetchers run concurrently
-// and clobber each other's transport.
-var httpsTransportMu sync.Mutex
+// The shared HTTPS-transport install lock moved to
+// internal/gittransport so the bare-mirror subpackage can use the
+// same gate without a circular import.
 
 // resolveTLS builds a *tls.Config from spec.secretRef for HTTPS
 // GitRepositories using a custom CA. Returns nil when no CA material

--- a/pkg/source/git/verify/verify.go
+++ b/pkg/source/git/verify/verify.go
@@ -1,4 +1,7 @@
-package git
+// Package verify performs PGP signature verification against a
+// freshly cloned GitRepository's HEAD commit and/or referenced tag,
+// matching source-controller's spec.verify behavior.
+package verify
 
 import (
 	"fmt"
@@ -11,15 +14,15 @@ import (
 	"github.com/home-operations/flate/pkg/source"
 )
 
-// verifySignatures applies the PGP verification configured by
-// spec.verify against the freshly-cloned repository. Returns nil
-// when no verification is configured. Fails loud on any failure —
-// missing secret, malformed keys, unsigned/badly-signed object.
+// Signatures applies the PGP verification configured by spec.verify
+// against the cloned repository at resolvedRef. Returns nil when no
+// verification is configured. Fails loud on any failure — missing
+// secret, malformed keys, unsigned/badly-signed object.
 //
 // The Secret named by spec.verify.secretRef may carry multiple
 // ASCII-armored public keys (any *.asc filename); they're
 // concatenated into a single keyring before verification.
-func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository, cloned *git.Repository, resolvedRef plumbing.Hash) error {
+func Signatures(secrets source.SecretGetter, repo *manifest.GitRepository, cloned *git.Repository, resolvedRef plumbing.Hash) error {
 	if repo.Verification == nil {
 		return nil
 	}
@@ -43,13 +46,13 @@ func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository,
 		return fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
 	}
 
-	if verifyHEAD(mode) {
+	if matchesHEAD(mode) {
 		if err := verifyCommit(cloned, resolvedRef, keyring); err != nil {
 			return fmt.Errorf("GitRepository %s/%s: HEAD verify: %w",
 				repo.Namespace, repo.Name, err)
 		}
 	}
-	if verifyTag(mode) {
+	if matchesTag(mode) {
 		tagName := ""
 		if repo.Reference != nil {
 			tagName = repo.Reference.Tag
@@ -66,17 +69,17 @@ func verifySignatures(secrets source.SecretGetter, repo *manifest.GitRepository,
 	return nil
 }
 
-func verifyHEAD(mode sourcev1.GitVerificationMode) bool {
+func matchesHEAD(mode sourcev1.GitVerificationMode) bool {
 	return mode == sourcev1.ModeGitHEAD || mode == sourcev1.ModeGitTagAndHEAD
 }
 
-func verifyTag(mode sourcev1.GitVerificationMode) bool {
+func matchesTag(mode sourcev1.GitVerificationMode) bool {
 	return mode == sourcev1.ModeGitTag || mode == sourcev1.ModeGitTagAndHEAD
 }
 
 // buildPGPKeyring concatenates every string value in the Secret into
 // one armored keyring. Each value is expected to be an armored PGP
-// public key block; flate doesn't validate the shape here — go-git's
+// public key block; the helper doesn't validate the shape — go-git's
 // Commit/Tag .Verify rejects malformed keyrings.
 //
 // Treats source.StringFromSecret's PLACEHOLDER wipe as missing so a

--- a/pkg/source/git/verify/verify_test.go
+++ b/pkg/source/git/verify/verify_test.go
@@ -1,4 +1,4 @@
-package git
+package verify
 
 import (
 	"strings"
@@ -10,27 +10,27 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-func TestVerifySignatures_NilVerifyIsNoOp(t *testing.T) {
+func TestSignatures_NilVerifyIsNoOp(t *testing.T) {
 	repo := &manifest.GitRepository{Name: "r", Namespace: "ns"}
-	if err := verifySignatures(nil, repo, nil, plumbing.ZeroHash); err != nil {
+	if err := Signatures(nil, repo, nil, plumbing.ZeroHash); err != nil {
 		t.Errorf("nil Verify should be a no-op, got %v", err)
 	}
 }
 
-func TestVerifySignatures_RequiresSecretRef(t *testing.T) {
+func TestSignatures_RequiresSecretRef(t *testing.T) {
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
 			Verification: &manifest.GitRepositoryVerify{Mode: manifest.GitVerifyModeHEAD},
 		},
 	}
-	err := verifySignatures(nil, repo, nil, plumbing.ZeroHash)
+	err := Signatures(nil, repo, nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "secretRef is required") {
 		t.Errorf("expected secretRef-required error; got %v", err)
 	}
 }
 
-func TestVerifySignatures_RequiresSecretGetter(t *testing.T) {
+func TestSignatures_RequiresSecretGetter(t *testing.T) {
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -40,13 +40,13 @@ func TestVerifySignatures_RequiresSecretGetter(t *testing.T) {
 			},
 		},
 	}
-	err := verifySignatures(nil, repo, nil, plumbing.ZeroHash)
+	err := Signatures(nil, repo, nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
 		t.Errorf("expected SecretGetter error; got %v", err)
 	}
 }
 
-func TestVerifySignatures_SecretNotFound(t *testing.T) {
+func TestSignatures_SecretNotFound(t *testing.T) {
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
@@ -57,7 +57,7 @@ func TestVerifySignatures_SecretNotFound(t *testing.T) {
 		},
 	}
 	getter := func(_, _ string) *manifest.Secret { return nil }
-	err := verifySignatures(getter, repo, nil, plumbing.ZeroHash)
+	err := Signatures(getter, repo, nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "verify secret") || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not-found error; got %v", err)
 	}
@@ -109,7 +109,7 @@ func TestBuildPGPKeyring(t *testing.T) {
 	}
 }
 
-func TestVerifyHEAD_Tag_HelperMatrix(t *testing.T) {
+func TestMatchesHEAD_Tag_HelperMatrix(t *testing.T) {
 	cases := []struct {
 		mode    sourcev1.GitVerificationMode
 		wantH   bool
@@ -122,11 +122,11 @@ func TestVerifyHEAD_Tag_HelperMatrix(t *testing.T) {
 		{"unknown", false, false},
 	}
 	for _, tc := range cases {
-		if got := verifyHEAD(tc.mode); got != tc.wantH {
-			t.Errorf("verifyHEAD(%q) = %v, want %v", tc.mode, got, tc.wantH)
+		if got := matchesHEAD(tc.mode); got != tc.wantH {
+			t.Errorf("matchesHEAD(%q) = %v, want %v", tc.mode, got, tc.wantH)
 		}
-		if got := verifyTag(tc.mode); got != tc.wantTag {
-			t.Errorf("verifyTag(%q) = %v, want %v", tc.mode, got, tc.wantTag)
+		if got := matchesTag(tc.mode); got != tc.wantTag {
+			t.Errorf("matchesTag(%q) = %v, want %v", tc.mode, got, tc.wantTag)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The git package was carrying three concerns in one namespace: fetch orchestration, the bare-mirror object store, and PGP verification. Each had its own file plus tests, but they shared the package import surface and grew tangled across reviews.

### New layout

\`\`\`
pkg/source/git/
  git.go              orchestration (Fetcher.Fetch + fetch)
  mirror/             bare-clone cache
    mirror.go         New + Cache + OpenOrFetch
  verify/             PGP signature verification
    verify.go         Signatures + internal keyring helpers
  internal/
    gittransport/     shared go-git HTTPS install lock
      gittransport.go InstallHTTPS — used by Fetch + mirror
\`\`\`

### Why \`internal/gittransport\`

The go-git HTTPS-transport install dance (\`client.InstallProtocol\` → run op → restore default) needs a process-global mutex because the install itself is process-global. Previously the lock lived in \`git/tls.go\` and was used by both \`Fetcher.Fetch\` and \`MirrorCache.openOrFetch\`. Moving \`mirror\` to its own subpackage required either exporting the lock or extracting a shared helper — the latter is cleaner. \`InstallHTTPS\` returns a deferred restore func, collapsing the lock/install/restore at every callsite.

### API renames

| Before | After |
|---|---|
| \`git.NewMirrorCache(layout)\` | \`mirror.New(layout)\` |
| \`git.MirrorCache\` | \`mirror.Cache\` |
| \`(*MirrorCache).openOrFetch\` | \`(*mirror.Cache).OpenOrFetch\` |
| \`verifySignatures\` | \`verify.Signatures\` |
| \`verifyHEAD\` / \`verifyTag\` | \`matchesHEAD\` / \`matchesTag\` (private to verify subpackage) |

\`pkg/orchestrator\` updates: \`Mirrors: git.NewMirrorCache(layout)\` → \`Mirrors: mirror.New(layout)\`. No other callers.

\`verify_test.go\` moves into the \`verify\` subpackage. \`mirror_test.go\` stays in \`git\` because some tests exercise \`Fetcher.canUseMirror\`, which is Fetcher-private.

## Test plan

- [x] \`go test ./...\` clean
- [x] \`golangci-lint run ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)