### PR TITLE
refactor(pkg/task): drop fmt import, trim what-comments, fix stale doc

### DIFF
--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -7,7 +7,6 @@ package task
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
@@ -66,7 +65,7 @@ func NewBounded(workers int) *Service {
 }
 
 // Go launches an active task. ctx is propagated to fn. Completion is
-// reported via WaitActive / BlockTillDone. When the Service is
+// reported via BlockTillDone. When the Service is
 // bounded (NewBounded), fn waits on the worker semaphore before it
 // executes — but Go itself never blocks.
 func (s *Service) Go(ctx context.Context, name string, fn func(context.Context)) {
@@ -99,19 +98,17 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 	}()
 }
 
-// taskDone decrements active and notifies any quiescence waiters
-// whose threshold the new count satisfies. Called via defer from
-// Go's body so panics and clean returns both fire it.
+// taskDone is deferred in Go so both clean returns and panics fire
+// the decrement and quiescence notification.
 func (s *Service) taskDone() {
 	now := s.active.Add(-1)
 	s.notifyQuiescence(now)
 }
 
-// notifyQuiescence closes every registered quiescence waiter whose
-// threshold the new active count satisfies. Called anywhere the
-// count drops — taskDone on goroutine exit AND YieldQuiescent on
-// entry — so depwait-blocked tasks don't keep the pool from
-// declaring quiescence on their own absence of productive work.
+// notifyQuiescence is called on every active-count decrement —
+// goroutine exit (taskDone) AND YieldQuiescent entry — so
+// depwait-blocked tasks don't prevent the pool from reaching
+// quiescence on their own absence of productive work.
 func (s *Service) notifyQuiescence(now int64) {
 	s.quiesceMu.Lock()
 	defer s.quiesceMu.Unlock()
@@ -271,17 +268,10 @@ func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(c
 	c.mu.Unlock()
 
 	c.svc.Go(ctx, name, func(ctx context.Context) {
-		// On panic, Service.Go's recover catches it; we still need to
-		// clear running so a future Submit on this key is dispatched
-		// instead of silently coalescing into a slot that no longer
-		// has a runner. If a coalesced submit had landed during the
-		// panicked run (s.pending == true), the previous code
-		// silently dropped that re-run — the event the submitter
-		// counted on was lost. Log at Warn so the loss is at least
-		// visible; the panicked run itself is already reported via
-		// Service.Go's recover. The pending re-run is genuinely
-		// dead — restarting it here would loop on the same panic if
-		// the input state is deterministic.
+		// On panic, clear the slot before re-raising so future Submits
+		// on this key dispatch normally. If a pending re-run exists it
+		// is dropped — restarting on deterministic-panic input loops —
+		// and logged so the loss is observable.
 		defer func() {
 			if r := recover(); r != nil {
 				c.mu.Lock()
@@ -290,7 +280,7 @@ func (c *Coalescer[K]) Submit(ctx context.Context, name string, key K, fn func(c
 				c.mu.Unlock()
 				if lostPending {
 					slog.Warn("task coalescer: dropped pending re-run because the previous run panicked",
-						"key", fmt.Sprintf("%v", key))
+						"key", key)
 				}
 				panic(r)
 			}


### PR DESCRIPTION
## Summary

Iter-3 of refactor loop.

- **Drop `fmt` import** — only use was `fmt.Sprintf("%v", key)` in `Coalescer.Submit`'s panic handler. Pass `key` directly to `slog.Warn`; `slog` handles `comparable` values via `slog.Any`, avoiding the pre-format allocation.
- **Stale doc on `Service.Go`** — godoc said "reported via WaitActive / BlockTillDone" but `WaitActive` has never existed; only `BlockTillDone` does.
- **What-comments → why-comments** in `taskDone`, `notifyQuiescence`, and the Coalescer panic handler.

Public API unchanged: `New`, `NewBounded`, `Go`, `YieldSlot`, `YieldQuiescent`, `QuiescenceCh`, `ActiveCount`, `BlockTillDone`, `Failures`, `Coalescer`, `NewCoalescer`, `Submit` all identical.

## Test plan
- [x] `go vet ./pkg/task/...`
- [x] `go test -count=3 -race -timeout=180s ./pkg/task/...` (count=3 for concurrency robustness)
- [x] **Downstream:** `go test -count=1 -race -timeout=180s ./pkg/orchestrator/... ./pkg/depwait/...` (orchestrator 2.2s, depwait 20s) — all green
- [x] `golangci-lint run ./pkg/task/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)