### PR TITLE
refactor: consolidate resolveInputProvider into pkg/resourceset.StoreResolver

### DIFF
--- a/pkg/discovery/rsexpand.go
+++ b/pkg/discovery/rsexpand.go
@@ -3,11 +3,8 @@ package discovery
 import (
 	"log/slog"
 
-	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
-	"github.com/home-operations/flate/pkg/store"
 )
 
 // renderResourceSet evaluates rs.Spec across its inputs and AddObjects
@@ -18,7 +15,7 @@ import (
 // the count of new objects added so the caller can detect a fixed
 // point in the expansion loop.
 func (d *discoverer) renderResourceSet(rs *manifest.ResourceSet) (int, error) {
-	docs, err := resourceset.Render(rs, d.resolveInputProvider)
+	docs, err := resourceset.Render(rs, resourceset.StoreResolver(d.cfg.Store))
 	if err != nil {
 		return 0, err
 	}
@@ -60,40 +57,4 @@ func (d *discoverer) renderResourceSet(rs *manifest.ResourceSet) (int, error) {
 		added++
 	}
 	return added, nil
-}
-
-// resolveInputProvider satisfies resourceset.ProviderResolver against
-// the discoverer's object store. Name lookups hit a single id;
-// selector matches walk the store's RSIPs in the requested namespace
-// and filter by metadata.labels.
-func (d *discoverer) resolveInputProvider(ref fluxopv1.InputProviderReference, namespace string) ([]*manifest.ResourceSetInputProvider, error) {
-	if ref.Name != "" {
-		id := manifest.NamedResource{
-			Kind:      manifest.KindResourceSetInputProvider,
-			Namespace: namespace,
-			Name:      ref.Name,
-		}
-		obj, ok := store.Get[*manifest.ResourceSetInputProvider](d.cfg.Store, id)
-		if !ok {
-			return nil, nil
-		}
-		return []*manifest.ResourceSetInputProvider{obj}, nil
-	}
-	if ref.Selector == nil {
-		return nil, nil
-	}
-	var out []*manifest.ResourceSetInputProvider
-	for _, p := range store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider) {
-		if p.Namespace != namespace {
-			continue
-		}
-		match, err := resourceset.MatchSelector(ref.Selector, p.Labels)
-		if err != nil {
-			return nil, err
-		}
-		if match {
-			out = append(out, p)
-		}
-	}
-	return out, nil
 }

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/home-operations/flate/pkg/loader"
@@ -95,7 +94,7 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 			if err := gctx.Err(); err != nil {
 				return err
 			}
-			docs, err := resourceset.Render(rs, o.resolveInputProvider)
+			docs, err := resourceset.Render(rs, resourceset.StoreResolver(o.store))
 			if err != nil {
 				o.store.UpdateStatus(rs.Named(), store.StatusFailed, err.Error())
 				return err
@@ -178,41 +177,4 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 		return err
 	}
 	return nil
-}
-
-// resolveInputProvider mirrors discovery.resolveInputProvider but
-// against the post-Run store, which now includes RSIPs emitted by
-// the KS controller from kustomize substitution. Same semantics:
-// name-only refs hit the exact id; selector refs walk the requested
-// namespace's RSIPs and filter by metadata.labels.
-func (o *Orchestrator) resolveInputProvider(ref fluxopv1.InputProviderReference, namespace string) ([]*manifest.ResourceSetInputProvider, error) {
-	if ref.Name != "" {
-		id := manifest.NamedResource{
-			Kind:      manifest.KindResourceSetInputProvider,
-			Namespace: namespace,
-			Name:      ref.Name,
-		}
-		obj, ok := store.Get[*manifest.ResourceSetInputProvider](o.store, id)
-		if !ok {
-			return nil, nil
-		}
-		return []*manifest.ResourceSetInputProvider{obj}, nil
-	}
-	if ref.Selector == nil {
-		return nil, nil
-	}
-	var out []*manifest.ResourceSetInputProvider
-	for _, p := range store.ListAs[*manifest.ResourceSetInputProvider](o.store, manifest.KindResourceSetInputProvider) {
-		if p.Namespace != namespace {
-			continue
-		}
-		match, err := resourceset.MatchSelector(ref.Selector, p.Labels)
-		if err != nil {
-			return nil, err
-		}
-		if match {
-			out = append(out, p)
-		}
-	}
-	return out, nil
 }

--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // providerInputs is one per-provider list of input sets carrying its
@@ -176,4 +177,44 @@ func MatchSelector(sel *metav1.LabelSelector, lbls map[string]string) (bool, err
 		return false, err
 	}
 	return s.Matches(labels.Set(lbls)), nil
+}
+
+// StoreResolver returns a ProviderResolver backed by s. Name-only refs
+// perform a direct id lookup; selector refs walk the store's
+// ResourceSetInputProviders in the requested namespace and filter by
+// metadata.labels. This is the canonical implementation shared by
+// discovery and the orchestrator — both call sites previously carried
+// identical local copies.
+func StoreResolver(s *store.Store) ProviderResolver {
+	return func(ref fluxopv1.InputProviderReference, namespace string) ([]*manifest.ResourceSetInputProvider, error) {
+		if ref.Name != "" {
+			id := manifest.NamedResource{
+				Kind:      manifest.KindResourceSetInputProvider,
+				Namespace: namespace,
+				Name:      ref.Name,
+			}
+			obj, ok := store.Get[*manifest.ResourceSetInputProvider](s, id)
+			if !ok {
+				return nil, nil
+			}
+			return []*manifest.ResourceSetInputProvider{obj}, nil
+		}
+		if ref.Selector == nil {
+			return nil, nil
+		}
+		var out []*manifest.ResourceSetInputProvider
+		for _, p := range store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider) {
+			if p.Namespace != namespace {
+				continue
+			}
+			match, err := MatchSelector(ref.Selector, p.Labels)
+			if err != nil {
+				return nil, err
+			}
+			if match {
+				out = append(out, p)
+			}
+		}
+		return out, nil
+	}
 }


### PR DESCRIPTION
## Summary

Iter-7 cross-cutting dedupe. `resolveInputProvider` existed in **two byte-for-byte identical copies** (flagged by 3 earlier agents):
- `pkg/discovery/rsexpand.go`
- `pkg/orchestrator/resourceset.go` (with explicit "this duplicates discovery" comment)

### Resolution

New `resourceset.StoreResolver(*store.Store) ProviderResolver` factory in `pkg/resourceset/inputs.go`. Closes over the store and returns a `ProviderResolver` closure — the existing function-type both call sites already accept.

- `pkg/resourceset` was already imported by both `discovery` and `orchestrator` (no new import edges)
- `pkg/store` is a leaf (only imports `pkg/manifest`), so adding it as a `pkg/resourceset` import creates no cycle
- Two callers (`renderResourceSet`, `expandResourceSetsPostRun`) pass the result directly to `resourceset.Render`

### Files

- `pkg/resourceset/inputs.go` — adds `StoreResolver` + `pkg/store` import
- `pkg/discovery/rsexpand.go` — removes local method, calls `resourceset.StoreResolver(d.cfg.Store)`; drops now-unused `fluxopv1` + `pkg/store` imports
- `pkg/orchestrator/resourceset.go` — removes local method, calls `resourceset.StoreResolver(o.store)`; drops now-unused `fluxopv1` import

Public API delta: 1 new export (`resourceset.StoreResolver`). Two unexported helpers removed (one per package).

## Test plan
- [x] `go vet ./...`
- [x] `go test -count=1 -race -timeout=300s ./...` — all 35 packages green
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)