### PR TITLE
Fix change fallback and trim render hot paths

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -110,6 +110,7 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
 		return a.Named().Compare(b.Named())
 	})
+	skipKinds := c.skipResourceKinds()
 	matched := 0
 	for _, obj := range objs {
 		id := obj.Named()
@@ -147,7 +148,7 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 			// kind set (orchestrator.go:555), so this is a no-op for
 			// the CLI path. Kept for SDK callers who hand-build a
 			// Result and pass it through writeRendered. See #169.
-			docs = manifest.DropKinds(docs, c.skipResourceKinds())
+			docs = manifest.DropKinds(docs, skipKinds)
 			if len(docs) == 0 {
 				continue
 			}

--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -240,9 +240,9 @@ func detectViaWalker(before, after string) (*Set, error) {
 
 	paths := make(map[string]struct{}, len(afterFS)/8)
 	type hashJob struct {
-		rel                          string
-		beforeAbs, after             string
-		beforeSymlink, afterSymlink  bool
+		rel                         string
+		beforeAbs, afterAbs         string
+		beforeSymlink, afterSymlink bool
 	}
 	var hashJobs []hashJob
 
@@ -266,7 +266,7 @@ func detectViaWalker(before, after string) (*Set, error) {
 		// The pre-removal mtime fast-path silently dropped real edits
 		// on coarse-mtime filesystems; correctness over speed here.
 		hashJobs = append(hashJobs, hashJob{
-			rel: rel, beforeAbs: bef.abs, after: after.abs,
+			rel: rel, beforeAbs: bef.abs, afterAbs: after.abs,
 			beforeSymlink: bef.symlink, afterSymlink: after.symlink,
 		})
 	}
@@ -288,7 +288,7 @@ func detectViaWalker(before, after string) (*Set, error) {
 					if err != nil {
 						return err
 					}
-					a, err := hashEntry(j.after, j.afterSymlink)
+					a, err := hashEntry(j.afterAbs, j.afterSymlink)
 					if err != nil {
 						return err
 					}
@@ -335,7 +335,7 @@ func scanTree(root string) (map[string]fileMeta, error) {
 		}
 		base := d.Name()
 		if d.IsDir() {
-			if base != root && shouldSkipDir(base) {
+			if p != root && shouldSkipDir(base) {
 				return fs.SkipDir
 			}
 			return nil

--- a/pkg/change/detect_test.go
+++ b/pkg/change/detect_test.go
@@ -98,9 +98,8 @@ func TestDetect_SkipsDotDirsAndVendor(t *testing.T) {
 	writeFile(t, before, "vendor/dep/file.go", "a")
 	writeFile(t, after, "vendor/dep/file.go", "b")
 	// Sanity check: a real file change still surfaces. Use
-	// different-sized content so the detector flags via size diff —
-	// same-size + same-mtime would be (correctly) skipped on
-	// filesystems with coarse mtime resolution.
+	// different-sized content so the detector flags via size diff and
+	// keeps the test focused on directory filtering.
 	writeFile(t, before, "real.yaml", "short")
 	writeFile(t, after, "real.yaml", "a longer payload")
 	got, err := Detect(before, after)
@@ -109,6 +108,24 @@ func TestDetect_SkipsDotDirsAndVendor(t *testing.T) {
 	}
 	if paths := got.Paths(); len(paths) != 1 || paths[0] != "real.yaml" {
 		t.Errorf("expected just real.yaml, got %v", paths)
+	}
+}
+
+func TestDetectViaWalker_DoesNotSkipHiddenScanRoot(t *testing.T) {
+	parent := t.TempDir()
+	before := filepath.Join(parent, ".before")
+	after := filepath.Join(parent, ".after")
+	writeFile(t, before, "same.yaml", "x")
+	writeFile(t, after, "same.yaml", "x")
+	writeFile(t, before, "mod.yaml", "old")
+	writeFile(t, after, "mod.yaml", "new")
+
+	got, err := detectViaWalker(before, after)
+	if err != nil {
+		t.Fatalf("detectViaWalker: %v", err)
+	}
+	if paths := got.Paths(); !slices.Equal(paths, []string{"mod.yaml"}) {
+		t.Errorf("hidden scan root paths = %v, want [mod.yaml]", paths)
 	}
 }
 

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -186,13 +186,7 @@ func (c *Client) TemplateDocs(ctx context.Context, hr *manifest.HelmRelease, val
 	}
 	applyHRCommonMetadata(docs, hr.CommonMetadata)
 	applyHROriginLabels(docs, hr)
-	skip := opts.SkipResourceKinds()
-	if len(skip) == 0 {
-		return docs, nil
-	}
-	return slices.DeleteFunc(docs, func(doc map[string]any) bool {
-		return slices.Contains(skip, manifest.DocKind(doc))
-	}), nil
+	return manifest.DropKinds(docs, opts.SkipResourceKinds()), nil
 }
 
 // applyHROriginLabels stamps the helm.toolkit.fluxcd.io/{name,namespace}
@@ -337,4 +331,3 @@ func filterShowOnly(content string, paths []string) string {
 func isTestHook(h *release.Hook) bool {
 	return slices.Contains(h.Events, release.HookTest)
 }
-

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"encoding/json"
-	"slices"
 	"strings"
 )
 
@@ -45,15 +44,28 @@ func DocAPIVersion(doc map[string]any) string {
 // already filters HR output upstream; this is the canonical helper
 // for downstream code that needs the same operation.
 func DropKinds(docs []map[string]any, drop []string) []map[string]any {
-	if len(drop) == 0 {
+	if len(drop) == 0 || len(docs) == 0 {
 		return docs
 	}
-	out := make([]map[string]any, 0, len(docs))
-	for _, doc := range docs {
-		if slices.Contains(drop, DocKind(doc)) {
+	dropSet := make(map[string]struct{}, len(drop))
+	for _, kind := range drop {
+		dropSet[kind] = struct{}{}
+	}
+	var out []map[string]any
+	for i, doc := range docs {
+		if _, skip := dropSet[DocKind(doc)]; skip {
+			if out == nil {
+				out = make([]map[string]any, 0, len(docs)-1)
+				out = append(out, docs[:i]...)
+			}
 			continue
 		}
-		out = append(out, doc)
+		if out != nil {
+			out = append(out, doc)
+		}
+	}
+	if out == nil {
+		return docs
 	}
 	return out
 }

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -279,8 +279,7 @@ func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(c
 			if r := recover(); r != nil {
 				c.mu.Lock()
 				lostPending := s.pending
-				s.running = false
-				s.pending = false
+				delete(c.slot, key)
 				c.mu.Unlock()
 				if lostPending {
 					slog.Warn("task coalescer: dropped pending re-run because the previous run panicked",
@@ -293,7 +292,7 @@ func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(c
 			fn(ctx)
 			c.mu.Lock()
 			if !s.pending {
-				s.running = false
+				delete(c.slot, key)
 				c.mu.Unlock()
 				return
 			}

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -104,6 +104,12 @@ func TestCoalescer_RecoversSlotAfterPanic(t *testing.T) {
 	if got := s.Failures(); got != 1 {
 		t.Errorf("Service.Failures: expected 1, got %d", got)
 	}
+	c.mu.Lock()
+	slots := len(c.slot)
+	c.mu.Unlock()
+	if slots != 0 {
+		t.Errorf("panicked slot was retained: len(slot) = %d, want 0", slots)
+	}
 
 	// Slot must be unlocked: a fresh Submit on the same key runs.
 	c.Submit(context.Background(), "recovery", "k", func(_ context.Context) {
@@ -112,6 +118,21 @@ func TestCoalescer_RecoversSlotAfterPanic(t *testing.T) {
 	s.BlockTillDone()
 	if got := calls.Load(); got != 2 {
 		t.Errorf("post-panic Submit blocked: expected 2 runs total, got %d", got)
+	}
+}
+
+func TestCoalescer_DropsIdleSlots(t *testing.T) {
+	s := New()
+	c := NewCoalescer[string](s)
+
+	c.Submit(context.Background(), "a", "a", func(_ context.Context) {})
+	s.BlockTillDone()
+
+	c.mu.Lock()
+	got := len(c.slot)
+	c.mu.Unlock()
+	if got != 0 {
+		t.Errorf("idle coalescer slots = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- fix the Go fallback change detector so hidden scan roots are not skipped
- make rendered-doc kind filtering allocation-conscious and reuse it from Helm
- clean up task coalescer slot bookkeeping after idle and panic paths

## Tests
- go test ./...
- go vet ./...
- golangci-lint run
- go test -race ./pkg/task ./pkg/change ./pkg/controllers/base ./pkg/controllers/source ./pkg/controllers/kustomization ./pkg/controllers/helmrelease ./pkg/orchestrator