### PR TITLE
fix(discovery): normalize slog attribute keys to snake_case

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -277,7 +277,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 		}
 	}
 	l.PreferExisting = false
-	slog.Debug("discovery: loaded objects", "count", total, "scanRoot", scanRoot, "sourceRoot", repoRoot)
+	slog.Debug("discovery: loaded objects", "count", total, "scan_root", scanRoot, "source_root", repoRoot)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Iter-9 final-pass quality audit (the cleanup loop's natural stopping point).

The agent scanned three areas:

| Area | Candidates | Fixed | Reason others skipped |
|---|---|---|---|
| slog snake_case keys | 2 (both in `pkg/discovery/discovery.go:280`) | 2 | Other grep hits were string message contents, not keys |
| Unused exports | 0 | 0 | `golangci-lint --enable-only=unused,revive` reports 0 issues |
| `cmp.Or` candidates | 0 | 0 | All `== ""` matches are guard clauses or function-call assignments — not pattern fits |

### Change

`pkg/discovery/discovery.go:280` — `scanRoot`/`sourceRoot` slog keys → `scan_root`/`source_root`. Matches repo convention.

### Verdict

After 9 iterations and ~40 merged PRs across all 25+ modules, the repo is in a good state. No abstractions need building, no further mechanical sweeps remain, and the remaining \`golangci-lint\` surface is at 0 issues. **This is where the loop should end.**

## Test plan
- [x] `go vet ./...`
- [x] `go test -count=1 -race -timeout=300s ./...` — all 36 packages green
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)