### PR TITLE
chore: post-merge cleanup pass on PRs #413-#420

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -67,16 +67,15 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 			}
 			name := firstArg(argv)
 			docs := []map[string]any{}
-			var collectErr error
+			var emitErr error
 			for _, kind := range kinds {
 				rendered, err := collectRendered(o, res, kind, name, c, b)
 				if err != nil {
-					collectErr = err
+					emitErr = err
 					break
 				}
 				docs = append(docs, rendered...)
 			}
-			emitErr := collectErr
 			if emitErr == nil {
 				emitErr = emitDocs(cmd.OutOrStdout(), docs, c.outputOrDefault(format.OutputYAML))
 			}
@@ -126,9 +125,7 @@ func collectRendered(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 			continue
 		}
 		matched++
-		// res.Manifests is the structured render output keyed by
-		// NamedResource — no more Store.GetArtifact + type-assertion
-		// dance. A missing entry means the resource didn't render
+		// A missing entry means the resource didn't render
 		// (failed, suspended, or produced zero docs).
 		mans, ok := res.Manifests[id]
 		if !ok || len(mans) == 0 {

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -37,12 +37,8 @@ type commonFlags struct {
 	enableOCI           bool
 	registryConfig      string
 	concurrency         int
-	// cacheDir is resolved lazily (and only when needed) via
-	// resolveCacheRoot — it points at the shared cache root used by
-	// both the orchestrator's source/helm caches and the baseline's
-	// content-addressed slots. Surfaced as a field (not just a
-	// function) so the value remains stable across multiple lookups
-	// within one command invocation.
+	// cacheDir is resolved lazily via resolveCacheRoot and memoized so
+	// multiple lookups within one invocation return the same value.
 	cacheDir string
 }
 
@@ -262,13 +258,6 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	}
 }
 
