### PR TITLE
refactor(source/blob): drop dead PutReader, tighten lock scopes

### DIFF
--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -93,10 +93,8 @@ func (r *Refs) Get(key string) (string, bool) {
 // to rebuild on the next reconcile, so the fsync barrier is not worth
 // the per-render I/O cost.
 func (r *Refs) Put(key, digest string) error {
-	unlockGC := RLockGC()
-	defer unlockGC()
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	// MkdirAll is idempotent and safe to call without the mutex; moving
+	// it outside shrinks the critical section around the atomic rename.
 	if err := os.MkdirAll(r.dir, 0o750); err != nil {
 		return fmt.Errorf("refs dir: %w", err)
 	}
@@ -104,6 +102,10 @@ func (r *Refs) Put(key, digest string) error {
 	if err != nil {
 		return err
 	}
+	unlockGC := RLockGC()
+	defer unlockGC()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if err := atomic.WriteFile(final, []byte(digest), 0o600, false); err != nil {
 		return err
 	}

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -19,7 +19,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -77,6 +76,7 @@ func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (
 	sum := sha256.Sum256(content)
 	digest := hex.EncodeToString(sum[:])
 	dir := s.Path(digest)
+	parent := filepath.Dir(dir)
 
 	unlockGC := RLockGC()
 	defer unlockGC()
@@ -92,10 +92,10 @@ func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (
 		_ = os.Chtimes(dir, now, now)
 		return dir, digest, nil
 	}
-	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {
+	if err := os.MkdirAll(parent, 0o750); err != nil {
 		return "", "", fmt.Errorf("blob parent: %w", err)
 	}
-	staging, err := os.MkdirTemp(filepath.Dir(dir), filepath.Base(dir)+".tmp.*")
+	staging, err := os.MkdirTemp(parent, filepath.Base(dir)+".tmp.*")
 	if err != nil {
 		return "", "", fmt.Errorf("blob staging: %w", err)
 	}
@@ -116,15 +116,3 @@ func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (
 	}
 	return dir, digest, nil
 }
-
-// PutReader is the streaming variant of PutBytes. Useful when the
-// caller has an io.Reader but doesn't want to buffer the whole
-// artifact in memory.
-func (s *Store) PutReader(ctx context.Context, r io.Reader, filename string) (string, string, error) {
-	buf, err := io.ReadAll(r)
-	if err != nil {
-		return "", "", err
-	}
-	return s.PutBytes(ctx, buf, filename)
-}
-


### PR DESCRIPTION
## Summary

Iter-3 of refactor loop.

- **Drop `Store.PutReader`** — zero callers across the repo (verified by grep). Removes unused `io` import.
- **`Refs.Put` lock scope** — move `MkdirAll` outside the mutex + GC-lock acquisition. MkdirAll is idempotent and OS-atomic; doesn't need serialization. The critical section now covers only the atomic rename and `mem.Store`.
- **`Refs.Put` MkdirTemp parent** — capture `filepath.Dir(dir)` into `parent` once instead of computing it twice.

Public API delta: `Store.PutReader` removed (dead).

## Test plan
- [x] `go vet ./pkg/source/blob/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/source/blob/...` (all 8 tests pass)
- [x] `golangci-lint run ./pkg/source/blob/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)