### PR TITLE
Fix CLI output scoping and cancellation safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ flate test all     --path ./kubernetes
 
 The `[name]` positional on `build`/`diff`/`test` is matched against the resource's bare name (`metadata.name`), not `namespace/name`. Use `-n / --namespace` to scope.
 
-Every command takes `--path <dir>` (default `.`); `--path-orig <dir>` switches into changed-only mode. `flate <verb> --help` lists every flag.
+Every command takes `--path <dir>` (default `.`); `--path-orig <dir>` switches into changed-only mode. `flate <verb> --help` lists every flag. All commands run the same offline reconcile pipeline before producing output, so referenced Git, OCI, Helm, Bucket, or remote kustomize sources must be reachable or already cached.
 
 | Verb | Targets | Notes |
 |---|---|---|

--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -65,14 +65,20 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 			if o == nil {
 				return runErr
 			}
-			w := cmd.OutOrStdout()
 			name := firstArg(argv)
-			var emitErr error
+			docs := []map[string]any{}
+			var collectErr error
 			for _, kind := range kinds {
-				if err := writeRendered(w, o, res, kind, name, c, b); err != nil {
-					emitErr = err
+				rendered, err := collectRendered(o, res, kind, name, c, b)
+				if err != nil {
+					collectErr = err
 					break
 				}
+				docs = append(docs, rendered...)
+			}
+			emitErr := collectErr
+			if emitErr == nil {
+				emitErr = emitDocs(cmd.OutOrStdout(), docs, c.outputOrDefault(format.OutputYAML))
 			}
 			// Per-resource Run failures: emit whatever we rendered, then
 			// flip the exit code so CI pipelines piping `flate build` into
@@ -97,7 +103,7 @@ func applyBuildFlags(c *commonFlags, b *buildFlags) {
 	}
 }
 
-func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags, b *buildFlags) error {
+func collectRendered(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags, b *buildFlags) ([]map[string]any, error) {
 	// Walk every loaded object of this kind so an explicit name positional
 	// that didn't render (failed reconcile, suspended, no docs) still
 	// counts as a match — without this the typo-detection error below
@@ -112,6 +118,7 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 	})
 	skipKinds := c.skipResourceKinds()
 	matched := 0
+	var out []map[string]any
 	for _, obj := range objs {
 		id := obj.Named()
 		if name != "" && id.Name != name {
@@ -145,31 +152,26 @@ func writeRendered(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.
 		} else {
 			// Defensive re-drop. Orchestrator.Render already filters
 			// Result.Manifests at the embed boundary using the same
-			// kind set (orchestrator.go:555), so this is a no-op for
-			// the CLI path. Kept for SDK callers who hand-build a
-			// Result and pass it through writeRendered. See #169.
+			// kind set, so this is a no-op for the normal CLI path.
 			docs = manifest.DropKinds(docs, skipKinds)
 			if len(docs) == 0 {
 				continue
 			}
 		}
-		if err := emitDocs(w, docs, c.outputOrDefault(format.OutputYAML)); err != nil {
-			return err
-		}
+		out = append(out, docs...)
 	}
 	// An explicit name positional that matches nothing in the store
 	// should error rather than silently emit an empty render — a typo
 	// shouldn't look like a successful build of a nonexistent resource.
 	if name != "" && matched == 0 {
-		return fmt.Errorf("no %s named %q in --path", kind, name)
+		return nil, fmt.Errorf("no %s named %q in --path", kind, name)
 	}
-	return nil
+	return out, nil
 }
 
 // emitDocs writes a sequence of rendered docs as either multi-doc YAML
