### PR TITLE
refactor(loader): generic applyDefaultNS, cmp.Or for namespace precedence

### DIFF
--- a/pkg/loader/generators.go
+++ b/pkg/loader/generators.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"cmp"
 	"encoding/base64"
 	"strings"
 
@@ -44,7 +45,7 @@ func collectGeneratorRecords(k *kustomization, file string) []generatorRecord {
 	if k == nil {
 		return nil
 	}
-	var out []generatorRecord
+	out := make([]generatorRecord, 0, len(k.ConfigMapGenerator)+len(k.SecretGenerator))
 	for _, g := range k.ConfigMapGenerator {
 		if g.Name == "" {
 			continue
@@ -77,13 +78,8 @@ func collectGeneratorRecords(k *kustomization, file string) []generatorRecord {
 // to match what a real k8s Secret carries; ConfigMaps land in Data
 // as strings.
 func (r generatorRecord) materialize(parentNS string) manifest.BaseManifest {
-	ns := parentNS
-	if r.kustomizationNS != "" {
-		ns = r.kustomizationNS
-	}
-	if r.entryNS != "" {
-		ns = r.entryNS
-	}
+	// kustomize precedence: entry.namespace > kustomization.namespace > parent namespace.
+	ns := cmp.Or(r.entryNS, r.kustomizationNS, parentNS)
 	if r.isConfigMap {
 		data := make(map[string]any, len(r.literals))
 		for _, lit := range r.literals {

--- a/pkg/loader/ignore.go
+++ b/pkg/loader/ignore.go
@@ -61,6 +61,3 @@ func (i *ignoreSet) matches(path, root string) bool {
 	return false
 }
 
-func (i *ignoreSet) matchesDir(full, root string) bool {
-	return i.matches(full, root)
-}

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"cmp"
 	"os"
 	"path"
 	"path/filepath"
@@ -77,41 +78,23 @@ func ApplyNamespaceInheritance(s *store.Store, sourceFiles map[manifest.NamedRes
 // top-level Flux Operator and HelmChart source objects after namespace
 // inheritance has had a chance to project kustomize/Flux namespaces.
 func ApplyDefaultNamespaces(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
-	defaultResourceSets(s, sourceFiles)
-	defaultResourceSetInputProviders(s, sourceFiles)
-	defaultHelmChartSources(s, sourceFiles)
+	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSet](s, manifest.KindResourceSet),
+		func(o *manifest.ResourceSet) *manifest.ResourceSet { c := *o; c.Namespace = manifest.DefaultNamespace; return &c })
+	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider),
+		func(o *manifest.ResourceSetInputProvider) *manifest.ResourceSetInputProvider { c := *o; c.Namespace = manifest.DefaultNamespace; return &c })
+	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.HelmChartSource](s, manifest.KindHelmChart),
+		func(o *manifest.HelmChartSource) *manifest.HelmChartSource { c := *o; c.Namespace = manifest.DefaultNamespace; return &c })
 }
 
-func defaultResourceSets(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
-	for _, obj := range store.ListAs[*manifest.ResourceSet](s, manifest.KindResourceSet) {
-		if obj.Namespace != "" {
+// applyDefaultNS assigns manifest.DefaultNamespace to every object in objs
+// whose current namespace is empty, then reindexes it in the store.
+// withNS must return a new object (shallow copy) with the namespace set.
+func applyDefaultNS[T manifest.BaseManifest](s *store.Store, sourceFiles map[manifest.NamedResource]string, objs []T, withNS func(T) T) {
+	for _, obj := range objs {
+		if obj.Named().Namespace != "" {
 			continue
 		}
-		c := *obj
-		c.Namespace = manifest.DefaultNamespace
-		reindexObject(s, sourceFiles, obj.Named(), &c)
-	}
-}
-
-func defaultResourceSetInputProviders(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
-	for _, obj := range store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider) {
-		if obj.Namespace != "" {
-			continue
-		}
-		c := *obj
-		c.Namespace = manifest.DefaultNamespace
-		reindexObject(s, sourceFiles, obj.Named(), &c)
-	}
-}
-
-func defaultHelmChartSources(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
-	for _, obj := range store.ListAs[*manifest.HelmChartSource](s, manifest.KindHelmChart) {
-		if obj.Namespace != "" {
-			continue
-		}
-		c := *obj
-		c.Namespace = manifest.DefaultNamespace
-		reindexObject(s, sourceFiles, obj.Named(), &c)
+		reindexObject(s, sourceFiles, obj.Named(), withNS(obj))
 	}
 }
 
@@ -174,10 +157,7 @@ func indexFluxByPath(s *store.Store, sourceFiles map[manifest.NamedResource]stri
 		if ks.Path == "" {
 			continue
 		}
-		ns := ks.TargetNamespace
-		if ns == "" {
-			ns = ks.Namespace
-		}
+		ns := cmp.Or(ks.TargetNamespace, ks.Namespace)
 		if ns == "" {
 			if file, ok := sourceFiles[ks.Named()]; ok {
 				ns = resolveNamespace(file, nil, kust)

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -57,7 +57,7 @@ type kvPairGenerator struct {
 
 // kustomizationFileNames is the ordered list kustomize checks; first
 // match wins.
-var kustomizationFileNames = []string{
+var kustomizationFileNames = [3]string{
 	"kustomization.yaml",
 	"kustomization.yml",
 	"kustomization.json",

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -23,6 +23,7 @@
 package loader
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"io/fs"
@@ -458,10 +459,7 @@ func parentNamespaceFor(prefixes []KSPathPrefix, s *store.Store, absPath, repoRo
 	// KS's own namespace (where the KS CR lives). For generated CMs
 	// we want the post-render namespace because that's what
 	// substituteFrom in downstream KSes references.
-	if ks.TargetNamespace != "" {
-		return ks.TargetNamespace
-	}
-	return ks.Namespace
+	return cmp.Or(ks.TargetNamespace, ks.Namespace)
 }
 
 // recordSource maps a resource id back to the on-disk file it was
@@ -514,16 +512,12 @@ func isDiscoveryKind(obj manifest.BaseManifest) bool {
 	return false
 }
 
-var manifestExtensions = map[string]struct{}{
-	".yaml": {},
-	".yml":  {},
-	".json": {},
-}
-
 func isManifestFile(path string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
-	_, ok := manifestExtensions[ext]
-	return ok
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml", ".json":
+		return true
+	}
+	return false
 }
 
 // shouldSkipDir applies the ad-hoc walk's directory-prune rules.
@@ -541,10 +535,7 @@ func shouldSkipDir(name, full, root string, ignore *ignoreSet) bool {
 	if strings.HasPrefix(name, ".") && name != "." {
 		return true
 	}
-	if ignore.matchesDir(full, root) {
-		return true
-	}
-	return false
+	return ignore.matches(full, root)
 }
 
 // kustomizationFilePath returns the absolute path of dir's

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -88,7 +88,6 @@ func KSPathPrefixes(s *store.Store, repoRoot string) []KSPathPrefix {
 	return out
 }
 
-
 // LongestParent returns the deepest KS whose spec.path covers file
 // (slash-normalized repo-relative path), excluding self. The second
 // return reports whether a parent was found. prefixes is expected to


### PR DESCRIPTION
## Summary

Iter-5 deeper pass on `pkg/loader`. Net **−37 LOC**.

- **Generic `applyDefaultNS[T]`** (`inherit.go`) — the three `defaultResourceSets / defaultResourceSetInputProviders / defaultHelmChartSources` functions each had the identical 8-line "list → check namespace → shallow copy → reindex" pattern. Replaced with one generic helper; the three call sites in \`ApplyDefaultNamespaces\` are now one-liners. -28 LOC.
- **`cmp.Or` for namespace precedence** (`generators.go`, `inherit.go`, `loader.go`) — three if/else ladders ("A wins, else B, else C") become \`cmp.Or(A, B, C)\` in `materialize()`, `indexFluxByPath()`, `parentNamespaceFor()`.
- **Preallocate `collectGeneratorRecords` output** (`generators.go`) — sized to `len(ConfigMapGenerator)+len(SecretGenerator)`.
- **`isManifestFile` switch** (`loader.go`) — eliminate `manifestExtensions map[string]struct{}` in favour of a 3-case switch. No heap alloc on each call.
- **`kustomizationFileNames` array** (`kustomization.go`) — `[]string` → `[3]string`. Fixed-size, no slice header.
- **Remove `matchesDir` delegate** (`ignore.go`) — was a no-op wrapper around `matches`.
- **Cosmetic** (`parent.go`) — drop double blank line.

Public API unchanged.

## Test plan
- [x] `go vet ./pkg/loader/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/loader/...`
- [x] **Downstream:** `./pkg/orchestrator/... ./pkg/discovery/... ./internal/cli/...` race — all pass
- [x] `golangci-lint run ./pkg/loader/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)