### PR TITLE
refactor(cli): move labels out of commonFlags, drop dup output validate, split cache gc flags

### DIFF
--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -23,6 +23,18 @@ func newCacheCmd() *cobra.Command {
 	return cmd
 }
 
+// cacheFlags holds the minimal set of flags needed by cache sub-commands.
+// It intentionally avoids embedding commonFlags — cache gc doesn't need
+// --path, --output, namespace filters, helm options, or any other
+// reconcile-oriented flag.
+type cacheFlags struct {
+	cacheDir string
+}
+
+func (f *cacheFlags) resolveRoot() string {
+	return resolveCacheRoot(&f.cacheDir)
+}
+
 // cacheGCFlags captures the GC verb's input.
 type cacheGCFlags struct {
 	maxAge         time.Duration
@@ -35,7 +47,7 @@ type cacheGCFlags struct {
 // optionally extends the prune to git mirrors.
 func newCacheGCCmd() *cobra.Command {
 	f := &cacheGCFlags{}
-	c := &commonFlags{}
+	cf := &cacheFlags{}
 	cmd := &cobra.Command{
 		Use:   "gc",
 		Short: "Prune stale entries from flate's on-disk cache",
@@ -51,7 +63,7 @@ Set --dry-run to see what would be removed without touching disk.`,
 			if f.maxAge < 0 {
 				return errors.New("--max-age must be non-negative")
 			}
-			layout := cacheroot.New(c.resolveCacheRoot())
+			layout := cacheroot.New(cf.resolveRoot())
 			res, err := source.Sweep(layout, source.SweepOpts{
 				MaxAge:         f.maxAge,
 				IncludeMirrors: f.includeMirrors,
@@ -86,7 +98,7 @@ Set --dry-run to see what would be removed without touching disk.`,
 		"also age-prune git mirrors (default off — mirrors are expensive to rebuild)")
 	cmd.Flags().BoolVar(&f.dryRun, "dry-run", false,
 		"report what would be removed without touching disk")
-	cmd.Flags().StringVar(&c.cacheDir, "cache-dir", "",
+	cmd.Flags().StringVar(&cf.cacheDir, "cache-dir", "",
 		"cache root to sweep (defaults to the same path flate uses for fetched artifacts)")
 	return cmd
 }

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -28,7 +28,6 @@ type commonFlags struct {
 	pathOrig            string
 	base                string
 	namespace           string
-	labels              map[string]string
 	skipCRDs            bool
 	skipSecrets         bool
 	allowMissingSecrets bool
@@ -81,11 +80,18 @@ func (c *commonFlags) skipResourceKinds() []string {
 	}.SkipResourceKinds()
 }
 
+// listFlags holds flags that are only meaningful for list/get commands.
+// Kept separate from commonFlags so commands that don't filter by labels
+// (build/diff/test) don't carry a dead field.
+type listFlags struct {
+	labels map[string]string
+}
+
 // bindSelector wires the `-l/--selector` flag. Scoped to commands that
 // actually filter by labels — today, only `get`. Binding it on
 // commands that ignore it (build/diff/test) would silently accept
 // `-l foo=bar` and do nothing.
-func bindSelector(fs *pflag.FlagSet, f *commonFlags) {
+func bindSelector(fs *pflag.FlagSet, f *listFlags) {
 	fs.StringToStringVarP(&f.labels, "selector", "l", nil, "label selector (key=value, repeatable)")
 }
 
@@ -258,11 +264,18 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	}
 }
 
-func (c *commonFlags) resolveCacheRoot() string {
-	if c.cacheDir == "" {
-		c.cacheDir = cacheroot.Default()
+// resolveCacheRoot returns dir if non-empty, or the platform default.
+// The result is memoized back into dir so repeated calls within one
+// invocation are cheap and return the same path.
+func resolveCacheRoot(dir *string) string {
+	if *dir == "" {
+		*dir = cacheroot.Default()
 	}
-	return c.cacheDir
+	return *dir
+}
+
+func (c *commonFlags) resolveCacheRoot() string {
+	return resolveCacheRoot(&c.cacheDir)
 }
 
 func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, *orchestrator.Result, error) {
@@ -276,9 +289,6 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 		if err := validatePathFlag("--path-orig", c.pathOrig); err != nil {
 			return nil, nil, err
 		}
-	}
-	if _, err := format.ParseOutput(c.output); err != nil {
-		return nil, nil, err
 	}
 	// Cleanup is deferred (not bound to ctx) so the tempdir survives
 	// SIGINT until the orchestrator's read paths have actually

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -22,8 +22,6 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-const outputDiff = "diff"
-
 func newDiffCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
@@ -157,7 +155,7 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 	// diff has no `name` output mode; only diff/yaml/json are
 	// meaningful. Reject early so the user sees a clear error instead
 	// of "unknown diff format" from pkg/diff.
-	if err := c.requireOutput(format.Output(outputDiff), format.OutputYAML, format.OutputJSON); err != nil {
+	if err := c.requireOutput(format.Output(diff.FormatDiff), format.OutputYAML, format.OutputJSON); err != nil {
 		return err
 	}
 	orig, current, runErr := runDiffOrchestrators(cmdContext(cmd), c, h)
@@ -177,7 +175,7 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 	if err != nil {
 		return errors.Join(err, diffRunErr)
 	}
-	formatted, err := diff.Render(diffs, diff.Format(c.outputOrDefault(format.Output(outputDiff))))
+	formatted, err := diff.Render(diffs, diff.Format(c.outputOrDefault(format.Output(diff.FormatDiff))))
 	if err != nil {
 		return errors.Join(err, diffRunErr)
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -181,6 +181,7 @@ func resourceListCmd[T manifest.BaseManifest](
 	cols []format.Column, mapper func(*orchestrator.Orchestrator, T) (map[string]string, map[string]any),
 ) *cobra.Command {
 	c := &commonFlags{}
+	l := &listFlags{}
 	h := &helmFlags{}
 	cmd := &cobra.Command{
 		Use:     use + " [name]",
@@ -194,7 +195,7 @@ func resourceListCmd[T manifest.BaseManifest](
 			}
 			sel := selector.Metadata{
 				Name:   firstArg(args),
-				Labels: c.labels,
+				Labels: l.labels,
 			}
 			if err := printResources(cmd.OutOrStdout(), o, sel, c, c.output, kind, cols, mapper); err != nil {
 				return errors.Join(err, scopedRunError(o, res, c, runErr))
@@ -203,7 +204,7 @@ func resourceListCmd[T manifest.BaseManifest](
 		},
 	}
 	bindCommon(cmd.Flags(), c)
-	bindSelector(cmd.Flags(), c)
+	bindSelector(cmd.Flags(), l)
 	bindHelmFlags(cmd.Flags(), h)
 	return cmd
 }


### PR DESCRIPTION
Phase-2 iter-10.

## 1. labels field leaks out of commonFlags
\`labels map[string]string\` was on commonFlags but only bindSelector → resourceListCmd reads it. Every other verb allocated it for nothing. Moved to local listFlags in get.go; bindSelector takes *listFlags.

## 2. Remove redundant ParseOutput in runOrchestrator
runOrchestrator validated output via format.ParseOutput but every caller already calls requireOutput before reaching it (and diff bypasses runOrchestrator entirely). Inner check was partial safety net at best. Removed.

## 3. Use diff.FormatDiff instead of local const outputDiff
diff.go had \`const outputDiff = \"diff\"\` shadowing the already-exported diff.FormatDiff. Now uses format.Output(diff.FormatDiff) directly.

## 4. Split cache gc from commonFlags
\`cache gc\` doesn't use --path / --output / namespace / helm flags. Was piggy-backing on commonFlags for cacheDir only. Extracted resolveCacheRoot to package-level function; cacheFlags{cacheDir} struct in cache.go owns the cache-gc flag set.

## Test plan
- [x] go vet + go test -race -timeout=180s ./internal/cli/...
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)