### PR TITLE
fix(kustomize): isHTTPClientError 4xx detection + idiom cleanups

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -166,22 +166,12 @@ func applyCommonMetadata(rm resmap.ResMap, rawSpec map[string]any) error {
 	}
 	for _, r := range rm.Resources() {
 		if len(labels) > 0 {
-			merged := maps.Clone(r.GetLabels())
-			if merged == nil {
-				merged = map[string]string{}
-			}
-			maps.Copy(merged, labels)
-			if err := r.SetLabels(merged); err != nil {
+			if err := r.SetLabels(overlayStringMap(r.GetLabels(), labels)); err != nil {
 				return err
 			}
 		}
 		if len(annotations) > 0 {
-			merged := maps.Clone(r.GetAnnotations())
-			if merged == nil {
-				merged = map[string]string{}
-			}
-			maps.Copy(merged, annotations)
-			if err := r.SetAnnotations(merged); err != nil {
+			if err := r.SetAnnotations(overlayStringMap(r.GetAnnotations(), annotations)); err != nil {
 				return err
 			}
 		}
@@ -205,25 +195,28 @@ func applyOwnerLabels(rm resmap.ResMap, rawSpec map[string]any) error {
 	}
 	namespace, _ := md["namespace"].(string)
 	const group = "kustomize.toolkit.fluxcd.io"
-	owner := map[string]string{
-		group + "/name":      name,
-		group + "/namespace": namespace,
+	// Build owner overlay with only non-empty values so a cluster-scoped
+	// Kustomization (no namespace) doesn't clobber an existing namespace label.
+	owner := make(map[string]string, 2)
+	owner[group+"/name"] = name
+	if namespace != "" {
+		owner[group+"/namespace"] = namespace
 	}
 	for _, r := range rm.Resources() {
-		merged := maps.Clone(r.GetLabels())
-		if merged == nil {
-			merged = map[string]string{}
-		}
-		for k, v := range owner {
-			if v != "" {
-				merged[k] = v
-			}
-		}
-		if err := r.SetLabels(merged); err != nil {
+		if err := r.SetLabels(overlayStringMap(r.GetLabels(), owner)); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// overlayStringMap returns a copy of base with every entry from overlay
+// merged in. overlay wins on key collisions. RNode.GetLabels /
+// GetAnnotations always return a non-nil map, so base is never nil here.
+func overlayStringMap(base, overlay map[string]string) map[string]string {
+	out := maps.Clone(base)
+	maps.Copy(out, overlay)
+	return out
 }
 
 func stringMap(v any) map[string]string {

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -151,10 +151,10 @@ func findMappingValue(doc *yaml.Node, key string) *yaml.Node {
 	if root.Kind != yaml.MappingNode {
 		return nil
 	}
-	// MappingNode.Content is [key, value, key, value, ...].
-	for i := 0; i+1 < len(root.Content); i += 2 {
-		if root.Content[i].Value == key {
-			return root.Content[i+1]
+	// MappingNode.Content is [key, value, key, value, ...]; iterate as pairs.
+	for pair := range slices.Chunk(root.Content, 2) {
+		if len(pair) == 2 && pair[0].Value == key {
+			return pair[1]
 		}
 	}
 	return nil

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -159,24 +160,21 @@ func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, 
 // response (which won't change between retries within one run).
 // Anything else — transport errors, timeouts, 5xx — is treated as
 // transient so the cache entry gets dropped.
+//
+// httpGetURL emits errors with the exact format "HTTP <code>", so we
+// parse the trailing decimal and range-check for 400–499 rather than
+// doing substring matching with padding spaces (which silently missed
+// end-of-string codes).
 func isHTTPClientError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	for _, code := range []string{
-		" 400 ", " 401 ", " 402 ", " 403 ", " 404 ",
-		" 405 ", " 406 ", " 407 ", " 408 ", " 409 ",
-		" 410 ", " 411 ", " 412 ", " 413 ", " 414 ",
-		" 415 ", " 416 ", " 417 ", " 418 ", " 421 ",
-		" 422 ", " 423 ", " 424 ", " 425 ", " 426 ",
-		" 428 ", " 429 ", " 431 ", " 451 ",
-	} {
-		if strings.Contains(msg, code) {
-			return true
-		}
+	_, after, ok := strings.Cut(err.Error(), "HTTP ")
+	if !ok {
+		return false
 	}
-	return false
+	code, parseErr := strconv.Atoi(after)
+	return parseErr == nil && code >= 400 && code < 500
 }
 
 // Stage returns the on-disk staged copy of source. The copy is created

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -2,6 +2,7 @@ package kustomize
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -284,5 +285,32 @@ func TestRestoreKustomization_DoesNotMutateSource(t *testing.T) {
 	}
 	if string(got) != "original\n" {
 		t.Errorf("source kustomization.yaml mutated by stage write: got %q", got)
+	}
+}
+
+// TestIsHTTPClientError pins the 4xx-detection contract after a bug
+// where the previous implementation checked for " 4xx " (with surrounding
+// spaces) and never matched "HTTP 404" (the exact format httpGetURL
+// emits), causing every 4xx to be treated as transient and retried.
+func TestIsHTTPClientError(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"HTTP 400", true},
+		{"HTTP 404", true},
+		{"HTTP 418", true},
+		{"HTTP 499", true},
+		{"HTTP 500", false},  // 5xx is transient
+		{"HTTP 200", false},  // success never hits this path, but guard it
+		{"connection refused", false},
+		{"context deadline exceeded", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isHTTPClientError(fmt.Errorf("%s", tc.msg))
+		if got != tc.want {
+			t.Errorf("isHTTPClientError(%q) = %v, want %v", tc.msg, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Iter-6 deeper pass on `pkg/kustomize`. **Includes a real bug fix.**

- **`stage.go isHTTPClientError` BUG FIX**: the check was \`strings.Contains(msg, " 404 ")\` with padding spaces on both sides. \`httpGetURL\` emits \`fmt.Errorf("HTTP %d", code)\` → actual string is \`"HTTP 404"\` (no trailing space). The padded check **never matched**, so every 4xx was incorrectly treated as transient and its cache entry dropped, forcing unnecessary retries on definitively-failed URLs. Fixed with \`strings.Cut(msg, "HTTP ") + strconv.Atoi + range 400-499\`. New test \`TestIsHTTPClientError\` pins the fix.
- **`flux.go` `overlayStringMap` extracted + dead nil guards removed**: \`RNode.GetLabels()/GetAnnotations()\` always return non-nil maps (confirmed in kyaml source — \`getMapFromMeta\` has explicit \`if result == nil { return make(...) }\` fallback). The \`if merged == nil { merged = map[string]string{} }\` guards after \`maps.Clone\` were dead code. New helper eliminates the 3-site clone+nil-guard+copy pattern. `applyOwnerLabels` simplified accordingly (owner overlay built directly with namespace-only-when-non-empty check).
- **`preflight.go slices.Chunk` for YAML pair iteration** — the C-style \`for i := 0; i+1 < len(content); i += 2\` loop in \`findMappingValue\` replaced with \`for pair := range slices.Chunk(root.Content, 2)\`. Self-documents that YAML MappingNode content is key-value pairs.

Public API unchanged.

## Test plan
- [x] `go vet ./pkg/kustomize/...`
- [x] `go test -count=1 -race -timeout=180s ./pkg/kustomize/...`
- [x] **Downstream:** `./pkg/controllers/kustomization/... ./pkg/orchestrator/... ./internal/cli/...` race — all pass
- [x] `golangci-lint run ./pkg/kustomize/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)