### PR TITLE
Harden reconcile architecture and source cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,25 @@ docker pull ghcr.io/home-operations/flate:latest
 flate get ks       --path ./kubernetes
 flate build hr     --path ./kubernetes plex
 flate diff ks      --path ./kubernetes --path-orig ../baseline/kubernetes
+flate diff all     --path ./kubernetes --path-orig ../baseline/kubernetes
 flate diff images  --path ./kubernetes --path-orig ../baseline/kubernetes -o json
 flate test all     --path ./kubernetes
 ```
 
-The `[name]` positional on `build`/`diff`/`test` is matched against the resource's bare name (`metadata.name`), not `namespace/name`. Use `-n / --namespace` to scope.
+The `[name]` positional on `get ks/hr` and `build`/`diff`/`test ks/hr` is matched against the resource's bare name (`metadata.name`), not `namespace/name`. Use `-n / --namespace` to scope.
 
-Every command takes `--path <dir>` (default `.`); `--path-orig <dir>` switches into changed-only mode. `flate <verb> --help` lists every flag. All commands run the same offline reconcile pipeline before producing output, so referenced Git, OCI, Helm, Bucket, or remote kustomize sources must be reachable or already cached.
+Every reconcile-running command takes `--path <dir>` (default `.`); `--path-orig <dir>` switches into changed-only mode. `flate <verb> --help` lists every flag. `get`, `build`, `diff`, and `test` all run the same offline reconcile pipeline before producing output, so referenced Git, OCI, Helm, Bucket, or remote kustomize sources must be reachable. Immutable pins can reuse cache; mutable refs refresh.
 
 | Verb | Targets | Notes |
 |---|---|---|
 | `get` | `ks`, `hr`, `images`, `all` | List or summarize. `-o table` / `yaml` / `json` / `name`. |
 | `build` | `ks`, `hr`, `all` | Render Kustomizations and HelmReleases to YAML or JSON. |
-| `diff` | `ks`, `hr`, `images` | Path-keyed diff against `--path-orig`, rendered via [dyff](https://github.com/homeport/dyff) in `--output github` mode. K8s-aware: list entries match by identifier (container name, env-var name), so a reorder shows as `⇆ order changed` instead of a wall of phantom value churn. |
+| `diff` | `ks`, `hr`, `images`, `all` | Path-keyed diff against `--path-orig`, rendered via [dyff](https://github.com/homeport/dyff) in `--output github` mode. K8s-aware: list entries match by identifier (container name, env-var name), so a reorder shows as `⇆ order changed` instead of a wall of phantom value churn. |
 | `test` | `ks`, `hr`, `all` | Pytest-style `PASS` / `FAIL` / `SKIPPED` per resource. Non-zero exit on any failure. |
 
-`get ks` and `get hr` accept `-l/--selector key=value` for label filtering. `diff` accepts `--strip-attr <key>` (repeatable) to drop annotation/label keys before comparison; the default set covers chart-bump noise (`helm.sh/chart`, `checksum/config`, `app.kubernetes.io/version`, `chart`). Helm template flags are available on every reconcile-running subcommand because flate reconciles the full graph before filtering output. Every subcommand accepts `--allow-missing-secrets` to soft-skip sources whose auth Secret is missing or PLACEHOLDER-wiped — see [Behaviors](#behaviors).
+`get ks` and `get hr` accept `-l/--selector key=value` for label filtering. `diff` accepts `--strip-attr <key>` (repeatable) to drop annotation/label keys before comparison; the default set covers chart-bump noise (`helm.sh/chart`, `checksum/config`, `app.kubernetes.io/version`, `chart`). Helm template flags are available on every reconcile-running subcommand because flate reconciles the full graph before filtering output. Reconcile-running subcommands accept `--allow-missing-secrets` to soft-skip sources whose auth Secret is missing or PLACEHOLDER-wiped — see [Behaviors](#behaviors).
 
-**Default output filters.** `--skip-secrets` and `--skip-crds` both default to `true` — `build`/`diff`/`test` strip rendered `Secret` and `CustomResourceDefinition` objects from output. Pass `--skip-secrets=false` / `--skip-crds=false` to include them; `--skip-kinds <kind>` (repeatable) drops additional kinds. These are output-stream filters, distinct from `--allow-missing-secrets`, which gates *source fetch* on missing auth Secrets.
+**Default output filters.** `--skip-secrets` and `--skip-crds` both default to `true` — `build` and `diff` strip rendered `Secret` and `CustomResourceDefinition` objects from manifest output. Pass `--skip-secrets=false` / `--skip-crds=false` to include them; `--skip-kinds <kind>` (repeatable) drops additional kinds. These are output-stream filters, distinct from `--allow-missing-secrets`, which gates *source fetch* on missing auth Secrets.
 
 ## Changed-only mode
 
@@ -70,7 +71,7 @@ flate diff ks --path ./kubernetes --path-orig ../baseline/kubernetes
 |---|---|---|
 | `GitRepository` | full | HTTPS: `username` + `password` or `bearerToken`. SSH: `identity` (+ optional `password`, `known_hosts`). |
 | `OCIRepository` | full | `.dockerconfigjson`. Falls back to `--registry-config`, then `~/.docker/config.json`. |
-| `HelmRepository` | full | HTTP basic: `username` + `password`. OCI flavor: use a sibling `OCIRepository`. |
+| `HelmRepository` | full | HTTP basic: `username` + `password`; OCI flavor routes through the OCI puller. |
 | `HelmChart` | full | Inline (`HR.spec.chart`) and standalone CRD. |
 | `Bucket` | `generic` only | `accesskey` + `secretkey`. `aws`/`gcp`/`azure` fail loud — use static creds. |
 | `ExternalArtifact` | `file://` only | `status.artifact.url` must be a local path. |
