### PR TITLE
perf(source/bucket): buffered IO + preallocated keys + close-error propagation

### DIFF
--- a/pkg/source/bucket/endpoint.go
+++ b/pkg/source/bucket/endpoint.go
@@ -12,14 +12,11 @@ import (
 func normalizeEndpoint(endpoint string, insecure bool) (host string, secure bool, err error) {
 	switch {
 	case strings.HasPrefix(endpoint, "https://"):
-		host = strings.TrimPrefix(endpoint, "https://")
-		secure = true
+		host, secure = strings.TrimPrefix(endpoint, "https://"), true
 	case strings.HasPrefix(endpoint, "http://"):
-		host = strings.TrimPrefix(endpoint, "http://")
-		secure = false
+		host, secure = strings.TrimPrefix(endpoint, "http://"), false
 	default:
-		host = endpoint
-		secure = !insecure
+		host, secure = endpoint, !insecure
 	}
 	host = strings.TrimRight(host, "/")
 	if host == "" {

--- a/pkg/source/bucket/fetcher.go
+++ b/pkg/source/bucket/fetcher.go
@@ -1,13 +1,5 @@
 // Package bucket implements the source.Fetcher for KindBucket
 // (S3-compatible object storage via minio-go).
-//
-// File map:
-//
-//	fetcher.go    — Fetcher type, Fetch entry, authIdentity
-//	auth.go       — credentials + transport (TLS+proxy) resolution
-//	endpoint.go   — Flux endpoint normalization, scheme picker
-//	walk.go       — list + parallel download + content-addressed revision
-//	traversal.go  — safe path join (defense in depth against key escape)
 package bucket
 
 import (

--- a/pkg/source/bucket/walk.go
+++ b/pkg/source/bucket/walk.go
@@ -1,12 +1,12 @@
 package bucket
 
 import (
+	"bufio"
 	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -15,6 +15,11 @@ import (
 	"github.com/minio/minio-go/v7"
 	"golang.org/x/sync/errgroup"
 )
+
+// downloadBufSize is the per-goroutine write buffer for object downloads.
+// 256 KiB amortises syscall overhead across the typical S3 object without
+// holding large chunks in memory when many goroutines run concurrently.
+const downloadBufSize = 256 << 10
 
 // walkBucket lists the bucket under prefix, downloads each object
 // into slot preserving the prefix-relative path, and returns the
@@ -31,8 +36,7 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 			return nil, "", obj.Err
 		}
 		if strings.HasSuffix(obj.Key, "/") {
-			// "Directory" placeholder — skip.
-			continue
+			continue // S3 directory-placeholder objects
 		}
 		entries = append(entries, entry{key: obj.Key, etag: obj.ETag})
 	}
@@ -73,10 +77,10 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 	// for identical contents — change detection across runs and any
 	// readyExpr keyed off status.artifact.revision would never align.
 	h := sha256.New()
-	keys := make([]string, 0, len(entries))
-	for _, e := range entries {
+	keys := make([]string, len(entries))
+	for i, e := range entries {
 		_, _ = fmt.Fprintf(h, "%s %s\n", e.key, e.etag)
-		keys = append(keys, e.key)
+		keys[i] = e.key
 	}
 	return keys, "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }
@@ -87,13 +91,19 @@ func downloadObject(ctx context.Context, client *minio.Client, bucket, key, dst 
 		return err
 	}
 	defer func() { _ = obj.Close() }()
+
 	f, err := os.Create(dst) //nolint:gosec // dst is composed from cache slot + bucket key
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
-	if _, err := io.Copy(f, obj); err != nil {
+	bw := bufio.NewWriterSize(f, downloadBufSize)
+	if _, err := bw.ReadFrom(obj); err != nil {
+		_ = f.Close()
 		return fmt.Errorf("copy %s: %w", key, err)
 	}
-	return nil
+	if err := bw.Flush(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("flush %s: %w", key, err)
+	}
+	return f.Close()
 }


### PR DESCRIPTION
## Summary

Iter-3 of refactor loop.

- **`downloadObject` hot path** — `bufio.NewWriterSize(f, 256 KiB)` + `bw.ReadFrom(obj)`. Batches small-object writes into one syscall; large objects use \`os.File.ReadFrom\` (zero-copy sendfile on Linux). Replaces \`defer _ = f.Close()\` with explicit \`bw.Flush() + f.Close()\` returning errors — the prior defer silently swallowed write-flush errors (e.g., disk full at close).
- **`walkBucket` keys** — `make([]string, len(entries))` + index assignment instead of `make([]string, 0, cap) + append`. Entry count is known, drops the append-growth overhead.
- **`normalizeEndpoint`** — fold each two-statement switch arm into a single parallel assignment.
- **`fetcher.go`** — drop a what-comment package-doc block listing the directory.

Public API unchanged: `Fetcher`, `Fetcher.Fetch`, `Fetcher.Cache`, `Fetcher.Secrets`. Artifact output is byte-identical.

## Test plan
- [x] `go vet ./pkg/source/bucket/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/source/bucket/...`
- [x] `golangci-lint run ./pkg/source/bucket/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)