### PR TITLE
refactor(controllers): consolidate preflight/waiter/parent into base.Controller

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"sync/atomic"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -39,6 +41,13 @@ import (
 //
 // Encoding it once means new pre-reconcile concerns (rate-limit,
 // retries, debug-mode toggle) drop into one place and propagate.
+//
+// The KS and HR controllers additionally share depwait configuration
+// (Existence, Renders) and a pre-reconcile preflight check (Preflight,
+// ParentOf). Configure these via SetDepwait / SetPreflight / SetParentOf
+// before Start so reconcile bodies can call NewWaiter, PreflightError,
+// and LookupParent without each controller duplicating the nil-check
+// boilerplate.
 type Controller struct {
 	Store *store.Store
 	Tasks *task.Service
@@ -57,6 +66,14 @@ type Controller struct {
 	// kindLabel prefixes coalescer keys ("source/", "kustomization/",
 	// "helmrelease/") and labels panic logs. Set by Start.
 	kindLabel string
+
+	// Shared KS/HR depwait and preflight state. Set via SetDepwait,
+	// SetPreflight, SetParentOf. The source controller leaves these nil;
+	// KS and HR configure them before Start via their Configure methods.
+	existence depwait.ExistenceLookup
+	renders   depwait.RenderInflight
+	preflight func(manifest.NamedResource) (string, bool)
+	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
 }
 
 // New constructs a base controller. Concrete controllers call this
@@ -77,6 +94,86 @@ func (c *Controller) SetFilter(f *change.Filter) {
 
 // Filter returns the configured filter (may be nil-but-non-active).
 func (c *Controller) Filter() *change.Filter { return c.filter }
+
+// SetDepwait installs the depwait resolution wires. Panics after Start.
+func (c *Controller) SetDepwait(existence depwait.ExistenceLookup, renders depwait.RenderInflight) {
+	if c.started.Load() {
+		panic("controller: SetDepwait called after Start")
+	}
+	c.existence = existence
+	c.renders = renders
+}
+
+// SetPreflight installs the pre-reconcile failure reporter. Panics after Start.
+func (c *Controller) SetPreflight(f func(manifest.NamedResource) (string, bool)) {
+	if c.started.Load() {
+		panic("controller: SetPreflight called after Start")
+	}
+	c.preflight = f
+}
+
+// SetParentOf installs the structural parent resolver. Panics after Start.
+func (c *Controller) SetParentOf(f func(manifest.NamedResource) (manifest.NamedResource, bool)) {
+	if c.started.Load() {
+		panic("controller: SetParentOf called after Start")
+	}
+	c.parentOf = f
+}
+
+// LookupParent reports the structural parent KS of id via the
+// configured resolver, or (zero, false) when no parent exists or no
+// resolver was configured.
+func (c *Controller) LookupParent(id manifest.NamedResource) (manifest.NamedResource, bool) {
+	if c.parentOf == nil {
+		return manifest.NamedResource{}, false
+	}
+	return c.parentOf(id)
+}
+
+// PreflightFailure reports the pre-reconcile failure for id if the
+// orchestrator detected a dependency-graph error. Returns ("", false)
+// when no preflight check is configured or no failure was recorded.
+func (c *Controller) PreflightFailure(id manifest.NamedResource) (string, bool) {
+	if c.preflight == nil {
+		return "", false
+	}
+	return c.preflight(id)
+}
+
+// PreflightError returns an error wrapping the preflight failure
+// message for id, or nil when no failure is recorded. Used at each
+// yield point inside reconcile so a cycle detection or topology error
+// published mid-flight aborts the current pass without waiting.
+func (c *Controller) PreflightError(id manifest.NamedResource) error {
+	if msg, failed := c.PreflightFailure(id); failed {
+		return errors.New(msg)
+	}
+	return nil
+}
+
+// NewWaiter constructs a depwait.Waiter pre-wired with the
+// controller's Store, Existence lookup, and Renders quiescence signal,
+// parented to id and budgeted from timeout. HR and KS controllers call
+// this rather than constructing their own Waiter literals so the
+// Existence/Renders wiring is set once in Configure and flows through
+// automatically.
+func (c *Controller) NewWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
+	return &depwait.Waiter{
+		Store:     c.Store,
+		Parent:    id,
+		Timeout:   depwait.TimeoutFromSpec(timeout),
+		Existence: c.existence,
+		Renders:   c.renders,
+	}
+}
+
+// IsFileIndexed reports whether id is tracked by the file-existence
+// index wired at Configure time. Returns false when no index is
+// configured (offline / unit-test paths), which degrades safely by
+// treating the resource as not-file-indexed.
+func (c *Controller) IsFileIndexed(id manifest.NamedResource) bool {
+	return c.existence != nil && c.existence.IsFileIndexed(id)
+}
 
 // StartLifecycle flips the started gate and allocates the coalescer.
 // Concrete controllers call this from their Start(ctx) before

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -9,11 +9,8 @@ package helmrelease
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -39,18 +36,6 @@ type Controller struct {
 	// templates.
 	WipeSecrets bool
 
-	// parentOf resolves each HR to its enclosing Flux KS at lookup
-	// time. The closure unifies two parent sources:
-	//   - file-loaded HRs: pre-built path-prefix index from
-	//     loader.BuildParentIndexForKind.
-	//   - render-emitted HRs (chart-of-charts, KS-substituted copies):
-	//     the orchestrator's renderedSet.ParentOf, populated when the
-	//     parent KS's emitRenderedChildren fires.
-	// Nil means "no parent enforcement"; matches pre-#221 behavior.
-	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
-	existence depwait.ExistenceLookup
-	renders   depwait.RenderInflight
-	preflight func(manifest.NamedResource) (string, bool)
 	// allowMissingSecrets extends the source-controller flag to
 	// HelmRelease valuesFrom refs that cannot be resolved offline.
 	allowMissingSecrets bool
@@ -105,36 +90,10 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 // read-only once dispatch begins.
 func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetFilter(opts.Filter)
-	c.parentOf = opts.ParentOf
-	c.existence = opts.Existence
-	c.renders = opts.Renders
-	c.preflight = opts.PreflightFailure
+	c.SetDepwait(opts.Existence, opts.Renders)
+	c.SetPreflight(opts.PreflightFailure)
+	c.SetParentOf(opts.ParentOf)
 	c.allowMissingSecrets = opts.AllowMissingSecrets
-}
-
-// lookupParent reports the structural parent KS of id via the
-// configured resolver, or (zero, false) when no parent exists or no
-// resolver was configured.
-func (c *Controller) lookupParent(id manifest.NamedResource) (manifest.NamedResource, bool) {
-	if c.parentOf == nil {
-		return manifest.NamedResource{}, false
-	}
-	return c.parentOf(id)
-}
-
-// newWaiter constructs a depwait.Waiter pre-wired with the
-// controller's Store and lazy-promotion fallback, parented to id and
-// budgeted from timeout (typically hr.Timeout). Centralizes the
-// boilerplate so the parent-KS gate, dependsOn wait, and chart-
-// source wait don't drift apart.
-func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
-	return &depwait.Waiter{
-		Store:     c.Store,
-		Parent:    id,
-		Timeout:   depwait.TimeoutFromSpec(timeout),
-		Existence: c.existence,
-		Renders:   c.renders,
-	}
 }
 
 // Start registers the listeners. The controller runs until Close.
@@ -160,7 +119,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if c.PreGate(id, hr.Suspend) {
 			return
 		}
-		if msg, failed := c.preflightFailure(id); failed {
+		if msg, failed := c.PreflightFailure(id); failed {
 			c.Store.UpdateStatus(id, store.StatusFailed, msg)
 			return
 		}
@@ -170,23 +129,9 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	}
 }
 
