### PR TITLE
fix(loader): .krmignore ** patterns now match (was silently no-op) + move NormalizePrefix

### DIFF
--- a/pkg/loader/ignore.go
+++ b/pkg/loader/ignore.go
@@ -5,18 +5,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/fluxcd/pkg/sourceignore/gitignore"
 )
 
 // ignoreSet is the matched-rule set from a .krmignore (or .gitignore-style)
 // file at the scan root.
 type ignoreSet struct {
-	patterns []string
+	matcher gitignore.Matcher
 }
 
 // loadIgnore reads <root>/.krmignore (or returns an empty set if not
-// present). The grammar is a subset of gitignore: hash comments, blank
-// lines, and one pattern per line; patterns are interpreted relative to
-// root via filepath.Match-style globbing.
+// present). The grammar is gitignore: hash comments, blank lines, and one
+// pattern per line. Patterns are interpreted relative to root and support
+// the full gitignore glob syntax, including ** for zero-or-more path
+// segments.
 func loadIgnore(root string) (*ignoreSet, error) {
 	out := &ignoreSet{}
 	path := filepath.Join(root, ".krmignore")
@@ -28,36 +31,45 @@ func loadIgnore(root string) (*ignoreSet, error) {
 		return out, err
 	}
 	defer func() { _ = f.Close() }()
+
+	// domain is the root split into path segments, used by the gitignore
+	// pattern parser to anchor absolute-style patterns correctly.
+	domain := strings.Split(filepath.ToSlash(root), "/")
+	var patterns []gitignore.Pattern
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
-		out.patterns = append(out.patterns, line)
+		patterns = append(patterns, gitignore.ParsePattern(line, domain))
 	}
-	return out, sc.Err()
+	if err := sc.Err(); err != nil {
+		return out, err
+	}
+	if len(patterns) > 0 {
+		out.matcher = gitignore.NewMatcher(patterns)
+	}
+	return out, nil
 }
 
 // matches reports whether path (an absolute file path under root)
 // should be ignored.
 func (i *ignoreSet) matches(path, root string) bool {
-	if i == nil || len(i.patterns) == 0 {
+	if i == nil || i.matcher == nil {
 		return false
 	}
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
 		return false
 	}
-	for _, pat := range i.patterns {
-		if matched, _ := filepath.Match(pat, rel); matched {
-			return true
-		}
-		// Support directory-prefix matches (pat/...).
-		if strings.HasPrefix(rel, strings.TrimSuffix(pat, "/")+string(filepath.Separator)) {
-			return true
-		}
-	}
-	return false
+	// Build a domain+relative segment slice: the gitignore matcher expects
+	// [domain... rel_segments...] where domain matches what was passed to
+	// ParsePattern. The segments are slash-separated path components.
+	relSlash := filepath.ToSlash(rel)
+	rootSlash := filepath.ToSlash(root)
+	domain := strings.Split(rootSlash, "/")
+	relParts := strings.Split(relSlash, "/")
+	segments := append(append([]string(nil), domain...), relParts...)
+	return i.matcher.Match(segments, false)
 }
-

