### PR TITLE
fix(selector): correct package doc to list all four supported types

### DIFF
--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -1,7 +1,8 @@
 // Package selector implements metadata filtering used by every flate
 // command. Selectors are translated from CLI flags by the cli package
 // and consumed by controllers and the orchestrator to decide which
-// Kustomizations/HelmReleases to consider.
+// Kustomizations, HelmReleases, ResourceSets, and ResourceSetInputProviders
+// to consider.
 package selector
 
 import "github.com/home-operations/flate/pkg/manifest"


### PR DESCRIPTION
Iter-2 of refactor loop. Tiny doc fix: package doc only mentioned 2 of the 4 selector-supported manifest types. Now lists `Kustomization`, `HelmRelease`, `ResourceSet`, and `ResourceSetInputProvider`.

No behavior change. No public API change. Module is otherwise already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)