### PR TITLE
refactor(pkg/helm): inline writeAtomic shim, RWMutex for chart cache reads

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -80,7 +80,7 @@ type Client struct {
 	// reconciles of the same chart issue exactly one loader.Load
 	// (thundering-herd coalesce); the rest hit the populated cache.
 	// Distinct paths still parse in parallel.
-	chartMu        sync.Mutex
+	chartMu        sync.RWMutex
 	chartCache     map[string]chartCacheEntry
 	chartLoadLocks *keylock.KeyMap[string]
 
@@ -424,9 +424,9 @@ func cloneValuesNode(v any) any {
 // so the caller re-parses. A missing or unstattable path also
 // returns false — the caller will surface that via loader.Load.
 func (c *Client) lookupCachedChart(path string) (*chart.Chart, bool) {
-	c.chartMu.Lock()
+	c.chartMu.RLock()
 	entry, ok := c.chartCache[path]
-	c.chartMu.Unlock()
+	c.chartMu.RUnlock()
 	if !ok {
 		return nil, false
 	}

--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -12,6 +12,7 @@ import (
 	"helm.sh/helm/v4/pkg/registry"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/atomic"
 )
 
 // locateOCIChart resolves a chart whose source is an OCIRepository.
@@ -239,23 +240,19 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 	if result == nil || result.Chart == nil {
 		return "", fmt.Errorf("oci pull %s: empty result", pullRef)
 	}
-	if err := writeAtomic(target, result.Chart.Data); err != nil {
+	if err := atomic.WriteFile(target, result.Chart.Data, 0o600, true); err != nil {
 		return "", err
 	}
 	return target, nil
 }
 
-// safeName sanitizes an OCI ref's base name into a filesystem-safe
-// token for the on-disk cache target.
+// safeName sanitizes an OCI ref into a filesystem-safe token for the
+// on-disk cache target. Non-alphanumeric / non-separator runes become '-'.
 func safeName(s string) string {
-	out := strings.Builder{}
-	for _, r := range s {
-		switch {
-		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-' || r == '_' || r == '.':
-			out.WriteRune(r)
-		default:
-			out.WriteRune('-')
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			return r
 		}
-	}
-	return out.String()
+		return '-'
+	}, s)
 }

--- a/pkg/helm/options.go
+++ b/pkg/helm/options.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"slices"
 	"strings"
 
 	"helm.sh/helm/v4/pkg/chart/common"
@@ -45,7 +44,15 @@ type Options struct {
 // SkipResourceKinds returns the union of canonical and user-specified
 // kinds to drop from rendered output.
 func (o Options) SkipResourceKinds() []string {
-	out := append([]string{}, o.SkipKinds...)
+	extra := 0
+	if o.SkipCRDs {
+		extra++
+	}
+	if o.SkipSecrets {
+		extra++
+	}
+	out := make([]string, len(o.SkipKinds), len(o.SkipKinds)+extra)
+	copy(out, o.SkipKinds)
 	if o.SkipCRDs {
 		out = append(out, "CustomResourceDefinition")
 	}
@@ -72,10 +79,10 @@ func (o Options) capabilities() (*common.Capabilities, error) {
 	return caps, nil
 }
 
-// splitComma splits s on commas / whitespace, dropping empty entries.
+// splitComma splits s on commas / whitespace into non-empty tokens.
+// strings.FieldsFunc already skips empty spans, so no post-filter needed.
 func splitComma(s string) []string {
-	fields := strings.FieldsFunc(s, func(r rune) bool {
+	return strings.FieldsFunc(s, func(r rune) bool {
 		return r == ',' || r == ' ' || r == '\t'
 	})
-	return slices.DeleteFunc(fields, func(p string) bool { return p == "" })
 }

--- a/pkg/helm/postrender.go
+++ b/pkg/helm/postrender.go
@@ -54,6 +54,13 @@ func runKustomizePostRender(in *bytes.Buffer, k *helmv2.Kustomize) (*bytes.Buffe
 		return nil, fmt.Errorf("postRenderer: write helm output: %w", err)
 	}
 
+	patches := make([]kustypes.Patch, len(k.Patches))
+	for i, p := range k.Patches {
+		patches[i] = kustypes.Patch{
+			Patch:  p.Patch,
+			Target: adaptSelector(p.Target),
+		}
+	}
 	cfg := kustypes.Kustomization{
 		TypeMeta: kustypes.TypeMeta{
 			APIVersion: kustypes.KustomizationVersion,
@@ -61,12 +68,7 @@ func runKustomizePostRender(in *bytes.Buffer, k *helmv2.Kustomize) (*bytes.Buffe
 		},
 		Resources: []string{inputFile},
 		Images:    adaptImages(k.Images),
-	}
-	for _, p := range k.Patches {
-		cfg.Patches = append(cfg.Patches, kustypes.Patch{
-			Patch:  p.Patch,
-			Target: adaptSelector(p.Target),
-		})
+		Patches:   patches,
 	}
 
 	raw, err := json.Marshal(cfg)
@@ -116,10 +118,10 @@ func adaptSelector(sel *kustomize.Selector) *kustypes.Selector {
 		LabelSelector:      sel.LabelSelector,
 		AnnotationSelector: sel.AnnotationSelector,
 	}
+	out.Group = sel.Group
+	out.Version = sel.Version
+	out.Kind = sel.Kind
 	out.Name = sel.Name
 	out.Namespace = sel.Namespace
-	out.Group = sel.Group
-	out.Kind = sel.Kind
-	out.Version = sel.Version
 	return out
 }

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -14,21 +14,12 @@ import (
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/source/atomic"
 	"github.com/home-operations/flate/pkg/store"
 )
 
 // chartCacheLocks serializes concurrent fetches of the same cached
 // chart tarball so two reconcilers don't race on the same file.
 var chartCacheLocks = keylock.New[string]()
-
-// writeAtomic delegates to pkg/source/atomic.WriteFile (with
-// syncDir=true so chart tarballs survive power loss). Kept as a
-// package-local thin wrapper so existing call sites keep their
-// hard-coded perm without each having to import atomic.
-func writeAtomic(path string, data []byte) error {
-	return atomic.WriteFile(path, data, 0o600, true)
-}
 
 // ChartLoadResult is the loaded chart plus the on-disk path it came from.
 type ChartLoadResult struct {

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -304,22 +304,20 @@ func releaseManifest(rel *release.Release, opts Options, disableHooks, skipTests
 }
 
 // filterShowOnly keeps only sections whose "# Source: <path>" header
-// matches one of the requested template paths.
+// matches one of the requested template paths. Paths lists are short
+// (typically 1-5 entries from --show-only), so linear scan avoids a
+// map allocation on the hot render path.
 func filterShowOnly(content string, paths []string) string {
-	want := make(map[string]bool, len(paths))
-	for _, p := range paths {
-		want[p] = true
-	}
 	var out strings.Builder
 	for section := range strings.SplitSeq(content, "\n---\n") {
-		header := ""
+		var header string
 		for line := range strings.SplitSeq(section, "\n") {
 			if rest, ok := strings.CutPrefix(line, "# Source: "); ok {
 				header = rest
 				break
 			}
 		}
-		if !want[header] {
+		if !slices.Contains(paths, header) {
 			continue
 		}
 		if out.Len() > 0 {


### PR DESCRIPTION
## Summary

Iter-5 deeper pass on `pkg/helm`.

| File | Change |
|---|---|
| `repo.go` | Remove `writeAtomic` 2-line shim; drop `pkg/source/atomic` import |
| `oci_chart.go` | Inline `atomic.WriteFile(…, 0o600, true)` directly; `strings.Map` replaces manual Builder loop in `safeName` |
| `client.go` | Promote `chartMu` to `RWMutex`; `lookupCachedChart` uses `RLock` (read-only map lookup), write path keeps `Lock` |
| `template.go` | `filterShowOnly`: `slices.Contains` replaces `map[string]bool` alloc (--show-only lists are 1-5 paths; linear scan cheaper than map alloc) |
| `options.go` | `SkipResourceKinds` pre-allocates; remove dead `slices.DeleteFunc(…, p=="")` (strings.FieldsFunc never emits empty); drop `slices` import |
| `postrender.go` | `runKustomizePostRender` pre-allocates patches by index; cosmetic struct-field ordering in `adaptSelector` |

Public API unchanged.

## Test plan
- [x] `go vet ./pkg/helm/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/helm/...`
- [x] **Downstream:** `./pkg/controllers/helmrelease/... ./pkg/orchestrator/... ./internal/cli/...` race — all pass
- [x] `golangci-lint run ./pkg/helm/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)