### PR TITLE
perf(depwait): skip MissingGrace when Existence index is wired

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -277,73 +277,14 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 
 	id := dep.NamedResource
 
-	// Fail fast on deps that never made it into the store: wait a
-	// short grace window for a late-arriving render output, then
-	// surface a clear error instead of timing out at the full
-	// per-dep budget. We treat "object exists" OR "status known" as
-	// proof of presence — the latter covers controllers that update
-	// status before AddObject (and unit tests that set status only).
+	// Fail fast on deps that never made it into the store: branch on
+	// the Existence index (when wired) before burning MissingGrace.
+	// We treat "object exists" OR "status known" as proof of presence
+	// — the latter covers controllers that update status before
+	// AddObject (and unit tests that set status only).
 	if !w.depExists(id) {
-		graceCtx, graceCancel := context.WithTimeout(ctx, MissingGrace)
-		_, err := w.Store.WatchExists(graceCtx, id)
-		graceCancel()
-		if err != nil && !w.depExists(id) {
-			// Step 1: ask the existence lookup to materialize the
-			// dep from the file-indexed Existence map. A true return
-			// means the dep is now in the Store and the wait can
-			// continue against built-in status / exists semantics
-			// below.
-			switch {
-			case w.Existence != nil && w.Existence.Promote(id):
-				// promoted; fall through to the regular wait.
-			case w.Existence != nil && !w.Existence.IsFileIndexed(id):
-				// Step 2: dep has no file record — it can only arrive
-				// via a parent render's emitRenderedChildren chain.
-				// Two complementary signals bound the wait:
-				//
-				//   - RenderProducingTimeout caps the absolute wall
-				//     time so a missing Renders signal doesn't burn
-				//     the full per-dep Timeout. Legacy embedders
-				//     without a task pool get this cap as the only
-				//     bound.
-				//   - Renders.OtherActive() short-circuits the wait
-				//     once no other reconcile in the pool is doing
-				//     work — at that point, no future render can
-				//     produce the missing dep. Typo'd dependsOn
-				//     fails as soon as the orchestrator drains
-				//     instead of waiting the full cap.
-				//
-				// On a real chain (the omada-controller-style
-				// component+replacement render), other reconciles
-				// stay active while the producing chain runs, so
-				// OtherActive returns true and the wait holds open
-				// until the dep arrives via subscription.
-				if err := w.waitRenderEmission(ctx, id); err != nil {
-					switch {
-					case errors.Is(ctx.Err(), context.Canceled):
-						return classify(id, ctx.Err(), "")
-					case errors.Is(err, errRenderCapExceeded),
-						errors.Is(err, context.DeadlineExceeded),
-						errors.Is(err, errRenderDrained):
-						// The render-emission cap fired (or the pool
-						// drained without producing, or the wait was
-						// bounded by the per-dep Timeout) — the dep
-						// isn't going to appear. Fast-fail with
-						// "dependency not found" rather than the
-						// ambiguous "timeout" label.
-						return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
-					default:
-						return Event{Dep: id, Status: DepFailed, Reason: err.Error()}
-					}
-				}
-			default:
-				// Step 3: either no Existence wired (legacy callers
-				// can't distinguish render-only from typo) or the
-				// dep is file-indexed but Promote failed (file
-				// disappeared / parse error). Either way the dep is
-				// not coming — fail fast at the grace boundary.
-				return Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
-			}
+		if err := w.resolveMissing(ctx, id); err != nil {
+			return *err
 		}
 	}
 
@@ -378,6 +319,71 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 		}
 	}
 	return Event{Dep: id, Status: DepReady, Reason: info.Message}
