### PR TITLE
perf(store): fixed-size listener array, inline dispatch, condition-first scan

### DIFF
--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -86,10 +86,10 @@ func (s *Store) OnArtifact(fn func(manifest.NamedResource, Artifact), replay boo
 // see the pre-registered state (live event misses this listener,
 // replay fires once). Exactly-one delivery either way.
 func (s *Store) AddListener(event EventKind, fn Listener, flush bool) Unsubscribe {
-	set, ok := s.listeners[event]
-	if !ok {
+	if event < 1 || int(event) > numEventKinds {
 		panic("store: unknown event kind")
 	}
+	set := s.listeners[event]
 	if !flush {
 		// Even the no-replay path serializes via s.mu so a concurrent
 		// writer can't snapshot listeners (under set.mu alone) and then
@@ -169,21 +169,14 @@ func (s *Store) snapshotForReplay(event EventKind) []idPayload {
 // (so the listener-contract gap is closed) and must stay cheap on
 // the render hot path when nothing's listening.
 func (s *Store) fireUnderLock(event EventKind, id manifest.NamedResource, payload any) func() {
-	set := s.listeners[event]
-	if set == nil {
-		return func() {}
-	}
-	listeners := set.snapshot()
+	listeners := s.listeners[event].snapshot()
 	if len(listeners) == 0 {
 		return func() {}
 	}
-	return func() { dispatch(listeners, id, payload) }
-}
-
-// dispatch invokes each listener with the payload, recovering panics.
-func dispatch(listeners []Listener, id manifest.NamedResource, payload any) {
-	for _, fn := range listeners {
-		safeInvoke(fn, id, payload)
+	return func() {
+		for _, fn := range listeners {
+			safeInvoke(fn, id, payload)
+		}
 	}
 }
 
@@ -250,8 +243,8 @@ func (l *listenerSet) snapshot() []Listener {
 		return nil
 	}
 	out := make([]Listener, len(l.entries))
-	for i := range l.entries {
-		out[i] = l.entries[i].fn
+	for i, e := range l.entries {
+		out[i] = e.fn
 	}
 	return out
 }

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -265,12 +265,18 @@ func conditionEqual(a, b Condition) bool {
 // otherwise resurrect a failure entry for an id that no longer exists.
 // Conditioning on s.objects ensures FailedResources never reports a
 // failure for a resource the orchestrator has explicitly removed.
+//
+// Iterating conditions rather than objects is faster when most objects
+// don't have conditions yet (common during bootstrap) — avoids the
+// secondary map lookup for every un-reconciled object.
 func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make(map[manifest.NamedResource]StatusInfo)
-	for id := range s.objects {
-		conds := s.conditions[id]
+	for id, conds := range s.conditions {
+		if _, inStore := s.objects[id]; !inStore {
+			continue
+		}
 		if info, ok := statusInfoFromConditions(conds); ok && info.Status == StatusFailed {
 			out[id] = info
 		}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -7,6 +7,11 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// numEventKinds is the number of distinct EventKind values (1-based, so
+// index 0 is unused). A fixed-size array indexed directly by EventKind
+// removes the map lookup and bucket overhead on every dispatch path.
+const numEventKinds = 3
+
 // Store is the central in-memory state container.
 //
 // # Immutability contract
@@ -42,27 +47,26 @@ type Store struct {
 	// Secret resolution) O(1) instead of O(total objects of that kind).
 	byName map[string]map[string]manifest.BaseManifest
 
-	// listeners is keyed by EventKind. Each entry is a slice of
-	// (id, listener) pairs. We use a slice + linear scan because:
-	//   - listener counts are tiny (a handful per event)
-	//   - removal preserves order
-	//   - Unsubscribe identity is the slice index encoded in a closure
-	listeners map[EventKind]*listenerSet
+	// listeners is indexed by EventKind (1-based; index 0 unused). A
+	// fixed-size array beats a map here: the set of kinds is closed,
+	// the index arithmetic is O(1) with no hash, and the array itself
+	// is inline in the Store struct rather than a separately-allocated
+	// map header. Every dispatch path benefits.
+	listeners [numEventKinds + 1]*listenerSet
 }
 
 // New constructs an empty Store.
 func New() *Store {
-	return &Store{
+	s := &Store{
 		objects:    make(map[manifest.NamedResource]manifest.BaseManifest),
 		conditions: make(map[manifest.NamedResource][]Condition),
 		artifacts:  make(map[manifest.NamedResource]Artifact),
 		byName:     make(map[string]map[string]manifest.BaseManifest),
-		listeners: map[EventKind]*listenerSet{
-			EventObjectAdded:     newListenerSet(),
-			EventStatusUpdated:   newListenerSet(),
-			EventArtifactUpdated: newListenerSet(),
-		},
 	}
+	s.listeners[EventObjectAdded] = newListenerSet()
+	s.listeners[EventStatusUpdated] = newListenerSet()
+	s.listeners[EventArtifactUpdated] = newListenerSet()
+	return s
 }
 
 func nameKey(namespace, name string) string { return namespace + "/" + name }


### PR DESCRIPTION
## Summary

Iter-4 deeper pass on `pkg/store`.

- **`listeners`: `map[EventKind]*listenerSet` → `[4]*listenerSet`** — `EventKind` is a closed 1-based iota (1/2/3); a fixed-size array drops the map-header allocation at `New()` and the hash lookup on every `fireUnderLock` call. Every reconcile write path (`AddObject`, `AddRendered`, `SetCondition`, `SetArtifact`) hits this hot path.
- **Inline `dispatch()` into `fireUnderLock`** — was a one-liner with no naming value.
- **Remove `set == nil` guard** in `fireUnderLock` — defensive dead code once the map was gone; the array is always initialized by `New()`.
- **`FailedResources` iterates conditions first** — most objects have no conditions during bootstrap; iterating the (smaller) conditions map and skipping ids not in `s.objects` is faster than the reverse. Phantom-filtering semantics preserved.
- **`snapshot()` micro-fix** — `for i, e := range l.entries` instead of index re-lookup.

Public API unchanged: `Store`, `New`, `AddObject`, `AddListener`, `WatchReady`, `WatchExists`, `EventKind` constants, typed helpers, artifact types.

## Test plan
- [x] `go vet ./pkg/store/...`
- [x] `go test -count=3 -race -timeout=300s ./pkg/store/...` — pass
- [x] **Downstream:** `./pkg/orchestrator/... ./pkg/depwait/... ./pkg/discovery/... ./pkg/controllers/...` race — pass
- [x] `golangci-lint run ./pkg/store/...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)