### PR TITLE
refactor(discovery): collapse redundant maps, CutPrefix, range-over-int

### DIFF
--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -85,14 +85,13 @@ func (d *discoverer) aliasBootstrapSources(repoRoot string) {
 // with `dependency not found`. Returns the IDs aliased so the multi-
 // source WARN sees them.
 func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifest.NamedResource {
+	// existing doubles as a dedup set: after a successful publish we add
+	// the new id so repeated sourceRefs across KSes are skipped without
+	// a second map.
 	existing := knownSourceIDs(d.cfg.Store, manifest.KindGitRepository, manifest.KindOCIRepository)
-	seen := make(map[manifest.NamedResource]struct{})
 	var aliased []manifest.NamedResource
 	for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
 		id := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
-		if _, dup := seen[id]; dup {
-			continue
-		}
 		if _, ok := existing[id]; ok {
 			continue
 		}
@@ -103,7 +102,7 @@ func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifes
 			// than a misleading half-publish would.
 			continue
 		}
-		seen[id] = struct{}{}
+		existing[id] = struct{}{}
 		aliased = append(aliased, id)
 	}
 	return aliased
@@ -216,8 +215,8 @@ func warnIfMultipleBootstrapAliases(aliased []manifest.NamedResource, repoRoot s
 		return
 	}
 	names := make([]string, len(aliased))
-	for i, id := range aliased {
-		names[i] = id.String()
+	for i := range len(aliased) {
+		names[i] = aliased[i].String()
 	}
 	slog.Warn("discovery: aliased multiple bootstrap sources to the working tree; cross-repo refs render against the wrong tree",
 		"count", len(aliased), "ids", names, "localPath", repoRoot)

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -221,11 +221,10 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			if _, seen := ksExpanded[id]; seen {
 				continue
 			}
+			ksExpanded[id] = struct{}{}
 			if ks.Path == "" {
-				ksExpanded[id] = struct{}{}
 				continue
 			}
-			ksExpanded[id] = struct{}{}
 			target := filepath.Join(repoRoot, filepath.FromSlash(stripDotSlash(ks.Path)))
 			// Canonicalize via EvalSymlinks so two spec.paths that
 			// resolve to the same on-disk directory (one direct, one

--- a/pkg/discovery/paths.go
+++ b/pkg/discovery/paths.go
@@ -49,16 +49,18 @@ func FindRepoRoot(p string) string {
 // pathUnderRoot.
 func stripDotSlash(p string) string {
 	for {
-		switch {
-		case strings.HasPrefix(p, "./"):
-			p = p[2:]
-		case p == ".":
-			return ""
-		case strings.HasPrefix(p, "/"):
-			p = p[1:]
-		default:
-			return p
+		if after, ok := strings.CutPrefix(p, "./"); ok {
+			p = after
+			continue
 		}
+		if after, ok := strings.CutPrefix(p, "/"); ok {
+			p = after
+			continue
+		}
+		if p == "." {
+			return ""
+		}
+		return p
 	}
 }
 


### PR DESCRIPTION
## Summary

Iter-4 deeper pass on `pkg/discovery`.

- **`bootstrap.go aliasMissingKustomizationSources`** — eliminate the redundant `seen` map. The `existing` set (built by `knownSourceIDs`) already has the right semantics; after a successful `publishBootstrapAlias` write the new id back to `existing`, so duplicate sourceRefs across KSes hit one single-map check.
- **`bootstrap.go warnIfMultipleBootstrapAliases`** — Go 1.22 range-over-int (`for i := range len(aliased)`) — clarifies index-only need.
- **`discovery.go` fixed-point KS loop** — lift `ksExpanded[id] = struct{}{}` above the empty-path/main-path branches; one write, clearer control flow.
- **`paths.go stripDotSlash`** — `strings.CutPrefix` replaces manual `HasPrefix` + slice-by-literal-offset.

Public API unchanged: `Run`, `Config`, `Result`, `ResolveScanPath`, `FindRepoRoot`.

## Out-of-scope concern noted

`pkg/orchestrator/resourceset.go:186` contains a near-copy of `discovery.resolveInputProvider` with a comment acknowledging the duplication. Extracting it to a shared package would eliminate the copy — separate PR.

## Test plan
- [x] `go vet ./pkg/discovery/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/discovery/...` — pass
- [x] **Downstream:** `./pkg/orchestrator/... ./internal/cli/...` race — pass
- [x] `golangci-lint run ./pkg/discovery/...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)