@@ -134,7 +135,7 @@ Other entry points worth knowing:
 discovery → Store ⇄ events ⇄ controllers (source · kustomization · helmrelease)
 ```
 
-Pipeline: bootstrap-source seed → loader pre-pass excluding `configMapGenerator`/`secretGenerator` data files → file walk → `spec.path` + ResourceSet fixed-point expansion → bootstrap-source aliasing for unresolved `GitRepository` refs → namespace inheritance → parent index → `dependsOn` validation + cycle break → change-filter → controllers fire → render → render-time keep-set extension for emitted children → orphan demotion → output.
+Pipeline: bootstrap-source seed → loader pre-pass excluding `configMapGenerator`/`secretGenerator` data files → file walk → `spec.path` + ResourceSet fixed-point expansion → bootstrap-source aliasing for unresolved `GitRepository` refs → namespace inheritance → parent index → `dependsOn` cycle preflight → change-filter → controllers fire → render → render-time keep-set extension for emitted children → orphan demotion → output.
 
 The Store is the single source of truth. Every stored manifest is immutable; mutation routes through `Store.Mutate[T]` (clone, mutate, AddObject). Helm chart loads coalesce through a per-path keylock — N parallel reconciles of the same chart issue exactly one parse.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -38,6 +38,7 @@ kind: Kustomization
 metadata:
   name: apps
   namespace: flux-system
+  labels: {app.kubernetes.io/name: apps}
 spec:
   interval: 10m
   path: ./apps
@@ -274,9 +275,44 @@ func TestRun_GetKS_NameFilter(t *testing.T) {
 	}
 }
 
+func TestRun_GetKS_NameFilter_NoMatch(t *testing.T) {
+	path := writeFixture(t)
+	_, stderr, code := runCLI(t, "get", "ks", "nonexistent", "--path", path)
+	if code == 0 {
+		t.Fatal("expected non-zero for nonexistent name on get")
+	}
+	if !strings.Contains(stderr, "nonexistent") {
+		t.Errorf("error should name the typo'd argument: %q", stderr)
+	}
+}
+
+func TestRun_GetKS_NameFilter_LabelMismatchIsEmpty(t *testing.T) {
+	path := writeFixture(t)
+	stdout, stderr, code := runCLI(t, "get", "ks", "apps", "--path", path, "-l", "app.kubernetes.io/name=other")
+	if code != 0 {
+		t.Fatalf("get ks apps with non-matching label exited %d: %s", code, stderr)
+	}
+	if strings.Contains(stderr, "no Kustomization named") {
+		t.Fatalf("name existed but label filter was reported as a missing name: %s", stderr)
+	}
+	if strings.Contains(stdout, "apps") {
+		t.Errorf("label mismatch should filter out apps:\n%s", stdout)
+	}
+}
+
+func TestRun_GetKS_NameFilter_NamespaceMismatchFails(t *testing.T) {
+	path := writeFixture(t)
+	_, stderr, code := runCLI(t, "get", "ks", "apps", "--path", path, "-n", "other")
+	if code == 0 {
+		t.Fatal("expected non-zero for name outside namespace scope")
+	}
+	if !strings.Contains(stderr, "apps") {
+		t.Errorf("error should name the scoped-out argument: %q", stderr)
+	}
+}
+
 // TestRun_BuildKS_NameFilter_NoMatch is the error path: typo name on
-// build should fail loud (the get verb is permissive — filters
-// silently — but build can't render a nonexistent target).
+// build should fail loud instead of rendering an empty target.
 func TestRun_BuildKS_NameFilter_NoMatch(t *testing.T) {
 	path := writeFixture(t)
 	_, stderr, code := runCLI(t, "build", "ks", "nonexistent", "--path", path)
@@ -393,6 +429,48 @@ func TestRun_TestAll_RespectsNamespace(t *testing.T) {
 	}
 }
 
+func TestRun_TestKS_NameFilter_NoMatch(t *testing.T) {
+	path := writeFixture(t)
+	_, stderr, code := runCLI(t, "test", "ks", "nonexistent", "--path", path)
+	if code == 0 {
+		t.Fatal("expected non-zero for nonexistent name on test")
+	}
+	if !strings.Contains(stderr, "nonexistent") {
+		t.Errorf("error should name the typo'd argument: %q", stderr)
+	}
+}
+
+func TestRun_TestAll_ReturnsStdoutWriteError(t *testing.T) {
+	path := writeFixture(t)
+	want := errors.New("stdout closed")
+	var stderr bytes.Buffer
+	code := Run([]string{"test", "all", "--path", path}, failingWriter{err: want}, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero for stdout write failure")
+	}
+	if !strings.Contains(stderr.String(), want.Error()) {
+		t.Errorf("stderr should include writer error %q: %q", want, stderr.String())
+	}
+}
+
+func TestRun_TestAll_JoinsVisibleFailuresWithRunError(t *testing.T) {
+	path := writeFixture(t)
+	if err := os.Remove(filepath.Join(path, "apps", "cm.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, stderr, code := runCLI(t, "test", "all", "--path", path)
+	if code == 0 {
+		t.Fatal("expected non-zero for failed reconcile")
+	}
+	if !strings.Contains(stdout, "FAILED") {
+		t.Errorf("stdout should still include failed test row:\n%s", stdout)
+	}
+	if !strings.Contains(stderr, "reconcile completed") {
+		t.Errorf("stderr should preserve scoped run error, got %q", stderr)
+	}
+}
+
 // TestRun_TestAll_RejectsOutput covers test's new -o rejection
 // (test only emits plain-text).
 func TestRun_TestAll_RejectsOutput(t *testing.T) {
@@ -442,6 +520,19 @@ func TestRun_DiffKS_ExplicitDiffOutput(t *testing.T) {
 	_, stderr, code := runCLI(t, "diff", "ks", "--path", current, "--path-orig", orig, "-o", "diff")
 	if code != 0 {
 		t.Fatalf("diff ks -o diff exited %d: %s", code, stderr)
+	}
+}
+
+func TestRun_DiffKS_NameFilter_NoMatch(t *testing.T) {
+	current := writeFixture(t)
+	orig := t.TempDir()
+	copyTree(t, current, orig)
+	_, stderr, code := runCLI(t, "diff", "ks", "nonexistent", "--path", current, "--path-orig", orig)
+	if code == 0 {
+		t.Fatal("expected non-zero for nonexistent name on diff")
+	}
+	if !strings.Contains(stderr, "nonexistent") {
+		t.Errorf("error should name the typo'd argument: %q", stderr)
 	}
 }
 
@@ -651,3 +742,11 @@ func TestJoinRunErrors(t *testing.T) {
 type dummyErr struct{ s string }
 
 func (d *dummyErr) Error() string { return d.s }
+
+type failingWriter struct {
+	err error
+}
+
+func (w failingWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
+}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -168,8 +168,12 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 	if orig.O == nil || current.O == nil {
 		return runErr
 	}
-	origDocs := gatherAllArtifacts(orig.O, orig.Res, kind, name, c)
-	currentDocs := gatherAllArtifacts(current.O, current.Res, kind, name, c)
+	origDocs, origMatched := gatherAllArtifacts(orig.O, orig.Res, kind, name, c)
+	currentDocs, currentMatched := gatherAllArtifacts(current.O, current.Res, kind, name, c)
+	diffRunErr := scopedDiffRunError(orig, current, c, runErr)
+	if name != "" && origMatched+currentMatched == 0 {
+		return errors.Join(fmt.Errorf("no %s named %q in --path or --path-orig", kind, name), diffRunErr)
+	}
 
 	outFormat := c.output
 	if outFormat == "table" {
@@ -179,16 +183,16 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 		StripAttrs: d.stripAttrs,
 	})
 	if err != nil {
-		return err
+		return errors.Join(err, diffRunErr)
 	}
 	formatted, err := diff.Render(diffs, diff.Format(outFormat))
 	if err != nil {
-		return errors.Join(err, scopedDiffRunError(orig, current, c, runErr))
+		return errors.Join(err, diffRunErr)
 	}
 	if _, err := cmd.OutOrStdout().Write(formatted); err != nil {
-		return errors.Join(err, scopedDiffRunError(orig, current, c, runErr))
+		return errors.Join(err, diffRunErr)
 	}
-	return scopedDiffRunError(orig, current, c, runErr)
+	return diffRunErr
 }
 
 // diffSide pairs an Orchestrator with its render Result. Diff
@@ -301,12 +305,13 @@ func scopedDiffRunError(orig, current diffSide, c *commonFlags, runErr error) er
 // Kustomization- and HelmRelease-rendered manifests in one pass.
 // Each kind's docs are gathered separately so the diff header
 // attribution (parent KS vs parent HR) stays accurate.
-func gatherAllArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
+func gatherAllArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) ([]diff.Doc, int) {
 	if kind != "" {
 		return gatherArtifacts(o, res, kind, name, c)
 	}
-	out := gatherArtifacts(o, res, manifest.KindKustomization, name, c)
-	return append(out, gatherArtifacts(o, res, manifest.KindHelmRelease, name, c)...)
+	out, matched := gatherArtifacts(o, res, manifest.KindKustomization, name, c)
+	hrs, hrMatched := gatherArtifacts(o, res, manifest.KindHelmRelease, name, c)
+	return append(out, hrs...), matched + hrMatched
 }
 
 // gatherArtifacts collects every rendered manifest produced by the
@@ -318,7 +323,7 @@ func gatherAllArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, 
 // Reads res.Manifests for the rendered docs; falls back to the Store
 // only to recover the producing object's spec.path (the diff header
 // shows it for KS parents).
-func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) []diff.Doc {
+func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) ([]diff.Doc, int) {
 	var out []diff.Doc
 	// Defensive re-drop of --skip-secrets / --skip-crds / --skip-kinds.
 	// Orchestrator.Render already applies the same set to Result.Manifests
@@ -328,7 +333,13 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 	if c != nil {
 		skip = c.skipResourceKinds()
 	}
-	for id, docs := range res.Manifests {
+	objs := o.Store().ListObjects(kind)
+	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
+		return a.Named().Compare(b.Named())
+	})
+	matched := 0
+	for _, obj := range objs {
+		id := obj.Named()
 		if id.Kind != kind {
 			continue
 		}
@@ -336,6 +347,11 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 			continue
 		}
 		if c != nil && !c.includeNamespace(o.Filter(), id.Namespace) {
+			continue
+		}
+		matched++
+		docs, ok := res.Manifests[id]
+		if !ok {
 			continue
 		}
 		parent := diff.Parent{Kind: id.Kind, Namespace: id.Namespace, Name: id.Name}
@@ -346,5 +362,5 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 			out = append(out, diff.Doc{Manifest: m, Parent: parent})
 		}
 	}
-	return out
+	return out, matched
 }

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"cmp"
 	"errors"
+	"fmt"
 	"io"
 	"maps"
 	"slices"
@@ -218,12 +219,17 @@ func printResources[T manifest.BaseManifest](
 		doc map[string]any
 	}
 	pairs := make([]pair, 0, len(objs))
+	nameExists := sel.Name == ""
 	for _, obj := range objs {
-		if !sel.Matches(obj) {
+		if sel.Name != "" && obj.Named().Name != sel.Name {
 			continue
 		}
 		id := obj.Named()
 		if !c.includeNamespace(o.Filter(), id.Namespace) {
+			continue
+		}
+		nameExists = true
+		if !(selector.Metadata{Labels: sel.Labels}).Matches(obj) {
 			continue
 		}
 		t, ok := obj.(T)
@@ -232,6 +238,9 @@ func printResources[T manifest.BaseManifest](
 		}
 		row, doc := mapper(o, t)
 		pairs = append(pairs, pair{row, doc})
+	}
+	if !nameExists {
+		return fmt.Errorf("no %s named %q in --path", kind, sel.Name)
 	}
 	// Store.ListObjects iterates a Go map (random order); sort the
 	// (row, doc) tuple so every output flavor — including yaml/json —

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,7 +4,7 @@
 //
 //   - get   ks|hr|images|all — list Flux objects, images, or cluster summary.
 //   - build ks|hr|all        — render Flux objects to YAML.
-//   - diff  ks|hr|images     — compare current vs. another path.
+//   - diff  ks|hr|images|all — compare current vs. another path.
 //   - test  ks|hr|all        — report reconcile status.
 //
 // Use New() to obtain a cobra.Command for embedding flate in a parent

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -61,20 +62,27 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 			// reconcile failures, so the runErr is informational here —
 			// the structured report is what the user reads. We still
 			// surface a non-zero exit on any failure.
+			name := firstArg(argv)
 			report := testrunner.Run(testrunner.Job{
 				Store: o.Store(),
 				Kinds: kinds,
-				Name:  firstArg(argv),
+				Name:  name,
 				Include: func(id manifest.NamedResource) bool {
 					return c.includeNamespace(o.Filter(), id.Namespace)
 				},
 			})
-			report.ShowSkipped = showSkipped
-			report.Write(cmd.OutOrStdout())
-			if report.AnyFailed() {
-				return errors.New("test failures detected")
+			runErr = scopedRunError(o, res, c, runErr)
+			if name != "" && report.Matched == 0 {
+				return errors.Join(fmt.Errorf("no %s named %q in --path", testKindName(kinds), name), runErr)
 			}
-			return scopedRunError(o, res, c, runErr)
+			report.ShowSkipped = showSkipped
+			if err := report.Write(cmd.OutOrStdout()); err != nil {
+				return errors.Join(err, runErr)
+			}
+			if report.AnyFailed() {
+				return errors.Join(errors.New("test failures detected"), runErr)
+			}
+			return runErr
 		},
 	}
 	bindCommon(cmd.Flags(), c)
@@ -82,4 +90,11 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 		"include SKIPPED resources in the per-resource listing (changed-only mode hides them by default to mirror `flate diff`)")
 	bindHelmFlags(cmd.Flags(), h)
 	return cmd
+}
+
+func testKindName(kinds []string) string {
+	if len(kinds) == 1 {
+		return kinds[0]
+	}
+	return "resource"
 }

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -12,6 +12,7 @@ package testrunner
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -54,6 +55,7 @@ type Report struct {
 	Passed  int
 	Skipped int
 	Failed  int
+	Matched int
 	// ShowSkipped controls whether SKIPPED cases appear in the
 	// per-resource listing that Write emits. When false (the
 	// default), only PASSED and FAILED rows are printed — matching
@@ -70,7 +72,7 @@ func (r Report) AnyFailed() bool { return r.Failed > 0 }
 // cases are suppressed from the per-resource listing unless
 // ShowSkipped is set, mirroring `flate diff`'s "only what changed"
 // output. The summary footer reports the full count regardless.
-func (r Report) Write(w io.Writer) {
+func (r Report) Write(w io.Writer) error {
 	var b strings.Builder
 	visible := len(r.Cases)
 	if !r.ShowSkipped {
@@ -98,7 +100,8 @@ func (r Report) Write(w io.Writer) {
 		b.WriteByte('\n')
 	}
 	fmt.Fprintf(&b, "\n%d passed, %d skipped, %d failed\n", r.Passed, r.Skipped, r.Failed)
-	_, _ = io.WriteString(w, b.String())
+	_, err := io.WriteString(w, b.String())
+	return err
 }
 
 // Run inspects the store and produces a Report. When j.Kinds is empty,
@@ -111,7 +114,11 @@ func Run(j Job) Report {
 	}
 	var rep Report
 	for _, kind := range kinds {
-		for _, obj := range j.Store.ListObjects(kind) {
+		objs := j.Store.ListObjects(kind)
+		slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
+			return a.Named().Compare(b.Named())
+		})
+		for _, obj := range objs {
 			id := obj.Named()
 			if j.Name != "" && id.Name != j.Name {
 				continue
@@ -132,6 +139,7 @@ func Run(j Job) Report {
 			if id == manifest.BootstrapSourceID {
 				continue
 			}
+			rep.Matched++
 			c := classify(j.Store, id)
 			switch c.Outcome {
 			case OutcomePassed:

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -2,6 +2,7 @@ package testrunner
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -21,7 +22,9 @@ func TestRun_AllPass(t *testing.T) {
 		t.Errorf("expected 2 passed, got %+v", rep)
 	}
 	var b bytes.Buffer
-	rep.Write(&b)
+	if err := rep.Write(&b); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
 	if !strings.Contains(b.String(), "2 passed") {
 		t.Errorf("missing summary: %s", b.String())
 	}
@@ -107,7 +110,9 @@ func TestWrite_HidesSkippedByDefault(t *testing.T) {
 	rep := Run(Job{Store: s})
 
 	var b bytes.Buffer
-	rep.Write(&b)
+	if err := rep.Write(&b); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
 	out := b.String()
 
 	if !strings.Contains(out, "changed") {
@@ -146,7 +151,9 @@ func TestWrite_ShowSkippedSurfacesEverything(t *testing.T) {
 	rep.ShowSkipped = true
 
 	var b bytes.Buffer
-	rep.Write(&b)
+	if err := rep.Write(&b); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
 	out := b.String()
 
 	if !strings.Contains(out, "untouched") {
@@ -168,8 +175,56 @@ func TestWrite_FailedNeverHidden(t *testing.T) {
 
 	rep := Run(Job{Store: s})
 	var b bytes.Buffer
-	rep.Write(&b)
+	if err := rep.Write(&b); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
 	if !strings.Contains(b.String(), "FAILED") {
 		t.Errorf("FAILED row must appear by default: %s", b.String())
 	}
+}
+
+func TestRun_DeterministicOrderAndMatchCount(t *testing.T) {
+	s := store.New()
+	for _, id := range []manifest.NamedResource{
+		{Kind: manifest.KindKustomization, Namespace: "z", Name: "last"},
+		{Kind: manifest.KindKustomization, Namespace: "a", Name: "first"},
+		{Kind: manifest.KindKustomization, Namespace: "m", Name: "middle"},
+	} {
+		s.AddObject(&manifest.Kustomization{Name: id.Name, Namespace: id.Namespace})
+		s.UpdateStatus(id, store.StatusReady, "")
+	}
+
+	rep := Run(Job{Store: s, Kinds: []string{manifest.KindKustomization}})
+
+	if rep.Matched != 3 {
+		t.Fatalf("Matched = %d, want 3", rep.Matched)
+	}
+	got := []manifest.NamedResource{rep.Cases[0].ID, rep.Cases[1].ID, rep.Cases[2].ID}
+	want := []manifest.NamedResource{
+		{Kind: manifest.KindKustomization, Namespace: "a", Name: "first"},
+		{Kind: manifest.KindKustomization, Namespace: "m", Name: "middle"},
+		{Kind: manifest.KindKustomization, Namespace: "z", Name: "last"},
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("case order = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestWrite_ReturnsWriterError(t *testing.T) {
+	want := errors.New("write failed")
+	rep := Report{Cases: []Case{{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "apps"}}}}
+
+	if err := rep.Write(errWriter{err: want}); !errors.Is(err, want) {
+		t.Fatalf("Write error = %v, want %v", err, want)
+	}
+}
+
+type errWriter struct {
+	err error
+}
+
+func (w errWriter) Write(_ []byte) (int, error) {
+	return 0, w.err
 }

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -175,15 +175,20 @@ func (c *Controller) Await(
 		c.Store.UpdateStatus(id, store.StatusPending, pendingMsg)
 	}
 	var sum depwait.Summary
-	// YieldQuiescent (not YieldSlot): the wait is on OTHER tasks'
-	// work, so this task isn't producing anything while parked.
-	// Decrementing active lets QuiescenceCh fire on a render-only
-	// dep the moment no productive task remains — without it, two
-	// reconciles both blocked in depwait hold the count at 2 and
-	// burn the full RenderProducingTimeout cap.
-	c.Tasks.YieldQuiescent(func() {
+	runWait := func() {
 		sum = depwait.WaitAll(w.Watch(ctx, deps))
-	})
+	}
+	if w.ReadyNow(deps) {
+		runWait()
+	} else {
+		// YieldQuiescent (not YieldSlot): the wait is on OTHER tasks'
+		// work, so this task isn't producing anything while parked.
+		// Decrementing active lets QuiescenceCh fire on a render-only
+		// dep the moment no productive task remains. The ReadyNow fast
+		// path above keeps an immediately-unblocked producer counted as
+		// active so consumers do not observe a false drained pool.
+		c.Tasks.YieldQuiescent(runWait)
+	}
 	if sum.AnyFailed() {
 		return onFail(sum)
 	}
@@ -264,10 +269,15 @@ func RunWithStatus[T manifest.BaseManifest](
 		s.UpdateStatus(id, store.StatusFailed, err.Error())
 		return
 	}
-	if existing, ok := s.GetStatus(id); ok && existing.Status == store.StatusReady && existing.Message != "" {
-		// Existing Ready message is informative (skipped:, unchanged,
-		// suspended, or any future Ready sub-state) — don't clobber.
-		return
+	if existing, ok := s.GetStatus(id); ok {
+		if existing.Status == store.StatusFailed {
+			return
+		}
+		if existing.Status == store.StatusReady && existing.Message != "" {
+			// Existing Ready message is informative (skipped:, unchanged,
+			// suspended, or any future Ready sub-state) — don't clobber.
+			return
+		}
 	}
 	s.UpdateStatus(id, store.StatusReady, "")
 }

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -129,3 +129,24 @@ func TestRunWithStatus_PreservesInformativeReadyMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestRunWithStatus_PreservesExternalFailure(t *testing.T) {
+	s := store.New()
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+	id := hr.Named()
+
+	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		func(_ context.Context, _ *manifest.HelmRelease) error {
+			s.UpdateStatus(id, store.StatusFailed, "dependency cycle detected")
+			return nil
+		},
+	)
+	got, _ := s.GetStatus(id)
+	if got.Status != store.StatusFailed {
+		t.Errorf("status = %v, want Failed", got.Status)
+	}
+	if got.Message != "dependency cycle detected" {
+		t.Errorf("external failure message was clobbered: %q", got.Message)
+	}
+}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -49,6 +49,7 @@ type Controller struct {
 	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
 	existence depwait.ExistenceLookup
 	renders   depwait.RenderInflight
+	preflight func(manifest.NamedResource) (string, bool)
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -76,6 +77,10 @@ type ReconcileOptions struct {
 	// short-circuits to "dependency not found" once Renders reports
 	// no other reconcile is in flight.
 	Renders depwait.RenderInflight
+	// PreflightFailure reports dependency-graph errors discovered by the
+	// orchestrator before reconcile. When set for an id, the controller
+	// marks the resource Failed and does not render it.
+	PreflightFailure func(manifest.NamedResource) (string, bool)
 }
 
 // New constructs a HelmRelease controller.
@@ -96,6 +101,7 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 	c.parentOf = opts.ParentOf
 	c.existence = opts.Existence
 	c.renders = opts.Renders
+	c.preflight = opts.PreflightFailure
 }
 
 // lookupParent reports the structural parent KS of id via the
@@ -146,14 +152,35 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if c.PreGate(id, hr.Suspend) {
 			return
 		}
+		if msg, failed := c.preflightFailure(id); failed {
+			c.Store.UpdateStatus(id, store.StatusFailed, msg)
+			return
+		}
 		c.Submit(ctx, id, func(ctx context.Context) {
 			base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
 		})
 	}
 }
 
+func (c *Controller) preflightFailure(id manifest.NamedResource) (string, bool) {
+	if c.preflight == nil {
+		return "", false
+	}
+	return c.preflight(id)
+}
+
+func (c *Controller) preflightError(id manifest.NamedResource) error {
+	if msg, failed := c.preflightFailure(id); failed {
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}
+
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {
 	id := hr.Named()
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 
 	// Parent gate: if this HR was file-loaded under a Flux KS's
 	// spec.path, wait for that KS to finish reconciling before
@@ -184,6 +211,9 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			hr = obj
 		}
 	}
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 
 	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
 	// each dependency reaching Ready before this HR reconciles.
@@ -211,6 +241,9 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			hr = obj
 		}
 	}
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 
 	// Pre-Prepare existence waits: helm.Prepare reads from the live
 	// Store synchronously, returning ErrObjectNotFound for missing
@@ -233,6 +266,9 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
 			hr = obj
 		}
+	}
+	if err := c.preflightError(id); err != nil {
+		return err
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
@@ -272,6 +308,9 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return fmt.Errorf("%w: chart source %s %s",
 			manifest.ErrSourceSkipped, srcID.String(), info.Message)
 	}
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 
 	// Fingerprint dedup: when the same HR id gets re-AddObject'd with
 	// the same effective spec (e.g. the parent KS render stamps
@@ -284,6 +323,9 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// the HR-render time on real-world trees.
 	fp := helmReleaseFingerprint(hr)
 	if existing, ok := c.Store.GetArtifact(id).(*store.HelmReleaseArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
+		if err := c.preflightError(id); err != nil {
+			return err
+		}
 		slog.Debug("helmrelease: skipped re-render (fingerprint unchanged)", "id", id.String())
 		// Skip helm.TemplateDocs (the expensive bit), but replay the
 		// cached docs through the dispatch loop so any source CRs
@@ -296,12 +338,18 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering chart")
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 	docs, err := c.Helm.TemplateDocs(ctx, hr, hr.Values, c.Options)
 	if err != nil {
 		return err
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 	c.emitRenderedChildren(id, docs)
 
 	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs, Fingerprint: fp})

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -44,6 +44,7 @@ type Controller struct {
 	renderTracker RenderTracker
 	existence     depwait.ExistenceLookup
 	renders       depwait.RenderInflight
+	preflight     func(manifest.NamedResource) (string, bool)
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -85,6 +86,10 @@ type Options struct {
 	// fails as soon as the orchestrator drains instead of burning
 	// the full RenderProducingTimeout cap.
 	Renders depwait.RenderInflight
+	// PreflightFailure reports dependency-graph errors discovered by the
+	// orchestrator before reconcile. When set for an id, the controller
+	// marks the resource Failed and does not render it.
+	PreflightFailure func(manifest.NamedResource) (string, bool)
 }
 
 // New constructs a Kustomization controller.
@@ -105,6 +110,7 @@ func (c *Controller) Configure(opts Options) {
 	c.renderTracker = opts.RenderTracker
 	c.existence = opts.Existence
 	c.renders = opts.Renders
+	c.preflight = opts.PreflightFailure
 }
 
 // markRendered reports a parent→child render emission to the
@@ -147,14 +153,35 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if c.PreGate(id, ks.Suspend) {
 			return
 		}
+		if msg, failed := c.preflightFailure(id); failed {
+			c.Store.UpdateStatus(id, store.StatusFailed, msg)
+			return
+		}
 		c.Submit(ctx, id, func(ctx context.Context) {
 			base.RunWithStatus(ctx, c.Store, id, "kustomization", c.reconcile)
 		})
 	}
 }
 
+func (c *Controller) preflightFailure(id manifest.NamedResource) (string, bool) {
+	if c.preflight == nil {
+		return "", false
+	}
+	return c.preflight(id)
+}
+
+func (c *Controller) preflightError(id manifest.NamedResource) error {
+	if msg, failed := c.preflightFailure(id); failed {
+		return fmt.Errorf("%s", msg)
+	}
+	return nil
+}
+
 func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) error {
 	id := ks.Named()
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
 
 	deps := c.collectDeps(ks)
@@ -181,6 +208,9 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 			ks = fresh
 		}
 	}
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving source artifact")
 	sourceRoot, err := c.resolveSourceRoot(ks)
@@ -197,6 +227,9 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	if err != nil {
 		return err
 	}
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 
 	// Fingerprint dedup: the same id may receive multiple AddObject
 	// events with the same effective spec (e.g. when the structural
@@ -206,6 +239,9 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	// post-Prepare inputs are byte-identical. Same pattern as HR (#219).
 	fp := kustomizationFingerprint(ks, sourceRoot)
 	if existing, ok := c.Store.GetArtifact(id).(*store.KustomizationArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
+		if err := c.preflightError(id); err != nil {
+			return err
+		}
 		slog.Debug("kustomization: skipped re-render (fingerprint unchanged)", "id", id.String())
 		// Skip kustomize.RenderFlux (the expensive bit), but still
 		// replay the cached artifact through emitRenderedChildren so
@@ -221,6 +257,9 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering")
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 	data, err := kustomize.RenderFlux(ctx, c.Staging, sourceRoot, ks.Path, ks.Contents)
 	if err != nil {
 		return err
@@ -252,6 +291,9 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
+	if err := c.preflightError(id); err != nil {
+		return err
+	}
 	c.emitRenderedChildren(id, docs)
 
 	c.Store.SetArtifact(id, &store.KustomizationArtifact{

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -62,13 +62,15 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		}
 	}
 	// Pass 2 — leaf reconcilables.
+	leaves := make([]manifest.BaseManifest, 0)
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			c.keepEmitted(id, p.obj.Named())
-			c.Store.AddObject(p.obj)
 			c.markRendered(id, p.obj.Named())
+			leaves = append(leaves, p.obj)
 		}
 	}
+	c.Store.AddObjects(leaves)
 }
 
 // keepEmitted extends the change filter's keep set so render-emitted

--- a/pkg/controllers/kustomization/dispatch_test.go
+++ b/pkg/controllers/kustomization/dispatch_test.go
@@ -3,7 +3,10 @@ package kustomization
 import (
 	"testing"
 
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
 )
 
 // TestShouldDispatchAsObject_KnownKinds documents which kinds the
@@ -98,5 +101,50 @@ func TestPass1Pass2Categories(t *testing.T) {
 		if isLeafReconcilable(k) && !shouldDispatchAsObject(k) {
 			t.Errorf("%T is a leaf reconcilable but not dispatch-as-object", k)
 		}
+	}
+}
+
+func TestEmitRenderedChildrenBatchesLeafDispatch(t *testing.T) {
+	s := store.New()
+	c := &Controller{Controller: base.New(s, task.New())}
+	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "parent"}
+
+	var sawBOnA bool
+	s.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
+		if id == idA {
+			sawBOnA = s.GetObject(idB) != nil
+		}
+	}, false)
+
+	c.emitRenderedChildren(parent, []map[string]any{
+		fluxKustomizationDoc("a", "b"),
+		fluxKustomizationDoc("b", "a"),
+	})
+	if !sawBOnA {
+		t.Fatal("first leaf dispatch did not see later emitted sibling")
+	}
+}
+
+func fluxKustomizationDoc(name, dep string) map[string]any {
+	return map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "ns",
+		},
+		"spec": map[string]any{
+			"interval": "10m",
+			"path":     "./" + name,
+			"sourceRef": map[string]any{
+				"kind": "GitRepository",
+				"name": "repo",
+			},
+			"dependsOn": []any{
+				map[string]any{"name": dep},
+			},
+		},
 	}
 }

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -245,6 +245,42 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 	return out
 }
 
+// ReadyNow reports whether every dependency is already satisfied
+// without waiting. Controllers use this to avoid marking a reconcile
+// quiescent while it is only confirming dependencies that are ready
+// and can continue producing render output immediately.
+func (w *Waiter) ReadyNow(deps []manifest.DependencyRef) bool {
+	for _, dep := range deps {
+		if !w.readyNow(dep) {
+			return false
+		}
+	}
+	return true
+}
+
+func (w *Waiter) readyNow(dep manifest.DependencyRef) bool {
+	id := dep.NamedResource
+	if !w.depExists(id) {
+		return false
+	}
+	if !store.SupportsStatus(id.Kind) {
+		return true
+	}
+	if dep.ReadyExpr != "" && !w.AdditiveReadyExpr {
+		ev, done := w.tryReadyExpr(dep.ReadyExpr, id)
+		return done && ev.Status == DepReady
+	}
+	info, ok := w.Store.GetStatus(id)
+	if !ok || info.Status != store.StatusReady {
+		return false
+	}
+	if dep.ReadyExpr != "" {
+		ev, done := w.tryReadyExpr(dep.ReadyExpr, id)
+		return done && ev.Status == DepReady
+	}
+	return true
+}
+
 // safeWatchOne wraps watchOne with panic recovery — a malformed CEL
 // ReadyExpr (or any other internal bug) reports the dep as failed
 // instead of taking the orchestrator down with it.

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -98,15 +98,11 @@ type Client struct {
 	indexCache sync.Map // map[string]*repo.IndexFile
 	indexLocks *keylock.KeyMap[string]
 
-	// chartBlobs is the content-addressed storage for downloaded
-	// helm chart tarballs. chartRefs maps the per-release identity
-	// tuple `(namespace, name, chartName, version)` to the current
-	// digest — so two HelmRepositories that happen to publish a
-	// chart with identical bytes share one on-disk slot, and a
-	// reconfigured cluster reading the same charts hits the CAS
-	// path without re-downloading.
+	// chartBlobs is the content-addressed storage for downloaded helm
+	// chart tarballs. HelmRepository charts hit this cache only when
+	// index.yaml supplies a digest; entries without a digest are
+	// treated as mutable and downloaded on each run.
 	chartBlobs *blob.Store
-	chartRefs  *blob.Refs
 }
 
 // chartCacheEntry pairs the parsed chart with the (mtime, size) of
@@ -152,7 +148,6 @@ func NewClient(layout cacheroot.Layout) (*Client, error) {
 		chartLoadLocks: keylock.New[string](),
 		indexLocks:     keylock.New[string](),
 		chartBlobs:     blob.NewStore(layout),
-		chartRefs:      blob.NewRefs(layout, "chart-tarballs"),
 	}, nil
 }
 

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -8,11 +8,12 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
+	release "helm.sh/helm/v4/pkg/release/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 func TestTemplate_LocalChart(t *testing.T) {
@@ -156,6 +157,24 @@ func TestTemplate_HRInstallDisableHooks(t *testing.T) {
 	// render path.
 	if !strings.Contains(out, "demo-cm") {
 		t.Errorf("expected non-hook ConfigMap to still render: %s", out)
+	}
+}
+
+func TestReleaseManifest_HookSeparators(t *testing.T) {
+	rel := &release.Release{
+		Manifest: "kind: ConfigMap",
+		Hooks: []*release.Hook{
+			{Path: "hooks/a.yaml", Manifest: "kind: Job", Events: []release.HookEvent{release.HookPreInstall}},
+			{Path: "hooks/b.yaml", Manifest: "kind: Secret\n", Events: []release.HookEvent{release.HookPreInstall}},
+		},
+	}
+
+	got := releaseManifest(rel, Options{}, false, false)
+	want := "kind: ConfigMap\n" +
+		"---\n# Source: hooks/a.yaml\nkind: Job\n" +
+		"---\n# Source: hooks/b.yaml\nkind: Secret\n"
+	if got != want {
+		t.Errorf("releaseManifest hook separators mismatch\nwant:\n%q\ngot:\n%q", want, got)
 	}
 }
 

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -81,6 +81,7 @@ func (c *Client) pullHelmRepoOCI(ctx context.Context, r *manifest.HelmRepository
 			Namespace: r.Namespace,
 		}
 		syn.URL = chartURL
+		syn.Provider = r.Provider
 		if hr.Chart.Version != "" {
 			ref := &manifest.OCIRepositoryRef{}
 			if strings.Contains(hr.Chart.Version, ":") {
@@ -172,27 +173,18 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 		return "", err
 	}
 
-	// Hot path: lookup the previously-resolved digest for this
-	// (repo, chart, version) identity in chartRefs, then ask chartBlobs
-	// to confirm the blob still exists. Two HelmRepositories that
-	// publish a chart with identical bytes share one blob slot — the
-	// refs table is the only place the (repo, name, version) tuple
-	// shows up.
-	refKey := safeName(r.Namespace+"-"+r.Name+"-"+hr.Chart.Name) + "-" + cv.Version
-	if path, ok := c.chartTarballFromCAS(refKey); ok {
+	wantDigest := normalizeChartDigest(cv.Digest)
+	if path, ok := c.chartTarballByDigest(wantDigest); ok {
 		return path, nil
 	}
 
-	// Coalesce concurrent downloads on the refKey — the digest is
-	// only knowable post-download, so the per-digest lock inside
-	// chartBlobs can't serve this duty.
-	release, err := chartCacheLocks.Acquire(ctx, refKey)
+	release, err := chartCacheLocks.Acquire(ctx, chartDownloadKey(r, hr, cv, chartURL, wantDigest))
 	if err != nil {
 		return "", err
 	}
 	defer release()
 
-	if path, ok := c.chartTarballFromCAS(refKey); ok {
+	if path, ok := c.chartTarballByDigest(wantDigest); ok {
 		return path, nil
 	}
 	g, err := getter.NewHTTPGetter()
@@ -207,21 +199,30 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 	if err != nil {
 		return "", fmt.Errorf("store chart %s: %w", chartURL, err)
 	}
-	if err := c.chartRefs.Put(refKey, digest); err != nil {
-		return "", fmt.Errorf("record chart ref %s: %w", refKey, err)
+	if wantDigest != "" && digest != wantDigest {
+		return "", fmt.Errorf("chart %s@%s digest mismatch: index has %s, downloaded %s",
+			hr.Chart.Name, cv.Version, wantDigest, digest)
 	}
 	return filepath.Join(dir, "chart.tgz"), nil
 }
 
-// chartTarballFromCAS returns the on-disk path to a previously-stored
-// chart tarball for refKey, or ("", false) when either the ref is
-// unknown or its digest is no longer materialized in the blob store.
-func (c *Client) chartTarballFromCAS(refKey string) (string, bool) {
-	digest, ok := c.chartRefs.Get(refKey)
-	if !ok || !c.chartBlobs.Exists(digest) {
+func (c *Client) chartTarballByDigest(digest string) (string, bool) {
+	if digest == "" || !c.chartBlobs.Exists(digest) {
 		return "", false
 	}
 	return filepath.Join(c.chartBlobs.Path(digest), "chart.tgz"), true
+}
+
+func normalizeChartDigest(digest string) string {
+	digest = strings.TrimSpace(digest)
+	return strings.TrimPrefix(digest, "sha256:")
+}
+
+func chartDownloadKey(r *manifest.HelmRepository, hr *manifest.HelmRelease, cv *repo.ChartVersion, chartURL, digest string) string {
+	if digest != "" {
+		return "sha256:" + digest
+	}
+	return safeName(r.Namespace+"-"+r.Name+"-"+hr.Chart.Name) + "-" + cv.Version + "@" + chartURL
 }
 
 // helmRepoAuthOptions / helmRepoTLSOptions live in auth.go (paired

--- a/pkg/helm/repo_test.go
+++ b/pkg/helm/repo_test.go
@@ -2,13 +2,21 @@ package helm
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"helm.sh/helm/v4/pkg/getter"
+
+	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 const indexYAMLFixture = `apiVersion: v1
@@ -85,6 +93,91 @@ func TestFetchIndex_DistinctKeysFetchSeparately(t *testing.T) {
 	}
 }
 
