### PR TITLE
docs(gittransport): tighten doc comments to why-only

### DIFF
--- a/pkg/source/git/internal/gittransport/gittransport.go
+++ b/pkg/source/git/internal/gittransport/gittransport.go
@@ -1,13 +1,11 @@
-// Package gittransport carries the shared HTTPS-transport install
-// lock that's serialized across the git.Fetcher and the bare-mirror
-// cache.
+// Package gittransport carries the shared HTTPS-transport install lock
+// serialized across git.Fetcher and the bare-mirror cache.
 //
-// go-git v5 has no per-CloneOptions TLS hook, so a custom-CA fetch
-// must register its transport on go-git's process-global protocol
-// map and restore the default afterward. The lock is package-global
-// because the install itself is — a per-Fetcher mutex would race
-// when two Fetchers ran concurrently and clobbered each other's
-// transport.
+// go-git v5 has no per-CloneOptions TLS hook, so a custom-CA fetch must
+// register its transport on go-git's process-global protocol map and
+// restore the default afterward. The lock is package-global because the
+// install itself is — a per-Fetcher mutex would race when two Fetchers ran
+// concurrently and clobbered each other's transport.
 package gittransport
 
 import (
@@ -23,18 +21,13 @@ import (
 
 var mu sync.Mutex
 
-// InstallHTTPS installs a TLS+proxy-customized HTTPS transport on
-// go-git's global protocol map and returns a restore function the
-// caller MUST defer. Acquires the process-global mutex on entry; the
-// restore releases it after re-installing the default client.
+// InstallHTTPS acquires the process-global mutex, installs a custom HTTPS
+// transport on go-git's protocol map, and returns a restore func the caller
+// MUST defer.
 //
-// The restore func is wrapped with sync.OnceFunc so a double-call
-// (e.g., explicit cleanup followed by defer) is a no-op rather than
-// a panic on unlock-of-unlocked-mutex. Today's only call sites defer
-// it immediately, but the OnceFunc guard makes the API hard to misuse.
-//
-// When tlsCfg is nil there's nothing to customize: returns a no-op
-// restore and no error, no lock acquired.
+// sync.OnceFunc prevents a double-restore (defer + explicit call) from
+// unlocking an already-unlocked mutex. When tlsCfg is nil there is nothing
+// to customize — returns a no-op without acquiring the lock.
 func InstallHTTPS(tlsCfg *tls.Config, proxy *source.ProxyConfig) (func(), error) {
 	if tlsCfg == nil {
 		return func() {}, nil


### PR DESCRIPTION
## Summary

Iter-3 of refactor loop. Doc-only cleanup: replaced what-narration with why-rationale (go-git global-map constraint, why the lock is package-level, why `sync.OnceFunc` guards against double-restore). Net −7 lines, behavior unchanged.

Public API unchanged: `InstallHTTPS(tlsCfg *tls.Config, proxy *source.ProxyConfig) (func(), error)`.

## Test plan
- [x] `go vet ./pkg/source/git/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/source/git/...`
- [x] `golangci-lint run ./pkg/source/git/internal/gittransport/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)