### PR TITLE
perf(resourceset): parse-once template hot path, O(1) cluster-scope, alloc reduction

### DIFF
--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -17,8 +17,8 @@ import (
 // raw (un-normalized) name. Used to dispatch on spec.inputStrategy:
 // Flatten concatenates; Permute scopes by name and Cartesian-products.
 type providerInputs struct {
-	name   string             // raw provider name (rs.Name for inline; RSIP.Name otherwise)
-	inputs []map[string]any   // each set already carries its `provider` block
+	name   string           // raw provider name (rs.Name for inline; RSIP.Name otherwise)
+	inputs []map[string]any // each set already carries its `provider` block
 }
 
 // buildInputSets gathers per-provider input lists then dispatches on
@@ -50,8 +50,13 @@ func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[s
 	if rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
 		return permute(groups, rs.InputStrategy.IncludeEmptyProviders)
 	}
-	// Default: Flatten — concatenate every provider's input list.
-	var out []map[string]any
+	// Default: Flatten — pre-size out to total input count across all
+	// providers to avoid incremental reallocations.
+	total := 0
+	for _, g := range groups {
+		total += len(g.inputs)
+	}
+	out := make([]map[string]any, 0, total)
 	for _, g := range groups {
 		out = append(out, g.inputs...)
 	}
@@ -64,7 +69,9 @@ func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[s
 // order. Each input set is stamped with a `provider` block so
 // templates can recover which CR sourced the values.
 func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) ([]providerInputs, error) {
-	var groups []providerInputs
+	// Pre-size: 1 for inline + one slot per inputsFrom reference (upper
+	// bound; deduplicated entries may yield fewer).
+	groups := make([]providerInputs, 0, 1+len(rs.InputsFrom))
 
 	// Provider 0: the ResourceSet itself with its inline spec.inputs.
 	inlineProv := map[string]any{
@@ -119,7 +126,7 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 		}
 		if exported == nil && p.Type != "" && p.Type != fluxopv1.InputProviderStatic {
 			slog.Warn("resourceset: dynamic input provider contributes no inputs offline",
-				"resourceSet", rs.Named().NamespacedName(),
+				"resource_set", rs.Named().NamespacedName(),
 				"provider", p.Named().NamespacedName(),
 				"type", p.Type)
 		}
@@ -140,7 +147,7 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 }
 
 func decodeInputSet(in fluxopv1.ResourceSetInput) map[string]any {
-	decoded := map[string]any{}
+	decoded := make(map[string]any, len(in))
 	for k, v := range in {
 		if v == nil {
 			decoded[k] = nil

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -44,23 +44,27 @@ func defaultNamespace(doc map[string]any, ns string) {
 	manifest.EnsureMetadata(doc)["namespace"] = ns
 }
 
+// clusterScopedKinds is the set of well-known cluster-scoped Kubernetes
+// kinds. Using a map gives O(1) lookup vs the O(n) switch it replaces.
+var clusterScopedKinds = map[string]struct{}{
+	"Namespace":                       {},
+	"ClusterRole":                     {},
+	"ClusterRoleBinding":              {},
+	"CustomResourceDefinition":        {},
+	"PersistentVolume":                {},
+	"StorageClass":                    {},
+	"PriorityClass":                   {},
+	"IngressClass":                    {},
+	"ClusterIssuer":                   {},
+	"MutatingWebhookConfiguration":   {},
+	"ValidatingWebhookConfiguration": {},
+	"APIService":                      {},
+	"Node":                            {},
+}
+
 func isClusterScoped(doc map[string]any) bool {
-	switch manifest.DocKind(doc) {
-	case "Namespace",
-		"ClusterRole", "ClusterRoleBinding",
-		"CustomResourceDefinition",
-		"PersistentVolume",
-		"StorageClass",
-		"PriorityClass",
-		"IngressClass",
-		"ClusterIssuer",
-		"MutatingWebhookConfiguration", "ValidatingWebhookConfiguration",
-		"APIService",
-		"Node":
-		return true
-	default:
-		return false
-	}
+	_, ok := clusterScopedKinds[manifest.DocKind(doc)]
+	return ok
 }
 
 func applyCommonMetadata(doc map[string]any, cm *fluxopv1.CommonMetadata) {
@@ -73,9 +77,6 @@ func applyCommonMetadata(doc map[string]any, cm *fluxopv1.CommonMetadata) {
 }
 
 func applyOwnerLabels(doc map[string]any, rs *manifest.ResourceSet) {
-	if rs == nil {
-		return
-	}
 	md := manifest.EnsureMetadata(doc)
 	labels, _ := md["labels"].(map[string]any)
 	if labels == nil {

--- a/pkg/resourceset/permute.go
+++ b/pkg/resourceset/permute.go
@@ -3,6 +3,7 @@ package resourceset
 import (
 	"fmt"
 	"hash/adler32"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -64,15 +65,17 @@ func permute(groups []providerInputs, includeEmpty bool) ([]map[string]any, erro
 	}
 
 	out := make([]map[string]any, 0, expected)
-	// Index vector — selectedInputs[i] is the index of the chosen
-	// input set within provider i. Standard mixed-radix counter.
+	// Index vector — sel[i] is the index of the chosen input set
+	// within provider i. Standard mixed-radix counter.
 	sel := make([]int, len(scoped))
+	// idParts is pre-allocated and reused across iterations; each
+	// element is overwritten before strings.Join, so no GC churn.
+	idParts := make([]string, len(scoped))
 	for {
 		perm := make(map[string]any, len(scoped)+1)
-		idParts := make([]string, 0, len(scoped))
 		for i, p := range scoped {
 			perm[p.name] = p.sets[sel[i]]
-			idParts = append(idParts, fmt.Sprintf("%s=%d", p.name, sel[i]))
+			idParts[i] = p.name + "=" + strconv.Itoa(sel[i])
 		}
 		perm["id"] = permID(strings.Join(idParts, "/"))
 		out = append(out, perm)
@@ -107,7 +110,7 @@ type scopedProvider struct {
 // in-cluster so diffs surface the actual configuration delta rather
 // than an id-format mismatch.
 func permID(s string) string {
-	return fmt.Sprintf("%d", adler32.Checksum([]byte(s)))
+	return strconv.FormatUint(uint64(adler32.Checksum([]byte(s))), 10)
 }
 
 // normalizeKeyForTemplate mirrors flux-operator/internal/inputs/keys.go:
@@ -121,22 +124,25 @@ func permID(s string) string {
 // Used here rather than re-exporting from upstream because flux-operator's
 // inputs package is in internal/.
 func normalizeKeyForTemplate(s string) string {
-	mapped := strings.Map(func(r rune) rune {
+	var b strings.Builder
+	b.Grow(len(s))
+	pendingUnderscore := false
+	for _, r := range s {
 		r = unicode.ToLower(r)
 		if unicode.IsSpace(r) || unicode.IsPunct(r) {
-			return '_'
+			pendingUnderscore = true
+			continue
 		}
 		if ('a' <= r && r <= 'z') || ('0' <= r && r <= '9') {
-			return r
+			if pendingUnderscore && b.Len() > 0 {
+				b.WriteByte('_')
+			}
+			pendingUnderscore = false
+			b.WriteRune(r)
+			continue
 		}
-		return -1
-	}, s)
-	parts := strings.Split(mapped, "_")
-	out := parts[:0]
-	for _, p := range parts {
-		if p != "" {
-			out = append(out, p)
-		}
+		// Drop characters outside [a-z0-9] without emitting underscore
+		// (they are neither word chars nor separators — rare Unicode).
 	}
-	return strings.Join(out, "_")
+	return b.String()
 }

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -75,14 +75,18 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	if len(inputs) == 0 && rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
 		return nil, nil
 	}
+
+	seen := make(map[string]struct{})
 	var docs []map[string]any
-	seen := map[string]bool{}
 	appendUnique := func(doc map[string]any) {
 		key := DedupKey(doc)
-		if key == "" || seen[key] {
+		if key == "" {
 			return
 		}
-		seen[key] = true
+		if _, dup := seen[key]; dup {
+			return
+		}
+		seen[key] = struct{}{}
 		docs = append(docs, doc)
 	}
 
@@ -116,19 +120,23 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 
 // renderResources templates a single spec.resources entry once per
 // input set (or once with nil when inputs is empty), returning the
-// decoded YAML docs.
+// decoded YAML docs. The template is parsed once and executed N times
+// to avoid repeated parse overhead on large input matrices.
 func renderResources(raw *apix.JSON, inputs []map[string]any) ([]map[string]any, error) {
 	if raw == nil {
 		return nil, nil
 	}
-	yamlTemplate, err := yaml.JSONToYAML(raw.Raw)
+	yamlBytes, err := yaml.JSONToYAML(raw.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("convert template to YAML: %w", err)
 	}
-	tmplStr := string(yamlTemplate)
+	pt, err := parseTemplate(string(yamlBytes))
+	if err != nil {
+		return nil, err
+	}
 
 	if len(inputs) == 0 {
-		doc, err := renderSingle(tmplStr, nil)
+		doc, err := renderSingle(pt, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -137,16 +145,13 @@ func renderResources(raw *apix.JSON, inputs []map[string]any) ([]map[string]any,
 		}
 		return []map[string]any{doc}, nil
 	}
-	var out []map[string]any
+	out := make([]map[string]any, 0, len(inputs))
 	for _, in := range inputs {
-		doc, err := renderSingle(tmplStr, in)
+		doc, err := renderSingle(pt, in)
 		if err != nil {
 			return nil, err
 		}
-		if doc == nil {
-			continue
-		}
-		if disabledByReconcileAnnotation(doc) {
+		if doc == nil || disabledByReconcileAnnotation(doc) {
 			continue
 		}
 		out = append(out, doc)
@@ -155,38 +160,46 @@ func renderResources(raw *apix.JSON, inputs []map[string]any) ([]map[string]any,
 }
 
 // renderResourcesTemplate templates the multi-document YAML string in
-// spec.resourcesTemplate once per input set.
+// spec.resourcesTemplate once per input set. The template is parsed once
+// and executed N times to avoid repeated parse overhead on large input
+// matrices.
 func renderResourcesTemplate(tmplStr string, inputs []map[string]any) ([]map[string]any, error) {
-	filter := func(docs []map[string]any) []map[string]any {
-		out := docs[:0]
-		for _, doc := range docs {
-			if disabledByReconcileAnnotation(doc) {
-				continue
-			}
-			out = append(out, doc)
-		}
-		return out
+	pt, err := parseTemplate(tmplStr)
+	if err != nil {
+		return nil, err
 	}
 	if len(inputs) == 0 {
-		docs, err := splitMultiDoc(tmplStr, nil)
+		docs, err := splitMultiDoc(pt, nil)
 		if err != nil {
 			return nil, err
 		}
-		return filter(docs), nil
+		return filterDisabled(docs), nil
 	}
 	var out []map[string]any
 	for _, in := range inputs {
-		docs, err := splitMultiDoc(tmplStr, in)
+		docs, err := splitMultiDoc(pt, in)
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, filter(docs)...)
+		out = append(out, filterDisabled(docs)...)
 	}
 	return out, nil
 }
 
-func splitMultiDoc(tmplStr string, inputSet map[string]any) ([]map[string]any, error) {
-	rendered, err := execute(tmplStr, inputSet)
+// filterDisabled removes docs carrying the reconcile-disabled annotation
+// in place, reusing the slice backing array.
+func filterDisabled(docs []map[string]any) []map[string]any {
+	out := docs[:0]
+	for _, doc := range docs {
+		if !disabledByReconcileAnnotation(doc) {
+			out = append(out, doc)
+		}
+	}
+	return out
+}
+
+func splitMultiDoc(pt *parsedTemplate, inputSet map[string]any) ([]map[string]any, error) {
+	rendered, err := executeTemplate(pt, inputSet)
 	if err != nil {
 		return nil, err
 	}
@@ -208,8 +221,8 @@ func splitMultiDoc(tmplStr string, inputSet map[string]any) ([]map[string]any, e
 	return out, nil
 }
 
-func renderSingle(tmplStr string, inputSet map[string]any) (map[string]any, error) {
-	rendered, err := execute(tmplStr, inputSet)
+func renderSingle(pt *parsedTemplate, inputSet map[string]any) (map[string]any, error) {
+	rendered, err := executeTemplate(pt, inputSet)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resourceset/template.go
+++ b/pkg/resourceset/template.go
@@ -3,6 +3,7 @@ package resourceset
 import (
 	"bytes"
 	"fmt"
+	"sync"
 	"text/template"
 
 	sprig "github.com/go-task/slim-sprig/v3"
@@ -21,7 +22,24 @@ func init() {
 	slug.EnableSmartTruncate = true
 }
 
-func execute(tmplStr string, inputSet map[string]any) ([]byte, error) {
+// bufPool reuses byte buffers across template executions to avoid a
+// per-document allocation on the render hot path.
+var bufPool = sync.Pool{New: func() any { return new(bytes.Buffer) }}
+
+// parsedTemplate holds a compiled template together with an indirection
+// cell for the `inputs` func so we can swap the active input set
+// without re-parsing. The cell is NOT safe for concurrent use — callers
+// must create one parsedTemplate per goroutine (via parseTemplate).
+type parsedTemplate struct {
+	tmpl *template.Template
+	cell *map[string]any // `inputs` func closes over this pointer
+}
+
+// parseTemplate compiles tmplStr once. The returned parsedTemplate is
+// NOT concurrency-safe; hot-path callers should parse once per resource
+// entry, then call execute for each input set sequentially.
+func parseTemplate(tmplStr string) (*parsedTemplate, error) {
+	cell := new(map[string]any)
 	tmpl, err := template.New("resourceset").
 		Delims("<<", ">>").
 		Funcs(sprig.HermeticTxtFuncMap()).
@@ -29,18 +47,32 @@ func execute(tmplStr string, inputSet map[string]any) ([]byte, error) {
 			"slugify":    slug.Make,
 			"toYaml":     toYaml,
 			"mustToYaml": mustToYaml,
-			"inputs":     func() any { return inputSet },
+			// inputs returns the current input set via an indirection cell
+			// swapped by executeTemplate without re-parsing.
+			"inputs": func() any { return *cell },
 		}).
 		Option("missingkey=error").
 		Parse(tmplStr)
 	if err != nil {
 		return nil, fmt.Errorf("parse template: %w", err)
 	}
-	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, nil); err != nil {
+	return &parsedTemplate{tmpl: tmpl, cell: cell}, nil
+}
+
+// executeTemplate runs pt with the given input set, reusing a pooled
+// buffer to reduce GC pressure. pt.cell is updated atomically before
+// execution; callers must not share a parsedTemplate across goroutines.
+func executeTemplate(pt *parsedTemplate, inputSet map[string]any) ([]byte, error) {
+	*pt.cell = inputSet
+
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufPool.Put(buf)
+
+	if err := pt.tmpl.Execute(buf, nil); err != nil {
 		return nil, fmt.Errorf("execute template: %w", err)
 	}
-	return buf.Bytes(), nil
+	return bytes.Clone(buf.Bytes()), nil
 }
 
 // toYaml mirrors upstream's silent-error variant — encodes v as YAML;


### PR DESCRIPTION
## Summary

Iter-4 deeper pass on `pkg/resourceset` (render hot path).

- **Hot-path parse-once** (`template.go`) — `parsedTemplate` wraps a `template.Template` parsed once per resource entry; executed N times per input set via a pointer-cell indirection for the `inputs` func. Eliminates N−1 redundant `template.Parse` calls on any ResourceSet with >1 input. Added `bufPool` (`sync.Pool[*bytes.Buffer]`) — one fewer alloc per template execution. Removed the now-dead `execute` wrapper.
- **O(1) cluster-scope lookup** (`output.go`) — `isClusterScoped` switch → package-level `map[string]struct{}` of 13 kinds. Removed unreachable nil-`rs` guard in `applyOwnerLabels` (all callers pass non-nil).
- **Alloc reduction** (`permute.go`) — `permID` uses `strconv.FormatUint` instead of `fmt.Sprintf`. `normalizeKeyForTemplate` rewritten as a single-pass `strings.Builder` state machine — drops the `strings.Split`+filter+`strings.Join` intermediate slice. `idParts` pre-allocated outside the permutation loop and reused.
- **Pre-sizing** (`inputs.go`, `render.go`) — `groups`, Flatten `out`, `renderResources` `out`, `decodeInputSet` map all pre-sized. `seen` map in `Render` changed from `map[string]bool` to `map[string]struct{}`. `slog` key `"resourceSet"` → `"resource_set"` for snake_case parity.

Public API unchanged: `Render`, `DedupKey`, `MatchSelector`, `ProviderResolver`. The unexported `execute` function (no callers after refactor) removed.

## Test plan
- [x] `go vet ./pkg/resourceset/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/resourceset/...` — pass
- [x] **Downstream:** `./pkg/orchestrator/... ./internal/cli/...` race — pass
- [x] `golangci-lint run ./pkg/resourceset/...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)