### PR TITLE
refactor(store,depwait): remove dead OtherActive, RLock AddListener, sort ListObjects

### DIFF
--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -120,13 +120,12 @@ type Waiter struct {
 	Existence ExistenceLookup
 
 	// Renders, when non-nil, drives the step-2 fast-fail signal:
-	// during the render-only long wait, depwait polls
-	// Renders.OtherActive(); a false return means no other
-	// reconcile in the orchestrator is doing work, so no future
-	// render can produce the missing dep. The wait short-circuits
-	// to "dependency not found" instead of burning the full
-	// RenderProducingTimeout cap. When Renders is nil, step-2 falls
-	// back to the fixed cap alone (preserves the legacy timing).
+	// when the orchestrator's task pool drains (no other reconcile
+	// is doing work), no future render can produce the missing dep.
+	// The wait short-circuits to "dependency not found" instead of
+	// burning the full RenderProducingTimeout cap. When Renders is
+	// nil, step-2 falls back to the fixed cap alone (preserves the
+	// legacy timing).
 	Renders RenderInflight
 }
 
@@ -167,11 +166,7 @@ type ExistenceLookup interface {
 }
 
 // RenderInflight is the positive quiescence signal depwait's step-2
-// uses to fail fast on truly-missing render-only deps. The
-// orchestrator's implementation reads from task.Service.ActiveCount
-// — true when more than the caller's own goroutine is active in
-// the task pool (and could therefore still emit the missing dep);
-// false when the orchestrator has drained.
+// uses to fail fast on truly-missing render-only deps.
 //
 // Semantically the inverse of the Existence-based step-2 wait: that
 // path keeps waiting on the absence of a finite signal