-// resolveCacheRoot picks the on-disk cache root used by every persistent
-// cache (orchestrator sources, baseline slots, helm tarballs). Lazy and
-// cached on commonFlags so multiple lookups within one invocation
-// return the same value. Prefers the OS user cache dir
-// ($XDG_CACHE_HOME on Linux, ~/Library/Caches on macOS,
-// %LocalAppData% on Windows) with a "flate" subdir; falls back to
-// $TMPDIR/flate-cache when UserCacheDir errors.
 func (c *commonFlags) resolveCacheRoot() string {
 	if c.cacheDir == "" {
 		c.cacheDir = cacheroot.Default()
@@ -291,9 +280,6 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 	if _, err := format.ParseOutput(c.output); err != nil {
 		return nil, nil, err
 	}
-	// Opt-in baseline materialization: build/get/test only fires
-	// resolveBaseline when the user explicitly set --base (or
-	// --path-orig). Bare command keeps the full-tree default.
 	// Cleanup is deferred (not bound to ctx) so the tempdir survives
 	// SIGINT until the orchestrator's read paths have actually
 	// unwound.
@@ -347,10 +333,8 @@ func (c *commonFlags) requireOutput(allowed ...format.Output) error {
 	if c.output == string(format.OutputTable) {
 		return nil
 	}
-	for _, a := range allowed {
-		if format.Output(c.output) == a {
-			return nil
-		}
+	if slices.Contains(allowed, format.Output(c.output)) {
+		return nil
 	}
 	names := make([]string, 0, len(allowed)+1)
 	names = append(names, string(format.OutputTable))
@@ -369,11 +353,6 @@ func (c *commonFlags) requireOutput(allowed ...format.Output) error {
 // resource failures: the partial output is still usable. A nil
 // orchestrator indicates a fatal init/bootstrap error and callers
 // should bail.
-//
-// Dogfooding Render here closes a drift hazard the iter-13 review
-// flagged: the embed API and the CLI used to read rendered artifacts
-// through different code paths (CLI reached straight into the Store
-// with a type assertion). Now there's one path.
 func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config) (*orchestrator.Orchestrator, *orchestrator.Result, error) {
 	o, err := orchestrator.New(cfg)
 	if err != nil {

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -127,11 +127,7 @@ func runDiffImages(cmd *cobra.Command, c *commonFlags, h *helmFlags, includeRemo
 		return runErr
 	}
 	imgs := imageSetDiff(collectImages(orig.O, orig.Res, c), collectImages(current.O, current.Res, c), includeRemoved)
-	out := c.output
-	if out == string(format.OutputTable) {
-		out = string(format.OutputName)
-	}
-	if err := emitImageList(cmd.OutOrStdout(), imgs, out); err != nil {
+	if err := emitImageList(cmd.OutOrStdout(), imgs, string(c.outputOrDefault(format.OutputName))); err != nil {
 		return errors.Join(err, scopedDiffRunError(orig, current, c, runErr))
 	}
 	return scopedDiffRunError(orig, current, c, runErr)
@@ -175,17 +171,13 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 		return errors.Join(fmt.Errorf("no %s named %q in --path or --path-orig", kind, name), diffRunErr)
 	}
 
-	outFormat := c.output
-	if outFormat == "table" {
-		outFormat = outputDiff
-	}
 	diffs, err := diff.Run(origDocs, currentDocs, diff.Options{
 		StripAttrs: d.stripAttrs,
 	})
 	if err != nil {
 		return errors.Join(err, diffRunErr)
 	}
-	formatted, err := diff.Render(diffs, diff.Format(outFormat))
+	formatted, err := diff.Render(diffs, diff.Format(c.outputOrDefault(format.Output(outputDiff))))
 	if err != nil {
 		return errors.Join(err, diffRunErr)
 	}
@@ -212,11 +204,9 @@ type diffSide struct {
 // on changed-only diffs.
 func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (diffSide, diffSide, error) {
 	// diff REQUIRES a baseline — when neither --path-orig nor --base
-	// is set, auto-detect via the merge-base ladder. resolveBaseline
-	// with autoFallback=true preserves the existing "bare diff
-	// figures it out" UX. Cleanup is deferred (not bound to ctx) so
-	// the tempdir survives SIGINT until both orchestrators' read
-	// paths have actually unwound.
+	// is set, auto-detect via the merge-base ladder. Cleanup is
+	// deferred (not bound to ctx) so the tempdir survives SIGINT
+	// until both orchestrators' read paths have actually unwound.
 	cleanup, err := resolveBaseline(ctx, c, true)
 	if err != nil {
 		return diffSide{}, diffSide{}, err

--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -2,7 +2,6 @@ package change
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -278,7 +277,7 @@ func detectViaWalker(before, after string) (*Set, error) {
 
 	if len(hashJobs) > 0 {
 		var mu sync.Mutex
-		hg, _ := errgroup.WithContext(context.Background())
+		var hg errgroup.Group
 		const hashWorkers = 8
 		jobs := make(chan hashJob, len(hashJobs))
 		for range hashWorkers {

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -9,6 +9,7 @@ package helmrelease
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -178,7 +179,7 @@ func (c *Controller) preflightFailure(id manifest.NamedResource) (string, bool) 
 
 func (c *Controller) preflightError(id manifest.NamedResource) error {
 	if msg, failed := c.preflightFailure(id); failed {
-		return fmt.Errorf("%s", msg)
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -7,6 +7,7 @@ package kustomization
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -172,7 +173,7 @@ func (c *Controller) preflightFailure(id manifest.NamedResource) (string, bool) 
 
 func (c *Controller) preflightError(id manifest.NamedResource) error {
 	if msg, failed := c.preflightFailure(id); failed {
-		return fmt.Errorf("%s", msg)
+		return errors.New(msg)
 	}
 	return nil
 }

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -62,7 +62,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		}
 	}
 	// Pass 2 — leaf reconcilables.
-	leaves := make([]manifest.BaseManifest, 0)
+	var leaves []manifest.BaseManifest
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			c.keepEmitted(id, p.obj.Named())

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -119,7 +119,6 @@ func (c *Controller) reconcile(ctx context.Context, obj manifest.BaseManifest) e
 
 	c.Store.UpdateStatus(id, store.StatusPending, "fetching")
 	started := time.Now()
-	slog.Debug("source: fetch", "id", id.String())
 
 	// Release the worker slot during the fetch so consumers of this
 	// source (KS/HR depwait watchers) can acquire one and make

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -503,8 +503,7 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 func (w *Waiter) tryReadyExpr(expr string, id manifest.NamedResource) (Event, bool) {
 	ok, err := evaluateReadyExpr(expr, w.Store, w.Parent, id)
 	if err != nil {
-		var compileErr *celCompileErr
-		if errors.As(err, &compileErr) {
+		if _, ok := errors.AsType[*celCompileErr](err); ok {
 			return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}, true
 		}
 		// Eval error: transient, re-poll on next event.
@@ -577,7 +576,6 @@ func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResour
 	}, false)
 	defer unsub()
 	if w.depExists(id) {
-		slog.Debug("depwait: render-only dependency already exists", "parent", w.Parent.String(), "dep", id.String(), "duration", time.Since(started))
 		return nil
 	}
 
@@ -614,10 +612,8 @@ func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResour
 			// classifies as DepCancelled; any deadline becomes a
 			// "render couldn't produce" fast-fail.
 			if errors.Is(ctx.Err(), context.Canceled) {
-				slog.Debug("depwait: render-only dependency cancelled", "parent", w.Parent.String(), "dep", id.String(), "duration", time.Since(started))
 				return ctx.Err()
 			}
-			slog.Debug("depwait: render-only dependency cap reached", "parent", w.Parent.String(), "dep", id.String(), "duration", time.Since(started))
 			return errRenderCapExceeded
 		}
 	}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -214,8 +214,7 @@ func (c *Client) chartTarballByDigest(digest string) (string, bool) {
 }
 
 func normalizeChartDigest(digest string) string {
-	digest = strings.TrimSpace(digest)
-	return strings.TrimPrefix(digest, "sha256:")
+	return strings.TrimPrefix(strings.TrimSpace(digest), "sha256:")
 }
 
 func chartDownloadKey(r *manifest.HelmRepository, hr *manifest.HelmRelease, cv *repo.ChartVersion, chartURL, digest string) string {

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -306,9 +306,9 @@ func releaseManifest(rel *release.Release, opts Options, disableHooks, skipTests
 // filterShowOnly keeps only sections whose "# Source: <path>" header
 // matches one of the requested template paths.
 func filterShowOnly(content string, paths []string) string {
-	want := make(map[string]struct{}, len(paths))
+	want := make(map[string]bool, len(paths))
 	for _, p := range paths {
-		want[p] = struct{}{}
+		want[p] = true
 	}
 	var out strings.Builder
 	for section := range strings.SplitSeq(content, "\n---\n") {
@@ -319,7 +319,7 @@ func filterShowOnly(content string, paths []string) string {
 				break
 			}
 		}
-		if _, ok := want[header]; !ok {
+		if !want[header] {
 			continue
 		}
 		if out.Len() > 0 {

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -21,16 +21,14 @@ func decodeTyped[T any](doc map[string]any, out *T) error {
 	return json.Unmarshal(raw, out)
 }
 
-// DocKind returns the "kind" field of a manifest document, or "" if
-// absent. Centralizes the doc["kind"].(string) cast.
+// DocKind returns the "kind" field of a manifest document, or "" if absent.
 func DocKind(doc map[string]any) string {
 	k, _ := doc["kind"].(string)
 	return k
 }
 
 // DocAPIVersion returns the "apiVersion" field of a manifest document,
-// or "" if absent. Centralizes the doc["apiVersion"].(string) cast so
-// callers don't repeat the same one-liner.
+// or "" if absent.
 func DocAPIVersion(doc map[string]any) string {
 	v, _ := doc["apiVersion"].(string)
 	return v

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -412,10 +412,7 @@ func (o *Orchestrator) replacePreflightFailures(failures map[manifest.NamedResou
 		o.preflightFailures = nil
 		return cleared
 	}
-	o.preflightFailures = make(map[manifest.NamedResource]string, len(failures))
-	for id, msg := range failures {
-		o.preflightFailures[id] = msg
-	}
+	o.preflightFailures = maps.Clone(failures)
 	return cleared
 }
 

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -58,8 +58,9 @@ func isClusterScoped(doc map[string]any) bool {
 		"APIService",
 		"Node":
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func applyCommonMetadata(doc map[string]any, cm *fluxopv1.CommonMetadata) {
@@ -76,17 +77,18 @@ func applyOwnerLabels(doc map[string]any, rs *manifest.ResourceSet) {
 		return
 	}
 	md := manifest.EnsureMetadata(doc)
-	manifest.MergeStringMap(md, "labels", map[string]string{
-		fluxopv1.OwnerLabelResourceSetName:      rs.Name,
-		fluxopv1.OwnerLabelResourceSetNamespace: rs.Namespace,
-	})
+	labels, _ := md["labels"].(map[string]any)
+	if labels == nil {
+		labels = make(map[string]any, 2)
+	}
+	labels[fluxopv1.OwnerLabelResourceSetName] = rs.Name
+	labels[fluxopv1.OwnerLabelResourceSetNamespace] = rs.Namespace
+	md["labels"] = labels
 }
 
 func disabledByReconcileAnnotation(doc map[string]any) bool {
 	md, _ := doc["metadata"].(map[string]any)
 	ann, _ := md["annotations"].(map[string]any)
-	if v, _ := ann[fluxopv1.ReconcileAnnotation].(string); v == fluxopv1.DisabledValue {
-		return true
-	}
-	return false
+	v, _ := ann[fluxopv1.ReconcileAnnotation].(string)
+	return v == fluxopv1.DisabledValue
 }

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -76,16 +76,13 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 		return nil, nil
 	}
 	var docs []map[string]any
-	seen := map[string]struct{}{}
+	seen := map[string]bool{}
 	appendUnique := func(doc map[string]any) {
 		key := DedupKey(doc)
-		if key == "" {
+		if key == "" || seen[key] {
 			return
 		}
-		if _, ok := seen[key]; ok {
-			return
-		}
-		seen[key] = struct{}{}
+		seen[key] = true
 		docs = append(docs, doc)
 	}
 

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -95,7 +95,7 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 	}{
 		{layout.Sources(), 2, nil},
 		{layout.Baselines(), 1, nil},
-		{layout.Blobs(), 1, func(name string) bool { _, ok := live[name]; return ok }},
+		{layout.Blobs(), 1, func(name string) bool { return live[name] }},
 	}
 	if opts.IncludeMirrors {
 		ageRoots = append(ageRoots, struct {
@@ -117,8 +117,8 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 // the set of digests they point at. Used to gate blob sweep: a fresh
 // ref must always be able to resolve, even if its blob is "old".
 // Malformed or missing refs land in res.Errors but don't abort.
-func markLiveDigests(layout cacheroot.Layout, res *SweepResult) map[string]struct{} {
-	live := map[string]struct{}{}
+func markLiveDigests(layout cacheroot.Layout, res *SweepResult) map[string]bool {
+	live := map[string]bool{}
 	refsRoot := layout.RefsRoot()
 	_ = filepath.WalkDir(refsRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -138,7 +138,7 @@ func markLiveDigests(layout cacheroot.Layout, res *SweepResult) map[string]struc
 		}
 		digest := strings.TrimSpace(string(b))
 		if looksLikeDigest(digest) {
-			live[digest] = struct{}{}
+			live[digest] = true
 		}
 		return nil
 	})

--- a/pkg/source/git/checkout.go
+++ b/pkg/source/git/checkout.go
@@ -20,18 +20,11 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef, sparse []s
 	if err != nil {
 		return err
 	}
-	// newOpts builds a CheckoutOptions pre-populated with sparse-checkout
-	// directories when configured. Repeated per call-site because
-	// CheckoutOptions is consumed by each Checkout invocation.
-	newOpts := func() *git.CheckoutOptions {
+	checkout := func(set func(*git.CheckoutOptions)) error {
 		opts := &git.CheckoutOptions{}
 		if len(sparse) > 0 {
 			opts.SparseCheckoutDirectories = append(opts.SparseCheckoutDirectories, sparse...)
 		}
-		return opts
-	}
-	checkout := func(set func(*git.CheckoutOptions)) error {
-		opts := newOpts()
 		set(opts)
 		return wt.Checkout(opts)
 	}

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -247,7 +248,7 @@ func gitCacheKey(repo *manifest.GitRepository, refLabel string) string {
 	}{
 		Ref:               refLabel,
 		Ignore:            ignore,
-		SparseCheckout:    append([]string(nil), repo.SparseCheckout...),
+		SparseCheckout:    slices.Clone(repo.SparseCheckout),
 		RecurseSubmodules: repo.RecurseSubmodules,
 		Verify:            gitVerifyCacheKey(repo.Namespace, repo.Verification),
 	}

--- a/pkg/source/git/marker.go
+++ b/pkg/source/git/marker.go
@@ -43,7 +43,11 @@ func cachedRevisionFresh(slot string, maxAge time.Duration) (string, bool) {
 	if err != nil || time.Since(info.ModTime()) > maxAge {
 		return "", false
 	}
-	rev := readCachedRevision(slot)
+	b, err := os.ReadFile(path) //nolint:gosec // slot is fetcher-owned cache path
+	if err != nil {
+		return "", false
+	}
+	rev := strings.TrimSpace(string(b))
 	return rev, rev != ""
 }
 

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -212,8 +212,5 @@ func writeBlobTo(dst string, objects *serializedObjectReader, hash plumbing.Hash
 		return fmt.Errorf("create %s: %w", dst, err)
 	}
 	defer func() { _ = out.Close() }()
-	if err := objects.copyBlobTo(hash, name, out); err != nil {
-		return err
-	}
-	return nil
+	return objects.copyBlobTo(hash, name, out)
 }

--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -208,11 +208,11 @@ func (f *Fetcher) loadCosignPublicKeys(repo *manifest.OCIRepository) ([]crypto.P
 		return nil, source.MissingSecretErr("OCIRepository",
 			repo.Namespace, repo.Name, repo.Verify.SecretRef.Name, "verify secret not found")
 	}
-	var keys []crypto.PublicKey
 	// Iterate the union of StringData + Data keys so PEM blocks stored
 	// under either field are discovered. k8s Secrets typically put
 	// `cosign.pub` under `data:` (base64-encoded); StringData is the
-	// at-apply-time convenience field.
+	// at-apply-time convenience field. The seen set deduplicates keys
+	// present in both fields; StringFromSecret prefers StringData.
 	seen := make(map[string]struct{}, len(sec.StringData)+len(sec.Data))
 	for k := range sec.StringData {
 		seen[k] = struct{}{}
@@ -220,18 +220,13 @@ func (f *Fetcher) loadCosignPublicKeys(repo *manifest.OCIRepository) ([]crypto.P
 	for k := range sec.Data {
 		seen[k] = struct{}{}
 	}
+	var keys []crypto.PublicKey
 	for k := range seen {
-		// StringFromSecret prefers StringData over Data and strips the
-		// PLACEHOLDER_-wipe marker, so callers see "" for wiped values.
 		s := source.StringFromSecret(sec, k)
 		if s == "" {
 			continue
 		}
-		parsed := parsePEMPublicKeys([]byte(s))
-		if len(parsed) == 0 {
-			continue
-		}
-		keys = append(keys, parsed...)
+		keys = append(keys, parsePEMPublicKeys([]byte(s))...)
 	}
 	return keys, nil
 }

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -117,23 +117,18 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}
 	defer slot.Release()
-	if slot.Exists && resolvedDigest != "" {
-		artifact, hit, hitErr := f.checkCacheHit(ctx, repoClient, repo, slot.Path, ref, versioned, resolvedDigest)
-		if hitErr != nil {
-			_ = slot.Reset()
-			return nil, hitErr
+	if slot.Exists {
+		if resolvedDigest != "" {
+			artifact, hit, hitErr := f.checkCacheHit(ctx, repoClient, repo, slot.Path, ref, versioned, resolvedDigest)
+			if hitErr != nil {
+				_ = slot.Reset()
+				return nil, hitErr
+			}
+			if hit {
+				return artifact, nil
+			}
 		}
-		if hit {
-			return artifact, nil
-		}
-		// Reset + restage for a fresh pull.
-		if err := slot.Reset(); err != nil {
-			return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
-		}
-		if err := slot.Stage(); err != nil {
-			return nil, fmt.Errorf("cache stage for %s: %w", versioned, err)
-		}
-	} else if slot.Exists {
+		// Stale or unresolved slot — wipe and stage a fresh pull target.
 		if err := slot.Reset(); err != nil {
 			return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
 		}

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -199,8 +199,10 @@ func digestPath(slot string, d digest.Digest) string {
 // Either signals an inconsistent slot. The OCI fetcher's cache-hit
 // path uses this to reset stale slots before serving them.
 func hasUnfinishedOCILayout(slot string) bool {
-	candidates := append([]string{stagedLayerFilename}, ociLayoutArtifacts...)
-	for _, name := range candidates {
+	if _, err := os.Stat(filepath.Join(slot, stagedLayerFilename)); err == nil {
+		return true
+	}
+	for _, name := range ociLayoutArtifacts {
 		if _, err := os.Stat(filepath.Join(slot, name)); err == nil {
 			return true
 		}

--- a/pkg/source/oci/marker.go
+++ b/pkg/source/oci/marker.go
@@ -68,8 +68,15 @@ func cachedDigestFresh(slot string, maxAge time.Duration) (string, bool) {
 	if err != nil || time.Since(info.ModTime()) > maxAge {
 		return "", false
 	}
-	digest := readCachedDigest(slot)
-	return digest, digest != ""
+	b, err := os.ReadFile(path) //nolint:gosec // slot is fetcher-owned cache path
+	if err != nil {
+		return "", false
+	}
+	d := strings.TrimSpace(string(b))
+	if !digestRE.MatchString(d) {
+		return "", false
+	}
+	return d, true
 }
 
 // verifyFingerprint hashes the verify spec into a short identifier

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -71,7 +71,7 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource, quies
 		default:
 		}
 	}
-	initial, hasInitial, unsub := s.subscribeWithStatus(EventStatusUpdated, listener, id)
+	initial, hasInitial, unsub := s.subscribeWithStatus(listener, id)
 	defer unsub()
 
 	var currentFailed *StatusInfo
@@ -251,7 +251,7 @@ func (s *Store) subscribeWithObject(fn Listener, id manifest.NamedResource) (man
 // EventStatusUpdated listener AND reads the current status for id
 // under one s.mu.RLock. Mirrors subscribeWithObject for the status
 // channel; same race-closing argument.
-func (s *Store) subscribeWithStatus(_ EventKind, fn Listener, id manifest.NamedResource) (StatusInfo, bool, Unsubscribe) {
+func (s *Store) subscribeWithStatus(fn Listener, id manifest.NamedResource) (StatusInfo, bool, Unsubscribe) {
 	set := s.listeners[EventStatusUpdated]
 	s.mu.RLock()
 	handle := set.add(fn)


### PR DESCRIPTION
## Summary

Tidy-up across 25 files following the rapid landings of #413-#420. Net **-51 lines**: collapses log redundancy, inlines a few one-use helpers, and tightens render/output hot paths. **No behavioral changes.**

Done via 7 parallel cleanup agents partitioned by disjoint file ownership, then a single diagnostic fix (`errors.As` → `errors.AsType` parity in `depwait.go`).

### Highlights

- `pkg/source/oci/fetch.go` — merge stale/unresolved slot branches so Reset+Stage is written once instead of twice
- `pkg/source/{git,oci}/marker.go` — single stat+read for cached revision/digest freshness
- `pkg/source/oci/layer.go` — drop per-call slice allocation in `hasUnfinishedOCILayout`
- `pkg/resourceset/output.go` — inline `applyOwnerLabels` write to avoid per-doc transient map allocation on the render hot path
- `pkg/depwait/depwait.go` — prune 3 `waitRenderEmission` debug logs whose returned error already conveys the outcome; `errors.AsType` parity with file's other use
- `pkg/controllers/{helmrelease,kustomization,source}` — `errors.New` instead of `fmt.Errorf("%s",...)`; drop redundant fetch-start log
- `internal/cli/diff.go` — replace two open-coded `"table"`→default fallbacks with the existing `c.outputOrDefault` helper used in `build.go`/`get.go`
- `pkg/store/watch.go` — remove dead `EventKind` param from `subscribeWithStatus`
- Small idiom cleanups: `slices.Clone`, `maps.Clone`, `map[string]bool` over `map[string]struct{}`, removed what-comments

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -count=1 ./...` — all packages green
- [x] `golangci-lint run` — 0 issues
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)