### PR TITLE
refactor(orchestrator): snake_case slog, slices/maps idioms, dead helper inline

### DIFF
--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -96,12 +96,9 @@ func findDependencyCycles(s *store.Store, kind string) [][]manifest.NamedResourc
 				visit(m)
 			case gray:
 				// Back-edge to a node currently on the stack → cycle.
-				start := 0
-				for i, sNode := range stack {
-					if sNode == m {
-						start = i
-						break
-					}
+				start := slices.Index(stack, m)
+				if start < 0 {
+					start = 0
 				}
 				cycle := append([]manifest.NamedResource(nil), stack[start:]...)
 				cycle = append(cycle, m) // close the loop visually

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -96,10 +96,7 @@ func findDependencyCycles(s *store.Store, kind string) [][]manifest.NamedResourc
 				visit(m)
 			case gray:
 				// Back-edge to a node currently on the stack → cycle.
-				start := slices.Index(stack, m)
-				if start < 0 {
-					start = 0
-				}
+				start := max(slices.Index(stack, m), 0)
 				cycle := append([]manifest.NamedResource(nil), stack[start:]...)
 				cycle = append(cycle, m) // close the loop visually
 				cycles = append(cycles, cycle)

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -124,11 +124,10 @@ func (o *Orchestrator) cascadeParentFailures(failed map[manifest.NamedResource]s
 			"parent", parent.String(),
 			"reason", parentInfo.Message)
 	}
-	for _, ks := range store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization) {
-		cascade(ks.Named())
-	}
-	for _, hr := range store.ListAs[*manifest.HelmRelease](o.store, manifest.KindHelmRelease) {
-		cascade(hr.Named())
+	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+		for _, obj := range o.store.ListObjects(kind) {
+			cascade(obj.Named())
+		}
 	}
 }
 
@@ -158,7 +157,7 @@ func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.Status
 	hrCount := len(o.store.ListObjects(manifest.KindHelmRelease))
 	slog.Debug("reconcile complete",
 		"kustomizations", ksCount,
-		"helmReleases", hrCount,
+		"helm_releases", hrCount,
 		"failed", len(failed))
 	// Surface a clear warning when the scan turned up nothing — covers
 	// the "typo'd --path that happens to be an empty directory" case
@@ -177,11 +176,11 @@ func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]sto
 		// stderr alongside the user-facing report and reads as
 		// "flate had an internal error" when it's just normal
 		// per-resource Flux failures the user expects to see.
-		args := []any{"id", id.String(), "reason", info.Message}
 		if f := o.sourceFiles[id]; f != "" {
-			args = append(args, "file", f)
+			slog.Debug("resource failed", "id", id.String(), "reason", info.Message, "file", f)
+		} else {
+			slog.Debug("resource failed", "id", id.String(), "reason", info.Message)
 		}
-		slog.Debug("resource failed", args...)
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -228,15 +228,15 @@ func New(cfg Config) (*Orchestrator, error) {
 	// payload at dispatch surfaces "<kind> fetcher: unexpected
 	// payload <T>" from the single adapter site rather than from
 	// four nearly-identical type assertions.
-	srcCtrl.Fetchers[manifest.KindGitRepository] = source.Wrap[*manifest.GitRepository](
+	srcCtrl.Fetchers[manifest.KindGitRepository] = source.Wrap(
 		manifest.KindGitRepository, &git.Fetcher{
 			Cache:   cache,
 			Secrets: secretGet,
 			Mirrors: mirror.New(layout),
 		})
-	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap[*manifest.ExternalArtifact](
+	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap(
 		manifest.KindExternalArtifact, &external.Fetcher{})
-	srcCtrl.Fetchers[manifest.KindBucket] = source.Wrap[*manifest.Bucket](
+	srcCtrl.Fetchers[manifest.KindBucket] = source.Wrap(
 		manifest.KindBucket, &bucket.Fetcher{Cache: cache, Secrets: secretGet})
 	// HelmRepository: existence-only — flate resolves charts via the
 	// Helm client's registry/repo machinery directly, the controller
@@ -245,7 +245,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	srcCtrl.Fetchers[manifest.KindHelmRepository] = source.ExistenceFetcher{}
 	if cfg.EnableOCI {
 		ociFetcher := &oci.Fetcher{Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet}
-		srcCtrl.Fetchers[manifest.KindOCIRepository] = source.Wrap[*manifest.OCIRepository](
+		srcCtrl.Fetchers[manifest.KindOCIRepository] = source.Wrap(
 			manifest.KindOCIRepository, ociFetcher)
 		// Share the same fetcher with helm.Client so HelmRepository
 		// (type=oci) and OCIRepository chart resolution both route
@@ -746,9 +746,7 @@ func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
 	// see sanitizeFailed for the contract. Centralizing in one
 	// helper keeps the three readers in sync if the strip rule
 	// changes.
-	for id, info := range sanitizeFailed(o.store.FailedResources()) {
-		res.Failed[id] = info
-	}
+	maps.Copy(res.Failed, sanitizeFailed(o.store.FailedResources()))
 	maps.Copy(res.Orphans, o.orphans)
 	return res, errors.Join(runErr, rsErr)
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -371,8 +371,8 @@ func (o *Orchestrator) warnOnDisabledOCIFeatures() {
 			continue
 		}
 		slog.Warn("OCIRepository spec fields ignored — EnableOCI=false wires ExistenceFetcher",
-			"ociRepository", repo.Namespace+"/"+repo.Name,
-			"ignoredFields", fields)
+			"oci_repository", repo.Namespace+"/"+repo.Name,
+			"ignored_fields", fields)
 	}
 }
 
@@ -395,14 +395,14 @@ func (o *Orchestrator) warnOnKSOCISourceRefWithoutOCI() {
 		}
 		slog.Warn("Kustomization sourceRef points at OCIRepository but --enable-oci=false; the synthesized existence-only artifact has no LocalPath and spec.path resolution will fail at render time",
 			"kustomization", ks.Namespace+"/"+ks.Name,
-			"sourceRef", ks.SourceNamespace+"/"+ks.SourceName)
+			"source_ref", ks.SourceNamespace+"/"+ks.SourceName)
 	}
 }
 
 func (o *Orchestrator) replacePreflightFailures(failures map[manifest.NamedResource]string) []manifest.NamedResource {
 	o.preflightMu.Lock()
 	defer o.preflightMu.Unlock()
-	var cleared []manifest.NamedResource
+	cleared := make([]manifest.NamedResource, 0, len(o.preflightFailures))
 	for id := range o.preflightFailures {
 		if _, stillFailed := failures[id]; !stillFailed {
 			cleared = append(cleared, id)
@@ -446,7 +446,7 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 		// silently render zero output.
 		if origAbs == currAbs {
 			slog.Warn("--path and --path-orig resolve to the same directory; ignoring --path-orig",
-				"resolvedPath", currAbs)
+				"resolved_path", currAbs)
 			return nil
 		}
 		// Widen the diff scope to each side's .git root when the user
@@ -481,7 +481,7 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 			}
 		}
 		slog.Debug("changed-only mode",
-			"baseline", diffOrig, "current", diffCurr, "changedFiles", cs.Len(), "widenedToRepoRoot", widened)
+			"baseline", diffOrig, "current", diffCurr, "changed_files", cs.Len(), "widened_to_repo_root", widened)
 		if cs.Len() == 0 {
 			slog.Warn("no changes detected between --path and --path-orig — output will be empty; verify both paths reference distinct snapshots")
 		}