-// (the default for `flate build`) or a single JSON array — the two
-// formats the agent quorum agreed make sense for build output. Other
-// -o values are rejected earlier by requireOutput.
+// (the default for `flate build`) or a single JSON array. Other -o
+// values are rejected earlier by requireOutput.
 func emitDocs(w io.Writer, docs []map[string]any, out format.Output) error {
 	switch out {
 	case format.OutputJSON:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -50,6 +51,41 @@ metadata: {name: hello, namespace: apps}
 data:
   greeting: hi
 `)
+	return k8s
+}
+
+func writeMultiNamespaceFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	k8s := filepath.Join(root, "kubernetes")
+	for _, tc := range []struct {
+		name      string
+		namespace string
+		path      string
+	}{
+		{name: "apps-a", namespace: "alpha", path: "apps-a"},
+		{name: "apps-b", namespace: "beta", path: "apps-b"},
+	} {
+		mustWrite(t, filepath.Join(k8s, "flux", tc.name+".yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: `+tc.name+`
+  namespace: `+tc.namespace+`
+spec:
+  interval: 10m
+  path: ./`+tc.path+`
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+		mustWrite(t, filepath.Join(k8s, tc.path, "kustomization.yaml"), "resources:\n- cm.yaml\n")
+		mustWrite(t, filepath.Join(k8s, tc.path, "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: `+tc.name+`, namespace: `+tc.namespace+`}
+data:
+  greeting: hi
+`)
+	}
 	return k8s
 }
 
@@ -158,6 +194,21 @@ func TestRun_BuildAll(t *testing.T) {
 	}
 }
 
+func TestRun_BuildAll_JSONSingleDocument(t *testing.T) {
+	path := writeMultiNamespaceFixture(t)
+	stdout, stderr, code := runCLI(t, "build", "all", "--path", path, "-o", "json")
+	if code != 0 {
+		t.Fatalf("build all -o json exited %d: stderr=%s", code, stderr)
+	}
+	var docs []map[string]any
+	if err := json.Unmarshal([]byte(stdout), &docs); err != nil {
+		t.Fatalf("build all -o json emitted invalid JSON: %v\n%s", err, stdout)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("expected 2 rendered docs, got %d: %#v", len(docs), docs)
+	}
+}
+
 // TestRun_BuildKS_RejectsBadOutput exercises requireOutput on the
 // build subcommand: build accepts yaml + json, not name.
 func TestRun_BuildKS_RejectsBadOutput(t *testing.T) {
@@ -181,6 +232,17 @@ func TestRun_BuildAll_OnlyCRDs(t *testing.T) {
 	}
 	if strings.Contains(stdout, "kind: ConfigMap") {
 		t.Errorf("--only-crds should filter out ConfigMap; got:\n%s", stdout)
+	}
+}
+
+func TestRun_BuildAll_OnlyCRDs_JSONEmptyArray(t *testing.T) {
+	path := writeFixture(t)
+	stdout, stderr, code := runCLI(t, "build", "all", "--path", path, "--only-crds", "-o", "json")
+	if code != 0 {
+		t.Fatalf("build --only-crds -o json exited %d: %s", code, stderr)
+	}
+	if strings.TrimSpace(stdout) != "[]" {
+		t.Errorf("empty JSON render = %q, want []", stdout)
 	}
 }
 
@@ -264,6 +326,21 @@ func TestRun_GetAll_Yaml(t *testing.T) {
 	}
 }
 