+func TestLocateHelmRepoChart_IndexDigestInvalidatesPersistentCache(t *testing.T) {
+	charts := [][]byte{
+		buildChartTarGz(t, "app-template", "1.0.0"),
+		buildChartTarGz(t, "app-template", "1.0.1"),
+	}
+	srv, setChart, hits := startMutableHelmRepo(t, true, charts...)
+	cacheRoot := t.TempDir()
+
+	c1, hr1 := newHelmRepoClient(t, cacheRoot, srv.URL)
+	if _, err := c1.locateHelmRepoChart(context.Background(), hr1); err != nil {
+		t.Fatalf("first locateHelmRepoChart: %v", err)
+	}
+	setChart(1)
+	c2, hr2 := newHelmRepoClient(t, cacheRoot, srv.URL)
+	if _, err := c2.locateHelmRepoChart(context.Background(), hr2); err != nil {
+		t.Fatalf("second locateHelmRepoChart: %v", err)
+	}
+	if got := hits(); got != 2 {
+		t.Fatalf("chart downloads = %d, want 2 after index digest changed", got)
+	}
+}
+
+func TestLocateHelmRepoChart_NoDigestDoesNotPersistMutableVersion(t *testing.T) {
+	charts := [][]byte{
+		buildChartTarGz(t, "app-template", "1.0.0"),
+		buildChartTarGz(t, "app-template", "1.0.1"),
+	}
+	srv, setChart, hits := startMutableHelmRepo(t, false, charts...)
+	cacheRoot := t.TempDir()
+
+	c1, hr1 := newHelmRepoClient(t, cacheRoot, srv.URL)
+	if _, err := c1.locateHelmRepoChart(context.Background(), hr1); err != nil {
+		t.Fatalf("first locateHelmRepoChart: %v", err)
+	}
+	setChart(1)
+	c2, hr2 := newHelmRepoClient(t, cacheRoot, srv.URL)
+	if _, err := c2.locateHelmRepoChart(context.Background(), hr2); err != nil {
+		t.Fatalf("second locateHelmRepoChart: %v", err)
+	}
+	if got := hits(); got != 2 {
+		t.Fatalf("chart downloads = %d, want 2 when index has no digest", got)
+	}
+}
+
+func TestPullHelmRepoOCI_PreservesProvider(t *testing.T) {
+	c, err := NewClient(cacheroot.New(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	wantErr := errors.New("stop")
+	var pulledFor *manifest.OCIRepository
+	c.SetOCIPuller(stubPuller{
+		fetch: func(_ context.Context, r *manifest.OCIRepository) (*store.SourceArtifact, error) {
+			pulledFor = r
+			return nil, wantErr
+		},
+	})
+
+	_, err = c.pullHelmRepoOCI(context.Background(), &manifest.HelmRepository{
+		Name:      "repo",
+		Namespace: "flux-system",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			URL:      "oci://example.com/charts",
+			Type:     manifest.RepoTypeOCI,
+			Provider: sourcev1.AmazonOCIProvider,
+		},
+	}, &manifest.HelmRelease{
+		Name:      "app",
+		Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:    "app-template",
+			Version: "1.0.0",
+		},
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("pullHelmRepoOCI err = %v, want %v", err, wantErr)
+	}
+	if pulledFor == nil {
+		t.Fatal("puller was not invoked")
+	}
+	if pulledFor.Provider != sourcev1.AmazonOCIProvider {
+		t.Fatalf("synthetic OCIRepository provider = %q, want %q", pulledFor.Provider, sourcev1.AmazonOCIProvider)
+	}
+}
+
 func TestOCIPullRef(t *testing.T) {
 	const repo = "oci://ghcr.io/bjw-s-labs/helm/app-template"
 	for _, tc := range []struct {
@@ -104,5 +197,78 @@ func TestOCIPullRef(t *testing.T) {
 				t.Errorf("ociPullRef(%q, %q) = %q, want %q", repo, tc.version, got, tc.want)
 			}
 		})
+	}
+}
+
+func startMutableHelmRepo(t *testing.T, includeDigest bool, charts ...[]byte) (*httptest.Server, func(int32), func() int32) {
+	t.Helper()
+	var current atomic.Int32
+	var hits atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		idx := int(current.Load())
+		digest := ""
+		if includeDigest {
+			digest = chartDigest(charts[idx])
+		}
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(helmRepoIndex(digest)))
+	})
+	mux.HandleFunc("/app-template-1.0.0.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		idx := int(current.Load())
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(charts[idx])
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, func(i int32) { current.Store(i) }, hits.Load
+}
+
+func helmRepoIndex(digest string) string {
+	digestLine := ""
+	if digest != "" {
+		digestLine = fmt.Sprintf("      digest: %s\n", digest)
+	}
+	return fmt.Sprintf(`apiVersion: v1
+entries:
+  app-template:
+    - name: app-template
+      version: 1.0.0
+%s      urls:
+        - app-template-1.0.0.tgz
+`, digestLine)
+}
+
+func chartDigest(chart []byte) string {
+	sum := sha256.Sum256(chart)
+	return hex.EncodeToString(sum[:])
+}
+
+func newHelmRepoClient(t *testing.T, cacheRoot, repoURL string) (*Client, *manifest.HelmRelease) {
+	t.Helper()
+	c, err := NewClient(cacheroot.New(cacheRoot))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	st := store.New()
+	st.AddObject(&manifest.HelmRepository{
+		Name:      "repo",
+		Namespace: "flux-system",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			URL: repoURL,
+		},
+	})
+	c.SetSourceResolver(NewStoreSourceResolver(st))
+	return c, &manifest.HelmRelease{
+		Name:      "app",
+		Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "app-template",
+			Version:       "1.0.0",
+			RepoName:      "repo",
+			RepoNamespace: "flux-system",
+			RepoKind:      manifest.KindHelmRepository,
+		},
 	}
 }

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -283,15 +283,17 @@ func releaseManifest(rel *release.Release, opts Options, disableHooks, skipTests
 	var b strings.Builder
 	b.Grow(size)
 	b.WriteString(rel.Manifest)
+	lastNewline := strings.HasSuffix(rel.Manifest, "\n")
 	if !disableHooks {
 		for _, h := range rel.Hooks {
 			if skipTests && isTestHook(h) {
 				continue
 			}
-			if !strings.HasSuffix(b.String(), "\n") {
+			if !lastNewline {
 				b.WriteByte('\n')
 			}
 			fmt.Fprintf(&b, "---\n# Source: %s\n%s", h.Path, h.Manifest)
+			lastNewline = strings.HasSuffix(h.Manifest, "\n")
 		}
 	}
 	out := b.String()

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -134,7 +135,7 @@ func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(ksFile, out, 0o600)
+	return writeStagedFile(ksFile, out, 0o600)
 }
 
 // findMappingValue returns the value node for the first mapping
@@ -179,6 +180,13 @@ func fetchRemoteResource(ctx context.Context, cache *StagingCache, dir, urlStr s
 		return "", err
 	}
 	return name, nil
+}
+
+func writeStagedFile(path string, data []byte, mode fs.FileMode) error {
+	if err := os.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	return os.WriteFile(path, data, mode) //nolint:gosec // path is inside flate's staged copy
 }
 
 // httpGetURL is the actual network call cache.FetchRemote dispatches

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -131,6 +131,49 @@ func TestPreflightRemoteResources_WalksNestedKustomizations(t *testing.T) {
 	}
 }
 
