### PR TITLE
fix(kustomize): typed httpStatusError sentinel survives error wrapping

### DIFF
--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -189,6 +189,19 @@ func writeStagedFile(path string, data []byte, mode fs.FileMode) error {
 	return os.WriteFile(path, data, mode) //nolint:gosec // path is inside flate's staged copy
 }
 
+// httpStatusError is a typed sentinel returned by httpGetURL when the
+// server responds with a non-2xx status code. Using a named type
+// (rather than a formatted string) lets isHTTPClientError classify
+// errors via errors.As so the check is robust against wrapping —
+// fmt.Errorf("preflight: %w", err) still matches.
+type httpStatusError struct {
+	Code int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d", e.Code)
+}
+
 // httpGetURL is the actual network call cache.FetchRemote dispatches
 // through OnceValues. Lives here (not on the StagingCache) because
 // it's a preflight detail — the cache only owns the dedup discipline.
@@ -205,7 +218,7 @@ func httpGetURL(ctx context.Context, urlStr string) ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+		return nil, &httpStatusError{Code: resp.StatusCode}
 	}
 	// Cap with LimitReader +1 so we can detect overflow precisely:
 	// read up to remoteFetchMaxBytes+1, and if we actually got

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -137,12 +136,9 @@ func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, 
 			// On transient failure (network / 5xx / timeout — anything
 			// that isn't a definitive 4xx), drop the cache entry so
 			// the next caller retries instead of inheriting our
-			// failure for the rest of the run. httpGetURL wraps with
-			// "http GET ...: ..." for 5xx and transport errors;
-			// 4xx surfaces via the same wrapper so the safest
-			// retry-on-error policy is to retry everything except
-			// 4xx, which we detect by substring on the wrapped
-			// status. The wrapper format is stable in stage.go.
+			// failure for the rest of the run. isHTTPClientError uses
+			// errors.As against httpStatusError so it stays correct
+			// even when the error is wrapped (e.g. "preflight: %w").
 			if rf.err != nil && !isHTTPClientError(rf.err) {
 				c.remoteFetches.CompareAndDelete(urlStr, rf)
 			}
@@ -161,20 +157,11 @@ func (c *StagingCache) FetchRemote(ctx context.Context, urlStr string) ([]byte, 
 // Anything else — transport errors, timeouts, 5xx — is treated as
 // transient so the cache entry gets dropped.
 //
-// httpGetURL emits errors with the exact format "HTTP <code>", so we
-// parse the trailing decimal and range-check for 400–499 rather than
-// doing substring matching with padding spaces (which silently missed
-// end-of-string codes).
+// Uses errors.As against httpStatusError so the check stays correct
+// when the error is wrapped (e.g. fmt.Errorf("preflight: %w", err)).
 func isHTTPClientError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, after, ok := strings.Cut(err.Error(), "HTTP ")
-	if !ok {
-		return false
-	}
-	code, parseErr := strconv.Atoi(after)
-	return parseErr == nil && code >= 400 && code < 500
+	var hse *httpStatusError
+	return errors.As(err, &hse) && hse.Code >= 400 && hse.Code < 500
 }
 
 // Stage returns the on-disk staged copy of source. The copy is created

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -288,29 +288,34 @@ func TestRestoreKustomization_DoesNotMutateSource(t *testing.T) {
 	}
 }
 
-// TestIsHTTPClientError pins the 4xx-detection contract after a bug
-// where the previous implementation checked for " 4xx " (with surrounding
-// spaces) and never matched "HTTP 404" (the exact format httpGetURL
-// emits), causing every 4xx to be treated as transient and retried.
+// TestIsHTTPClientError pins the 4xx-detection contract: only HTTP
+// 4xx responses (definitive client errors) return true; 5xx, transport
+// errors and nil all return false. Uses the httpStatusError sentinel
+// directly (so the test is independent of the string format) and also
+// verifies that wrapping via fmt.Errorf still classifies correctly —
+// the whole point of the typed sentinel over string parsing.
 func TestIsHTTPClientError(t *testing.T) {
 	cases := []struct {
-		msg  string
+		name string
+		err  error
 		want bool
 	}{
-		{"HTTP 400", true},
-		{"HTTP 404", true},
-		{"HTTP 418", true},
-		{"HTTP 499", true},
-		{"HTTP 500", false},  // 5xx is transient
-		{"HTTP 200", false},  // success never hits this path, but guard it
-		{"connection refused", false},
-		{"context deadline exceeded", false},
-		{"", false},
+		{"400", &httpStatusError{Code: 400}, true},
+		{"404", &httpStatusError{Code: 404}, true},
+		{"418", &httpStatusError{Code: 418}, true},
+		{"499", &httpStatusError{Code: 499}, true},
+		{"500 transient", &httpStatusError{Code: 500}, false},
+		{"200 never-client-error", &httpStatusError{Code: 200}, false},
+		{"wrapped 404", fmt.Errorf("preflight: %w", &httpStatusError{Code: 404}), true},
+		{"wrapped 500", fmt.Errorf("preflight: %w", &httpStatusError{Code: 500}), false},
+		{"transport error", fmt.Errorf("connection refused"), false},
+		{"deadline", fmt.Errorf("context deadline exceeded"), false},
+		{"nil", nil, false},
 	}
 	for _, tc := range cases {
-		got := isHTTPClientError(fmt.Errorf("%s", tc.msg))
+		got := isHTTPClientError(tc.err)
 		if got != tc.want {
-			t.Errorf("isHTTPClientError(%q) = %v, want %v", tc.msg, got, tc.want)
+			t.Errorf("isHTTPClientError(%q) = %v, want %v", tc.name, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Phase-2 iter-10.

isHTTPClientError parsed err.Error() for \"HTTP \" + decimal status. If httpGetURL ever wrapped its error (\`fmt.Errorf(\"preflight: %w\", ...)\`), the string check would silently miss and every wrapped 4xx would be reclassified as transient → evicted from the cache and retried on every call.

Fix: unexported httpStatusError{Code int} struct; httpGetURL returns &httpStatusError{...}; isHTTPClientError uses errors.As. Survives any wrapping depth. Stale comment in FetchRemote also updated. Test rewritten to add wrapped-4xx and wrapped-5xx cases.

## Test plan
- [x] go vet + go test -race -timeout=180s ./pkg/kustomize/... + downstream
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)