-func (c *Controller) preflightFailure(id manifest.NamedResource) (string, bool) {
-	if c.preflight == nil {
-		return "", false
-	}
-	return c.preflight(id)
-}
-
-func (c *Controller) preflightError(id manifest.NamedResource) error {
-	if msg, failed := c.preflightFailure(id); failed {
-		return errors.New(msg)
-	}
-	return nil
-}
-
 func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) error {
 	id := hr.Named()
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
@@ -200,8 +145,8 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// parent-patching chain (tholinka/home-ops's cluster KS applies
 	// driftDetection / install.crds / upgrade strategy / rollback to
 	// every HR, so all of them were hit by this).
-	if parent, ok := c.lookupParent(id); ok {
-		err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout),
+	if parent, ok := c.LookupParent(id); ok {
+		err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout),
 			[]manifest.DependencyRef{{NamedResource: parent}},
 			"waiting for parent KS",
 			func(sum depwait.Summary) error {
@@ -219,14 +164,14 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			hr = obj
 		}
 	}
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
 	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
 	// each dependency reaching Ready before this HR reconciles.
 	if deps := c.collectHRDeps(hr); len(deps) > 0 {
-		err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout), deps,
+		err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout), deps,
 			"resolving dependencies",
 			func(sum depwait.Summary) error {
 				return &manifest.DependencyFailedError{
@@ -249,7 +194,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			hr = obj
 		}
 	}
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
@@ -272,7 +217,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			break
 		}
 		var preSum depwait.Summary
