### PR TITLE
fix(mirror): remove deadlocking InstallHTTPS call inside OpenOrFetch

### DIFF
--- a/pkg/source/git/mirror/mirror.go
+++ b/pkg/source/git/mirror/mirror.go
@@ -21,7 +21,6 @@ import (
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
-	"github.com/home-operations/flate/pkg/source/git/internal/gittransport"
 )
 
 // Cache holds one bare clone per unique upstream URL. The mirror is
@@ -65,28 +64,32 @@ func (m *Cache) pathFor(url string) string {
 	return m.layout.GitMirror(urlHash(url))
 }
 
+// proxyOptions converts a nullable ProxyConfig into go-git's inline
+// struct so every call site doesn't repeat the nil guard.
+func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
+	if proxy == nil {
+		return transport.ProxyOptions{}
+	}
+	return transport.ProxyOptions{
+		URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
+	}
+}
+
 // OpenOrFetch returns the bare mirror repo for url, ensuring it
 // carries up-to-date refs. First call for a URL runs a bare clone;
 // subsequent calls incrementally Fetch. Holds the per-URL lock across
 // the network operation so two concurrent callers serialize.
 //
-// auth/proxy/tlsCfg are applied to whichever network operation runs
-// (clone or fetch). For HTTPS with a custom TLS config, the global
-// process-level transport-install lock (gittransport.InstallHTTPS) is
-// taken so concurrent mirror Fetches don't clobber each other's
-// transport.
+// tlsCfg is accepted for API compatibility; the caller (Fetch) already
+// holds the process-global HTTPS-transport lock for the duration of the
+// mirror operation, so installing it here would deadlock.
 func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config, plan FetchPlan) (*git.Repository, error) {
+	_ = tlsCfg // transport lock held by caller; see gittransport.InstallHTTPS
 	release, err := m.locks.Acquire(ctx, urlHash(url))
 	if err != nil {
 		return nil, err
 	}
 	defer release()
-
-	restore, err := gittransport.InstallHTTPS(tlsCfg, proxy)
-	if err != nil {
-		return nil, err
-	}
-	defer restore()
 
 	path := m.pathFor(url)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
@@ -104,19 +107,20 @@ func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.Auth
 		return nil, fmt.Errorf("mirror open %s: %w", path, openErr)
 	}
 
-	cloneOpts := &git.CloneOptions{URL: url, Auth: auth}
-	if proxy != nil {
-		cloneOpts.ProxyOptions = transport.ProxyOptions{
-			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
-		}
-	}
-	repo, err = git.PlainCloneContext(ctx, path, true, cloneOpts) // bare = true
+	repo, err = git.PlainCloneContext(ctx, path, true, &git.CloneOptions{
+		URL:          url,
+		Auth:         auth,
+		ProxyOptions: proxyOptions(proxy),
+	})
 	if err != nil {
 		// Leave nothing partial behind so the next attempt re-clones
 		// from scratch rather than tripping over a half-written mirror.
 		_ = os.RemoveAll(path)
 		return nil, fmt.Errorf("mirror clone %s: %w", url, err)
 	}
+	// Fetch the plan's narrow refspecs after cloning — clone only pulls the
+	// server's default refs (typically refs/heads/*), so non-default refs
+	// such as refs/pull/* won't be present until an explicit targeted fetch.
 	if err := m.fetchInto(ctx, repo, auth, proxy, plan.RefSpecs); err != nil {
 		_ = os.RemoveAll(path)
 		return nil, err
@@ -132,16 +136,12 @@ func (m *Cache) fetchInto(ctx context.Context, repo *git.Repository, auth transp
 	if len(refSpecs) == 0 {
 		refSpecs = []config.RefSpec{"+refs/*:refs/*"}
 	}
-	opts := &git.FetchOptions{
-		Auth:     auth,
-		RefSpecs: refSpecs,
-	}
-	if proxy != nil {
-		opts.ProxyOptions = transport.ProxyOptions{
-			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
-		}
-	}
-	if err := repo.FetchContext(ctx, opts); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
+	err := repo.FetchContext(ctx, &git.FetchOptions{
+		Auth:         auth,
+		RefSpecs:     refSpecs,
+		ProxyOptions: proxyOptions(proxy),
+	})
+	if err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return fmt.Errorf("mirror fetch: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary

Iter-6 work on `pkg/source/git/mirror`. **Fixes a latent deadlock** for HTTPS git repos with a custom CA bundle.

- **Deadlock fix**: `OpenOrFetch` was calling `gittransport.InstallHTTPS` while `pkg/source/git.Fetcher.Fetch` already held the same non-reentrant `sync.Mutex` (the InstallHTTPS lock). For any HTTPS repo with `spec.secretRef` containing `ca.crt`/`caFile`, this was a guaranteed hang. The transport lock belongs to the outermost caller (`Fetch` does it once and the install covers nested `OpenOrFetch` calls within the same invocation). `tlsCfg` retained in the signature with `_ = tlsCfg` to avoid breaking the out-of-scope `fetcher.go` caller in this PR; can be removed in a follow-up that touches `fetcher.go`.
- **`proxyOptions(*source.ProxyConfig)` extracted** — the three-way nil-check + struct literal was repeated at the clone site and twice inside `fetchInto`. One place now.
- **Post-clone `fetchInto` preserved** — bare clone only materialises the server's default refs (\`refs/heads/*\`). Non-default refspecs (\`refs/pull/*\`, \`refs/merge-*\`) need the targeted fetch. `TestMirror_RefNameResolvesNonBranchRefs` pins this; the agent dropped it in an earlier attempt and caught the regression.

Public API unchanged: `Cache`, `FetchPlan`, `New`, `OpenOrFetch` signatures identical.

## Concern for reviewer

The deadlock is latent — it only triggers with HTTPS + custom CA, which test infra here doesn't hit. Worth a real-world smoke test before relying on this.

## Test plan
- [x] `go vet ./pkg/source/git/mirror/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/source/git/...` — all 6 mirror tests pass incl. ref-resolution
- [x] `golangci-lint run ./pkg/source/git/mirror/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)