### PR TITLE
refactor(mirror): drop unused tlsCfg param from OpenOrFetch

### DIFF
--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -16,7 +16,6 @@ import (
 	"cmp"
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -84,7 +83,7 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 		return nil, err
 	}
 	defer restore()
-	return f.fetch(ctx, repo, auth, proxy, tlsCfg)
+	return f.fetch(ctx, repo, auth, proxy)
 }
 
 // fetch clones the GitRepository, then runs verification, ignore, and
@@ -97,11 +96,7 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 // auth may be nil for anonymous clones; proxy may be nil for direct.
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
-//
-// tlsCfg is the already-resolved spec.secretRef CA bundle (resolved by
-// Fetch); pass through to fetchViaMirror so the mirror path doesn't
-// re-resolve the Secret + re-parse the PEM bundle.
-func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*store.SourceArtifact, error) {
+func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
 	cache := f.Cache
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
@@ -166,7 +161,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	}
 
 	if f.canUseMirror(repo, url) {
-		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy, tlsCfg)
+		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy)
 	}
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
@@ -363,12 +358,8 @@ func (f *Fetcher) canUseMirror(repo *manifest.GitRepository, _ string) bool {
 // materialize the tree into the slot's staging dir. PGP verification
 // runs against the mirror (which has the object store); ApplyIgnore
 // and the revision-marker write delegate to applyIgnoreAndMark.
-//
-// tlsCfg is the caller's pre-resolved spec.secretRef CA bundle —
-// hoisting it out of this function avoids re-reading the Secret +
-// re-parsing PEM on every mirror fetch.
-func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitRepository, refStr string, slot *source.Slot, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config) (*store.SourceArtifact, error) {
-	mirrorRepo, err := f.Mirrors.OpenOrFetch(ctx, repo.URL, auth, proxy, tlsCfg, mirrorFetchPlan(repo.Reference))
+func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitRepository, refStr string, slot *source.Slot, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
+	mirrorRepo, err := f.Mirrors.OpenOrFetch(ctx, repo.URL, auth, proxy, mirrorFetchPlan(repo.Reference))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/source/git/mirror/mirror.go
+++ b/pkg/source/git/mirror/mirror.go
@@ -7,7 +7,6 @@ package mirror
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -79,12 +78,7 @@ func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
 // carries up-to-date refs. First call for a URL runs a bare clone;
 // subsequent calls incrementally Fetch. Holds the per-URL lock across
 // the network operation so two concurrent callers serialize.
-//
-// tlsCfg is accepted for API compatibility; the caller (Fetch) already
-// holds the process-global HTTPS-transport lock for the duration of the
-// mirror operation, so installing it here would deadlock.
-func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, tlsCfg *tls.Config, plan FetchPlan) (*git.Repository, error) {
-	_ = tlsCfg // transport lock held by caller; see gittransport.InstallHTTPS
+func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, plan FetchPlan) (*git.Repository, error) {
 	release, err := m.locks.Acquire(ctx, urlHash(url))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Iter-8 follow-up. Iter-6's mirror deadlock fix removed the inner `InstallHTTPS(tlsCfg, proxy)` call but kept `tlsCfg` in `OpenOrFetch`'s signature with `_ = tlsCfg` to avoid breaking the caller in one PR. Now safe to drop the param.

Cascades cleanly:
- `mirror.go`: drop `tlsCfg *tls.Config` from `OpenOrFetch` signature; drop the no-op blank assignment; drop the `crypto/tls` import
- `fetcher.go`: drop the `tlsCfg` argument from the `OpenOrFetch` call site; the cascade also lets `fetchViaMirror` and `fetch` drop their forwarding params; remove now-unused `crypto/tls` import

No behavior change — the param has been a confirmed no-op since iter-6 merged.

## Test plan
- [x] `go vet ./pkg/source/git/...`
- [x] `go test -count=1 -race -timeout=300s ./pkg/source/git/...`
- [x] `golangci-lint run ./pkg/source/git/...` (0 issues)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)