### PR TITLE
perf(manifest): preallocate dependsOn slices and input decode maps

### DIFF
--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -326,7 +326,7 @@ func parseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 	if cr.Spec.Upgrade != nil && cr.Spec.Upgrade.CRDs != "" {
 		crdsPolicy = string(cr.Spec.Upgrade.CRDs)
 	}
-	var dependsOn []DependencyRef
+	dependsOn := make([]DependencyRef, 0, len(cr.Spec.DependsOn))
 	for _, dep := range cr.Spec.DependsOn {
 		if dep.Name == "" {
 			return nil, inputf("HelmRelease missing dependsOn.name")

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -214,7 +214,7 @@ func parseKustomization(doc map[string]any) (*Kustomization, error) {
 		}
 	}
 
-	var dependsOn []DependencyRef
+	dependsOn := make([]DependencyRef, 0, len(cr.Spec.DependsOn))
 	for _, dep := range cr.Spec.DependsOn {
 		if dep.Name == "" {
 			return nil, inputf("Kustomization missing dependsOn.name")

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -136,7 +136,7 @@ func (p *ResourceSetInputProvider) ExportedInputs() ([]map[string]any, error) {
 func decodeResourceSetInputs(inputs []fluxopv1.ResourceSetInput) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(inputs))
 	for i, in := range inputs {
-		decoded := map[string]any{}
+		decoded := make(map[string]any, len(in))
 		for k, v := range in {
 			if v == nil {
 				decoded[k] = nil


### PR DESCRIPTION
## Summary

Iter-5 deeper pass on `pkg/manifest` (largest module, 2313 LOC). Three targeted hot-path allocation fixes; the rest of the module is already clean.

- `parseKustomization`: \`var dependsOn []DependencyRef\` → \`make([]DependencyRef, 0, len(cr.Spec.DependsOn))\` — eliminates realloc growth on every KS parse with any \`dependsOn\` entries
- `parseHelmRelease`: same preallocate fix for \`dependsOn\` (HRs with dependsOn are common in Flux-native repos)
- `decodeResourceSetInputs`: \`decoded := map[string]any{}\` → \`make(map[string]any, len(in))\`

## Test plan
- [x] `go vet ./pkg/manifest/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/manifest/...`
- [x] **Whole-repo:** `go test -count=1 -race -timeout=180s ./...` — all 36 packages green
- [x] `golangci-lint run ./pkg/manifest/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)