### PR TITLE
refactor(pkg/diff): preallocate Header parts, fix stale doc claim

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -74,7 +74,7 @@ type ResourceDiff struct {
 // Header returns the flux-local-style "[path] Parent: ns/name
 // Child: ns/name" prefix used in diff output.
 func (d ResourceDiff) Header() string {
-	var parts []string
+	parts := make([]string, 0, 3)
 	if d.Parent.Path != "" {
 		parts = append(parts, d.Parent.Path)
 	}

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -16,11 +16,9 @@
 //
 // Three output flavors are supported:
 //
-//   - Diff — concatenated dyff bodies, one per resource. Multi-
-//     resource output prefixes each body with a single `#`-style
-//     header line identifying the parent KS/HR; single-resource
-//     output omits the header because dyff's `@@ <path> @@` is
-//     unambiguous on its own (the default).
+//   - Diff — concatenated dyff bodies, one per resource. Every body
+//     is prefixed with a single `#`-style header line identifying
+//     the parent KS/HR and the child resource (the default).
 //   - YAML — structured YAML where each entry is a resource and its
 //     dyff body.
 //   - JSON — same shape as YAML, marshaled as JSON.


### PR DESCRIPTION
## Summary

Iteration 1 of the autonomous module-refactor loop. Tiny scope:

- `pkg/diff/diff.go` — preallocate `Header()` parts slice (`make([]string, 0, 3)`) to skip the grow-from-nil path
- `pkg/diff/doc.go` — drop the stale claim that "single-resource output omits the header". `TestRender_DiffHeaderAlwaysEmitted` explicitly pins that every diff body emits a `#` header line; the package has always done so

No behavior change. Public API unchanged.

## Test plan

- [x] `go vet ./pkg/diff/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/diff/...`
- [x] `golangci-lint run ./pkg/diff/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)