+}
+
+// resolveMissing handles the "dep isn't in the store yet" branch.
+// Returns a non-nil Event pointer when the wait should terminate
+// (success cases fall through to the normal Ready/Exists wait by
+// returning nil).
+//
+// Branch order depends on whether the embedder wired an Existence
+// index. Orchestrator path (Existence != nil): try synchronous
+// Promote first, then route file-indexed-but-unpromotable failures
+// to fast-fail and render-only deps to waitRenderEmission. The 2s
+// MissingGrace is pure wall-clock waste here — Promote is the
+// authoritative materializer, and waitRenderEmission has its own
+// EventObjectAdded subscription for the chained-render race.
+//
+// Legacy path (Existence == nil): preserves the historic
+// "WatchExists with grace, fast-fail on timeout" shape since
+// embedders without an existence index can't distinguish typo from
+// render-only.
+func (w *Waiter) resolveMissing(ctx context.Context, id manifest.NamedResource) *Event {
+	if w.Existence == nil {
+		graceCtx, graceCancel := context.WithTimeout(ctx, MissingGrace)
+		_, err := w.Store.WatchExists(graceCtx, id)
+		graceCancel()
+		if err != nil && !w.depExists(id) {
+			return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+		}
+		return nil
+	}
+
+	if w.Existence.Promote(id) {
+		// Lazy-promoted into the Store; fall through to the regular
+		// wait.
+		return nil
+	}
+	if w.Existence.IsFileIndexed(id) {
+		// File was indexed at scan time but Promote failed — parse
+		// error, file mutated since record, etc. No amount of waiting
+		// will materialize this dep.
+		return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+	}
+
+	// No file record: dep can only arrive via a parent render's
+	// emitRenderedChildren chain. waitRenderEmission has its own
+	// EventObjectAdded subscription (no race) and is bounded by
+	// RenderProducingTimeout / QuiescenceCh / parent ctx.
+	if err := w.waitRenderEmission(ctx, id); err != nil {
+		switch {
+		case errors.Is(ctx.Err(), context.Canceled):
+			ev := classify(id, ctx.Err(), "")
+			return &ev
+		case errors.Is(err, errRenderCapExceeded),
+			errors.Is(err, context.DeadlineExceeded),
+			errors.Is(err, errRenderDrained):
+			// The render-emission cap fired (or the pool drained
+			// without producing, or the wait was bounded by the
+			// per-dep Timeout) — the dep isn't going to appear.
+			// Fast-fail with "dependency not found" rather than the
+			// ambiguous "timeout" label.
+			return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+		default:
+			return &Event{Dep: id, Status: DepFailed, Reason: err.Error()}
+		}
+	}
+	return nil
 }
 
 // watchReadyExpr evaluates expr against id's projected state and

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -323,8 +323,12 @@ func TestWaiter_FileIndexedPromoteFailsFastAtGrace(t *testing.T) {
 // wait must end at the cap, not at the full per-dep budget. Before
 // the cap landed, a typo'd dependsOn (IsFileIndexed returns false the
 // same as a render-only dep) burned the full per-dep Timeout —
-// ~30s instead of ~2s — surfacing as a UX regression vs the old
-// MissingGrace fast-fail.
+// ~30s instead of ~RenderProducingTimeout.
+//
+// With Existence wired, MissingGrace is skipped entirely — Promote
+// is synchronous so there's nothing to wait for at the grace
+// boundary. The cap thus equals RenderProducingTimeout (not
+// MissingGrace + RenderProducingTimeout).
 func TestWaiter_RenderOnlyCappedAtRenderProducingTimeout(t *testing.T) {
 	// Shrink the cap so the test doesn't burn 10s.
 	old := RenderProducingTimeout
@@ -349,15 +353,16 @@ func TestWaiter_RenderOnlyCappedAtRenderProducingTimeout(t *testing.T) {
 	if !sum.AnyFailed() {
 		t.Fatalf("expected fail for capped render-only dep: %+v", sum)
 	}
-	// elapsed should be approximately MissingGrace + RenderProducingTimeout.
-	// Allow generous slack for slow CI but reject the uncapped 30s case.
-	upperBound := MissingGrace + RenderProducingTimeout + 1*time.Second
+	// elapsed should be approximately RenderProducingTimeout (grace
+	// is skipped when Existence is wired). Allow generous slack for
+	// slow CI but reject the uncapped 30s case.
+	upperBound := RenderProducingTimeout + 1*time.Second
 	if elapsed > upperBound {
 		t.Errorf("step-2 cap not enforced: elapsed=%s, upper bound=%s", elapsed, upperBound)
 	}
-	if elapsed < MissingGrace+RenderProducingTimeout-100*time.Millisecond {
+	if elapsed < RenderProducingTimeout-100*time.Millisecond {
 		t.Errorf("step-2 returned before cap: elapsed=%s, lower bound=%s",
-			elapsed, MissingGrace+RenderProducingTimeout-100*time.Millisecond)
+			elapsed, RenderProducingTimeout-100*time.Millisecond)
 	}
 	if got := sum.Messages[dep]; got != "dependency not found" {
 		t.Errorf("expected 'dependency not found', got %q", got)


### PR DESCRIPTION
## Summary

\`watchOne\` burned \`MissingGrace\` (2s) waiting for missing deps to arrive via a concurrent reconcile before consulting the \`Existence\` lookup. With \`Existence\` wired (the orchestrator's path), the grace is pure wall-clock waste:

- \`Existence.Promote(id)\` is synchronous and idempotent — file-indexed deps materialize into the Store immediately, no waiting needed.
- \`Existence.IsFileIndexed(id)\` is a constant-time map lookup — render-only deps and typos are classified instantly.
- \`waitRenderEmission\` already subscribes to \`EventObjectAdded\` before checking \`depExists\`, so the chained-render race the grace defended is covered by the existing event-driven path.

## Reproduction (the user's report)

On \`~/k8s-gitops\` with one typo'd \`dependsOn\` (\`envoy-gateway\` → \`envoy-gateway-typo\`):

| | wall time |
| --- | --- |
| Baseline (no typo)        | 0.8s |
| Before this PR (one typo) | 2.4s |
| After this PR  (one typo) | 1.7s |

Savings scale with the number of typo'd / file-indexed-but-late deps in a run.

## Refactor

Extracted the missing-dep branch into \`resolveMissing\` for clarity — the original \`switch\` hid the Existence-vs-legacy split inside a post-grace cascade. The helper makes the two paths and their trade-offs explicit.

## Compatibility

Legacy callers (\`Existence == nil\` — embedders without a loader index) preserve the historic \`MissingGrace\` + fast-fail shape since they can't distinguish typo from render-only.

## Test plan

- [x] \`mise run vet\` clean
- [x] \`mise run lint\` clean
- [x] \`mise run test\` clean (one test updated to drop \`MissingGrace\` from its expected cap — the cap itself is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)