### PR TITLE
refactor(depwait): map lookup for apiVersion, Go 1.22 loop vars, WaitGroup.Go

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -181,17 +181,16 @@ func projectObject(s *store.Store, id manifest.NamedResource) map[string]any {
 		// — a common Flux readiness idiom — never spuriously fail.
 		"generation": int64(1),
 	}
-	if labels, annotations := labelsAndAnnotations(obj); labels != nil || annotations != nil {
-		if labels != nil {
-			meta["labels"] = labels
-		}
-		if annotations != nil {
-			meta["annotations"] = annotations
-		}
+	labels, annotations := labelsAndAnnotations(obj)
+	if labels != nil {
+		meta["labels"] = labels
+	}
+	if annotations != nil {
+		meta["annotations"] = annotations
 	}
 	return map[string]any{
 		"kind":       id.Kind,
-		"apiVersion": apiVersionFor(id.Kind),
+		"apiVersion": kindAPIVersion[id.Kind],
 		"metadata":   meta,
 		"status": map[string]any{
 			"observedGeneration": int64(1),
@@ -238,25 +237,19 @@ func conditionToMap(c metav1.Condition) map[string]any {
 	}
 }
 
-// apiVersionFor returns the well-known apiVersion for kinds flate
-// tracks. Used so CEL expressions inspecting `object.apiVersion`
-// behave sensibly. Unknown kinds get an empty apiVersion — that's
-// fine; most ReadyExpr formulations don't read it.
-func apiVersionFor(kind string) string {
-	switch kind {
-	case manifest.KindKustomization:
-		return manifest.FluxKustomizeDomain + "/v1"
-	case manifest.KindHelmRelease:
-		return manifest.HelmReleaseDomain + "/v2"
-	case manifest.KindGitRepository,
-		manifest.KindOCIRepository,
-		manifest.KindHelmRepository,
-		manifest.KindHelmChart,
-		manifest.KindBucket,
-		manifest.KindExternalArtifact:
-		return manifest.SourceDomain + "/v1"
-	}
-	return ""
+// kindAPIVersion maps each tracked Kind to its canonical apiVersion.
+// Used by projectObject so CEL expressions inspecting object.apiVersion
+// behave sensibly. Kinds absent from the map return "" — most ReadyExpr
+// formulations don't read it, so the empty value is a safe default.
+var kindAPIVersion = map[string]string{
+	manifest.KindKustomization:   manifest.FluxKustomizeDomain + "/v1",
+	manifest.KindHelmRelease:     manifest.HelmReleaseDomain + "/v2",
+	manifest.KindGitRepository:   manifest.SourceDomain + "/v1",
+	manifest.KindOCIRepository:   manifest.SourceDomain + "/v1",
+	manifest.KindHelmRepository:  manifest.SourceDomain + "/v1",
+	manifest.KindHelmChart:       manifest.SourceDomain + "/v1",
+	manifest.KindBucket:          manifest.SourceDomain + "/v1",
+	manifest.KindExternalArtifact: manifest.SourceDomain + "/v1",
 }
 
 func asBool(v ref.Val) (bool, error) {

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -223,9 +223,7 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 
 	var wg sync.WaitGroup
 	for _, dep := range deps {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// Recover from panics in watchOne (e.g. malformed CEL expression
 			// evaluating against an unexpected payload type) so the whole
 			// run isn't killed. The dep is reported failed instead.
@@ -235,7 +233,7 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 			// dropped events on cancellation, leaving the consumer with
 			// a Pending dep that would time out at the full budget.
 			out <- safeWatchOne(ctx, w, dep, timeout)
-		}()
+		})
 	}
 
 	go func() {

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -224,7 +224,7 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 	var wg sync.WaitGroup
 	for _, dep := range deps {
 		wg.Add(1)
-		go func(dep manifest.DependencyRef) {
+		go func() {
 			defer wg.Done()
 			// Recover from panics in watchOne (e.g. malformed CEL expression
 			// evaluating against an unexpected payload type) so the whole
@@ -235,7 +235,7 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 			// dropped events on cancellation, leaving the consumer with
 			// a Pending dep that would time out at the full budget.
 			out <- safeWatchOne(ctx, w, dep, timeout)
-		}(dep)
+		}()
 	}
 
 	go func() {
@@ -411,22 +411,22 @@ func (w *Waiter) resolveMissing(ctx context.Context, id manifest.NamedResource) 
 	// EventObjectAdded subscription (no race) and is bounded by
 	// RenderProducingTimeout / QuiescenceCh / parent ctx.
 	if err := w.waitRenderEmission(ctx, id); err != nil {
-		switch {
-		case errors.Is(ctx.Err(), context.Canceled):
-			ev := classify(id, ctx.Err(), "")
+		// waitRenderEmission returns ctx.Err() (context.Canceled)
+		// on parent cancellation — propagate as DepCancelled so logs
+		// and Summary counters stay accurate.
+		if errors.Is(err, context.Canceled) {
+			ev := classify(id, err, "")
 			return &ev
-		case errors.Is(err, errRenderCapExceeded),
-			errors.Is(err, context.DeadlineExceeded),
-			errors.Is(err, errRenderDrained):
-			// The render-emission cap fired (or the pool drained
-			// without producing, or the wait was bounded by the
-			// per-dep Timeout) — the dep isn't going to appear.
-			// Fast-fail with "dependency not found" rather than the
-			// ambiguous "timeout" label.
-			return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
-		default:
-			return &Event{Dep: id, Status: DepFailed, Reason: err.Error()}
 		}
+		// All non-cancel terminations (render cap, pool drain, deadline)
+		// mean the dep isn't going to appear. Fast-fail with the
+		// canonical message instead of the ambiguous "timeout" label.
+		if errors.Is(err, errRenderCapExceeded) ||
+			errors.Is(err, context.DeadlineExceeded) ||
+			errors.Is(err, errRenderDrained) {
+			return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+		}
+		return &Event{Dep: id, Status: DepFailed, Reason: err.Error()}
 	}
 	return nil
 }
@@ -503,7 +503,7 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 func (w *Waiter) tryReadyExpr(expr string, id manifest.NamedResource) (Event, bool) {
 	ok, err := evaluateReadyExpr(expr, w.Store, w.Parent, id)
 	if err != nil {
-		if _, ok := errors.AsType[*celCompileErr](err); ok {
+		if _, isCompile := errors.AsType[*celCompileErr](err); isCompile {
 			return Event{Dep: id, Status: DepFailed, Reason: "readyExpr: " + err.Error()}, true
 		}
 		// Eval error: transient, re-poll on next event.


### PR DESCRIPTION
## Summary

Iter-4 deeper pass on `pkg/depwait`.

- **`cel.go` `apiVersionFor` switch → `kindAPIVersion` map** — was up to 8 string compares per CEL eval tick; map is O(1) hash and extensible.
- **`cel.go` redundant outer nil guard removed** in `condsAny`.
- **`depwait.go` Go 1.22 loop-var capture** — drop the explicit `go func(dep …) {…}(dep)` copy; per-iteration loop vars make the closure capture safe.
- **`depwait.go` `WatchAll` uses `sync.WaitGroup.Go`** (Go 1.25+) instead of manual `Add(1)`+`defer Done()` — two fewer lines per goroutine, no risk of misplaced `Done`.
- **`depwait.go` `resolveMissing`** — flatten `switch { case errors.Is(...) }` into sequential `if` blocks; the cancel branch now checks the returned `err` directly (avoids subtle ctx TOCTOU).
- **`depwait.go` `tryReadyExpr`** — rename `ok` shadow to `isCompile`.

Public API unchanged.

## Test plan
- [x] `go vet ./pkg/depwait/...`
- [x] `go test -count=3 -race -timeout=300s ./pkg/depwait/...` — pass
- [x] **Downstream:** `./pkg/orchestrator/... ./pkg/controllers/...` race — pass
- [x] `golangci-lint run ./pkg/depwait/...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)