### PR TITLE
refactor(source/git): decouple verify from manifest type, drop ssh known_hosts tempfile

### DIFF
--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -309,7 +309,11 @@ func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifa
 		if herr != nil {
 			return fmt.Errorf("verify: resolve HEAD: %w", herr)
 		}
-		if err := verify.Signatures(f.Secrets, repo, cloned, head.Hash()); err != nil {
+		tagName := ""
+		if repo.Reference != nil {
+			tagName = repo.Reference.Tag
+		}
+		if err := verify.Signatures(f.Secrets, repo.Namespace, repo.Name, repo.Verification.SecretRef.Name, repo.Verification.GetMode(), tagName, cloned, head.Hash()); err != nil {
 			return err
 		}
 	}
@@ -371,7 +375,11 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 		return nil, fmt.Errorf("materialize %s at %s: %w", hash, refStr, err)
 	}
 	if repo.Verification != nil {
-		if err := verify.Signatures(f.Secrets, repo, mirrorRepo, hash); err != nil {
+		tagName := ""
+		if repo.Reference != nil {
+			tagName = repo.Reference.Tag
+		}
+		if err := verify.Signatures(f.Secrets, repo.Namespace, repo.Name, repo.Verification.SecretRef.Name, repo.Verification.GetMode(), tagName, mirrorRepo, hash); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/source/git/ssh.go
+++ b/pkg/source/git/ssh.go
@@ -18,23 +18,24 @@ func insecureIgnoreHostKey(_ string, _ net.Addr, _ ssh.PublicKey) error {
 }
 
 // knownHostsCallback returns an SSH HostKeyCallback that validates
-// against the provided known_hosts data. knownhosts.New only accepts
-// file paths, so we materialize a temp file; New reads and parses it
-// synchronously and returns a callback that holds the parsed data in
-// memory, so the file is safe to remove immediately after New returns.
+// against the provided known_hosts data. It feeds the data through an
+// os.Pipe so no temp file is written to disk; the write side is closed
+// before New returns so New reads all data synchronously.
 func knownHostsCallback(data []byte) (ssh.HostKeyCallback, error) {
-	f, err := os.CreateTemp("", "flate-known-hosts-*")
+	r, w, err := os.Pipe()
 	if err != nil {
-		return nil, fmt.Errorf("temp known_hosts: %w", err)
+		return nil, fmt.Errorf("pipe known_hosts: %w", err)
 	}
-	name := f.Name()
-	defer os.Remove(name) //nolint:errcheck // best-effort cleanup of temp file
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		return nil, fmt.Errorf("write known_hosts: %w", err)
+	writeErr := make(chan error, 1)
+	go func() {
+		_, werr := w.Write(data)
+		writeErr <- werr
+		_ = w.Close() // write side closed after data is sent
+	}()
+	cb, parseErr := knownhosts.New(fmt.Sprintf("/dev/fd/%d", r.Fd()))
+	_ = r.Close() // read side no longer needed after New returns
+	if werr := <-writeErr; werr != nil && parseErr == nil {
+		return nil, fmt.Errorf("write known_hosts pipe: %w", werr)
 	}
-	if err := f.Close(); err != nil {
-		return nil, fmt.Errorf("close known_hosts: %w", err)
-	}
-	return knownhosts.New(name)
+	return cb, parseErr
 }

--- a/pkg/source/git/verify/verify.go
+++ b/pkg/source/git/verify/verify.go
@@ -15,56 +15,58 @@ import (
 	"github.com/home-operations/flate/pkg/source"
 )
 
-// Signatures applies the PGP verification configured by spec.verify
-// against the cloned repository at resolvedRef. Returns nil when no
-// verification is configured. Fails loud on any failure — missing
-// secret, malformed keys, unsigned/badly-signed object.
+// GitVerificationMode is the Flux GitVerificationMode type re-exported
+// so callers do not need to import sourcev1 just to call Signatures.
+type GitVerificationMode = sourcev1.GitVerificationMode
+
+// Signatures applies PGP verification for the given namespace/name owner,
+// looking up the keyring secret secretRefName in ns, applying the given
+// mode, and (for tag/tagAndHEAD modes) verifying the annotated tag tagName.
+// Pass tagName="" when mode does not require it. Returns nil when mode is
+// unrecognised/empty (i.e. no verification configured).
 //
-// The Secret named by spec.verify.secretRef may carry multiple
-// ASCII-armored public keys (any *.asc filename); they're
-// concatenated into a single keyring before verification.
-func Signatures(secrets source.SecretGetter, repo *manifest.GitRepository, cloned *git.Repository, resolvedRef plumbing.Hash) error {
-	if repo.Verification == nil {
+// Fails loud on any failure — missing secret, malformed keys,
+// unsigned/badly-signed object.
+//
+// The Secret named by secretRefName may carry multiple ASCII-armored public
+// keys (any *.asc filename); they're concatenated into a single keyring
+// before verification.
+func Signatures(secrets source.SecretGetter, ns, name, secretRefName string, mode GitVerificationMode, tagName string, cloned *git.Repository, resolvedRef plumbing.Hash) error {
+	if !matchesHEAD(mode) && !matchesTag(mode) {
 		return nil
 	}
-	v := repo.Verification
-	mode := v.GetMode()
-	if v.SecretRef.Name == "" {
+	if secretRefName == "" {
 		return fmt.Errorf("GitRepository %s/%s: spec.verify.secretRef is required",
-			repo.Namespace, repo.Name)
+			ns, name)
 	}
 	if secrets == nil {
 		return fmt.Errorf("GitRepository %s/%s: spec.verify set but no source.SecretGetter is wired",
-			repo.Namespace, repo.Name)
+			ns, name)
 	}
-	sec := secrets(repo.Namespace, v.SecretRef.Name)
+	sec := secrets(ns, secretRefName)
 	if sec == nil {
 		return fmt.Errorf("GitRepository %s/%s: verify secret %s/%s not found",
-			repo.Namespace, repo.Name, repo.Namespace, v.SecretRef.Name)
+			ns, name, ns, secretRefName)
 	}
 	keyring, err := buildPGPKeyring(sec)
 	if err != nil {
-		return fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+		return fmt.Errorf("GitRepository %s/%s: %w", ns, name, err)
 	}
 
 	if matchesHEAD(mode) {
 		if err := verifyCommit(cloned, resolvedRef, keyring); err != nil {
 			return fmt.Errorf("GitRepository %s/%s: HEAD verify: %w",
-				repo.Namespace, repo.Name, err)
+				ns, name, err)
 		}
 	}
 	if matchesTag(mode) {
-		tagName := ""
-		if repo.Reference != nil {
-			tagName = repo.Reference.Tag
-		}
 		if tagName == "" {
 			return fmt.Errorf("GitRepository %s/%s: verify mode %q requires spec.ref.tag",
-				repo.Namespace, repo.Name, mode)
+				ns, name, mode)
 		}
 		if err := verifyTagObject(cloned, tagName, keyring); err != nil {
 			return fmt.Errorf("GitRepository %s/%s: tag verify: %w",
-				repo.Namespace, repo.Name, err)
+				ns, name, err)
 		}
 	}
 	return nil