+func TestRenderFlux_RemotePreflightDoesNotMutateSourceNestedKustomization(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata: {name: remote}\n"))
+	}))
+	t.Cleanup(srv.Close)
+
+	src := t.TempDir()
+	mustWriteFile(t, filepath.Join(src, "kustomization.yaml"), "resources:\n  - ./child\n")
+	child := "resources:\n  - " + srv.URL + "/remote.yaml\n"
+	mustWriteFile(t, filepath.Join(src, "child", "kustomization.yaml"), child)
+
+	cache, err := NewStagingCache(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	_, err = RenderFlux(context.Background(), cache, src, ".", map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata": map[string]any{
+			"name":      "apps",
+			"namespace": "flux-system",
+		},
+		"spec": map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(src, "child", "kustomization.yaml")) //nolint:gosec // src is t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != child {
+		t.Fatalf("source nested kustomization was mutated:\nwant %q\ngot  %q", child, got)
+	}
+	matches, _ := filepath.Glob(filepath.Join(src, "child", ".flate-remote-*.yaml"))
+	if len(matches) != 0 {
+		t.Fatalf("remote preflight wrote fetched files into source tree: %v", matches)
+	}
+}
+
 // TestPreflightRemoteResources_HonorsAlternateFilenames sanity-
 // checks the filename matcher: kustomize accepts kustomization.yml
 // and Kustomization in addition to kustomization.yaml.

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -73,6 +73,7 @@ type ResourceSetInputProvider struct {
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
 	fluxopv1.ResourceSetInputProviderSpec `json:",inline" yaml:",inline"`
+	Status                                fluxopv1.ResourceSetInputProviderStatus `json:"status,omitempty" yaml:"status,omitempty"`
 
 	Labels map[string]string `json:"-" yaml:"-"`
 }
@@ -98,6 +99,7 @@ func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvide
 		Name:                         cr.Name,
 		Namespace:                    cr.Namespace,
 		ResourceSetInputProviderSpec: cr.Spec,
+		Status:                       cr.Status,
 		Labels:                       cr.Labels,
 	}, nil
 }
@@ -109,20 +111,16 @@ func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvide
 // APIs offline. Each returned set is a fresh map[string]any safe for
 // the caller to mutate (e.g. to inject the provider block).
 func (p *ResourceSetInputProvider) ExportedInputs() ([]map[string]any, error) {
+	if len(p.Status.ExportedInputs) > 0 {
+		return decodeResourceSetInputs(p.Status.ExportedInputs)
+	}
 	switch p.Type {
 	case fluxopv1.InputProviderStatic, "":
-		defaults := map[string]any{}
-		for k, v := range p.DefaultValues {
-			if v == nil {
-				defaults[k] = nil
-				continue
-			}
-			var raw any
-			if err := json.Unmarshal(v.Raw, &raw); err != nil {
-				return nil, fmt.Errorf("defaultValues[%s]: %w", k, err)
-			}
-			defaults[k] = raw
+		exported, err := decodeResourceSetInputs([]fluxopv1.ResourceSetInput{p.DefaultValues})
+		if err != nil {
+			return nil, fmt.Errorf("defaultValues: %w", err)
 		}
+		defaults := exported[0]
 		// Upstream injects a synthetic "id" derived from the RSIP UID.
 		// flate has no UIDs; a deterministic hash of namespace/name is
 		// stable across runs and still uniquely identifies the input set
@@ -133,6 +131,26 @@ func (p *ResourceSetInputProvider) ExportedInputs() ([]map[string]any, error) {
 		return []map[string]any{defaults}, nil
 	}
 	return nil, nil
+}
+
+func decodeResourceSetInputs(inputs []fluxopv1.ResourceSetInput) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(inputs))
+	for i, in := range inputs {
+		decoded := map[string]any{}
+		for k, v := range in {
+			if v == nil {
+				decoded[k] = nil
+				continue
+			}
+			var raw any
+			if err := json.Unmarshal(v.Raw, &raw); err != nil {
+				return nil, fmt.Errorf("input[%d].%s: %w", i, k, err)
+			}
+			decoded[k] = raw
+		}
+		out = append(out, decoded)
+	}
+	return out, nil
 }
 
 // derivedID is the placeholder for upstream's UID-derived id field —

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -27,71 +27,35 @@ func (o *Orchestrator) detectDependsOnCycles() [][]manifest.NamedResource {
 	return all
 }
 
