### PR TITLE
refactor(source,blob): WithSweepLock encapsulates GC mutex, Slot.Refresh consolidates Reset+Stage

### DIFF
--- a/pkg/source/blob/gclock.go
+++ b/pkg/source/blob/gclock.go
@@ -22,17 +22,20 @@ import "sync"
 // the (rare) GC sweep.
 var gcMu sync.RWMutex
 
-// RLockGC acquires a shared lock against the GC sweep. Caller must
-// invoke the returned function to release.
-func RLockGC() func() {
+// rLockGC acquires a shared lock against the GC sweep. Caller must
+// invoke the returned function to release. Internal to the blob
+// package — callers outside blob use WithSweepLock.
+func rLockGC() func() {
 	gcMu.RLock()
 	return gcMu.RUnlock
 }
 
-// LockGC acquires the exclusive sweep lock. Held across mark + sweep
-// so no Refs.Put can finalize within the window. Caller must invoke
-// the returned function to release.
-func LockGC() func() {
+// WithSweepLock acquires the exclusive sweep lock, calls fn, then
+// releases the lock. Held across mark + sweep so no Refs.Put can
+// finalize within the window. The error returned by fn is propagated
+// unchanged; the lock is always released.
+func WithSweepLock(fn func() error) error {
 	gcMu.Lock()
-	return gcMu.Unlock
+	defer gcMu.Unlock()
+	return fn()
 }

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -102,7 +102,7 @@ func (r *Refs) Put(key, digest string) error {
 	if err != nil {
 		return err
 	}
-	unlockGC := RLockGC()
+	unlockGC := rLockGC()
 	defer unlockGC()
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -78,7 +78,7 @@ func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (
 	dir := s.Path(digest)
 	parent := filepath.Dir(dir)
 
-	unlockGC := RLockGC()
+	unlockGC := rLockGC()
 	defer unlockGC()
 
 	release, err := s.locks.Acquire(ctx, digest)

--- a/pkg/source/bucket/fetcher.go
+++ b/pkg/source/bucket/fetcher.go
@@ -75,11 +75,8 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 	if slot.Exists {
 		// Drop the prior committed slot and re-stage so the upcoming
 		// walk writes into an empty staging dir.
-		if err := slot.Reset(); err != nil {
-			return nil, fmt.Errorf("bucket %s/%s reset: %w", b.Namespace, b.Name, err)
-		}
-		if err := slot.Stage(); err != nil {
-			return nil, fmt.Errorf("bucket %s/%s stage: %w", b.Namespace, b.Name, err)
+		if err := slot.Refresh(); err != nil {
+			return nil, fmt.Errorf("bucket %s/%s refresh: %w", b.Namespace, b.Name, err)
 		}
 	}
 

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -263,6 +263,18 @@ func (s *Slot) Reset() error {
 	return nil
 }
 
+// Refresh wipes the final slot and allocates a fresh staging directory
+// in one step. It is equivalent to calling Reset followed by Stage and
+// is intended for callers that detect a stale immutable cache hit and
+// need to re-fetch from scratch. The Reset+Stage sequence is preserved
+// unchanged; this method exists only to avoid repeating the pair.
+func (s *Slot) Refresh() error {
+	if err := s.Reset(); err != nil {
+		return err
+	}
+	return s.Stage()
+}
+
 // Stage allocates the staging dir for a Slot that was returned with
 // Exists == true and then explicitly Reset by the caller. The new Path
 // is the staging dir. No-op when staging is already allocated.

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -77,38 +77,40 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 	// and the blob sweep — the race would otherwise purge a freshly-
 	// referenced blob as orphan-old. Refs.Put takes the shared lock so
 	// the gate is invisible for the common case (no GC running).
-	unlockGC := blob.LockGC()
-	defer unlockGC()
+	if err := blob.WithSweepLock(func() error {
+		live := markLiveDigests(layout, &res)
 
-	live := markLiveDigests(layout, &res)
-
-	// Each entry pairs a directory to sweep with the depth at which
-	// the age comparison applies and whether the leaf's basename is
-	// a content digest to consult the live set with. Sources land at
-	// <root>/sources/<slug>/<hash>/ so age comparison is two levels
-	// in; blobs sit one level below the algo segment and are gated
-	// by mark.
-	ageRoots := []struct {
-		dir   string
-		depth int
-		gate  func(name string) bool // skip when gate returns true
-	}{
-		{layout.Sources(), 2, nil},
-		{layout.Baselines(), 1, nil},
-		{layout.Blobs(), 1, func(name string) bool { return live[name] }},
-	}
-	if opts.IncludeMirrors {
-		ageRoots = append(ageRoots, struct {
+		// Each entry pairs a directory to sweep with the depth at which
+		// the age comparison applies and whether the leaf's basename is
+		// a content digest to consult the live set with. Sources land at
+		// <root>/sources/<slug>/<hash>/ so age comparison is two levels
+		// in; blobs sit one level below the algo segment and are gated
+		// by mark.
+		ageRoots := []struct {
 			dir   string
 			depth int
-			gate  func(name string) bool
-		}{layout.GitMirrors(), 1, nil})
-	}
-	for _, ar := range ageRoots {
-		sweepDirByAge(ar.dir, ar.depth, cutoff, ar.gate, opts.DryRun, &res)
-	}
+			gate  func(name string) bool // skip when gate returns true
+		}{
+			{layout.Sources(), 2, nil},
+			{layout.Baselines(), 1, nil},
+			{layout.Blobs(), 1, func(name string) bool { return live[name] }},
+		}
+		if opts.IncludeMirrors {
+			ageRoots = append(ageRoots, struct {
+				dir   string
+				depth int
+				gate  func(name string) bool
+			}{layout.GitMirrors(), 1, nil})
+		}
+		for _, ar := range ageRoots {
+			sweepDirByAge(ar.dir, ar.depth, cutoff, ar.gate, opts.DryRun, &res)
+		}
 
-	sweepDanglingRefs(layout, opts.DryRun, &res)
+		sweepDanglingRefs(layout, opts.DryRun, &res)
+		return nil
+	}); err != nil {
+		return res, err
+	}
 
 	return res, nil
 }

--- a/pkg/source/gc_test.go
+++ b/pkg/source/gc_test.go
@@ -224,10 +224,10 @@ func TestSweep_UnreferencedOldBlobIsPruned(t *testing.T) {
 //
 // Pre-fix: Sweep marks refs before PutBytes refreshes the (old) blob's
 // mtime, then ages-out the blob; Refs.Put then writes a ref pointing
-// at a deleted blob. Post-fix: PutBytes holds RLockGC and refreshes
-// mtime, Refs.Put holds RLockGC, Sweep holds the exclusive LockGC —
-// the three operations serialize cleanly so the invariant holds in
-// every interleaving.
+// at a deleted blob. Post-fix: PutBytes holds rLockGC and refreshes
+// mtime, Refs.Put holds rLockGC, Sweep holds the exclusive lock via
+// blob.WithSweepLock — the three operations serialize cleanly so the
+// invariant holds in every interleaving.
 func TestSweep_PutInFlightPreservesBlob(t *testing.T) {
 	layout := cacheroot.New(t.TempDir())
 	store := blob.NewStore(layout)

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -145,10 +145,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 			}
 		} else {
 			// Stale immutable slot — wipe and stage a fresh clone target.
-			if err := slot.Reset(); err != nil {
-				return nil, err
-			}
-			if err := slot.Stage(); err != nil {
+			if err := slot.Refresh(); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -129,11 +129,8 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 			}
 		}
 		// Stale or unresolved slot — wipe and stage a fresh pull target.
-		if err := slot.Reset(); err != nil {
-			return nil, fmt.Errorf("cache reset for %s: %w", versioned, err)
-		}
-		if err := slot.Stage(); err != nil {
-			return nil, fmt.Errorf("cache stage for %s: %w", versioned, err)
+		if err := slot.Refresh(); err != nil {
+			return nil, fmt.Errorf("cache refresh for %s: %w", versioned, err)
 		}
 	}
 


### PR DESCRIPTION
Phase-2 iter-10.

## 1. blob.WithSweepLock encapsulates the GC mutex
Old: blob.LockGC()/RLockGC() exported the bare mutex, with source/gc.go acquiring it to coordinate sweep across PutBytes/Put — a parent package coordinating a child package's internal invariant. New: \`blob.WithSweepLock(fn func() error) error\` (public); rLockGC unexported for PutBytes/Put internal use. The invariant (sweep is exclusive vs put-during-sweep) is now sealed inside blob.

## 2. Slot.Refresh() consolidates the Reset+Stage pair
Three callers (git/fetcher.go, oci/fetch.go, bucket/fetcher.go) all had the identical \`slot.Reset() + slot.Stage()\` pair for refreshing a stale slot. New Slot.Refresh() method does both with one error path; semantics identical.

## Test plan
- [x] go vet + go test -race -timeout=300s ./pkg/source/...
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)