### PR TITLE
refactor(helm): move chartCacheLocks onto Client, drop cloneValuesMap dup

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -103,6 +103,13 @@ type Client struct {
 	// index.yaml supplies a digest; entries without a digest are
 	// treated as mutable and downloaded on each run.
 	chartBlobs *blob.Store
+
+	// chartDownloadLocks serializes concurrent downloads of the same
+	// chart tarball so two reconcilers don't race writing the same
+	// cache file. Keyed by content-address digest (when available) or
+	// a name+version+URL token — matches the pattern of chartLoadLocks
+	// and indexLocks above.
+	chartDownloadLocks *keylock.KeyMap[string]
 }
 
 // chartCacheEntry pairs the parsed chart with the (mtime, size) of
@@ -141,13 +148,14 @@ func NewClient(layout cacheroot.Layout) (*Client, error) {
 		return nil, fmt.Errorf("helm registry: %w", err)
 	}
 	return &Client{
-		tmpDir:         tmpDir,
-		cacheDir:       cacheDir,
-		registry:       reg,
-		chartCache:     map[string]chartCacheEntry{},
-		chartLoadLocks: keylock.New[string](),
-		indexLocks:     keylock.New[string](),
-		chartBlobs:     blob.NewStore(layout),
+		tmpDir:             tmpDir,
+		cacheDir:           cacheDir,
+		registry:           reg,
+		chartCache:         map[string]chartCacheEntry{},
+		chartLoadLocks:     keylock.New[string](),
+		indexLocks:         keylock.New[string](),
+		chartDownloadLocks: keylock.New[string](),
+		chartBlobs:         blob.NewStore(layout),
 	}, nil
 }
 
@@ -378,7 +386,7 @@ func cloneChartForRender(src *chart.Chart) *chart.Chart {
 		}
 		out.Metadata = &md
 	}
-	out.Values = cloneValuesMap(src.Values)
+	out.Values = manifest.DeepCopyMap(src.Values)
 	if subs := src.Dependencies(); len(subs) > 0 {
 		clones := make([]*chart.Chart, 0, len(subs))
 		for _, sub := range subs {
@@ -387,35 +395,6 @@ func cloneChartForRender(src *chart.Chart) *chart.Chart {
 		out.SetDependencies(clones...)
 	}
 	return &out
-}
-
-// cloneValuesMap deep-copies a chart.Values map (`map[string]any`).
-// Mirrors pkg/manifest.DeepCopyMap but kept local to avoid widening
-// the helm→manifest import seam for one helper.
-func cloneValuesMap(src map[string]any) map[string]any {
-	if src == nil {
-		return nil
-	}
-	out := make(map[string]any, len(src))
-	for k, v := range src {
-		out[k] = cloneValuesNode(v)
-	}
-	return out
-}
-
-func cloneValuesNode(v any) any {
-	switch t := v.(type) {
-	case map[string]any:
-		return cloneValuesMap(t)
-	case []any:
-		out := make([]any, len(t))
-		for i, e := range t {
-			out[i] = cloneValuesNode(e)
-		}
-		return out
-	default:
-		return v
-	}
 }
 
 // lookupCachedChart returns the cached chart only when the on-disk

--- a/pkg/helm/oci_chart.go
+++ b/pkg/helm/oci_chart.go
@@ -213,7 +213,7 @@ func (c *Client) fetchOCIChart(ctx context.Context, ref, version string) (string
 	// a tag re-push silently serve stale bytes to a digest reference.
 	target := filepath.Join(c.cacheDir, safeName(strings.TrimPrefix(pullRef, "oci://"))+".tgz")
 
-	release, err := chartCacheLocks.Acquire(ctx, target)
+	release, err := c.chartDownloadLocks.Acquire(ctx, target)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -12,14 +12,9 @@ import (
 	"helm.sh/helm/v4/pkg/getter"
 	repo "helm.sh/helm/v4/pkg/repo/v1"
 
-	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
-
-// chartCacheLocks serializes concurrent fetches of the same cached
-// chart tarball so two reconcilers don't race on the same file.
-var chartCacheLocks = keylock.New[string]()
 
 // ChartLoadResult is the loaded chart plus the on-disk path it came from.
 type ChartLoadResult struct {
@@ -169,7 +164,7 @@ func (c *Client) locateHelmRepoChart(ctx context.Context, hr *manifest.HelmRelea
 		return path, nil
 	}
 
-	release, err := chartCacheLocks.Acquire(ctx, chartDownloadKey(r, hr, cv, chartURL, wantDigest))
+	release, err := c.chartDownloadLocks.Acquire(ctx, chartDownloadKey(r, hr, cv, chartURL, wantDigest))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Phase-2 iter-10.

## 1. chartCacheLocks → Client.chartDownloadLocks
Removed package-level \`var chartCacheLocks\` (broke per-Client isolation; two Clients shared the same lock table for paths). Now per-Client field initialized in NewClient, matching the chartLoadLocks / indexLocks pattern.

## 2. Drop cloneValuesMap / cloneValuesNode (duplicate of manifest.DeepCopyMap)
The comment apologized for the dup as "kept local to avoid widening the helm→manifest import seam for one helper" — but pkg/helm already imports manifest in 5+ files. Deleted local copies; cloneChartForRender calls manifest.DeepCopyMap directly.

## Test plan
- [x] go vet ./pkg/helm/...
- [x] go test -race -timeout=180s ./pkg/helm/... + downstream (controllers/helmrelease, orchestrator, internal/cli)
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)