-// breakDependsOnCycles detects cycles and strips the dependsOn edges
-// between cycle members so depwait completes immediately. The cycle
-// path is logged for the user to see — flate's reconcile output may
-// then show whatever real failure (or success) the cycle members
-// have once they're no longer waiting on each other. Without this,
-// every cycle member burned its full per-dep budget waiting for a
-// peer that would never become Ready.
-//
-// Stripping is the pragmatic choice: the alternative (pre-marking
-// every member Failed with the cycle message) loses the message when
-// the controller's reconcile overwrites status. The warn log keeps
-// the cycle information visible regardless.
-func (o *Orchestrator) breakDependsOnCycles() {
+// failDependsOnCycles detects cycles and records preflight failures for
+// every cycle member. Flux blocks cyclic dependency graphs; flate must
+// fail those resources before render instead of stripping edges and
+// rendering manifests that would not reconcile in-cluster.
+func (o *Orchestrator) failDependsOnCycles() {
+	o.cycleMu.Lock()
 	cycles := o.detectDependsOnCycles()
-	if len(cycles) == 0 {
-		return
-	}
-	// Collect every id involved in any cycle, keyed by kind, so we can
-	// strip its dependsOn edges only against cycle peers of the same
-	// kind. A KS in a cycle with another KS still keeps any legitimate
-	// dependsOn entry on a non-cycle KS — only the cycle edge goes.
-	inCycle := map[string]map[manifest.NamedResource]struct{}{
-		manifest.KindKustomization: {},
-		manifest.KindHelmRelease:   {},
-	}
+	failures := map[manifest.NamedResource]string{}
 	for _, path := range cycles {
-		slog.Warn("dependency cycle detected; stripping cycle edges to fail fast",
-			"cycle", formatCyclePath(path))
+		msg := "dependency cycle detected: " + formatCyclePath(path)
+		slog.Warn("dependency cycle detected", "cycle", formatCyclePath(path))
 		for _, id := range path {
-			if set, ok := inCycle[id.Kind]; ok {
-				set[id] = struct{}{}
+			if id.Kind == manifest.KindKustomization || id.Kind == manifest.KindHelmRelease {
+				failures[id] = msg
 			}
 		}
 	}
-	for _, k := range store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization) {
-		if _, member := inCycle[manifest.KindKustomization][k.Named()]; !member {
-			continue
-		}
-		stripped := stripCycleDeps(k.DependsOn, inCycle[manifest.KindKustomization])
-		store.Mutate(o.store, k.Named(), func(x *manifest.Kustomization) { x.DependsOn = stripped })
-	}
-	for _, h := range store.ListAs[*manifest.HelmRelease](o.store, manifest.KindHelmRelease) {
-		if _, member := inCycle[manifest.KindHelmRelease][h.Named()]; !member {
-			continue
-		}
-		stripped := stripCycleDeps(h.DependsOn, inCycle[manifest.KindHelmRelease])
-		store.Mutate(o.store, h.Named(), func(x *manifest.HelmRelease) { x.DependsOn = stripped })
-	}
+	cleared := o.replacePreflightFailures(failures)
+	o.cycleMu.Unlock()
+	o.refireClearedPreflightFailures(cleared)
 }
 
-// stripCycleDeps returns deps minus any entry whose target is in the
-// cycle set. The original slice is left untouched (the caller swaps
-// the returned value into a fresh Clone via store.Mutate).
-func stripCycleDeps(deps []manifest.DependencyRef, cycleMembers map[manifest.NamedResource]struct{}) []manifest.DependencyRef {
-	if len(deps) == 0 {
-		return deps
-	}
-	out := make([]manifest.DependencyRef, 0, len(deps))
-	for _, d := range deps {
-		if _, ok := cycleMembers[d.NamedResource]; ok {
-			continue
+func (o *Orchestrator) refireClearedPreflightFailures(ids []manifest.NamedResource) {
+	slices.SortFunc(ids, manifest.NamedResource.Compare)
+	for _, id := range ids {
+		if id.Kind == manifest.KindKustomization || id.Kind == manifest.KindHelmRelease {
+			o.store.Refire(id)
 		}
-		out = append(out, d)
 	}
-	return out
 }
 
 // findDependencyCycles walks the dependsOn graph of one kind using

--- a/pkg/orchestrator/cycles_test.go
+++ b/pkg/orchestrator/cycles_test.go
@@ -63,14 +63,13 @@ func TestDetectDependsOnCycles_NoCycleNoOutput(t *testing.T) {
 	}
 }
 
-// TestBreakDependsOnCycles_StripsCycleEdges verifies the runtime
-// behavior the user cares about: after Bootstrap, KSes that were in
-// a cycle have their cycle-closing dependsOn entries dropped. Their
-// reconcile won't hang 30s waiting on a peer that can't become Ready.
-func TestBreakDependsOnCycles_StripsCycleEdges(t *testing.T) {
+// TestFailDependsOnCycles_RecordsPreflightFailures verifies the runtime
+// behavior the user cares about: cycle members fail before render, while
+// their Flux dependsOn graph remains intact.
+func TestFailDependsOnCycles_RecordsPreflightFailures(t *testing.T) {
 	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
 	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
-	// `extra` is an acyclic dep — it must SURVIVE the strip.
+	// `extra` is an acyclic dep — it must not be marked failed.
 	idExtra := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "extra"}
 
 	o := &Orchestrator{store: store.New()}
@@ -78,58 +77,90 @@ func TestBreakDependsOnCycles_StripsCycleEdges(t *testing.T) {
 	o.store.AddObject(makeKS("b", "ns", idA))
 	o.store.AddObject(makeKS("extra", "ns"))
 
-	o.breakDependsOnCycles()
+	o.failDependsOnCycles()
 
 	a, _ := o.store.GetObject(idA).(*manifest.Kustomization)
 	b, _ := o.store.GetObject(idB).(*manifest.Kustomization)
 	if a == nil || b == nil {
 		t.Fatal("post-Bootstrap objects went missing")
 	}
-	// a should no longer depend on b (cycle edge), but should still
-	// depend on extra (acyclic).
-	for _, d := range a.DependsOn {
-		if d.NamedResource == idB {
-			t.Errorf("a→b cycle edge not stripped from a.DependsOn: %+v", a.DependsOn)
+	if len(a.DependsOn) != 2 || len(b.DependsOn) != 1 {
+		t.Fatalf("cycle detection must not rewrite dependsOn: a=%+v b=%+v", a.DependsOn, b.DependsOn)
+	}
+	for _, id := range []manifest.NamedResource{idA, idB} {
+		msg, ok := o.preflightFailure(id)
+		if !ok || !strings.Contains(msg, "dependency cycle detected") {
+			t.Fatalf("%s preflight failure = %q, %v", id, msg, ok)
 		}
 	}
-	hasExtra := false
-	for _, d := range a.DependsOn {
-		if d.NamedResource == idExtra {
-			hasExtra = true
-		}
+	if msg, ok := o.preflightFailure(idExtra); ok {
+		t.Fatalf("acyclic dependency was marked failed: %q", msg)
 	}
-	if !hasExtra {
-		t.Errorf("a→extra acyclic dep was stripped along with the cycle edge: %+v", a.DependsOn)
+}
+
+func TestFailDependsOnCycles_ClearsResolvedCycle(t *testing.T) {
+	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+
+	o := &Orchestrator{store: store.New()}
+	o.store.AddObject(makeKS("a", "ns", idB))
+	o.store.AddObject(makeKS("b", "ns", idA))
+	o.failDependsOnCycles()
+	if msg, ok := o.preflightFailure(idA); !ok || !strings.Contains(msg, "dependency cycle detected") {
+		t.Fatalf("initial cycle was not recorded: %q, %v", msg, ok)
 	}
-	// b should have lost its only edge.
-	for _, d := range b.DependsOn {
-		if d.NamedResource == idA {
-			t.Errorf("b→a cycle edge not stripped: %+v", b.DependsOn)
+
+	o.store.AddObject(makeKS("a", "ns"))
+	o.failDependsOnCycles()
+	for _, id := range []manifest.NamedResource{idA, idB} {
+		if msg, ok := o.preflightFailure(id); ok {
+			t.Fatalf("resolved cycle member still has preflight failure %s: %q", id, msg)
 		}
 	}
 }
 
-// TestBreakDependsOnCycles_RenderEmittedCycle verifies the runtime
+func TestFailDependsOnCycles_RefiresResolvedMembers(t *testing.T) {
+	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+
+	o := &Orchestrator{store: store.New()}
+	o.store.AddObject(makeKS("a", "ns", idB))
+	o.store.AddObject(makeKS("b", "ns", idA))
+	o.failDependsOnCycles()
+
+	seen := map[manifest.NamedResource]int{}
+	o.store.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
+		seen[id]++
+	}, false)
+
+	o.store.AddObject(makeKS("a", "ns"))
+	o.failDependsOnCycles()
+
+	if seen[idB] == 0 {
+		t.Fatal("resolved cycle member b was not refired after preflight failure cleared")
+	}
+}
+
+// TestFailDependsOnCycles_RenderEmittedCycle verifies the runtime
 // cycle-detection listener: when a parent KS's render emits two
 // children whose dependsOn closes a loop, the orchestrator's
-// post-Bootstrap listener re-runs breakDependsOnCycles and strips
-// the cycle edges. Pre-fix, Bootstrap's one-shot pass never saw the
-// emitted nodes and every cycle member burned its full per-dep
-// timeout waiting on a peer that would never become Ready.
+// post-Bootstrap listener re-runs failDependsOnCycles and records
+// preflight failures. Bootstrap's one-shot pass never saw the emitted
+// nodes.
 //
-// The test invokes breakDependsOnCycles directly (mirrors what the
+// The test invokes failDependsOnCycles directly (mirrors what the
 // Run-time listener does) AFTER adding the emit'd children to the
 // store. End-to-end coverage of the listener wiring sits in the
 // e2e suite — but pinning the load-bearing behavior here keeps the
 // listener honest if it ever gets refactored.
-func TestBreakDependsOnCycles_RenderEmittedCycle(t *testing.T) {
+func TestFailDependsOnCycles_RenderEmittedCycle(t *testing.T) {
 	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
 	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
 
 	o := &Orchestrator{store: store.New()}
 	// Bootstrap-time graph: just one acyclic KS. No cycles to break.
 	o.store.AddObject(makeKS("acyclic", "ns"))
-	o.breakDependsOnCycles()
+	o.failDependsOnCycles()
 
 	// Now simulate the render-emit: a parent KS adds two children
 	// whose dependsOn closes a loop. Bootstrap's pass missed these.
@@ -137,17 +168,17 @@ func TestBreakDependsOnCycles_RenderEmittedCycle(t *testing.T) {
 	o.store.AddObject(makeKS("b", "ns", idA))
 	// Re-run the cycle detector (the post-Bootstrap listener fires
 	// this on every KS/HR add).
-	o.breakDependsOnCycles()
+	o.failDependsOnCycles()
 
 	a, _ := o.store.GetObject(idA).(*manifest.Kustomization)
 	b, _ := o.store.GetObject(idB).(*manifest.Kustomization)
 	if a == nil || b == nil {
 		t.Fatal("emitted children went missing")
 	}
-	if len(a.DependsOn) != 0 {
-		t.Errorf("a's cycle edge not stripped post-emit: %+v", a.DependsOn)
-	}
-	if len(b.DependsOn) != 0 {
-		t.Errorf("b's cycle edge not stripped post-emit: %+v", b.DependsOn)
+	for _, id := range []manifest.NamedResource{idA, idB} {
+		msg, ok := o.preflightFailure(id)
+		if !ok || !strings.Contains(msg, "dependency cycle detected") {
+			t.Fatalf("%s preflight failure = %q, %v", id, msg, ok)
+		}
 	}
 }

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -77,17 +77,10 @@ func (o *Orchestrator) finalize() error {
 
 // cascadeParentFailures downgrades render-emitted children whose
 // ancestor (via renderedSet.ParentOf) ended up Failed. Closes a race
-// window where a parent KS's first reconcile transiently sets Ready
-// (validateDependsOn dropped a dangling dep at Bootstrap; reconcile
-// passes; renders; emits children; sets Ready), then a sibling
-// parent's render re-emits the parent with the dropped dep
-// restored, the second reconcile fails, and the children that
-// already observed the brief Ready window have proceeded to their
-// own Ready state. Without this cascade, dependents that raced past
-// their parent gate stay Ready in the final report even though the
-// parent is Failed — producing the "sometimes only the KS fails,
-// sometimes both fail" non-determinism users hit on typo'd
-// dependsOn.
+// window where a parent KS's first reconcile sets Ready, emits
+// children, and then a later re-emission of that parent fails. Without
+// this cascade, dependents that already passed their parent gate stay
+// Ready in the final report even though the parent is Failed.
 //
 // Walks the ParentOf chain per child so a deep render tree (grand-
 // parent → parent → child) propagates failures all the way down in

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -141,6 +140,14 @@ type Orchestrator struct {
 	// from genuine successes. Keyed by id, value is the original
 	// failure message.
 	orphans map[manifest.NamedResource]string
+
+	// preflightFailures records dependency cycles found before a
+	// controller renders the resource. Controllers consult it from
+	// their object listeners and mark the resource Failed instead of
+	// waiting on a graph that cannot converge.
+	cycleMu           sync.Mutex
+	preflightMu       sync.RWMutex
+	preflightFailures map[manifest.NamedResource]string
 
 	// rsExtensions holds non-Flux docs produced by ResourceSet renders,
 	// keyed by the owning structural-parent Kustomization. Populated
@@ -320,10 +327,8 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	o.parentOf = res.ParentOf
 	o.existence = res.Existence
 
-	o.validateDependsOn()
-	o.breakDependsOnCycles()
+	o.failDependsOnCycles()
 	o.warnOnDisabledOCIFeatures()
-	o.warnOnUnsupportedHelmRepoSecretRef()
 	o.warnOnKSOCISourceRefWithoutOCI()
 	if err := o.buildChangeFilter(res.RepoRoot); err != nil {
 		return err
@@ -373,32 +378,6 @@ func (o *Orchestrator) warnOnDisabledOCIFeatures() {
 	}
 }
 
-// warnOnUnsupportedHelmRepoSecretRef surfaces the OCI-HelmRepository
-// + SecretRef gap at bootstrap. The helm-side
-// locateHelmRepoChart hard-errors at render time on this combo
-// (see pkg/helm/repo.go) — by then the user is one helm template
-// failure deep into a reconcile pass with a non-obvious "not yet
-// implemented" message. Warn up front so the operator can switch
-// the manifests to OCIRepository CRs (the recommended workaround)
-// before iterating.
-//
-// Triggered for any HelmRepository whose spec.type is "oci" OR
-// whose URL starts with `oci://` AND has a SecretRef — matches
-// the render-time check exactly.
-func (o *Orchestrator) warnOnUnsupportedHelmRepoSecretRef() {
-	for _, repo := range store.ListAs[*manifest.HelmRepository](o.store, manifest.KindHelmRepository) {
-		if repo.SecretRef == nil {
-			continue
-		}
-		if repo.Type != manifest.RepoTypeOCI && !strings.HasPrefix(repo.URL, "oci://") {
-			continue
-		}
-		slog.Warn("HelmRepository: SecretRef on OCI HelmRepositories is not yet implemented and will fail at render time; reference the chart via a sibling OCIRepository CR instead",
-			"helmRepository", repo.Namespace+"/"+repo.Name,
-			"url", repo.URL)
-	}
-}
-
 // warnOnKSOCISourceRefWithoutOCI surfaces the EnableOCI=false +
 // KS-sourceRef=OCIRepository combo at bootstrap. Without OCI
 // reconciliation, source/ExistenceFetcher gives the OCIRepository a
@@ -422,38 +401,31 @@ func (o *Orchestrator) warnOnKSOCISourceRefWithoutOCI() {
 	}
 }
 
-// validateDependsOn drops dangling dependsOn references on both
-// Kustomizations and HelmReleases so the dependency-wait phase fails
-// fast on typos instead of stalling out the full per-dep budget.
-func (o *Orchestrator) validateDependsOn() {
-	known := map[string]map[string]struct{}{
-		manifest.KindKustomization: {},
-		manifest.KindHelmRelease:   {},
-	}
-	ksList := store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization)
-	for _, ks := range ksList {
-		known[manifest.KindKustomization][ks.Named().NamespacedName()] = struct{}{}
-	}
-	hrList := store.ListAs[*manifest.HelmRelease](o.store, manifest.KindHelmRelease)
-	for _, hr := range hrList {
-		known[manifest.KindHelmRelease][hr.Named().NamespacedName()] = struct{}{}
-	}
-	// Mutate via the Store helper — encodes the clone-then-AddObject
-	// contract so callers don't have to remember it.
-	for _, ks := range ksList {
-		kept, dropped := manifest.FilterDependsOn(ks.DependsOn, known[manifest.KindKustomization])
-		if dropped == 0 {
-			continue
+func (o *Orchestrator) replacePreflightFailures(failures map[manifest.NamedResource]string) []manifest.NamedResource {
+	o.preflightMu.Lock()
+	defer o.preflightMu.Unlock()
+	var cleared []manifest.NamedResource
+	for id := range o.preflightFailures {
+		if _, stillFailed := failures[id]; !stillFailed {
+			cleared = append(cleared, id)
 		}
-		store.Mutate(o.store, ks.Named(), func(k *manifest.Kustomization) { k.DependsOn = kept })
 	}
-	for _, hr := range hrList {
-		kept, dropped := manifest.FilterDependsOn(hr.DependsOn, known[manifest.KindHelmRelease])
-		if dropped == 0 {
-			continue
-		}
-		store.Mutate(o.store, hr.Named(), func(h *manifest.HelmRelease) { h.DependsOn = kept })
+	if len(failures) == 0 {
+		o.preflightFailures = nil
+		return cleared
 	}
+	o.preflightFailures = make(map[manifest.NamedResource]string, len(failures))
+	for id, msg := range failures {
+		o.preflightFailures[id] = msg
+	}
+	return cleared
+}
+
+func (o *Orchestrator) preflightFailure(id manifest.NamedResource) (string, bool) {
+	o.preflightMu.RLock()
+	defer o.preflightMu.RUnlock()
+	msg, ok := o.preflightFailures[id]
+	return msg, ok
 }
 
 // buildChangeFilter computes the file-level change set (if changed-only
@@ -641,45 +613,58 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}
 	renders := &orchestratorRenderInflight{tasks: o.tasks}
 	o.ksc.Configure(kustomization.Options{
-		Filter:        o.filter,
-		ParentOf:      parentResolver,
-		RenderTracker: o.rendered,
-		Existence:     existence,
-		Renders:       renders,
+		Filter:           o.filter,
+		ParentOf:         parentResolver,
+		RenderTracker:    o.rendered,
+		Existence:        existence,
+		Renders:          renders,
+		PreflightFailure: o.preflightFailure,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
-		Filter:    o.filter,
-		ParentOf:  parentResolver,
-		Existence: existence,
-		Renders:   renders,
+		Filter:           o.filter,
+		ParentOf:         parentResolver,
+		Existence:        existence,
+		Renders:          renders,
+		PreflightFailure: o.preflightFailure,
 	})
 	// Re-detect dependsOn cycles when render-emitted children land.
 	// Bootstrap's one-shot pass only sees file-loaded resources; a
-	// parent KS render that emits a child with a dependsOn pointing
-	// at another freshly-emitted (or pre-existing) peer can introduce
-	// a cycle invisible to the Bootstrap pass. breakDependsOnCycles
+	// parent KS render that emits a child with a dependsOn pointing at
+	// another freshly-emitted (or pre-existing) peer can introduce a
+	// cycle invisible to the Bootstrap pass. failDependsOnCycles
 	// short-circuits when no cycle is present (O(N+E) DFS, then
-	// early-return), so re-running on every KS/HR add is cheap even
-	// on render-heavy passes.
+	// early-return), so re-running on every KS/HR add is cheap even on
+	// render-heavy passes.
 	//
-	// REGISTERED BEFORE the controllers: listeners fire in
-	// registration order, so this strips cycle edges via store.Mutate
-	// synchronously BEFORE the controllers' listeners spawn their
-	// reconcile goroutines. Without the ordering the controller
-	// goroutine could read the un-stripped DependsOn from the store
-	// concurrently with cycle-stripping and burn its full per-dep
-	// Timeout waiting on a peer that's also waiting on it.
+	// REGISTERED BEFORE the controllers: listeners fire in registration
+	// order, so this records preflight failures synchronously BEFORE the
+	// controllers' listeners spawn their reconcile goroutines. Without
+	// the ordering the controller goroutine could start waiting on a peer
+	// that's also waiting on it.
 	unsubCycles := o.store.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
 		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
 			return
 		}
-		o.breakDependsOnCycles()
+		o.failDependsOnCycles()
 	}, false)
 	defer unsubCycles()
 
+	// Keep depwait's render-quiescence signal open while listener
+	// flushes submit the bootstrap objects. Without this marker, a
+	// Kustomization can start waiting on a render-emitted dependency
+	// before the producer's replay event has been submitted and
+	// incorrectly conclude that the render pool is drained.
+	startupDone := make(chan struct{})
+	o.tasks.Go(ctx, "orchestrator/startup", func(ctx context.Context) {
+		select {
+		case <-startupDone:
+		case <-ctx.Done():
+		}
+	})
 	o.src.Start(ctx)
 	o.ksc.Start(ctx)
 	o.hrc.Start(ctx)
+	close(startupDone)
 	defer o.Stop()
 
 	// Race ctx.Done() against task drain so a Ctrl-C during a stuck
@@ -728,7 +713,7 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 	// pre-Bootstrap renders see only literal-file RSIPs and miss
 	// these. The output attributes non-Flux children to the owning
 	// parent KS so `flate build` surfaces them.
-	o.expandResourceSetsPostRun()
+	rsErr := o.expandResourceSetsPostRun(ctx)
 	res := &Result{
 		Manifests: map[manifest.NamedResource][]map[string]any{},
 		Failed:    map[manifest.NamedResource]store.StatusInfo{},
@@ -775,7 +760,7 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 		res.Failed[id] = info
 	}
 	maps.Copy(res.Orphans, o.orphans)
-	return res, runErr
+	return res, errors.Join(runErr, rsErr)
 }
 
 // Stop shuts the controllers down in reverse-construction order and

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -3,9 +3,12 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
@@ -191,6 +194,78 @@ data: {k: v}
 	}
 }
 
+func TestOrchestrator_DependsOnCanArriveFromRenderedKustomization(t *testing.T) {
+	dir := t.TempDir()
+	produced := `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: produced
+  namespace: flux-system
+spec:
+  path: ./produced
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(produced))
+	}))
+	t.Cleanup(srv.Close)
+	testutil.WriteFile(t, dir, "flux/producer.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: producer
+  namespace: flux-system
+spec:
+  path: ./producer
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "flux/consumer.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: consumer
+  namespace: flux-system
+spec:
+  path: ./consumer
+  dependsOn:
+    - name: produced
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "producer/kustomization.yaml", "resources:\n- "+srv.URL+"/produced.yaml\n")
+	testutil.WriteFile(t, dir, "consumer/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "consumer/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: consumer}
+data: {k: v}
+`)
+	testutil.WriteFile(t, dir, "produced/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "produced/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: produced}
+data: {k: v}
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	consumerID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "consumer"}
+	if msg, ok := o.preflightFailure(consumerID); ok {
+		t.Fatalf("consumer should wait for rendered dependency, not fail preflight: %s", msg)
+	}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, name := range []string{"produced", "consumer"} {
+		id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+		info, ok := o.Store().GetStatus(id)
+		if !ok || info.Status != store.StatusReady {
+			t.Fatalf("%s status = (%+v, %v), want Ready", id, info, ok)
+		}
+	}
+}
+
 func TestOrchestrator_RunReturnsContextCancellation(t *testing.T) {
 	dir := t.TempDir()
 	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -223,6 +298,56 @@ data: {k: v}
 	cancel()
 	if err := o.Run(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run with pre-canceled context = %v, want context.Canceled", err)
+	}
+}
+
+func TestExpandResourceSetsPostRun_ReturnsRenderError(t *testing.T) {
+	parent := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	rs := &manifest.ResourceSet{
+		Name: "broken", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			ResourcesTemplate: `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: << inputs.nonexistent >>
+`,
+		},
+	}
+	o := &Orchestrator{
+		store:    store.New(),
+		rendered: newRenderedSet(),
+		sourceFiles: map[manifest.NamedResource]string{
+			rs.Named(): "apps/resourceset.yaml",
+		},
+	}
+	o.store.AddObject(parent)
+	o.store.AddObject(rs)
+
+	err := o.expandResourceSetsPostRun(context.Background())
+	if err == nil {
+		t.Fatal("expected ResourceSet render error")
+	}
+	if !strings.Contains(err.Error(), "ResourceSet/flux-system/broken") {
+		t.Fatalf("error should identify ResourceSet: %v", err)
+	}
+	info, ok := o.store.GetStatus(rs.Named())
+	if !ok || info.Status != store.StatusFailed {
+		t.Fatalf("ResourceSet status = (%+v, %v), want Failed", info, ok)
+	}
+}
+
+func TestExpandResourceSetsPostRun_RespectsCanceledContext(t *testing.T) {
+	rs := &manifest.ResourceSet{Name: "apps", Namespace: "flux-system"}
+	o := &Orchestrator{store: store.New()}
+	o.store.AddObject(rs)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := o.expandResourceSetsPostRun(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expandResourceSetsPostRun canceled = %v, want context.Canceled", err)
 	}
 }
 

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"cmp"
+	"context"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -29,10 +30,13 @@ import (
 // it's too late in the pipeline to add reconcilable objects. Discovery
 // is the canonical seeding point for Flux-kind RS children; this pass
 // only handles the visibility gap for non-Flux output.
-func (o *Orchestrator) expandResourceSetsPostRun() {
+func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 	rsList := store.ListAs[*manifest.ResourceSet](o.store, manifest.KindResourceSet)
 	if len(rsList) == 0 {
-		return
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	// Owner index keyed by deepest spec.path prefix wins, mirroring
 	// loader.BuildParentIndex. The RS's source-file path lives below
@@ -83,12 +87,19 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 		seen = map[string]struct{}{}
 		out  = map[manifest.NamedResource][]map[string]any{}
 	)
-	g := new(errgroup.Group)
+	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(8)
 	for _, rs := range rsList {
 		g.Go(func() error {
+			if err := gctx.Err(); err != nil {
+				return err
+			}
 			docs, err := resourceset.Render(rs, o.resolveInputProvider)
-			if err != nil || len(docs) == 0 {
+			if err != nil {
+				o.store.UpdateStatus(rs.Named(), store.StatusFailed, err.Error())
+				return err
+			}
+			if len(docs) == 0 {
 				return nil
 			}
 			// Resolve parent KS in priority order:
@@ -154,8 +165,22 @@ func (o *Orchestrator) expandResourceSetsPostRun() {
 			return nil
 		})
 	}
-	_ = g.Wait() // render errors are intentionally swallowed (same as before)
+	err := g.Wait()
 	o.rsExtensions = out
+	if err != nil {
+		failed := map[manifest.NamedResource]store.StatusInfo{}
+		for _, rs := range rsList {
+			id := rs.Named()
+			if info, ok := o.store.GetStatus(id); ok && info.Status == store.StatusFailed {
+				failed[id] = info
+			}
+		}
+		if len(failed) > 0 {
+			return o.aggregateFailures(failed)
+		}
+		return err
+	}
+	return nil
 }
 
 // resolveInputProvider mirrors discovery.resolveInputProvider but

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -556,6 +556,75 @@ func TestRender_MissingKeyErrors(t *testing.T) {
 	}
 }
 
+func TestRender_UsesResourceSetInputProviderStatusExportedInputs(t *testing.T) {
+	rs := &manifest.ResourceSet{
+		Name: "apps", Namespace: "flux-system",
+		ResourceSetSpec: fluxopv1.ResourceSetSpec{
+			InputsFrom: []fluxopv1.InputProviderReference{{
+				Kind: manifest.KindResourceSetInputProvider, Name: "branches",
+			}},
+			Resources: []*apix.JSON{
+				jsonTmpl(t, `{
+					"apiVersion": "v1", "kind": "ConfigMap",
+					"metadata": {"name": "<< inputs.name >>", "namespace": "flux-system"},
+					"data": {"id": "<< inputs.id >>"}
+				}`),
+			},
+		},
+	}
+	rsip := &manifest.ResourceSetInputProvider{
+		Name: "branches", Namespace: "flux-system",
+		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+			Type: fluxopv1.InputProviderGitHubBranch,
+		},
+		Status: fluxopv1.ResourceSetInputProviderStatus{
+			ExportedInputs: []fluxopv1.ResourceSetInput{{
+				"name": jsonTmpl(t, `"feature-a"`),
+				"id":   jsonTmpl(t, `"status-id"`),
+			}},
+		},
+	}
+
+	docs, err := resourceset.Render(rs, func(fluxopv1.InputProviderReference, string) ([]*manifest.ResourceSetInputProvider, error) {
+		return []*manifest.ResourceSetInputProvider{rsip}, nil
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected one status-exported doc, got %d", len(docs))
+	}
+	if docs[0]["metadata"].(map[string]any)["name"] != "feature-a" {
+		t.Fatalf("status exported name not used: %+v", docs[0])
+	}
+	if docs[0]["data"].(map[string]any)["id"] != "status-id" {
+		t.Fatalf("status exported id should be preserved: %+v", docs[0])
+	}
+}
+
+func TestResourceSetInputProvider_StatusExportedInputsOverrideDerivedID(t *testing.T) {
+	rsip := &manifest.ResourceSetInputProvider{
+		Name: "static", Namespace: "flux-system",
+		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
+			Type:          fluxopv1.InputProviderStatic,
+			DefaultValues: fluxopv1.ResourceSetInput{"id": jsonTmpl(t, `"default-id"`)},
+		},
+		Status: fluxopv1.ResourceSetInputProviderStatus{
+			ExportedInputs: []fluxopv1.ResourceSetInput{{
+				"id": jsonTmpl(t, `"exported-id"`),
+			}},
+		},
+	}
+
+	inputs, err := rsip.ExportedInputs()
+	if err != nil {
+		t.Fatalf("ExportedInputs: %v", err)
+	}
+	if len(inputs) != 1 || inputs[0]["id"] != "exported-id" {
+		t.Fatalf("status exported id should win, got %+v", inputs)
+	}
+}
+
 // TestRender_MalformedTemplateErrors surfaces a parse error rather than
 // silently swallowing the broken template.
 func TestRender_MalformedTemplateErrors(t *testing.T) {

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -349,5 +350,20 @@ func TestSlugifyRepo(t *testing.T) {
 		if got := slugifyRepo(in); got != want {
 			t.Errorf("slugifyRepo(%q) = %q want %q", in, got, want)
 		}
+	}
+}
+
+func TestMutableCacheKeyIsUnique(t *testing.T) {
+	base := "branch:main#opts:abc123"
+	a := MutableCacheKey(base)
+	b := MutableCacheKey(base)
+	if a == b {
+		t.Fatalf("MutableCacheKey returned the same key twice: %q", a)
+	}
+	if !strings.HasPrefix(a, base+"#mutable:") {
+		t.Fatalf("MutableCacheKey(%q) = %q", base, a)
+	}
+	if !strings.HasPrefix(b, base+"#mutable:") {
+		t.Fatalf("MutableCacheKey(%q) = %q", base, b)
 	}
 }

--- a/pkg/source/git/checkout.go
+++ b/pkg/source/git/checkout.go
@@ -37,6 +37,9 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef, sparse []s
 	}
 	switch {
 	case ref.Commit != "":
+		if err := validateCommitBranch(repo, plumbing.NewHash(ref.Commit), ref.Branch); err != nil {
+			return err
+		}
 		return checkout(func(o *git.CheckoutOptions) { o.Hash = plumbing.NewHash(ref.Commit) })
 	case ref.Name != "":
 		// Full ref name takes precedence (e.g. "refs/pull/420/head",

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -15,7 +15,10 @@ package git
 import (
 	"cmp"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -106,19 +109,23 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		return nil, fmt.Errorf("%w: GitRepository %s missing url", manifest.ErrInput, repo.RepoName())
 	}
 
-	refStr := "HEAD"
+	refLabel := "HEAD"
 	if repo.Reference != nil {
-		refStr = cmp.Or(manifest.GitRefString(*repo.Reference), refStr)
+		refLabel = cmp.Or(gitRefLabel(*repo.Reference), refLabel)
+	}
+	slotRef := gitCacheKey(repo, refLabel)
+	if !canUseCachedGitSlot(repo.Reference) {
+		slotRef = source.MutableCacheKey(slotRef)
 	}
 
 	authID := authIdentity(repo)
-	slot, err := cache.Slot(ctx, repo.URL, refStr, authID)
+	slot, err := cache.Slot(ctx, repo.URL, slotRef, authID)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", repo.URL, err)
 	}
 	defer slot.Release()
 
-	if slot.Exists {
+	if slot.Exists && canUseCachedGitSlot(repo.Reference) {
 		// The flate-revision marker is written AFTER a successful
 		// clone+checkout (and committed via atomic rename only after
 		// the marker write), so any committed slot will have it. A
@@ -137,6 +144,13 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		if err := slot.Stage(); err != nil {
 			return nil, err
 		}
+	} else if slot.Exists {
+		if err := slot.Reset(); err != nil {
+			return nil, err
+		}
+		if err := slot.Stage(); err != nil {
+			return nil, err
+		}
 	}
 
 	url := repo.URL
@@ -146,7 +160,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	}
 
 	if f.canUseMirror(repo, url) {
-		return f.fetchViaMirror(ctx, repo, refStr, slot, auth, proxy, tlsCfg)
+		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy, tlsCfg)
 	}
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
@@ -177,7 +191,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		return nil, err
 	}
 	if err := checkoutRef(cloned, ref, repo.SparseCheckout); err != nil {
-		return nil, fmt.Errorf("checkout %s: %w", refStr, err)
+		return nil, fmt.Errorf("checkout %s: %w", refLabel, err)
 	}
 	if repo.RecurseSubmodules {
 		if err := updateSubmodules(cloned, auth); err != nil {
@@ -205,6 +219,56 @@ func effectiveNamedRef(ref manifest.GitRepositoryRef) string {
 		return ""
 	}
 	return ref.Name
+}
+
+func gitRefLabel(ref manifest.GitRepositoryRef) string {
+	if ref.Commit != "" && ref.Branch != "" {
+		return "branch:" + ref.Branch + "@commit:" + ref.Commit
+	}
+	return manifest.GitRefString(ref)
+}
+
+func gitCacheKey(repo *manifest.GitRepository, refLabel string) string {
+	ignore := ""
+	if repo.Ignore != nil {
+		ignore = *repo.Ignore
+	}
+	payload := struct {
+		Ref               string   `json:"ref"`
+		Ignore            string   `json:"ignore,omitempty"`
+		SparseCheckout    []string `json:"sparseCheckout,omitempty"`
+		RecurseSubmodules bool     `json:"recurseSubmodules,omitempty"`
+		Verify            string   `json:"verify,omitempty"`
+	}{
+		Ref:               refLabel,
+		Ignore:            ignore,
+		SparseCheckout:    append([]string(nil), repo.SparseCheckout...),
+		RecurseSubmodules: repo.RecurseSubmodules,
+		Verify:            gitVerifyCacheKey(repo.Namespace, repo.Verification),
+	}
+	return refLabel + "#opts:" + cacheKeyHash(payload)
+}
+
+func gitVerifyCacheKey(namespace string, v *manifest.GitRepositoryVerify) string {
+	if v == nil {
+		return ""
+	}
+	return string(v.GetMode()) + ":" + namespace + "/" + v.SecretRef.Name
+}
+
+func cacheKeyHash(v any) string {
+	b, _ := json.Marshal(v)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:8])
+}
+
+func canUseCachedGitSlot(ref *manifest.GitRepositoryRef) bool {
+	return ref != nil &&
+		ref.Commit != "" &&
+		ref.Branch == "" &&
+		ref.Tag == "" &&
+		ref.SemVer == "" &&
+		ref.Name == ""
 }
 
 func fetchExplicitNamedRef(ctx context.Context, repo *git.Repository, auth transport.AuthMethod, proxy *source.ProxyConfig, name string) error {

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -39,13 +41,69 @@ func TestFetcher_LocalFileURL(t *testing.T) {
 		t.Errorf("expected checked-out file: %v", err)
 	}
 
-	// Second call should reuse cache.
 	art2, err := f.Fetch(context.Background(), repo)
 	if err != nil {
 		t.Fatalf("Fetch second: %v", err)
 	}
-	if art2.LocalPath != sa.LocalPath {
-		t.Errorf("cache slot changed: %s vs %s", sa.LocalPath, art2.LocalPath)
+	if art2.Revision != sa.Revision {
+		t.Errorf("unchanged default ref revision changed: %s vs %s", sa.Revision, art2.Revision)
+	}
+}
+
+func TestFetcher_MutableDefaultRefRefreshesCache(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
+	repo := &manifest.GitRepository{
+		Name: "test", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+	}
+	f := &Fetcher{Cache: cache}
+
+	art1, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch first: %v", err)
+	}
+	want := mustCommitFile(t, src, "later.txt", "new content")
+	art2, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch second: %v", err)
+	}
+	if art2.Revision == art1.Revision {
+		t.Fatalf("mutable default ref reused stale revision %s", art2.Revision)
+	}
+	if art2.Revision != want {
+		t.Fatalf("revision = %s, want %s", art2.Revision, want)
+	}
+	if _, err := os.Stat(filepath.Join(art2.LocalPath, "later.txt")); err != nil {
+		t.Fatalf("refreshed checkout missing later.txt: %v", err)
+	}
+}
+
+func TestFetcher_MutableRefreshFailureKeepsPreviousSlot(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
+	repo := &manifest.GitRepository{
+		Name: "test", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+	}
+	f := &Fetcher{Cache: cache}
+
+	art, err := f.Fetch(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("Fetch first: %v", err)
+	}
+	if err := os.RemoveAll(src); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Fetch(context.Background(), repo); err == nil {
+		t.Fatal("expected refresh to fail after removing upstream repo")
+	}
+	if _, err := os.Stat(filepath.Join(art.LocalPath, "hello.txt")); err != nil {
+		t.Fatalf("failed mutable refresh removed previous committed slot: %v", err)
 	}
 }
 
@@ -215,6 +273,46 @@ func TestFetcher_CommitPrecedesUnresolvableRefName(t *testing.T) {
 	}
 }
 
