### PR TITLE
refactor(pkg/image): unexport unused IsImageRef, prune what-comments

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -22,9 +22,7 @@ import (
 	"github.com/distribution/reference"
 )
 
-// Extract returns the unique sorted image references found anywhere
-// inside doc. Non-string values are ignored. Returns nil when no
-// images are found.
+// Extract returns nil when no images are found.
 func Extract(doc map[string]any) []string {
 	set := map[string]struct{}{}
 	walk(doc, set)
@@ -34,8 +32,6 @@ func Extract(doc map[string]any) []string {
 	return slices.Sorted(maps.Keys(set))
 }
 
-// walk recursively descends into v collecting strings that look like
-// OCI image references.
 func walk(v any, set map[string]struct{}) {
 	switch tv := v.(type) {
 	case map[string]any:
@@ -47,18 +43,18 @@ func walk(v any, set map[string]struct{}) {
 			walk(item, set)
 		}
 	case string:
-		if IsImageRef(tv) {
+		if isImageRef(tv) {
 			set[tv] = struct{}{}
 		}
 	}
 }
 
-// IsImageRef reports whether s looks like a tagged or digested OCI
-// image reference. distribution/reference is permissive — many
-// non-image strings ("count:up0", "system:auth-delegator",
-// "localhost:11220") parse cleanly as `name:tag` — so we apply
-// cheap heuristics first to weed out common false positives.
-func IsImageRef(s string) bool {
+// isImageRef reports whether s looks like a tagged or digested OCI image
+// reference. distribution/reference is permissive — many non-image strings
+// ("count:up0", "system:auth-delegator", "localhost:11220") parse cleanly as
+// `name:tag` — so we apply cheap heuristics first to weed out common false
+// positives.
+func isImageRef(s string) bool {
 	if len(s) < 5 {
 		return false
 	}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -119,7 +119,7 @@ func TestExtract_RejectsNonImages(t *testing.T) {
 	}
 }
 
-func TestIsImageRef(t *testing.T) {
+func Test_isImageRef(t *testing.T) {
 	yes := []string{
 		"ghcr.io/owner/repo:v1",
 		"ghcr.io/owner/repo@sha256:" + sha256(),
@@ -131,7 +131,7 @@ func TestIsImageRef(t *testing.T) {
 	}
 	for _, s := range yes {
 		t.Run("yes/"+s, func(t *testing.T) {
-			if !IsImageRef(s) {
+			if !isImageRef(s) {
 				t.Errorf("expected image ref")
 			}
 		})
@@ -160,14 +160,13 @@ func TestIsImageRef(t *testing.T) {
 	}
 	for _, s := range no {
 		t.Run("no/"+s, func(t *testing.T) {
-			if IsImageRef(s) {
+			if isImageRef(s) {
 				t.Errorf("expected NOT image ref")
 			}
 		})
 	}
 }
 
-// sha256 returns a 64-hex stub used as a digest fixture.
 func sha256() string {
 	return "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 }


### PR DESCRIPTION
## Summary

Iteration 1 of the autonomous module-refactor loop.

- `IsImageRef` → `isImageRef` (unexported): not referenced outside the package (verified via repo-wide grep including `internal/cli/images.go` which uses `image.Extract`, not `IsImageRef`)
- Tests updated in-place (white-box `package image`); `TestIsImageRef` → `Test_isImageRef`
- Removed what-comments on the `walk` helper and the `sha256` test setup

Public API: `IsImageRef` removed. The only public surface is now `Extract`.

The big inline comment in `isImageRef` (false-positive examples like `apiserver_request:burnrate1d`, `system:auth-delegator`, `localhost:11220`) is kept as a living spec for the heuristic.

## Test plan

- [x] `go vet ./pkg/image/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/image/...` — all pass
- [x] `golangci-lint run ./pkg/image/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)