### PR TITLE
refactor(keylock): drop heap alloc on cancelled Acquire

### DIFF
--- a/internal/keylock/keylock.go
+++ b/internal/keylock/keylock.go
@@ -8,6 +8,9 @@ import (
 	"sync"
 )
 
+// noop is the zero-allocation release func returned on cancelled acquires.
+var noop = func() {}
+
 // KeyMap holds one lock per key value, allocated on first use.
 type KeyMap[K comparable] struct {
 	mu    sync.Mutex
@@ -36,6 +39,6 @@ func (m *KeyMap[K]) Acquire(ctx context.Context, key K) (release func(), err err
 	case lock <- struct{}{}:
 		return func() { <-lock }, nil
 	case <-ctx.Done():
-		return func() {}, ctx.Err()
+		return noop, ctx.Err()
 	}
 }


### PR DESCRIPTION
## Summary

Iter-2 of refactor loop. Replace the inline `func(){}` closure on the cancellation path with a shared package-level `noop` var. Every cancelled `Acquire` previously allocated a new closure on the heap; the shared var eliminates that.

Public API unchanged (`New[K]`, `Acquire` signatures and semantics identical).

## Notable

- Race-clean (`go test -race`)
- Out-of-scope concern (worth a follow-up): the lock-per-key map grows unbounded with distinct keys. Fixing safely needs reference counting and is a behaviour change — not done here.

## Test plan

- [x] `go vet ./internal/keylock/...`
- [x] `go test -count=1 -race -timeout=180s ./internal/keylock/...`
- [x] `golangci-lint run ./internal/keylock/...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)