+func TestRun_GetAll_RespectsNamespace(t *testing.T) {
+	path := writeMultiNamespaceFixture(t)
+	stdout, stderr, code := runCLI(t, "get", "all", "--path", path, "-o", "json", "-n", "alpha")
+	if code != 0 {
+		t.Fatalf("get all -n alpha exited %d: %s", code, stderr)
+	}
+	var summary map[string]int
+	if err := json.Unmarshal([]byte(stdout), &summary); err != nil {
+		t.Fatalf("get all emitted invalid JSON: %v\n%s", err, stdout)
+	}
+	if summary["kustomizations"] != 1 || summary["helmReleases"] != 0 {
+		t.Errorf("namespace-scoped summary = %#v, want 1 KS and 0 HR", summary)
+	}
+}
+
 // TestRun_GetImages_NameDefault exercises the default name format
 // (one image per line).
 func TestRun_GetImages_NameDefault(t *testing.T) {
@@ -298,6 +375,20 @@ func TestRun_TestAll(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "PASSED") {
 		t.Errorf("expected PASSED in test report:\n%s", stdout)
+	}
+}
+
+func TestRun_TestAll_RespectsNamespace(t *testing.T) {
+	path := writeMultiNamespaceFixture(t)
+	stdout, stderr, code := runCLI(t, "test", "all", "--path", path, "-n", "alpha")
+	if code != 0 {
+		t.Fatalf("test all -n alpha exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "Kustomization/alpha/apps-a") {
+		t.Errorf("namespace-scoped test output missing alpha KS:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "Kustomization/beta/apps-b") {
+		t.Errorf("namespace-scoped test output included beta KS:\n%s", stdout)
 	}
 }
 
@@ -340,6 +431,16 @@ func TestRun_DiffKS_TwoTreesNoDelta(t *testing.T) {
 	}
 	if strings.Contains(stdout, "@@") {
 		t.Errorf("identical tree should produce no hunks:\n%s", stdout)
+	}
+}
+
+func TestRun_DiffKS_ExplicitDiffOutput(t *testing.T) {
+	current := writeFixture(t)
+	orig := t.TempDir()
+	copyTree(t, current, orig)
+	_, stderr, code := runCLI(t, "diff", "ks", "--path", current, "--path-orig", orig, "-o", "diff")
+	if code != 0 {
+		t.Fatalf("diff ks -o diff exited %d: %s", code, stderr)
 	}
 }
 
@@ -467,10 +568,10 @@ func TestCompareDocs_OrdersByKindNamespaceName(t *testing.T) {
 		a, b map[string]any
 		want int
 	}{
-		{mkDoc("ConfigMap", "a", "x"), mkDoc("Secret", "a", "x"), -1},     // kind wins
-		{mkDoc("CM", "a", "x"), mkDoc("CM", "b", "x"), -1},                // ns wins after kind tie
-		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "y"), -1},                // name wins last
-		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "x"), 0},                 // identical
+		{mkDoc("ConfigMap", "a", "x"), mkDoc("Secret", "a", "x"), -1}, // kind wins
+		{mkDoc("CM", "a", "x"), mkDoc("CM", "b", "x"), -1},            // ns wins after kind tie
+		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "y"), -1},            // name wins last
+		{mkDoc("CM", "a", "x"), mkDoc("CM", "a", "x"), 0},             // identical
 	}
 	for _, tc := range cases {
 		got := compareDocs(tc.a, tc.b)

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -22,6 +22,8 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+const outputDiff = "diff"
+
 func newDiffCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
@@ -160,10 +162,10 @@ func imageSetDiff(orig, current map[string]struct{}, includeRemoved bool) []stri
 }
 
 func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kind, name string) error {
-	// diff has no `name` output mode; only diff/yaml/json/object are
+	// diff has no `name` output mode; only diff/yaml/json are
 	// meaningful. Reject early so the user sees a clear error instead
 	// of "unknown diff format" from pkg/diff.
-	if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+	if err := c.requireOutput(format.Output(outputDiff), format.OutputYAML, format.OutputJSON); err != nil {
 		return err
 	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
@@ -175,7 +177,7 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 
 	outFormat := c.output
 	if outFormat == "table" {
-		outFormat = "diff"
+		outFormat = outputDiff
 	}
 	diffs, err := diff.Run(origDocs, currentDocs, diff.Options{
 		StripAttrs: d.stripAttrs,

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -126,7 +126,7 @@ func newGetAllCmd() *cobra.Command {
 			if o == nil {
 				return runErr
 			}
-			if err := printCluster(cmd.OutOrStdout(), o, string(c.outputOrDefault(format.OutputYAML))); err != nil {
+			if err := printCluster(cmd.OutOrStdout(), o, c, string(c.outputOrDefault(format.OutputYAML))); err != nil {
 				return errors.Join(err, runErr)
 			}
 			return runErr
@@ -281,10 +281,10 @@ var (
 	}
 )
 
-func printCluster(w io.Writer, o *orchestrator.Orchestrator, out string) error {
+func printCluster(w io.Writer, o *orchestrator.Orchestrator, c *commonFlags, out string) error {
 	summary := map[string]any{
-		"kustomizations": len(o.Store().ListObjects(manifest.KindKustomization)),
-		"helmReleases":   len(o.Store().ListObjects(manifest.KindHelmRelease)),
+		"kustomizations": countObjects(o, c, manifest.KindKustomization),
+		"helmReleases":   countObjects(o, c, manifest.KindHelmRelease),
 	}
 	if format.Output(out) == format.OutputJSON {
 		return format.JSON(w, summary)
@@ -292,3 +292,12 @@ func printCluster(w io.Writer, o *orchestrator.Orchestrator, out string) error {
 	return format.YAML(w, summary)
 }
 
+func countObjects(o *orchestrator.Orchestrator, c *commonFlags, kind string) int {
+	count := 0
+	for _, obj := range o.Store().ListObjects(kind) {
+		if c == nil || c.includeNamespace(o.Filter(), obj.Named().Namespace) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -65,6 +65,9 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 				Store: o.Store(),
 				Kinds: kinds,
 				Name:  firstArg(argv),
+				Include: func(id manifest.NamedResource) bool {
+					return c.includeNamespace(o.Filter(), id.Namespace)
+				},
 			})
 			report.ShowSkipped = showSkipped
 			report.Write(cmd.OutOrStdout())

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -26,6 +26,9 @@ type Job struct {
 	Kinds []string
 	// Name optionally narrows the report to a single resource.
 	Name string
+	// Include optionally narrows the report by resource identity.
+	// Nil includes every resource that passes Kinds and Name.
+	Include func(manifest.NamedResource) bool
 }
 
 // Outcome enumerates the per-resource result.
@@ -111,6 +114,9 @@ func Run(j Job) Report {
 		for _, obj := range j.Store.ListObjects(kind) {
 			id := obj.Named()
 			if j.Name != "" && id.Name != j.Name {
+				continue
+			}
+			if j.Include != nil && !j.Include(id) {
 				continue
 			}
 			// Skip the synthetic bootstrap GitRepository the

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -70,6 +70,26 @@ func TestRun_NoStatus(t *testing.T) {
 	}
 }
 
+func TestRun_IncludePredicate(t *testing.T) {
+	s := store.New()
+	alpha := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "alpha", Name: "apps"}
+	beta := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "beta", Name: "apps"}
+	s.AddObject(&manifest.Kustomization{Name: alpha.Name, Namespace: alpha.Namespace})
+	s.AddObject(&manifest.Kustomization{Name: beta.Name, Namespace: beta.Namespace})
+	s.UpdateStatus(alpha, store.StatusReady, "")
+	s.UpdateStatus(beta, store.StatusReady, "")
+
+	rep := Run(Job{
+		Store: s,
+		Include: func(id manifest.NamedResource) bool {
+			return id.Namespace == "alpha"
+		},
+	})
+	if rep.Passed != 1 || len(rep.Cases) != 1 || rep.Cases[0].ID != alpha {
+		t.Errorf("Include predicate report = %+v, want only %s", rep, alpha)
+	}
+}
+
 // TestWrite_HidesSkippedByDefault pins the output-consistency
 // behavior: under changed-only mode, unchanged resources are
 // SKIPPED — they have no per-resource information worth surfacing

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -449,6 +449,9 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 				return ev
 			}
 		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return Event{Dep: id, Status: DepCancelled, Reason: "cancelled"}
+			}
 			return Event{Dep: id, Status: DepTimeout, Reason: "readyExpr timeout: " + ctx.Err().Error()}
 		}
 	}

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -394,8 +394,8 @@ func TestWaiter_RenderInflightDrainShortCircuits(t *testing.T) {
 	dep := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "network", Name: "typo-or-gone"}
 
 	w := &Waiter{
-		Store:     s,
-		Timeout:   30 * time.Second,
+		Store:   s,
+		Timeout: 30 * time.Second,
 		Existence: lookupStub{
 			promote:     func(manifest.NamedResource) bool { return false },
 			fileIndexed: func(manifest.NamedResource) bool { return false },
@@ -436,8 +436,8 @@ func TestWaiter_RenderInflightActiveHoldsTheWait(t *testing.T) {
 	// Renders is "active" throughout; the only thing that ends the
 	// wait is the dep arriving via AddObject.
 	w := &Waiter{
-		Store:     s,
-		Timeout:   MissingGrace + 5*time.Second,
+		Store:   s,
+		Timeout: MissingGrace + 5*time.Second,
 		Existence: lookupStub{
 			promote:     func(manifest.NamedResource) bool { return false },
 			fileIndexed: func(manifest.NamedResource) bool { return false },
@@ -490,6 +490,25 @@ func TestWaiter_RenderOnlyCancelDuringLongWaitSurfacesCancelled(t *testing.T) {
 	// classify() maps context.Canceled to DepCancelled / "cancelled".
 	if got := sum.Messages[dep]; got != "cancelled" {
 		t.Errorf("expected 'cancelled' after step-2 ctx cancel, got %q", got)
+	}
+}
+
+func TestWaiter_ReadyExprCancelSurfacesCancelled(t *testing.T) {
+	s := store.New()
+	dep := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "network", Name: "expr-cancelled"}
+	s.AddObject(&manifest.Kustomization{Name: dep.Name, Namespace: dep.Namespace})
+	s.UpdateStatus(dep, store.StatusPending, "waiting")
+
+	w := &Waiter{Store: s, Timeout: 30 * time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sum := WaitAll(w.Watch(ctx, []manifest.DependencyRef{{
+		NamedResource: dep,
+		ReadyExpr:     "false",
+	}}))
+	if got := sum.Messages[dep]; got != "cancelled" {
+		t.Errorf("expected readyExpr cancellation to report 'cancelled', got %q", got)
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -21,8 +22,8 @@ import (
 	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
-	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/source/bucket"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/source/external"
 	"github.com/home-operations/flate/pkg/source/git"
 	"github.com/home-operations/flate/pkg/source/git/mirror"
@@ -694,16 +695,15 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}()
 	select {
 	case <-done:
-		return o.finalize()
+		return errors.Join(o.finalize(), ctx.Err())
 	case <-ctx.Done():
 		// Wait for in-flight tasks to wind down before finalizing so
-		// the store snapshot is internally consistent — but if they
-		// take longer than the parent ctx's grace window, the worst
-		// case is the orchestrator hangs at the same point it would
-		// have before this fix. Net: Ctrl-C is at least observable
-		// in logs now; eventual exit semantics unchanged.
+		// the store snapshot is internally consistent, then preserve
+		// the cancellation in the returned error. Queued bounded tasks
+		// may never acquire a worker slot once ctx is canceled; a clean
+		// partial snapshot must not look like a successful full run.
 		<-done
-		return o.finalize()
+		return errors.Join(o.finalize(), ctx.Err())
 	}
 }
 
@@ -798,4 +798,3 @@ func (o *Orchestrator) Stop() {
 		}
 	})
 }
-

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -187,6 +188,41 @@ data: {k: v}
 	}
 	if got := len(o.Store().ListObjects(manifest.KindConfigMap)); got < 1 {
 		t.Errorf("expected at least 1 ConfigMap after reconcile, got %d", got)
+	}
+}
+
+func TestOrchestrator_RunReturnsContextCancellation(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello}
+data: {k: v}
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 1})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := o.Run(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run with pre-canceled context = %v, want context.Canceled", err)
 	}
 }
 

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -171,19 +171,39 @@ func (s *Slot) Commit() error {
 	if s.Exists || s.committed {
 		return nil
 	}
-	// os.Rename across an existing target is platform-dependent —
-	// remove the (definitely empty by our protocol; we checked it on
-	// Slot construction) target first so the rename is unambiguous.
-	if err := os.RemoveAll(s.final); err != nil {
-		return fmt.Errorf("cache commit prep: %w", err)
-	}
 	if err := os.Rename(s.staging, s.final); err != nil {
+		if existingSlotPopulated(s.final) {
+			// Another process using the same cache root may have
+			// finalized this slot while we were staging. keylock only
+			// coordinates goroutines in this process, so adopt the
+			// existing non-empty slot instead of deleting it.
+			_ = os.RemoveAll(s.staging)
+			s.committed = true
+			s.staging = ""
+			s.Path = s.final
+			s.Exists = true
+			return nil
+		}
 		return fmt.Errorf("cache commit: %w", err)
 	}
 	s.committed = true
 	s.staging = ""
 	s.Path = s.final
 	return nil
+}
+
+func existingSlotPopulated(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	f, err := os.Open(path) //nolint:gosec // path is the cache slot final path
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+	entries, err := f.Readdirnames(1)
+	return err == nil && len(entries) > 0
 }
 
 // Release drops the slot mutex AND, if Commit wasn't called, removes

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -194,6 +194,39 @@ func TestCache_SlotCommitPersists(t *testing.T) {
 	slot.Release()
 }
 
+func TestCache_CommitAdoptsExistingFinalSlot(t *testing.T) {
+	c := NewCache(cacheroot.New(t.TempDir()))
+
+	slot, err := c.Slot(context.Background(), "https://example.com/repo", "v1", "")
+	if err != nil {
+		t.Fatalf("Slot: %v", err)
+	}
+	staging := slot.Path
+	if err := os.WriteFile(filepath.Join(staging, "ours"), []byte("ours"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(slot.final, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(slot.final, "theirs"), []byte("theirs"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := slot.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(slot.final, "theirs")); err != nil {
+		t.Errorf("existing final slot was not preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(slot.final, "ours")); !os.IsNotExist(err) {
+		t.Errorf("staged contents should not overwrite adopted final slot; stat err=%v", err)
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Errorf("adopted staging dir leaked: %v", err)
+	}
+	slot.Release()
+}
+
 // TestCache_AuthIDIsolatesSlots locks in that two source CRs with the
 // same (URL, ref) but different auth IDs do not collide on disk —
 // otherwise the first fetch's clone is silently reused for the second
@@ -302,10 +335,10 @@ func TestSlugifyRepo(t *testing.T) {
 		// the tag — otherwise the cache layout collapses
 		// every release of every chart into the same `&lt;tag&gt;/`
 		// directory.
-		"oci://ghcr.io/bjw-s-labs/helm/app-template:5.0.1":           "app-template",
-		"oci://ghcr.io/bjw-s-labs/helm/app-template:1.2.3-rc4":       "app-template",
-		"oci://registry.local:5000/charts/mychart:1.2.3":             "mychart",
-		"oci://registry.local:5000/charts/mychart":                   "mychart",
+		"oci://ghcr.io/bjw-s-labs/helm/app-template:5.0.1":     "app-template",
+		"oci://ghcr.io/bjw-s-labs/helm/app-template:1.2.3-rc4": "app-template",
+		"oci://registry.local:5000/charts/mychart:1.2.3":       "mychart",
+		"oci://registry.local:5000/charts/mychart":             "mychart",
 		// Digest suffix: same concern as tags.
 		"oci://ghcr.io/foo/bar@sha256:1111111111111111111111111111111111111111111111111111111111111111": "bar",
 		// SCP-style git URL with `@` userinfo must NOT be


### PR DESCRIPTION
## Summary
- emit build JSON once across all selected resources and accept explicit diff output
- apply namespace scoping to get all and test reports
- propagate context cancellation from orchestrator runs and classify CEL wait cancellation correctly
- make source cache commit adopt an existing finalized slot instead of deleting it
- document that all commands reconcile before output

## Tests
- go mod tidy
- go test ./...
- go vet ./...
- golangci-lint run
- go test -race ./internal/cli ./pkg/orchestrator ./pkg/depwait ./pkg/source