+func TestFetcher_CommitMustBeReachableFromBranch(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+	initial := mustHead(t, src)
+	mainOnly := mustCommitFile(t, src, "main-only.txt", "main")
+	mustSetRefToHash(t, src, "refs/heads/staging", initial)
+
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
+	f := &Fetcher{Cache: cache}
+
+	commitOnly := &manifest.GitRepository{
+		Name: "commit-only", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Commit: mainOnly},
+		},
+	}
+	if _, err := f.Fetch(context.Background(), commitOnly); err != nil {
+		t.Fatalf("commit-only fetch should populate the unconstrained cache slot: %v", err)
+	}
+
+	constrained := &manifest.GitRepository{
+		Name: "constrained", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL: "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "staging",
+				Commit: mainOnly,
+			},
+		},
+	}
+	_, err := f.Fetch(context.Background(), constrained)
+	if err == nil {
+		t.Fatal("expected branch-constrained commit fetch to fail")
+	}
+	if !strings.Contains(err.Error(), "not reachable from branch") {
+		t.Fatalf("error should explain branch reachability, got %v", err)
+	}
+}
+
 // TestFetcher_SparseCheckout exercises spec.sparseCheckout — when
 // the repo declares specific directories, the worktree contains only
 // those (plus any tree-root metadata go-git keeps).
@@ -295,11 +393,13 @@ func TestFetcher_CacheMarkerSurvivesIgnore(t *testing.T) {
 
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	patterns := "/*\n!/hello.txt\n"
+	commit := mustHead(t, src)
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
 		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:    "file://" + src,
-			Ignore: &patterns,
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+			Ignore:    &patterns,
 		},
 	}
 	f := &Fetcher{Cache: cache}
