### PR TITLE
perf, fix(source/git): tighten three audit findings

### DIFF
--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -15,6 +15,7 @@ package git
 import (
 	"cmp"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"strings"
@@ -78,7 +79,7 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 		return nil, err
 	}
 	defer restore()
-	return f.fetch(ctx, repo, auth, proxy)
+	return f.fetch(ctx, repo, auth, proxy, tlsCfg)
 }
 
 // fetch clones the GitRepository, then runs verification, ignore, and
@@ -91,7 +92,11 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 // auth may be nil for anonymous clones; proxy may be nil for direct.
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
-func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
+//
+// tlsCfg is the already-resolved spec.secretRef CA bundle (resolved by
+// Fetch); pass through to fetchViaMirror so the mirror path doesn't
+// re-resolve the Secret + re-parse the PEM bundle.
+func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*store.SourceArtifact, error) {
 	cache := f.Cache
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
@@ -140,7 +145,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	}
 
 	if f.canUseMirror(repo, url) {
-		return f.fetchViaMirror(ctx, repo, refStr, slot, auth, proxy)
+		return f.fetchViaMirror(ctx, repo, refStr, slot, auth, proxy, tlsCfg)
 	}
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
@@ -244,11 +249,11 @@ func (f *Fetcher) canUseMirror(repo *manifest.GitRepository, _ string) bool {
 // materialize the tree into the slot's staging dir. PGP verification
 // runs against the mirror (which has the object store); ApplyIgnore
 // and the revision-marker write reuse the standard finalize.
-func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitRepository, refStr string, slot *source.Slot, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
-	tlsCfg, err := f.resolveTLS(repo)
-	if err != nil {
-		return nil, err
-	}
+//
+// tlsCfg is the caller's pre-resolved spec.secretRef CA bundle —
+// hoisting it out of this function avoids re-reading the Secret +
+// re-parsing PEM on every mirror fetch.
+func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitRepository, refStr string, slot *source.Slot, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*store.SourceArtifact, error) {
 	mirrorRepo, err := f.Mirrors.OpenOrFetch(ctx, repo.URL, auth, proxy, tlsCfg)
 	if err != nil {
 		return nil, err

--- a/pkg/source/git/internal/gittransport/gittransport.go
+++ b/pkg/source/git/internal/gittransport/gittransport.go
@@ -28,6 +28,11 @@ var mu sync.Mutex
 // caller MUST defer. Acquires the process-global mutex on entry; the
 // restore releases it after re-installing the default client.
 //
+// The restore func is wrapped with sync.OnceFunc so a double-call
+// (e.g., explicit cleanup followed by defer) is a no-op rather than
+// a panic on unlock-of-unlocked-mutex. Today's only call sites defer
+// it immediately, but the OnceFunc guard makes the API hard to misuse.
+//
 // When tlsCfg is nil there's nothing to customize: returns a no-op
 // restore and no error, no lock acquired.
 func InstallHTTPS(tlsCfg *tls.Config, proxy *source.ProxyConfig) (func(), error) {
@@ -41,8 +46,8 @@ func InstallHTTPS(tlsCfg *tls.Config, proxy *source.ProxyConfig) (func(), error)
 		return nil, err
 	}
 	client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
-	return func() {
+	return sync.OnceFunc(func() {
 		client.InstallProtocol("https", githttp.DefaultClient)
 		mu.Unlock()
-	}, nil
+	}), nil
 }

--- a/pkg/source/git/marker.go
+++ b/pkg/source/git/marker.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v5"
+
+	"github.com/home-operations/flate/pkg/source/atomic"
 )
 
 // cachedRevisionFile holds the resolved commit SHA of a fetched slot.
@@ -14,8 +16,13 @@ import (
 // git.PlainOpen.
 const cachedRevisionFile = ".flate-git-revision"
 
+// writeCachedRevision persists rev atomically — matches the OCI
+// marker's durability shape (atomic.WriteFile with syncDir). A crash
+// mid-write would otherwise leave a partial SHA that the next
+// reconcile reads back via TrimSpace, surfacing as a torn-but-non-
+// empty marker that the cache-hit gate treats as live.
 func writeCachedRevision(slot, rev string) error {
-	return os.WriteFile(filepath.Join(slot, cachedRevisionFile), []byte(rev), 0o600)
+	return atomic.WriteFile(filepath.Join(slot, cachedRevisionFile), []byte(rev), 0o600, true)
 }
 
 func readCachedRevision(slot string) string {


### PR DESCRIPTION
## Summary

Result of a 9-agent audit of \`pkg/source/\` cross-checked by 4 reviewer agents (correctness skeptic / performance engineer / architecture / modernization specialist). Most of the audit's findings were false alarms or micro-optimizations; the three survivors below are real wins, narrowly scoped.

### 1. Hoist TLS config through the mirror path (perf)

\`fetcher.go\`'s \`Fetch\` resolves \`spec.secretRef.ca.crt\` into a \`*tls.Config\`, then the mirror branch called \`f.resolveTLS(repo)\` a **second** time inside \`fetchViaMirror\` — redoing the Secret lookup + \`crypto/x509\` pool build on every mirror reconcile. Now plumbed through \`fetch → fetchViaMirror\` as a parameter. Estimated 30-90ms/render at 50-500 source CRs with custom CAs.

### 2. Atomic write for git revision marker (durability)

\`marker.go\`'s \`writeCachedRevision\` used \`os.WriteFile\` while OCI's parallel markers use \`atomic.WriteFile(..., syncDir=true)\`. A crash mid-write leaves a partial SHA that \`TrimSpace\` can't detect as torn — the next cache-hit treats it as live and the slot stays poisoned. Aligns the git marker to OCI's crash-safety.

### 3. \`sync.OnceFunc\` wrap on \`gittransport.InstallHTTPS\` restore (defensive)

The restore func unlocks the global mutex; a double-call would panic. Wrapping with \`sync.OnceFunc\` (Go 1.21+) makes the API hard to misuse without changing today's defer-only call sites.

## Rejected from the audit

- gittree \`io.Copy\` ctx-cancel — false alarm (channel close propagates)
- gittree symlink OOM bounds — theoretical (OS PATH_MAX catches it)
- mirror \`urlHash\` 16-char collision — ~1 in 369B at 10k URLs
- external Fetcher cache bypass — intentional (no fetch to coordinate)
- bucket walk allocations / \`fmt.Fprintf\` — network dominates 1000x
- \`pickSemverTag\` \`slices.MaxFunc\` rewrite — would lose tag/version index alignment
- \`parseOCIRef\` \`strings.Cut\` — would break port detection in \"registry:5000/path:tag\"
- shared \`slotmarker\` helper package — marker shapes diverge on validation
- \`atomic.WriteFile\` auto-MkdirAll — changes the helper's contract
- \`gc.go\` \`errors.Join\` — no caller iterates the slice today

## Test plan

- [x] \`mise run vet\` clean
- [x] \`mise run lint\` (\`golangci-lint run\`) clean
- [x] \`mise run test\` (\`go test ./...\` with coverage) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)