### PR TITLE
fix(source/cache): drop duplicate Slot.Refresh — fixes broken build

### DIFF
--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -295,18 +295,6 @@ func (s *Slot) Stage() error {
 	return nil
 }
 
-// Refresh wipes the final slot and allocates a fresh staging directory
-// in one step. It is equivalent to calling Reset followed by Stage and
-// is intended for callers that detect a stale immutable cache hit and
-// need to re-fetch from scratch. The Reset+Stage sequence is preserved
-// unchanged; this method exists only to avoid repeating the pair.
-func (s *Slot) Refresh() error {
-	if err := s.Reset(); err != nil {
-		return err
-	}
-	return s.Stage()
-}
-
 // StageRefresh allocates a staging directory while preserving the
 // current final slot until Commit. It is for interval-based refreshes:
 // readers keep a usable old artifact if the fetch fails before commit,


### PR DESCRIPTION
## Summary

\`pkg/source/cache.go\` has \`Slot.Refresh()\` declared twice (lines 271 and 303, byte-identical). \`go build ./pkg/source/...\` fails with \`method Slot.Refresh already declared\`.

Root cause: iter-10 PRs #460 (\"manifest\") and #465 (\"source,blob\") both added the same method. Reviewing the actual diffs shows #460's title doesn't match its content — the manifest agent's intended changes (parseSecret fix, dead field removal, GetLabels on RS/RSIP, selector dedup) never landed; #460 actually shipped the source-blob agent's work. Followup PR with the missing manifest changes is in flight.

This PR just removes the duplicate to restore the build. Behavior unchanged.

## Test plan
- [x] go vet ./...
- [x] go test -count=1 ./... (all 36 packages green)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)