@@ -326,6 +426,111 @@ func TestFetcher_CacheMarkerSurvivesIgnore(t *testing.T) {
 	}
 	if art2.Revision != string(b) {
 		t.Errorf("warm Fetch returned a different revision: %q vs %q", art2.Revision, string(b))
+	}
+}
+
+func TestFetcher_CommitCacheKeyIncludesIgnore(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{
+		"hello.txt": "hello",
+		"docs.md":   "docs",
+	})
+	commit := mustHead(t, src)
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
+	f := &Fetcher{Cache: cache}
+
+	ignore := "docs.md\n"
+	ignoredRepo := &manifest.GitRepository{
+		Name: "ignored", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+			Ignore:    &ignore,
+		},
+	}
+	ignored, err := f.Fetch(context.Background(), ignoredRepo)
+	if err != nil {
+		t.Fatalf("Fetch ignored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(ignored.LocalPath, "docs.md")); !os.IsNotExist(err) {
+		t.Fatalf("ignored checkout should not contain docs.md: %v", err)
+	}
+
+	plainRepo := &manifest.GitRepository{
+		Name: "plain", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+		},
+	}
+	plain, err := f.Fetch(context.Background(), plainRepo)
+	if err != nil {
+		t.Fatalf("Fetch plain: %v", err)
+	}
+	if plain.LocalPath == ignored.LocalPath {
+		t.Fatalf("different ignore policies reused cache slot %s", plain.LocalPath)
+	}
+	if _, err := os.Stat(filepath.Join(plain.LocalPath, "docs.md")); err != nil {
+		t.Fatalf("plain checkout lost docs.md through ignored cache slot: %v", err)
+	}
+}
+
+func TestFetcher_CommitCacheKeyIncludesVerification(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+	commit := mustHead(t, src)
+	cache := source.NewCache(cacheroot.New(t.TempDir()))
+	f := &Fetcher{Cache: cache}
+
+	plainRepo := &manifest.GitRepository{
+		Name: "plain", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+		},
+	}
+	if _, err := f.Fetch(context.Background(), plainRepo); err != nil {
+		t.Fatalf("Fetch plain: %v", err)
+	}
+
+	verifiedRepo := &manifest.GitRepository{
+		Name: "verified", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL:       plainRepo.URL,
+			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+			Verification: &manifest.GitRepositoryVerify{
+				Mode:      manifest.GitVerifyModeHEAD,
+				SecretRef: manifest.LocalObjectReference{Name: "trusted-keys"},
+			},
+		},
+	}
+	if _, err := f.Fetch(context.Background(), verifiedRepo); err == nil {
+		t.Fatal("verified fetch reused an unverified commit cache slot")
+	} else if !strings.Contains(err.Error(), "source.SecretGetter") {
+		t.Fatalf("verified fetch error = %v, want missing SecretGetter", err)
+	}
+}
+
+func TestGitCacheKeyIncludesVerificationNamespace(t *testing.T) {
+	ref := sourcev1.GitRepositoryRef{Commit: strings.Repeat("a", 40)}
+	mkRepo := func(ns string) *manifest.GitRepository {
+		return &manifest.GitRepository{
+			Name: "repo", Namespace: ns,
+			GitRepositorySpec: sourcev1.GitRepositorySpec{
+				URL:       "https://example.com/repo.git",
+				Reference: &ref,
+				Verification: &manifest.GitRepositoryVerify{
+					Mode:      manifest.GitVerifyModeHEAD,
+					SecretRef: manifest.LocalObjectReference{Name: "trusted-keys"},
+				},
+			},
+		}
+	}
+
+	a := gitCacheKey(mkRepo("ns-a"), gitRefLabel(ref))
+	b := gitCacheKey(mkRepo("ns-b"), gitRefLabel(ref))
+	if a == b {
+		t.Fatalf("verification cache key ignored namespace: %q", a)
 	}
 }
 
@@ -376,6 +581,31 @@ func mustTagHEAD(t *testing.T, dir, tag string) string {
 		t.Fatalf("CreateTag: %v", err)
 	}
 	return head.Hash().String()
+}
+
+func mustHead(t *testing.T, dir string) string {
+	t.Helper()
+	r, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	head, err := r.Head()
+	if err != nil {
+		t.Fatalf("Head: %v", err)
+	}
+	return head.Hash().String()
+}
+
+func mustSetRefToHash(t *testing.T, dir, refName, hash string) {
+	t.Helper()
+	r, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	ref := plumbing.NewHashReference(plumbing.ReferenceName(refName), plumbing.NewHash(hash))
+	if err := r.Storer.SetReference(ref); err != nil {
+		t.Fatalf("SetReference %s: %v", refName, err)
+	}
 }
 
 func mustCommitFile(t *testing.T, dir, name, content string) string {

--- a/pkg/source/git/mirror_test.go
+++ b/pkg/source/git/mirror_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -53,13 +54,15 @@ func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
 		t.Errorf("expected one mirror dir, got %d: %v", len(entries), entries)
 	}
 
-	// Second fetch reuses the slot AND the mirror.
+	// Second fetch reuses the mirror. The mutable HEAD ref gets a fresh
+	// worktree slot so no in-place reset can race consumers of the first
+	// artifact.
 	art2, err := f.Fetch(context.Background(), repo)
 	if err != nil {
 		t.Fatalf("Fetch 2: %v", err)
 	}
-	if art2.LocalPath != art.LocalPath {
-		t.Errorf("slot path drifted: %s vs %s", art.LocalPath, art2.LocalPath)
+	if art2.Revision != art.Revision {
+		t.Errorf("revision drifted: %s vs %s", art.Revision, art2.Revision)
 	}
 	entries2, _ := os.ReadDir(mirrorDir)
 	if len(entries2) != 1 {
@@ -166,6 +169,36 @@ func TestMirror_RefNameResolvesNonBranchRefs(t *testing.T) {
 	}
 	if art.Revision != want {
 		t.Errorf("revision = %q, want %q", art.Revision, want)
+	}
+}
+
+func TestMirror_CommitMustBeReachableFromBranch(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+	initial := mustHead(t, src)
+	mainOnly := mustCommitFile(t, src, "main-only.txt", "main")
+	mustSetRefToHash(t, src, "refs/heads/staging", initial)
+
+	layout := cacheroot.New(t.TempDir())
+	cache := source.NewCache(layout)
+	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
+	repo := &manifest.GitRepository{
+		Name: "constrained", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{
+			URL: "file://" + src,
+			Reference: &sourcev1.GitRepositoryRef{
+				Branch: "staging",
+				Commit: mainOnly,
+			},
+		},
+	}
+
+	_, err := f.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatal("expected branch-constrained commit fetch to fail through mirror")
+	}
+	if !strings.Contains(err.Error(), "not reachable from branch") {
+		t.Fatalf("error should explain branch reachability, got %v", err)
 	}
 }
 

--- a/pkg/source/git/resolve.go
+++ b/pkg/source/git/resolve.go
@@ -29,7 +29,11 @@ func resolveRefHash(repo *git.Repository, ref *manifest.GitRepositoryRef) (plumb
 	}
 	switch {
 	case ref.Commit != "":
-		return plumbing.NewHash(ref.Commit), nil
+		hash := plumbing.NewHash(ref.Commit)
+		if err := validateCommitBranch(repo, hash, ref.Branch); err != nil {
+			return plumbing.ZeroHash, err
+		}
+		return hash, nil
 	case ref.Name != "":
 		return resolveNamedRef(repo, ref.Name)
 	case ref.SemVer != "":
@@ -72,6 +76,32 @@ func resolveBranch(repo *git.Repository, name string) (plumbing.Hash, error) {
 	return plumbing.ZeroHash, fmt.Errorf("branch %q not found in mirror", name)
 }
 
+func validateCommitBranch(repo *git.Repository, commit plumbing.Hash, branch string) error {
+	if branch == "" {
+		return nil
+	}
+	branchHash, ok := lookupBranch(repo, branch)
+	if !ok {
+		return fmt.Errorf("branch %q not found for commit %s", branch, commit)
+	}
+	commitObj, err := repo.CommitObject(commit)
+	if err != nil {
+		return fmt.Errorf("commit %s not found: %w", commit, err)
+	}
+	branchObj, err := repo.CommitObject(branchHash)
+	if err != nil {
+		return fmt.Errorf("branch %q target %s is not a commit: %w", branch, branchHash, err)
+	}
+	reachable, err := commitObj.IsAncestor(branchObj)
+	if err != nil {
+		return fmt.Errorf("check commit %s reachability from branch %q: %w", commit, branch, err)
+	}
+	if !reachable {
+		return fmt.Errorf("commit %s is not reachable from branch %q", commit, branch)
+	}
+	return nil
+}
+
 func lookupTag(repo *git.Repository, name string) (plumbing.Hash, bool) {
 	tag, err := repo.Tag(name)
 	if err != nil {
@@ -85,11 +115,16 @@ func lookupTag(repo *git.Repository, name string) (plumbing.Hash, bool) {
 }
 
 func lookupBranch(repo *git.Repository, name string) (plumbing.Hash, bool) {
-	r, err := repo.Reference(plumbing.NewBranchReferenceName(name), true)
-	if err != nil {
-		return plumbing.ZeroHash, false
+	for _, refName := range []plumbing.ReferenceName{
+		plumbing.NewBranchReferenceName(name),
+		plumbing.NewRemoteReferenceName("origin", name),
+	} {
+		r, err := repo.Reference(refName, true)
+		if err == nil {
+			return r.Hash(), true
+		}
 	}
-	return r.Hash(), true
+	return plumbing.ZeroHash, false
 }
 
 // resolveSemver picks the highest tag in repo satisfying expr.

--- a/pkg/source/mutable.go
+++ b/pkg/source/mutable.go
@@ -1,0 +1,24 @@
+package source
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+)
+
+var mutableCacheFallbackSeq atomic.Uint64
+
+// MutableCacheKey returns a one-shot cache key for mutable source refs.
+// Mutable refs must refresh instead of serving a stale slot, but a failed
+// refresh must also leave any previously committed artifact intact.
+func MutableCacheKey(base string) string {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err == nil {
+		return base + "#mutable:" + hex.EncodeToString(nonce[:])
+	}
+	return fmt.Sprintf("%s#mutable:%d:%d:%d",
+		base, os.Getpid(), time.Now().UnixNano(), mutableCacheFallbackSeq.Add(1))
+}

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -3,7 +3,10 @@ package oci
 import (
 	"cmp"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -85,12 +88,16 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	}
 
 	versioned := versionedURL(repo.URL, ref)
-	slot, err := cache.Slot(ctx, versioned, "", authIdentity(repo))
+	slotRef := ociCacheKey(repo, ref)
+	if !canUseCachedOCISlot(ref) {
+		slotRef = source.MutableCacheKey(slotRef)
+	}
+	slot, err := cache.Slot(ctx, repo.URL, slotRef, authIdentity(repo))
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
 	defer slot.Release()
-	if slot.Exists {
+	if slot.Exists && canUseCachedOCISlot(ref) {
 		artifact, hit, hitErr := f.checkCacheHit(ctx, repoClient, repo, slot.Path, ref, versioned)
 		if hitErr != nil {
 			_ = slot.Reset()
@@ -100,6 +107,13 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 			return artifact, nil
 		}
 		// Reset + restage for a fresh pull.
+		if err := slot.Reset(); err != nil {
+			return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
+		}
+		if err := slot.Stage(); err != nil {
+			return nil, fmt.Errorf("cache stage for %s: %w", versioned, err)
+		}
+	} else if slot.Exists {
 		if err := slot.Reset(); err != nil {
 			return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
 		}
@@ -196,6 +210,39 @@ func ociArtifact(repo *manifest.OCIRepository, localPath string, ref manifest.OC
 		Digest:    digest,
 		Size:      size,
 	}
+}
+
+func canUseCachedOCISlot(ref manifest.OCIRepositoryRef) bool {
+	return ref.Digest != ""
+}
+
+func ociCacheKey(repo *manifest.OCIRepository, ref manifest.OCIRepositoryRef) string {
+	ignore := ""
+	if repo.Ignore != nil {
+		ignore = *repo.Ignore
+	}
+	mediaType := ""
+	if repo.LayerSelector != nil {
+		mediaType = repo.LayerSelector.MediaType
+	}
+	payload := struct {
+		Ref            string `json:"ref"`
+		LayerMediaType string `json:"layerMediaType,omitempty"`
+		LayerOperation string `json:"layerOperation,omitempty"`
+		Ignore         string `json:"ignore,omitempty"`
+	}{
+		Ref:            cmp.Or(versionTag(ref), "latest"),
+		LayerMediaType: mediaType,
+		LayerOperation: effectiveLayerOperation(repo.LayerSelector),
+		Ignore:         ignore,
+	}
+	return payload.Ref + "#opts:" + ociCacheKeyHash(payload)
+}
+
+func ociCacheKeyHash(v any) string {
+	b, _ := json.Marshal(v)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:8])
 }
 
 // checkCacheHit applies the cache-hit gauntlet to a populated slot:

--- a/pkg/source/oci/fetch_test.go
+++ b/pkg/source/oci/fetch_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -202,6 +203,140 @@ func TestFetcher_ExtractCollidesWithOCILayoutName(t *testing.T) {
 	}
 }
 
+func TestFetcher_MutableTagRefreshesCache(t *testing.T) {
+	v1 := newFakeOCIArtifact(t, map[string]string{"app.yaml": "version: v1\n"})
+	v2 := newFakeOCIArtifact(t, map[string]string{"app.yaml": "version: v2\n"})
+	srv, setArtifact := startMutableFakeRegistry(t, v1, v2)
+
+	f := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))}
+	repo := &manifest.OCIRepository{
+		Name:      "mutable",
+		Namespace: "test",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
+			Insecure:  true,
+			Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
+		},
+	}
+
+	art1, err := f.Fetch(t.Context(), repo)
+	if err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+	if got := mustReadFile(t, filepath.Join(art1.LocalPath, "app.yaml")); !strings.Contains(got, "v1") {
+		t.Fatalf("first fetch content = %q", got)
+	}
+
+	setArtifact(1)
+	art2, err := f.Fetch(t.Context(), repo)
+	if err != nil {
+		t.Fatalf("second Fetch: %v", err)
+	}
+	if art2.Digest == art1.Digest {
+		t.Fatalf("mutable tag reused stale digest %s", art2.Digest)
+	}
+	if got := mustReadFile(t, filepath.Join(art2.LocalPath, "app.yaml")); !strings.Contains(got, "v2") {
+		t.Fatalf("second fetch content = %q", got)
+	}
+}
+
+func TestFetcher_MutableRefreshFailureKeepsPreviousSlot(t *testing.T) {
+	v1 := newFakeOCIArtifact(t, map[string]string{"app.yaml": "version: v1\n"})
+	srv, _ := startMutableFakeRegistry(t, v1)
+
+	f := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))}
+	repo := &manifest.OCIRepository{
+		Name:      "mutable",
+		Namespace: "test",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
+			Insecure:  true,
+			Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
+		},
+	}
+
+	art, err := f.Fetch(t.Context(), repo)
+	if err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+	srv.Close()
+	if _, err := f.Fetch(t.Context(), repo); err == nil {
+		t.Fatal("expected refresh to fail after registry shutdown")
+	}
+	if got := mustReadFile(t, filepath.Join(art.LocalPath, "app.yaml")); !strings.Contains(got, "v1") {
+		t.Fatalf("failed mutable refresh damaged previous slot; app.yaml = %q", got)
+	}
+}
+
+func TestFetcher_DigestRefUsesCachedSlot(t *testing.T) {
+	v1 := newFakeOCIArtifact(t, map[string]string{"app.yaml": "version: v1\n"})
+	srv := startFakeRegistry(t, v1.manifest, v1.config, v1.layer)
+
+	f := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))}
+	repo := &manifest.OCIRepository{
+		Name:      "pinned",
+		Namespace: "test",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       fmt.Sprintf("oci://%s/pinned", mustURL(t, srv.URL).Host),
+			Insecure:  true,
+			Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
+		},
+	}
+	if _, err := f.Fetch(t.Context(), repo); err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+	srv.Close()
+	if _, err := f.Fetch(t.Context(), repo); err != nil {
+		t.Fatalf("digest-pinned cache hit should not need registry: %v", err)
+	}
+}
+
+func TestFetcher_DigestCacheKeyIncludesLayerSelector(t *testing.T) {
+	v1 := newFakeOCIArtifact(t, map[string]string{"app.yaml": "version: v1\n"})
+	srv := startFakeRegistry(t, v1.manifest, v1.config, v1.layer)
+	f := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))}
+
+	copyRepo := &manifest.OCIRepository{
+		Name:      "copy",
+		Namespace: "test",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       fmt.Sprintf("oci://%s/app", mustURL(t, srv.URL).Host),
+			Insecure:  true,
+			Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
+			LayerSelector: &sourcev1.OCILayerSelector{
+				Operation: manifest.OCILayerOperationCopy,
+			},
+		},
+	}
+	copyArt, err := f.Fetch(t.Context(), copyRepo)
+	if err != nil {
+		t.Fatalf("copy Fetch: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(copyArt.LocalPath, "layer.tar.gz")); err != nil {
+		t.Fatalf("copy artifact missing layer.tar.gz: %v", err)
+	}
+
+	extractRepo := &manifest.OCIRepository{
+		Name:      "extract",
+		Namespace: "test",
+		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
+			URL:       copyRepo.URL,
+			Insecure:  true,
+			Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
+		},
+	}
+	extractArt, err := f.Fetch(t.Context(), extractRepo)
+	if err != nil {
+		t.Fatalf("extract Fetch: %v", err)
+	}
+	if extractArt.LocalPath == copyArt.LocalPath {
+		t.Fatalf("different layer selectors reused cache slot %s", extractArt.LocalPath)
+	}
+	if got := mustReadFile(t, filepath.Join(extractArt.LocalPath, "app.yaml")); !strings.Contains(got, "v1") {
+		t.Fatalf("extract artifact content = %q", got)
+	}
+}
+
 // startFakeRegistry serves the minimum subset of the OCI Distribution
 // API that oras.Copy needs: a /v2/ probe, manifests by tag, and blobs
 // by digest. httptest.NewTLSServer's self-signed cert pairs with the