--- a/pkg/source/git/verify/verify_test.go
+++ b/pkg/source/git/verify/verify_test.go
@@ -4,60 +4,35 @@ import (
 	"strings"
 	"testing"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
 func TestSignatures_NilVerifyIsNoOp(t *testing.T) {
-	repo := &manifest.GitRepository{Name: "r", Namespace: "ns"}
-	if err := Signatures(nil, repo, nil, plumbing.ZeroHash); err != nil {
-		t.Errorf("nil Verify should be a no-op, got %v", err)
+	// Empty mode — neither HEAD nor tag — should be a no-op.
+	if err := Signatures(nil, "ns", "r", "", "", "", nil, plumbing.ZeroHash); err != nil {
+		t.Errorf("empty mode should be a no-op, got %v", err)
 	}
 }
 
 func TestSignatures_RequiresSecretRef(t *testing.T) {
-	repo := &manifest.GitRepository{
-		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			Verification: &manifest.GitRepositoryVerify{Mode: manifest.GitVerifyModeHEAD},
-		},
-	}
-	err := Signatures(nil, repo, nil, plumbing.ZeroHash)
+	err := Signatures(nil, "ns", "r", "", manifest.GitVerifyModeHEAD, "", nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "secretRef is required") {
 		t.Errorf("expected secretRef-required error; got %v", err)
 	}
 }
 
 func TestSignatures_RequiresSecretGetter(t *testing.T) {
-	repo := &manifest.GitRepository{
-		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			Verification: &manifest.GitRepositoryVerify{
-				Mode:      manifest.GitVerifyModeHEAD,
-				SecretRef: manifest.LocalObjectReference{Name: "keys"},
-			},
-		},
-	}
-	err := Signatures(nil, repo, nil, plumbing.ZeroHash)
+	err := Signatures(nil, "ns", "r", "keys", manifest.GitVerifyModeHEAD, "", nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {
 		t.Errorf("expected SecretGetter error; got %v", err)
 	}
 }
 
 func TestSignatures_SecretNotFound(t *testing.T) {
-	repo := &manifest.GitRepository{
-		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			Verification: &manifest.GitRepositoryVerify{
-				Mode:      manifest.GitVerifyModeHEAD,
-				SecretRef: manifest.LocalObjectReference{Name: "missing"},
-			},
-		},
-	}
 	getter := func(_, _ string) *manifest.Secret { return nil }
-	err := Signatures(getter, repo, nil, plumbing.ZeroHash)
+	err := Signatures(getter, "ns", "r", "missing", manifest.GitVerifyModeHEAD, "", nil, plumbing.ZeroHash)
 	if err == nil || !strings.Contains(err.Error(), "verify secret") || !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected not-found error; got %v", err)
 	}
@@ -111,7 +86,7 @@ func TestBuildPGPKeyring(t *testing.T) {
 
 func TestMatchesHEAD_Tag_HelperMatrix(t *testing.T) {
 	cases := []struct {
-		mode    sourcev1.GitVerificationMode
+		mode    GitVerificationMode
 		wantH   bool
 		wantTag bool
 	}{


### PR DESCRIPTION
Phase-2 iter-10.

## 1. verify.Signatures decoupled from *manifest.GitRepository
Took the whole CR type to read 4 fields. Now: \`Signatures(secrets, ns, name, secretRefName string, mode GitVerificationMode, tagName string, cloned *git.Repository, hash plumbing.Hash)\`. Manifest dependency dropped from verify's exported surface (still imported internally for buildPGPKeyring(*manifest.Secret), a narrow necessary dep). GitVerificationMode re-exported as a type alias so callers avoid a transitive sourcev1 import. Both fetcher.go call sites updated.

## 2. ssh.go knownHostsCallback: drop temp file
Old code did os.CreateTemp → write → knownhosts.New(path) → defer os.Remove. golang.org/x/crypto@v0.51.0 (pinned) doesn't yet have NewFromReader, so used os.Pipe() + goroutine + /dev/fd/N. No temp file, no removes, no file creation errors. Note: /dev/fd/N is macOS+Linux; if flate ever runs on Windows this needs a fallback.

## Test plan
- [x] go vet + go test -race -timeout=180s ./pkg/source/git/...
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)