--- a/pkg/loader/ignore_test.go
+++ b/pkg/loader/ignore_test.go
@@ -1,0 +1,119 @@
+package loader
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+)
+
+// TestLoadIgnore_GlobStarMatchesAcrossDirectories is the regression test for
+// the original bug: filepath.Match does not expand ** across separators, so
+// patterns like "apps/junk/**" silently never matched files inside
+// apps/junk/sub/file.yaml.  After the fix, the gitignore-based matcher
+// handles ** correctly.
+func TestLoadIgnore_GlobStarMatchesAcrossDirectories(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, ".krmignore", "apps/junk/**\n")
+
+	ig, err := loadIgnore(root)
+	if err != nil {
+		t.Fatalf("loadIgnore: %v", err)
+	}
+
+	cases := []struct {
+		rel     string
+		wantHit bool
+	}{
+		// Direct child — must match.
+		{"apps/junk/file.yaml", true},
+		// Nested several levels deep — the original bug: ** must cross /
+		{"apps/junk/sub/file.yaml", true},
+		{"apps/junk/a/b/c/deep.yaml", true},
+		// Outside the ignored tree — must NOT match.
+		{"apps/other/file.yaml", false},
+		{"other/junk/file.yaml", false},
+	}
+	for _, tc := range cases {
+		abs := filepath.Join(root, filepath.FromSlash(tc.rel))
+		if got := ig.matches(abs, root); got != tc.wantHit {
+			t.Errorf("matches(%q) = %v, want %v", tc.rel, got, tc.wantHit)
+		}
+	}
+}
+
+// TestLoadIgnore_SingleGlobPattern confirms that single-level wildcard
+// patterns (e.g. "apps/*.yaml") still work after the matcher change.
+func TestLoadIgnore_SingleGlobPattern(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, ".krmignore", "apps/*.yaml\n")
+
+	ig, err := loadIgnore(root)
+	if err != nil {
+		t.Fatalf("loadIgnore: %v", err)
+	}
+
+	abs := func(rel string) string { return filepath.Join(root, filepath.FromSlash(rel)) }
+
+	if !ig.matches(abs("apps/foo.yaml"), root) {
+		t.Error("apps/foo.yaml should match apps/*.yaml")
+	}
+	if ig.matches(abs("apps/sub/foo.yaml"), root) {
+		t.Error("apps/sub/foo.yaml must NOT match single-level apps/*.yaml")
+	}
+	if ig.matches(abs("other/foo.yaml"), root) {
+		t.Error("other/foo.yaml must NOT match apps/*.yaml")
+	}
+}
+
+// TestLoadIgnore_NoFile confirms that a missing .krmignore returns a
+// no-op set without error.
+func TestLoadIgnore_NoFile(t *testing.T) {
+	root := t.TempDir()
+	ig, err := loadIgnore(root)
+	if err != nil {
+		t.Fatalf("loadIgnore on missing file: %v", err)
+	}
+	// Should match nothing.
+	if ig.matches(filepath.Join(root, "anything.yaml"), root) {
+		t.Error("empty ignore set should not match anything")
+	}
+}
+
+// TestLoadIgnore_CommentsAndBlankLines verifies the parser skips
+// comment lines and blank lines without error.
+func TestLoadIgnore_CommentsAndBlankLines(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, ".krmignore", `
+# this is a comment
+apps/junk/**
+
+# another comment
+`)
+
+	ig, err := loadIgnore(root)
+	if err != nil {
+		t.Fatalf("loadIgnore: %v", err)
+	}
+	if !ig.matches(filepath.Join(root, "apps", "junk", "x.yaml"), root) {
+		t.Error("apps/junk/x.yaml should match after blank lines and comments are stripped")
+	}
+}
+
+// TestNormalizePrefix_LivesInParent is a compile-time + behavioural check
+// that NormalizePrefix is accessible from the parent.go scope (i.e. the
+// move didn't accidentally make it unexported or shadow it).
+func TestNormalizePrefix_LivesInParent(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"./apps/plex", "apps/plex/"},
+		{"apps/plex/", "apps/plex/"},
+		{"apps/plex", "apps/plex/"},
+	}
+	for _, tc := range cases {
+		if got := NormalizePrefix(tc.in); got != tc.want {
+			t.Errorf("NormalizePrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -217,17 +217,6 @@ func readKustomizeNamespace(repoRoot, dir string) string {
 	return ""
 }
 
-// NormalizePrefix turns a Kustomization spec.path into a slash-
-// terminated repo-relative prefix suitable for HasPrefix matching.
-// Applies filepath.ToSlash first so Windows-style spec.path values
-// (rare, but possible since the Flux CRD doesn't constrain it)
-// normalize to the same shape as loader.SourceFiles entries.
-func NormalizePrefix(p string) string {
-	p = filepath.ToSlash(p)
-	p = strings.TrimPrefix(p, "./")
-	return strings.TrimSuffix(p, "/") + "/"
-}
-
 // cloneWithNamespace returns a shallow copy of obj with metadata.namespace
 // (and HelmRelease.Chart.RepoNamespace, when implicit) rewritten to ns.
 // Returns nil for kinds the loader doesn't reposition. Honors the Store

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -11,6 +11,17 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// NormalizePrefix turns a Kustomization spec.path into a slash-
+// terminated repo-relative prefix suitable for HasPrefix matching.
+// Applies filepath.ToSlash first so Windows-style spec.path values
+// (rare, but possible since the Flux CRD doesn't constrain it)
+// normalize to the same shape as loader.SourceFiles entries.
+func NormalizePrefix(p string) string {
+	p = filepath.ToSlash(p)
+	p = strings.TrimPrefix(p, "./")
+	return strings.TrimSuffix(p, "/") + "/"
+}
+
 // KSPathPrefix pairs a Kustomization id with one of its
 // slash-terminated, repo-relative claimed-path prefixes. A KS may
 // produce multiple prefixes — one for spec.path plus one per


### PR DESCRIPTION
Phase-2 iter-10.

## 1. .krmignore ** patterns (bug fix)
Old ignore.go used filepath.Match, which does NOT expand ** across path separators. A line like \`apps/junk/**\` never matched \`apps/junk/sub/file.yaml\`. The comment in loader.go was documenting a remaining bug, not a fixed one. Switched to fluxcd/pkg/sourceignore/gitignore matcher (already in deps as transitive — now direct). Aligns with pkg/source/ignore.go (which already uses go-git's gitignore matcher). Adds tests for ** across dirs, single *, missing file, comments, blanks.

## 2. Move NormalizePrefix from inherit.go → parent.go
Used by path-prefix machinery (KSPathPrefix, LongestParent, BuildParentIndexForKind) in parent.go but lived in inherit.go (namespace inheritance). Reader following the prefix contract now finds it in the right file. Pure file move; orchestrator callers untouched.

## Test plan
- [x] go vet + go test -race -timeout=180s ./pkg/loader/...
- [x] Downstream tests (orchestrator, discovery, internal/cli) — all green
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)