-		if err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout), preDeps,
+		if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout), preDeps,
 			"awaiting pre-render references",
 			func(sum depwait.Summary) error {
 				preSum = sum
@@ -302,7 +247,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		}
 		break
 	}
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
@@ -326,7 +271,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	srcID := manifest.NamedResource{
 		Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
 	}
-	if err := c.Await(ctx, id, c.newWaiter(id, hr.Timeout),
+	if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout),
 		[]manifest.DependencyRef{{NamedResource: srcID}},
 		"", // status already set above
 		func(sum depwait.Summary) error {
@@ -343,7 +288,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return fmt.Errorf("%w: chart source %s %s",
 			manifest.ErrSourceSkipped, srcID.String(), info.Message)
 	}
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
@@ -358,7 +303,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// the HR-render time on real-world trees.
 	fp := helmReleaseFingerprint(hr)
 	if existing, ok := c.Store.GetArtifact(id).(*store.HelmReleaseArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
-		if err := c.preflightError(id); err != nil {
+		if err := c.PreflightError(id); err != nil {
 			return err
 		}
 		slog.Debug("helmrelease: skipped re-render (fingerprint unchanged)", "id", id.String())
@@ -373,7 +318,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering chart")
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 	docs, err := c.Helm.TemplateDocs(ctx, hr, hr.Values, c.Options)
@@ -382,7 +327,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 	c.emitRenderedChildren(id, docs)
@@ -457,7 +402,7 @@ func (c *Controller) omitValuesFrom(
 			filtered = append(filtered, ref)
 			continue
 		}
-		if c.existence != nil && c.existence.IsFileIndexed(id) {
+		if c.IsFileIndexed(id) {
 			filtered = append(filtered, ref)
 			continue
 		}

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -7,12 +7,9 @@ package kustomization
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -40,12 +37,8 @@ type Controller struct {
 	// parsing rendered manifests.
 	WipeSecrets bool
 
-	// Set via Configure() — see Options.
-	parentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
+	// renderTracker receives every reconcilable child emitted during render.
 	renderTracker RenderTracker
-	existence     depwait.ExistenceLookup
-	renders       depwait.RenderInflight
-	preflight     func(manifest.NamedResource) (string, bool)
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -107,11 +100,10 @@ func New(s *store.Store, t *task.Service, staging *kustomize.StagingCache, wipeS
 // read-only once the controller is dispatching.
 func (c *Controller) Configure(opts Options) {
 	c.SetFilter(opts.Filter)
-	c.parentOf = opts.ParentOf
+	c.SetDepwait(opts.Existence, opts.Renders)
+	c.SetPreflight(opts.PreflightFailure)
+	c.SetParentOf(opts.ParentOf)
 	c.renderTracker = opts.RenderTracker
-	c.existence = opts.Existence
-	c.renders = opts.Renders
-	c.preflight = opts.PreflightFailure
 }
 
 // markRendered reports a parent→child render emission to the
@@ -120,19 +112,6 @@ func (c *Controller) Configure(opts Options) {
 func (c *Controller) markRendered(parent, child manifest.NamedResource) {
 	if c.renderTracker != nil {
 		c.renderTracker.MarkRendered(parent, child)
-	}
-}
-
-// newWaiter constructs a depwait.Waiter pre-wired with the
-// controller's Store and lazy-promotion fallback, parented to id and
-// budgeted from timeout (typically ks.Timeout).
-func (c *Controller) newWaiter(id manifest.NamedResource, timeout *metav1.Duration) *depwait.Waiter {
-	return &depwait.Waiter{
-		Store:     c.Store,
-		Parent:    id,
-		Timeout:   depwait.TimeoutFromSpec(timeout),
-		Existence: c.existence,
-		Renders:   c.renders,
 	}
 }
 
@@ -154,7 +133,7 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 		if c.PreGate(id, ks.Suspend) {
 			return
 		}
-		if msg, failed := c.preflightFailure(id); failed {
+		if msg, failed := c.PreflightFailure(id); failed {
 			c.Store.UpdateStatus(id, store.StatusFailed, msg)
 			return
 		}
@@ -164,30 +143,16 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 	}
 }
 
-func (c *Controller) preflightFailure(id manifest.NamedResource) (string, bool) {
-	if c.preflight == nil {
-		return "", false
-	}
-	return c.preflight(id)
-}
-
-func (c *Controller) preflightError(id manifest.NamedResource) error {
-	if msg, failed := c.preflightFailure(id); failed {
-		return errors.New(msg)
-	}
-	return nil
-}
-
 func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) error {
 	id := ks.Named()
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
 
 	deps := c.collectDeps(ks)
 	if len(deps) > 0 {
-		err := c.Await(ctx, id, c.newWaiter(id, ks.Timeout), deps,
+		err := c.Await(ctx, id, c.NewWaiter(id, ks.Timeout), deps,
 			"", // status set above
 			func(sum depwait.Summary) error {
 				return &manifest.DependencyFailedError{
@@ -209,7 +174,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 			ks = fresh
 		}
 	}
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
@@ -228,7 +193,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	if err != nil {
 		return err
 	}
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 
@@ -240,7 +205,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	// post-Prepare inputs are byte-identical. Same pattern as HR (#219).
 	fp := kustomizationFingerprint(ks, sourceRoot)
 	if existing, ok := c.Store.GetArtifact(id).(*store.KustomizationArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
-		if err := c.preflightError(id); err != nil {
+		if err := c.PreflightError(id); err != nil {
 			return err
 		}
 		slog.Debug("kustomization: skipped re-render (fingerprint unchanged)", "id", id.String())
@@ -258,7 +223,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering")
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 	data, err := kustomize.RenderFlux(ctx, c.Staging, sourceRoot, ks.Path, ks.Contents)
@@ -292,7 +257,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))
-	if err := c.preflightError(id); err != nil {
+	if err := c.PreflightError(id); err != nil {
 		return err
 	}
 	c.emitRenderedChildren(id, docs)
@@ -335,10 +300,8 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 			},
 		})
 	}
-	if c.parentOf != nil {
-		if parent, ok := c.parentOf(ks.Named()); ok {
-			deps = append(deps, manifest.DependencyRef{NamedResource: parent})
-		}
+	if parent, ok := c.LookupParent(ks.Named()); ok {
+		deps = append(deps, manifest.DependencyRef{NamedResource: parent})
 	}
 	for _, ref := range ks.PostBuildSubstituteFrom {
 		if ref.Optional {


### PR DESCRIPTION
## Summary

Iter-6 deeper pass on `pkg/controllers/**`. **Cross-controller deduplication** is the key win — HR and KS controllers each maintained identical private fields and four identical methods built on them. All consolidated into `base.Controller`. Net **~55 LOC** of duplication removed.

### What moved up to `base.Controller`

Fields:
- `existence depwait.ExistenceLookup`
- `renders depwait.RenderInflight`
- `preflight func(...)`
- `parentOf func(...)`

Methods (now exported on `*base.Controller`):
- `PreflightFailure(id) (string, bool)` — nil-safe check
- `PreflightError(id) error` — wraps the above
- `NewWaiter(id, timeout) *depwait.Waiter` — was a byte-identical struct literal in both controllers
- `LookupParent(id) (NamedResource, bool)` — was HR-only with a different nil-check style in KS
- `IsFileIndexed(id) bool` — used by HR's `omitValuesFrom`

Setters (Configure-after-Start panic contract matches existing `SetFilter`):
- `SetDepwait(existence, renders)`
- `SetPreflight(fn)`
- `SetParentOf(fn)`

### Public API delta

5 new exported methods + 3 new setters on `*base.Controller`. All callers are only `helmrelease` and `kustomization` sub-packages within this PR (verified by grep).

## Test plan
- [x] `go vet ./pkg/controllers/...`
- [x] `go test -count=1 -race -timeout=300s ./pkg/controllers/...`
- [x] **Downstream:** `./pkg/orchestrator/... ./internal/cli/...` race — all pass
- [x] `golangci-lint run ./pkg/controllers/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)