### PR TITLE
refactor(source/oci): slices.MaxFunc, single open for stat+read, pre-alloc

### DIFF
--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -220,7 +220,7 @@ func (f *Fetcher) loadCosignPublicKeys(repo *manifest.OCIRepository) ([]crypto.P
 	for k := range sec.Data {
 		seen[k] = struct{}{}
 	}
-	var keys []crypto.PublicKey
+	keys := make([]crypto.PublicKey, 0, len(seen))
 	for k := range seen {
 		s := source.StringFromSecret(sec, k)
 		if s == "" {

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -282,13 +282,9 @@ func ociResolveCacheKey(repo *manifest.OCIRepository, ref manifest.OCIRepository
 }
 
 func ociCacheKey(repo *manifest.OCIRepository, ref manifest.OCIRepositoryRef, resolvedDigest string) string {
-	ignore := ""
+	var ignore string
 	if repo.Ignore != nil {
 		ignore = *repo.Ignore
-	}
-	mediaType := ""
-	if repo.LayerSelector != nil {
-		mediaType = repo.LayerSelector.MediaType
 	}
 	payload := struct {
 		Ref            string `json:"ref"`
@@ -297,7 +293,7 @@ func ociCacheKey(repo *manifest.OCIRepository, ref manifest.OCIRepositoryRef, re
 		Ignore         string `json:"ignore,omitempty"`
 	}{
 		Ref:            cmp.Or(resolvedDigest, versionTag(ref), "latest"),
-		LayerMediaType: mediaType,
+		LayerMediaType: layerMediaType(repo.LayerSelector),
 		LayerOperation: effectiveLayerOperation(repo.LayerSelector),
 		Ignore:         ignore,
 	}

--- a/pkg/source/oci/marker.go
+++ b/pkg/source/oci/marker.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -63,12 +64,16 @@ func cachedDigestFresh(slot string, maxAge time.Duration) (string, bool) {
 	if maxAge <= 0 {
 		return "", false
 	}
-	path := filepath.Join(slot, cachedDigestFile)
-	info, err := os.Stat(path)
+	f, err := os.Open(filepath.Join(slot, cachedDigestFile)) //nolint:gosec // slot is fetcher-owned cache path
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
 	if err != nil || time.Since(info.ModTime()) > maxAge {
 		return "", false
 	}
-	b, err := os.ReadFile(path) //nolint:gosec // slot is fetcher-owned cache path
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return "", false
 	}

--- a/pkg/source/oci/resolve.go
+++ b/pkg/source/oci/resolve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -92,8 +93,8 @@ func ociRevision(ref manifest.OCIRepositoryRef, digest string) string {
 // Mirrors source-controller's `getTagBySemver` (ocirepository_controller.go).
 func resolveOCISemver(ctx context.Context, repoClient *remote.Repository, expr, filterPattern, mediaType string) (string, error) {
 	var collected []string
-	if err := repoClient.Tags(ctx, "", func(tags []string) error {
-		collected = append(collected, tags...)
+	if err := repoClient.Tags(ctx, "", func(batch []string) error {
+		collected = append(collected, batch...)
 		return nil
 	}); err != nil {
 		return "", fmt.Errorf("list tags: %w", err)
@@ -117,7 +118,7 @@ func pickSemverTag(tags []string, expr, filterPattern, mediaType string) (string
 		}
 	}
 
-	var matching semver.Collection
+	matching := make(semver.Collection, 0, len(tags))
 	for _, tag := range tags {
 		if pattern != nil && !pattern.MatchString(tag) {
 			continue
@@ -133,14 +134,8 @@ func pickSemverTag(tags []string, expr, filterPattern, mediaType string) (string
 	if len(matching) == 0 {
 		return "", fmt.Errorf("no tag matched semver %q (filter %q)", expr, filterPattern)
 	}
-	// Highest match wins.
-	hi := 0
-	for i := 1; i < len(matching); i++ {
-		if matching[hi].LessThan(matching[i]) {
-			hi = i
-		}
-	}
-	return convertSemVerToOCITag(matching[hi].Original(), mediaType), nil
+	best := slices.MaxFunc(matching, (*semver.Version).Compare)
+	return convertSemVerToOCITag(best.Original(), mediaType), nil
 }
 
 const helmChartLayerMediaType = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"


### PR DESCRIPTION
## Summary

Iter-5 deeper pass on `pkg/source/oci`.

- **`resolve.go pickSemverTag`** — 6-line manual max-index loop → `slices.MaxFunc(matching, (*semver.Version).Compare)` (method value, no closure). Pre-allocate \`matching\` to \`cap(len(tags))\`.
- **`resolve.go resolveOCISemver`** — rename callback param \`tags→batch\` to avoid shadowing outer \`tags\` parameter
- **`marker.go cachedDigestFresh`** — fold double syscall (\`os.Stat\` then \`os.ReadFile\`) into one \`os.Open\` + \`f.Stat()\` + \`io.ReadAll(f)\`. Closes a small TOCTOU window between mtime check and content read.
- **`fetch.go ociCacheKey`** — eliminate redundant nil-guard for \`LayerSelector.MediaType\` via the existing \`layerMediaType()\` helper
- **`cosign.go loadCosignPublicKeys`** — pre-allocate \`keys\` slice to \`cap(len(seen))\`

Public API unchanged. Fetcher artifact output byte-identical.

## Test plan
- [x] `go vet ./pkg/source/oci/...`
- [x] `go test -count=1 -race -timeout=300s ./pkg/source/oci/...`
- [x] **Downstream:** `./pkg/source/... ./pkg/controllers/source/...` race — all 12 packages pass
- [x] `golangci-lint run ./pkg/source/oci/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)