@@ -238,6 +373,80 @@ func startFakeRegistry(t *testing.T, manifestBytes, configBytes, layerBytes []by
 	srv := httptest.NewTLSServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
+}
+
+type fakeOCIArtifact struct {
+	manifest       []byte
+	config         []byte
+	layer          []byte
+	manifestDigest string
+	configDigest   string
+	layerDigest    string
+}
+
+func newFakeOCIArtifact(t *testing.T, files map[string]string) fakeOCIArtifact {
+	t.Helper()
+	layer := mustTarGz(t, files)
+	config := []byte(`{}`)
+	manifest := mustManifestJSON(t, config, layer,
+		"application/vnd.cncf.flux.config.v1+json",
+		"application/vnd.cncf.flux.content.v1.tar+gzip",
+	)
+	return fakeOCIArtifact{
+		manifest:       manifest,
+		config:         config,
+		layer:          layer,
+		manifestDigest: sha256Digest(manifest),
+		configDigest:   sha256Digest(config),
+		layerDigest:    sha256Digest(layer),
+	}
+}
+
+func startMutableFakeRegistry(t *testing.T, artifacts ...fakeOCIArtifact) (*httptest.Server, func(int)) {
+	t.Helper()
+	if len(artifacts) == 0 {
+		t.Fatal("no OCI artifacts")
+	}
+	var (
+		mu      sync.RWMutex
+		current int
+		blobs   = map[string][]byte{}
+	)
+	for _, art := range artifacts {
+		blobs[art.configDigest] = art.config
+		blobs[art.layerDigest] = art.layer
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/v2/"):
+			return
+		case strings.Contains(r.URL.Path, "/manifests/"):
+			mu.RLock()
+			art := artifacts[current]
+			mu.RUnlock()
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+			w.Header().Set("Docker-Content-Digest", art.manifestDigest)
+			_, _ = w.Write(art.manifest)
+		case strings.Contains(r.URL.Path, "/blobs/"):
+			d := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+			if body, ok := blobs[d]; ok {
+				_, _ = w.Write(body)
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	setArtifact := func(i int) {
+		mu.Lock()
+		defer mu.Unlock()
+		current = i
+	}
+	return srv, setArtifact
 }
 
 // mustManifestJSON builds an OCI image manifest pointing at the given
@@ -291,4 +500,13 @@ func slotEntries(t *testing.T, dir string) []string {
 		names = append(names, e.Name())
 	}
 	return names
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -99,6 +99,38 @@ func (s *Store) AddObject(obj manifest.BaseManifest) {
 	dispatch()
 }
 
+// AddObjects inserts multiple manifests, then dispatches their events
+// after every changed object is visible in the store. Use this when a
+// render emits a coherent sibling set whose listeners need the whole
+// set before reacting.
+func (s *Store) AddObjects(objs []manifest.BaseManifest) {
+	if len(objs) == 0 {
+		return
+	}
+	type event struct {
+		id  manifest.NamedResource
+		obj manifest.BaseManifest
+	}
+	s.mu.Lock()
+	events := make([]event, 0, len(objs))
+	for _, obj := range objs {
+		id := obj.Named()
+		if cur, ok := s.objects[id]; ok && reflect.DeepEqual(cur, obj) {
+			continue
+		}
+		s.setLocked(id, obj)
+		events = append(events, event{id: id, obj: obj})
+	}
+	dispatches := make([]func(), 0, len(events))
+	for _, e := range events {
+		dispatches = append(dispatches, s.fireUnderLock(EventObjectAdded, e.id, e.obj))
+	}
+	s.mu.Unlock()
+	for _, dispatch := range dispatches {
+		dispatch()
+	}
+}
+
 // setLocked is the single funnel for inserting an object into both
 // the primary `objects` map and the secondary `byName` index. Three
 // write paths (AddObject, AddRendered, future renames) must keep
@@ -186,10 +218,10 @@ type Cloneable[T any] interface {
 // clone-then-AddObject. Returns false when no object of type T is
 // stored under id (no-op).
 //
-// Use this for any post-load mutation — validateDependsOn pruning,
-// namespace-inheritance rewrites, alias seeding. Listeners fire as
-// they would on a fresh AddObject (intentionally — downstream
-// controllers re-reconcile against the mutated spec).
+// Use this for any post-load mutation such as namespace-inheritance
+// rewrites or alias seeding. Listeners fire as they would on a fresh
+// AddObject (intentionally — downstream controllers re-reconcile
+// against the mutated spec).
 func Mutate[T interface {
 	manifest.BaseManifest
 	Cloneable[T]
@@ -310,4 +342,3 @@ func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 	}
 	return out
 }
-

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -72,6 +72,26 @@ func TestStore_AddObject_CloneTriggersUpdate(t *testing.T) {
 	}
 }
 
+func TestStore_AddObjectsDispatchesAfterAllWrites(t *testing.T) {
+	s := New()
+	a := newCM("a", "ns")
+	b := newCM("b", "ns")
+	idA := a.Named()
+	idB := b.Named()
+
+	var sawBOnA bool
+	s.AddListener(EventObjectAdded, func(id manifest.NamedResource, _ any) {
+		if id == idA {
+			sawBOnA = s.GetObject(idB) != nil
+		}
+	}, false)
+
+	s.AddObjects([]manifest.BaseManifest{a, b})
+	if !sawBOnA {
+		t.Fatal("listener for first object did not see later batch sibling")
+	}
+}
+
 func TestStore_AddListener_Flush(t *testing.T) {
 	s := New()
 	s.AddObject(newCM("a", "ns"))
@@ -691,10 +711,11 @@ func TestStore_AddRendered_DispatchesListeners(t *testing.T) {
 // listener registered with flush=false against a hot writer doesn't
 // miss the next live event. Pre-fix, the non-flush branch took
 // set.mu but not s.mu, so a writer could:
-//   1. Lock s.mu, mutate store.
-//   2. Capture set.snapshot() under set.mu (independent of s.mu).
-//   3. Release s.mu.
-//   4. Dispatch to the pre-add snapshot.
+//  1. Lock s.mu, mutate store.
+//  2. Capture set.snapshot() under set.mu (independent of s.mu).
+//  3. Release s.mu.
+//  4. Dispatch to the pre-add snapshot.
+//
 // while the registrar slid set.add(fn) between steps 2 and 4. fn
 // silently misses the live event. Holding s.mu around set.add
 // closes the window. Test races N writers against AddListener and
@@ -704,10 +725,10 @@ func TestStore_AddListenerNoFlush_NoMissedConcurrentWrites(t *testing.T) {
 	s := New()
 	const writers = 64
 	var (
-		writerWG sync.WaitGroup
+		writerWG      sync.WaitGroup
 		registerReady = make(chan struct{})
-		registered = make(chan struct{})
-		seen atomic.Int64
+		registered    = make(chan struct{})
+		seen          atomic.Int64
 	)
 	// Pre-populate so AddObject takes the "update existing" path
 	// uniformly — keeps test deterministic.

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -2,6 +2,7 @@ package values
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -133,16 +134,13 @@ func DeepMergeInto(dst, override map[string]any) map[string]any {
 // merges them with hr.Values (inline values take precedence per Helm
 // semantics), and writes the result back to hr.Values.
 //
-// Honors ValuesReference.Optional: missing references on Optional=true
-// refs are skipped silently; missing references on Optional=false (the
-// default) return ErrObjectNotFound so the orchestrator can surface a
-// real failure or honor --allow-missing-secrets. Matches Flux's helm-
-// controller, which fails the reconcile on a missing non-optional
-// valuesFrom but tolerates a missing optional one.
+// Honors ValuesReference.Optional: missing resources or values keys on
+// Optional=true refs are skipped silently; Optional=false refs fail.
+// Matches Flux helm-controller chartutil semantics.
 //
-// Hard errors from the lookup itself — unsupported kind, missing key
-// in a present resource, malformed binaryData — always bubble up; they
-// are unrelated to whether the ref is optional.
+// Hard errors from the lookup itself — unsupported kind, malformed
+// binaryData — always bubble up; they are unrelated to whether the ref
+// is optional.
 func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 	if hr == nil || len(hr.ValuesFrom) == 0 {
 		return nil
@@ -151,18 +149,11 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 	for _, ref := range hr.ValuesFrom {
 		found, err := lookupValueRef(ref, hr.Namespace, provider)
 		if err != nil {
-			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
-		}
-		if found == "" {
-			// Resource missing. lookupValueRef only returns "" when
-			// the underlying CM/Secret was absent AND no TargetPath
-			// short-circuit produced a placeholder; that's the only
-			// case where Optional applies.
-			if !ref.Optional {
-				return fmt.Errorf("%w: HelmRelease %s: valuesFrom %s %s/%s not found",
-					manifest.ErrObjectNotFound, hr.Named().NamespacedName(), ref.Kind, hr.Namespace, ref.Name)
+			var missing *missingValueRefError
+			if ref.Optional && errors.As(err, &missing) {
+				continue
 			}
-			continue
+			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
 		merged, err := updateHelmReleaseValues(ref, found, values)
 		if err != nil {
@@ -183,10 +174,7 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider) error {
 	return nil
 }
 
-// lookupValueRef returns the raw string value referenced by ref, or an
-// empty string when the referenced object is missing and the ref is
-// optional. Missing-but-optional refs with a target_path produce a
-// placeholder so the downstream YAML still parses.
+// lookupValueRef returns the raw string value referenced by ref.
 func lookupValueRef(ref manifest.ValuesReference, namespace string, p Provider) (string, error) {
 	var data map[string]string
 	var err error
@@ -215,20 +203,41 @@ func lookupValueRef(ref manifest.ValuesReference, namespace string, p Provider) 
 		return "", err
 	}
 	if data == nil {
-		// Missing reference.
-		if ref.TargetPath != "" {
-			return fmt.Sprintf(manifest.ValuePlaceholderTemplate, ref.Name), nil
+		return "", &missingValueRefError{
+			kind: ref.Kind, namespace: namespace, name: ref.Name,
 		}
-		return "", nil
 	}
 
 	key := ref.GetValuesKey()
 	val, ok := data[key]
 	if !ok {
-		return "", fmt.Errorf("%w: key %q not found in %s/%s",
-			manifest.ErrInvalidValuesReference, key, namespace, ref.Name)
+		return "", &missingValueRefError{
+			kind: ref.Kind, namespace: namespace, name: ref.Name, key: key,
+		}
 	}
 	return val, nil
+}
+
+type missingValueRefError struct {
+	kind      string
+	namespace string
+	name      string
+	key       string
+}
+
+func (e *missingValueRefError) Error() string {
+	if e.key != "" {
+		return fmt.Sprintf("valuesFrom %s %s/%s key %q not found",
+			e.kind, e.namespace, e.name, e.key)
+	}
+	return fmt.Sprintf("valuesFrom %s %s/%s not found", e.kind, e.namespace, e.name)
+}
+
+func (e *missingValueRefError) Unwrap() error {
+	if e.key != "" {
+		return manifest.ErrInvalidValuesReference
+	}
+	return manifest.ErrObjectNotFound
 }
 
 // decodeBag normalizes ConfigMap/Secret data so callers see a single

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -1,6 +1,7 @@
 package values
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -153,6 +154,7 @@ func TestExpandValueReferences_TargetPath(t *testing.T) {
 func TestExpandValueReferences_MissingOptionalTargetPath(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
+		Values: map[string]any{"existing": "kept"},
 		HelmReleaseSpec: helmv2.HelmReleaseSpec{
 			ValuesFrom: []manifest.ValuesReference{
 				{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k", Optional: true},
@@ -163,8 +165,50 @@ func TestExpandValueReferences_MissingOptionalTargetPath(t *testing.T) {
 	if err := ExpandValueReferences(hr, provider); err != nil {
 		t.Fatalf("ExpandValueReferences: %v", err)
 	}
-	if got, _ := hr.Values["k"].(string); got == "" {
-		t.Errorf("expected placeholder, got %v", hr.Values["k"])
+	if _, ok := hr.Values["k"]; ok {
+		t.Errorf("optional missing targetPath ref should be skipped, got %v", hr.Values["k"])
+	}
+	if hr.Values["existing"] != "kept" {
+		t.Errorf("inline values should remain: %+v", hr.Values)
+	}
+}
+
+func TestExpandValueReferences_MissingRequiredTargetPathFails(t *testing.T) {
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k"},
+			},
+		},
+	}
+
+	err := ExpandValueReferences(hr, &SliceProvider{})
+	if !errors.Is(err, manifest.ErrObjectNotFound) {
+		t.Fatalf("missing required targetPath ref = %v, want ErrObjectNotFound", err)
+	}
+}
+
+func TestExpandValueReferences_MissingOptionalKeySkipped(t *testing.T) {
+	cm := &manifest.ConfigMap{
+		Name: "extra", Namespace: "default",
+		Data: map[string]any{"other.yaml": "ignored: true\n"},
+	}
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Values: map[string]any{"existing": "kept"},
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "ConfigMap", Name: "extra", ValuesKey: "missing.yaml", Optional: true},
+			},
+		},
+	}
+
+	if err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}); err != nil {
+		t.Fatalf("ExpandValueReferences: %v", err)
+	}
+	if hr.Values["existing"] != "kept" || len(hr.Values) != 1 {
+		t.Errorf("optional missing key should leave values unchanged: %+v", hr.Values)
 	}
 }
 


### PR DESCRIPTION
## Summary
- align CLI get/test/diff scoping and error propagation with the reconcile-first command model
- harden dependency cycle preflight, render-emitted sibling dispatch, and ResourceSet post-run errors
- tighten mutable/immutable source cache behavior for Git, OCI, and Helm sources, including Git verify cache identity
- preserve Flux parity for valuesFrom optional refs, HelmRepository OCI provider propagation, and ResourceSetInputProvider status replay
- update README quick-reference docs without expanding scope

## Verification
- go mod tidy
- go test ./...
- go vet ./...
- golangci-lint run ./...
- go test -race ./internal/cli ./internal/testrunner ./pkg/orchestrator ./pkg/controllers/base ./pkg/controllers/kustomization ./pkg/controllers/helmrelease ./pkg/depwait ./pkg/source ./pkg/source/git ./pkg/source/oci ./pkg/helm ./pkg/values ./pkg/resourceset ./pkg/kustomize ./pkg/store
- full real-repo golden matrix with fresh clones under /private/tmp/flate-goldens/full-20260526132820; no source-tree mutations or .flate-remote leakage; clean passes for buroa-k8s test-all, jory-test test/diff, jory-utility test, phycoforce test; remaining nonzero cases are upstream source fetch timeouts or repo-local missing Secret/ConfigMap state, recorded in per-case logs