### PR TITLE
refactor(source/git): fix known-hosts temp leak, single-open marker, dedupe ignore+mark

### DIFF
--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -318,13 +318,23 @@ func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifa
 			return err
 		}
 	}
+	return applyIgnoreAndMark(repo, art)
+}
+
+// applyIgnoreAndMark applies the source-controller-compatible ignore
+// patterns to the materialized slot, then writes the revision marker.
+// Separated from finalize so the mirror path can call it without
+// re-opening the local worktree for verification (the mirror path
+// verifies against the bare-repo object store instead).
+//
+// The marker is written AFTER ApplyIgnore so it survives user-supplied
+// "exclude all" patterns (common: `/*` + reincludes). Next run's
+// cache-hit check avoids the expensive re-clone for big repos whose
+// .git/ was wiped by the ignore step.
+func applyIgnoreAndMark(repo *manifest.GitRepository, art *store.SourceArtifact) error {
 	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
 		return fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
 	}
-	// Write the revision marker AFTER ApplyIgnore so it survives any
-	// user-supplied "exclude all" patterns (common — `/*` + reincludes).
-	// Next run's cache-hit check (readCachedRevision) avoids the
-	// expensive re-clone for big repos whose .git/ was wiped by ignore.
 	if art.Revision != "" {
 		_ = writeCachedRevision(art.LocalPath, art.Revision)
 	}
@@ -352,7 +362,7 @@ func (f *Fetcher) canUseMirror(repo *manifest.GitRepository, _ string) bool {
 // per-URL mirror, resolve the requested ref to a commit hash, then
 // materialize the tree into the slot's staging dir. PGP verification
 // runs against the mirror (which has the object store); ApplyIgnore
-// and the revision-marker write reuse the standard finalize.
+// and the revision-marker write delegate to applyIgnoreAndMark.
 //
 // tlsCfg is the caller's pre-resolved spec.secretRef CA bundle —
 // hoisting it out of this function avoids re-reading the Secret +
@@ -378,11 +388,8 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 		Kind: manifest.KindGitRepository,
 		URL:  repo.URL, LocalPath: slot.Path, Revision: hash.String(),
 	}
-	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
-	}
-	if art.Revision != "" {
-		_ = writeCachedRevision(art.LocalPath, art.Revision)
+	if err := applyIgnoreAndMark(repo, art); err != nil {
+		return nil, err
 	}
 	if err := slot.Commit(); err != nil {
 		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)

--- a/pkg/source/git/marker.go
+++ b/pkg/source/git/marker.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,12 +39,18 @@ func cachedRevisionFresh(slot string, maxAge time.Duration) (string, bool) {
 	if maxAge <= 0 {
 		return "", false
 	}
-	path := filepath.Join(slot, cachedRevisionFile)
-	info, err := os.Stat(path)
+	// Single open: fstat for mtime, then read — avoids the TOCTOU window
+	// between a separate os.Stat and os.ReadFile on a fetcher-written file.
+	f, err := os.Open(filepath.Join(slot, cachedRevisionFile)) //nolint:gosec // slot is fetcher-owned cache path
+	if err != nil {
+		return "", false
+	}
+	defer f.Close() //nolint:errcheck
+	info, err := f.Stat()
 	if err != nil || time.Since(info.ModTime()) > maxAge {
 		return "", false
 	}
-	b, err := os.ReadFile(path) //nolint:gosec // slot is fetcher-owned cache path
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return "", false
 	}

--- a/pkg/source/git/ssh.go
+++ b/pkg/source/git/ssh.go
@@ -18,24 +18,23 @@ func insecureIgnoreHostKey(_ string, _ net.Addr, _ ssh.PublicKey) error {
 }
 
 // knownHostsCallback returns an SSH HostKeyCallback that validates
-// against the provided known_hosts data. The data is materialized to
-// a temp file because golang.org/x/crypto/ssh/knownhosts only exposes
-// a file-based New constructor.
+// against the provided known_hosts data. knownhosts.New only accepts
+// file paths, so we materialize a temp file; New reads and parses it
+// synchronously and returns a callback that holds the parsed data in
+// memory, so the file is safe to remove immediately after New returns.
 func knownHostsCallback(data []byte) (ssh.HostKeyCallback, error) {
 	f, err := os.CreateTemp("", "flate-known-hosts-*")
 	if err != nil {
 		return nil, fmt.Errorf("temp known_hosts: %w", err)
 	}
+	name := f.Name()
+	defer os.Remove(name) //nolint:errcheck // best-effort cleanup of temp file
 	if _, err := f.Write(data); err != nil {
 		_ = f.Close()
-		_ = os.Remove(f.Name())
 		return nil, fmt.Errorf("write known_hosts: %w", err)
 	}
 	if err := f.Close(); err != nil {
-		_ = os.Remove(f.Name())
 		return nil, fmt.Errorf("close known_hosts: %w", err)
 	}
-	// Note: the file leaks until process exit. Acceptable for a CLI
-	// run; revisit if flate ever grows a watch mode.
-	return knownhosts.New(f.Name())
+	return knownhosts.New(name)
 }


### PR DESCRIPTION
## Summary

Iter-6 deeper pass on top-level `pkg/source/git/*.go`.

- **`ssh.go` — temp-file leak fixed**: `knownHostsCallback` left the `flate-known-hosts-*` temp file until process exit ("acceptable for a CLI run — revisit for watch mode"). `knownhosts.New` reads + parses the file fully before returning and holds no path reference, so a `defer os.Remove` immediately after `New` returns cleans up regardless of watch-mode future.
- **`marker.go` — single-open in `cachedRevisionFresh`**: replace separate `os.Stat` + `os.ReadFile` (two path lookups) with `os.Open` → `f.Stat()` → `io.ReadAll(f)`. Closes a small TOCTOU window between mtime check and content read.
- **`fetcher.go` — `applyIgnoreAndMark` extracted**: `finalize` and `fetchViaMirror` each inlined the identical `source.ApplyIgnore` + `writeCachedRevision` sequence. One helper now. Verification stays split correctly (PlainClone uses worktree repo; mirror uses bare-repo object store).

Public API unchanged.

## Test plan
- [x] `go vet ./pkg/source/git/...`
- [x] `go test -count=1 -race -timeout=300s ./pkg/source/git/...`
- [x] **Downstream:** `./pkg/source/... ./pkg/controllers/source/...` race — all 12 packages pass
- [x] `golangci-lint run ./pkg/source/git/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)