@@ -515,15 +515,9 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 			o.store.Refire(id)
 		}
 	}
-	o.attachFilter(f)
+	o.filter = f
 	slog.Debug("changed-only keep set", "size", o.filter.Size(), "items", o.filter.KeepNames())
 	return nil
-}
-
-// attachFilter records the resolved Filter; controllers consume it
-// via Configure() at Run time.
-func (o *Orchestrator) attachFilter(f *change.Filter) {
-	o.filter = f
 }
 
 // orchestratorExistence adapts the orchestrator's

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -45,8 +45,9 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 		prefix string
 		id     manifest.NamedResource
 	}
-	var owners []owner
-	for _, ks := range store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization) {
+	ksList := store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization)
+	owners := make([]owner, 0, len(ksList))
+	for _, ks := range ksList {
 		if ks.Path == "" {
 			continue
 		}
@@ -116,17 +117,13 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 					return nil
 				}
 				slashFile := filepath.ToSlash(file)
-				matched := false
-				for _, w := range owners {
-					if strings.HasPrefix(slashFile, w.prefix) {
-						parentKS = w.id
-						matched = true
-						break
-					}
-				}
-				if !matched {
+				i := slices.IndexFunc(owners, func(w owner) bool {
+					return strings.HasPrefix(slashFile, w.prefix)
+				})
+				if i < 0 {
 					return nil
 				}
+				parentKS = owners[i].id
 			}
 			// Filter docs to RawObjects + collect dedup keys
 			// outside the mutex; the mutex only holds for the


### PR DESCRIPTION
## Summary

Iter-5 deeper pass on `pkg/orchestrator`.

- **snake_case slog keys** — fixed 7 camelCase attributes (\`ociRepository\`, \`ignoredFields\`, \`sourceRef\`, \`resolvedPath\`, \`changedFiles\`, \`widenedToRepoRoot\`, \`helmReleases\`)
- **Inline `attachFilter`** — single-line helper, only one caller (`buildChangeFilter`)
- **`cascadeParentFailures` loop merge** (`finalize.go`) — two separate typed `store.ListAs` range loops (one for KS, one for HR) replaced with a single `for _, kind := range []string{...}` + `o.store.ListObjects(kind)` loop. Drops the `store.ListAs` import.
- **`slices.Index` in DFS** (`cycles.go`) — replace open-coded scan for cycle start
- **`slices.IndexFunc` for owner lookup** (`resourceset.go`) — replace `matched`-flag + `break` pattern
- **Slice pre-allocation** — `owners` in `expandResourceSetsPostRun`, `cleared` in `replacePreflightFailures`
- **`logResourceFailures` — drop heap-allocated `[]any`** — `args := []any{...}` + conditional `append` + variadic slog call replaced with two direct `slog.Debug` calls
- **Lint diagnostics applied** — `max(slices.Index(...), 0)` in cycles.go; drop 4 unnecessary `[*manifest.X]` type args on `source.Wrap` (inferred); replace failed-results loop with `maps.Copy`

Public API unchanged.

## Test plan
- [x] `go vet ./pkg/orchestrator/...`
- [x] `go test -count=1 -race -timeout=300s ./pkg/orchestrator/...`
- [x] **Downstream:** `./internal/cli/... ./pkg/controllers/...` race — all pass
- [x] `golangci-lint run ./pkg/orchestrator/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)