### PR TITLE
refactor(testutil): consolidate mapLister test fixture, replace m[k]=v with maps.Copy

### DIFF
--- a/internal/testutil/maplister.go
+++ b/internal/testutil/maplister.go
@@ -1,0 +1,22 @@
+package testutil
+
+import "github.com/home-operations/flate/pkg/manifest"
+
+// MapLister is a test fixture that implements change.ObjectLister via a
+// plain map. Used by controller tests that need a minimal ObjectLister
+// (typically an empty one) to construct a change.Filter.
+type MapLister map[manifest.NamedResource]manifest.BaseManifest
+
+// GetObject returns the manifest stored under id, or nil if absent.
+func (m MapLister) GetObject(id manifest.NamedResource) manifest.BaseManifest { return m[id] }
+
+// ListObjects returns all manifests whose kind matches the given string.
+func (m MapLister) ListObjects(kind string) []manifest.BaseManifest {
+	var out []manifest.BaseManifest
+	for id, obj := range m {
+		if id.Kind == kind {
+			out = append(out, obj)
+		}
+	}
+	return out
+}

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -87,7 +87,7 @@ func TestController_FilterUnchangedShortCircuitsToReady(t *testing.T) {
 		change.NewSet(nil),
 		map[manifest.NamedResource]string{},
 		"",
-		mapLister{},
+		testutil.MapLister{},
 	)
 	_, st := newTestController(t, filter)
 	hr := &manifest.HelmRelease{Name: "demo", Namespace: "default"}
@@ -283,15 +283,3 @@ func TestController_CollectHRDepsClone(t *testing.T) {
 	}
 }
 
-type mapLister map[manifest.NamedResource]manifest.BaseManifest
-
-func (m mapLister) GetObject(id manifest.NamedResource) manifest.BaseManifest { return m[id] }
-func (m mapLister) ListObjects(kind string) []manifest.BaseManifest {
-	var out []manifest.BaseManifest
-	for id, obj := range m {
-		if id.Kind == kind {
-			out = append(out, obj)
-		}
-	}
-	return out
-}

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/manifest"
 	src "github.com/home-operations/flate/pkg/source"
@@ -36,9 +38,7 @@ func newController(t *testing.T, fetchers map[string]src.Fetcher) (*Controller, 
 	st := store.New()
 	ts := task.New()
 	c := New(st, ts)
-	for k, f := range fetchers {
-		c.Fetchers[k] = f
-	}
+	maps.Copy(c.Fetchers, fetchers)
 	c.Start(context.Background())
 	t.Cleanup(func() {
 		c.Close()
@@ -203,7 +203,7 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 		change.NewSet(nil), // no changed files
 		map[manifest.NamedResource]string{},
 		"",
-		mapLister{},
+		testutil.MapLister{},
 	)
 	c := New(st, ts)
 	c.Fetchers[manifest.KindGitRepository] = f
@@ -229,15 +229,3 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 	}
 }
 
-type mapLister map[manifest.NamedResource]manifest.BaseManifest
-
-func (m mapLister) GetObject(id manifest.NamedResource) manifest.BaseManifest { return m[id] }
-func (m mapLister) ListObjects(kind string) []manifest.BaseManifest {
-	var out []manifest.BaseManifest
-	for id, obj := range m {
-		if id.Kind == kind {
-			out = append(out, obj)
-		}
-	}
-	return out
-}


### PR DESCRIPTION
## Summary

Iter-7 cross-cutting dedupe.

- **mapLister moved to testutil**: `pkg/controllers/source/controller_test.go` and `pkg/controllers/helmrelease/controller_test.go` each defined a byte-for-byte identical `type mapLister` (same underlying type \`map[manifest.NamedResource]manifest.BaseManifest\`, same two methods, same body). Both satisfied `change.ObjectLister`, both used identically (empty literal passed to `change.NewFilter`). Hoisted to `internal/testutil.MapLister` (exported, with doc comments).
- **`source/controller_test.go` Fetchers init**: small lint-driven fix in the same file — replaced `for k, f := range fetchers { c.Fetchers[k] = f }` with `maps.Copy(c.Fetchers, fetchers)`.

### Files

- `internal/testutil/maplister.go` — new file with `MapLister` type + methods
- `pkg/controllers/source/controller_test.go` — drop local def, import testutil, use `testutil.MapLister{}`, add `maps` import for the Fetchers init
- `pkg/controllers/helmrelease/controller_test.go` — drop local def, use `testutil.MapLister{}` (testutil already imported)

White-box `package source` test imports `internal/testutil` cleanly (same module).

## Test plan
- [x] `go vet ./...`
- [x] `go test -count=1 -race -timeout=300s ./pkg/controllers/...` — all 4 controller packages green
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)