@@ -184,20 +179,11 @@ type ExistenceLookup interface {
 // — embedders that don't drive a task pool get the legacy
 // behavior.
 type RenderInflight interface {
-	// OtherActive reports whether at least one reconcile beyond the
-	// caller's own task is still running in the orchestrator's task
-	// pool. depwait calls this from inside a Submit'd reconcile
-	// body, so the caller's goroutine is counted; OtherActive
-	// returns true iff the total active count exceeds 1.
-	OtherActive() bool
-
 	// QuiescenceCh returns a channel closed when the pool drains to
-	// "no other work in flight" — the event-driven counterpart of
-	// OtherActive that lets waitRenderEmission select on the
-	// quiescence signal instead of polling. Each call returns a
-	// fresh channel; callers Receive once. Implementations that
-	// can't deliver an event-driven signal may return a nil channel,
-	// in which case waitRenderEmission falls back to the legacy poll.
+	// "no other work in flight". Each call returns a fresh channel;
+	// callers receive once. Implementations that can't deliver an
+	// event-driven signal may return a nil channel, in which case
+	// waitRenderEmission falls back to the timeout cap.
 	QuiescenceCh() <-chan struct{}
 }
 
@@ -542,19 +528,13 @@ var errRenderDrained = errors.New("render pool drained without emission")
 //
 //   - Store.EventObjectAdded fires for id → returns nil (caller
 //     falls through to the regular Ready wait).
-//   - Renders.QuiescenceCh closes (the event-driven counterpart of
-//     OtherActive) → returns errRenderDrained (no future emission
-//     could produce id; caller fails fast).
+//   - Renders.QuiescenceCh closes → returns errRenderDrained (no
+//     future emission could produce id; caller fails fast).
 //   - ctx hits its deadline / cancellation → returns ctx.Err().
 //
 // An overall cap of RenderProducingTimeout is layered onto ctx so
 // the wait can't run past it even when Renders is nil (legacy
 // embedders without a task pool).
-//
-// The previous implementation polled OtherActive every 100ms. With
-// N concurrent waiters during a render that's N×10 wakes/sec doing
-// nothing useful most of the time; the quiescence channel replaces
-// the poll with one event per drain.
 func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResource) error {
 	started := time.Now()
 	renderCtx, renderCancel := context.WithTimeout(ctx, RenderProducingTimeout)

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -45,23 +45,16 @@ func (l lookupStub) IsFileIndexed(id manifest.NamedResource) bool {
 }
 
 // rendersStub satisfies RenderInflight from inline closures so tests
-// can pin the OtherActive / QuiescenceCh behavior precisely.
+// can pin the QuiescenceCh behavior precisely.
 type rendersStub struct {
 	otherActive func() bool
 	quiesce     func() <-chan struct{}
 }
 
-func (r rendersStub) OtherActive() bool {
-	if r.otherActive == nil {
-		return false
-	}
-	return r.otherActive()
-}
-
-// QuiescenceCh returns a channel matching otherActive: closed when
-// otherActive returns false (drained), open otherwise. Returning nil
-// when no quiesce closure is wired exercises the "fall back to ctx
-// deadline" path in waitRenderEmission.
+// QuiescenceCh returns a closed channel when otherActive returns
+// false (drained), nil when otherActive returns true (active), and
+// delegates to quiesce when explicitly set. Returning nil exercises
+// the "fall back to ctx deadline" path in waitRenderEmission.
 func (r rendersStub) QuiescenceCh() <-chan struct{} {
 	if r.quiesce != nil {
 		return r.quiesce()

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -542,17 +542,9 @@ func (e *orchestratorExistence) IsFileIndexed(id manifest.NamedResource) bool {
 	return ok
 }
 
-// orchestratorRenderInflight adapts task.Service.ActiveCount into
-// depwait.RenderInflight. OtherActive returns true when any task
-// is doing productive work — the caller itself is parked in
-// task.Service.YieldQuiescent (see base.Controller.Await), so its
-// own slot is excluded from the count and a non-zero active reading
-// is by definition "other work in flight".
+// orchestratorRenderInflight adapts task.Service into
+// depwait.RenderInflight.
 type orchestratorRenderInflight struct{ tasks *task.Service }
-
-func (r *orchestratorRenderInflight) OtherActive() bool {
-	return r.tasks.ActiveCount() > 0
-}
 
 // QuiescenceCh delegates to task.Service.QuiescenceCh(0). The
 // threshold is 0 because depwait callers reach this method while

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -73,37 +73,43 @@ func (s *Store) OnArtifact(fn func(manifest.NamedResource, Artifact), replay boo
 // are recovered, same as live dispatch. The returned Unsubscribe
 // removes the listener.
 //
-// The flush=true path holds s.mu across the (register + capture
-// replay snapshot) pair. Without that serialization, a concurrent
-// writer (AddObject / SetCondition / SetArtifact) could update its
-// map, release s.mu, snapshot listeners (now including this fresh
-// listener because set.add already ran), and dispatch the live event
-// to fn — while THIS goroutine separately replays the same object
-// from the post-update map snapshot. The result is a double-fire.
-// Holding s.mu while we both register AND capture the replay state
-// means writers either see the listener-registered state before
-// dispatch (replay returns nothing new, live event fires once) or
-// see the pre-registered state (live event misses this listener,
-// replay fires once). Exactly-one delivery either way.
+// Lock strategy:
+//   - flush=false: holds s.mu.RLock() during set.add so a concurrent
+//     writer can't snapshot listeners (fireUnderLock) and dispatch
+//     before fn is registered. RLock is sufficient because the
+//     non-flush path doesn't read or write store maps.
+//   - flush=true: holds s.mu.Lock() across (register + snapshot) so
+//     the pair is atomic with respect to writers. Without the write
+//     lock, a concurrent AddObject could update the map, snapshot
+//     listeners (already including fn via set.add), and dispatch —
+//     while this goroutine replays the same object from the
+//     post-update map snapshot, double-firing fn. Exactly-one
+//     delivery is the invariant.
 func (s *Store) AddListener(event EventKind, fn Listener, flush bool) Unsubscribe {
 	if event < 1 || int(event) > numEventKinds {
 		panic("store: unknown event kind")
 	}
 	set := s.listeners[event]
 	if !flush {
-		// Even the no-replay path serializes via s.mu so a concurrent
-		// writer can't snapshot listeners (under set.mu alone) and then
-		// dispatch BEFORE this fn lands in the set. Without the s.mu
-		// hold, a registration racing AddObject can miss the very
-		// event it was registered for: writer takes s.mu → captures
-		// pre-add snapshot via set.snapshot → releases s.mu → registrar
-		// runs set.add(fn) → writer's deferred dispatch fires the
-		// pre-snapshot listeners, fn is silently missing.
-		s.mu.Lock()
+		// The no-replay path needs only a read lock on s.mu. Writers
+		// hold s.mu.Lock() while capturing their listener-set snapshot
+		// (fireUnderLock), so holding s.mu.RLock() here is exclusive
+		// with any concurrent writer's lock acquisition: the writer
+		// either (a) completes its snapshot BEFORE this add (fn misses
+		// that event — expected, the listener wasn't registered yet) or
+		// (b) starts AFTER this add (fn is in the snapshot — correct).
+		// Without any s.mu hold, a writer could snapshot listeners under
+		// set.mu alone, release s.mu, and dispatch before fn lands —
+		// silently missing the very event the caller registered for.
+		// RLock is sufficient because we're only mutating set (which
+		// has its own internal mutex), not s.objects/conditions/artifacts.
+		s.mu.RLock()
 		handle := set.add(fn)
-		s.mu.Unlock()
+		s.mu.RUnlock()
 		return func() { set.remove(handle) }
 	}
+	// flush=true: must hold write lock so the (register + capture
+	// replay snapshot) pair is atomic with respect to writers.
 	s.mu.Lock()
 	handle := set.add(fn)
 	pairs := s.snapshotForReplay(event)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"reflect"
+	"slices"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -324,25 +325,36 @@ func (s *Store) GetByName(kind, namespace, name string) manifest.BaseManifest {
 	return nil
 }
 
-// ListObjects returns every stored manifest, optionally filtered by kind.
-// An empty kind matches all objects. The byName index is hit directly
-// when kind is set — O(K) instead of O(N) — which matters on the
-// orchestrator's per-pass list calls when one kind dominates the
-// store (HelmReleases are typically the bulk).
+// ListObjects returns every stored manifest, optionally filtered by kind,
+// sorted deterministically by (Kind, Namespace, Name). An empty kind
+// matches all objects. The byName index is hit directly when kind is set
+// — O(K) instead of O(N) — which matters on the orchestrator's per-pass
+// list calls when one kind dominates the store (HelmReleases are
+// typically the bulk).
+//
+// Deterministic order is a correctness requirement: ownership
+// tie-breaking in change/ownership.go (and any future tie-break) must
+// produce the same winner across runs. Go map iteration is randomized,
+// so without sorting the same file can be attributed to different
+// KS owners on different runs.
 func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	var out []manifest.BaseManifest
 	if kind != "" {
 		inner := s.byName[kind]
-		out := make([]manifest.BaseManifest, 0, len(inner))
+		out = make([]manifest.BaseManifest, 0, len(inner))
 		for _, obj := range inner {
 			out = append(out, obj)
 		}
-		return out
+	} else {
+		out = make([]manifest.BaseManifest, 0, len(s.objects))
+		for _, obj := range s.objects {
+			out = append(out, obj)
+		}
 	}
-	out := make([]manifest.BaseManifest, 0, len(s.objects))
-	for _, obj := range s.objects {
-		out = append(out, obj)
-	}
+	slices.SortFunc(out, func(a, b manifest.BaseManifest) int {
+		return a.Named().Compare(b.Named())
+	})
 	return out
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -319,6 +319,49 @@ func TestStore_ListObjects_ByKindIndex(t *testing.T) {
 	}
 }
 
+// TestStore_ListObjects_DeterministicOrder pins the sort contract:
+// two ListObjects calls with concurrent concurrent adds must return
+// objects in the same (Kind, Namespace, Name) order. Without the
+// sort, Go map iteration is randomized and ownership tie-breaking in
+// change/ownership.go can attribute the same file to different KS
+// owners on different runs.
+func TestStore_ListObjects_DeterministicOrder(t *testing.T) {
+	s := New()
+	// Add objects in non-alphabetical order so insertion order can't
+	// accidentally hide a missing sort.
+	objects := []*manifest.ConfigMap{
+		{Name: "z", Namespace: "b"},
+		{Name: "a", Namespace: "z"},
+		{Name: "m", Namespace: "a"},
+		{Name: "a", Namespace: "a"},
+		{Name: "z", Namespace: "a"},
+	}
+	for _, obj := range objects {
+		s.AddObject(obj)
+	}
+
+	first := s.ListObjects(manifest.KindConfigMap)
+	second := s.ListObjects(manifest.KindConfigMap)
+
+	if len(first) != len(second) {
+		t.Fatalf("lengths differ: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		a, b := first[i].Named(), second[i].Named()
+		if a != b {
+			t.Errorf("position %d differs between calls: %v vs %v", i, a, b)
+		}
+	}
+	// Verify the order is actually sorted by (namespace, name) within
+	// the same kind.
+	for i := 1; i < len(first); i++ {
+		prev, cur := first[i-1].Named(), first[i].Named()
+		if prev.Compare(cur) > 0 {
+			t.Errorf("unsorted at [%d]: %v > %v", i, prev, cur)
+		}
+	}
+}
+
 func TestStore_WatchReady_AlreadyReady(t *testing.T) {
 	s := New()
 	id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}


### PR DESCRIPTION
Phase-2 iter-10.

## 1. Remove dead RenderInflight.OtherActive() (interface + impl + stub)
Method existed in the interface and orchestratorRenderInflight, never called anywhere (depwait's waitRenderEmission uses QuiescenceCh-based select). Removed from interface, impl, and rendersStub test helper.

## 2. AddListener(flush=false) now uses RLock
The non-flush path took s.mu write lock but reads nothing from s.objects/conditions/artifacts. The subscribeWith* helpers already use RLock for the same invariant (set.add has its own listenerSet.mu). Reduces startup-time contention with many concurrent AddListener calls.

## 3. Sort store.ListObjects output by NamedResource
ListObjects iterated map[NamedResource]BaseManifest → nondeterministic order. ownership tie-breaking in change/ownership.go SortStableFunc'd by path-length, but equal-length paths got nondeterministic tie-break, attributing changed files to different KS owners across runs. Now sorted by (Kind, Namespace, Name) via existing NamedResource.Compare. ListAs inherits the order. New test pins deterministic order across consecutive calls.

## Test plan
- [x] go vet + go test -count=3 -race -timeout=300s ./pkg/store/... ./pkg/depwait/...
- [x] Whole-repo go test -race — all 36 packages pass
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)