### PR TITLE
fix(manifest,selector): apply the changes that iter-10 PR #460 promised but didn't ship

### DIFF
--- a/pkg/manifest/configmap.go
+++ b/pkg/manifest/configmap.go
@@ -62,22 +62,28 @@ func parseSecret(doc map[string]any, wipeSecrets bool) (*Secret, error) {
 	}
 	s := &Secret{Name: name, Namespace: ns}
 	if data, ok := doc["data"].(map[string]any); ok {
-		if wipeSecrets {
-			for k := range data {
-				data[k] = base64.StdEncoding.EncodeToString(
+		out := make(map[string]any, len(data))
+		for k, v := range data {
+			if wipeSecrets {
+				out[k] = base64.StdEncoding.EncodeToString(
 					fmt.Appendf(nil, ValuePlaceholderTemplate, k),
 				)
+			} else {
+				out[k] = v
 			}
 		}
-		s.Data = data
+		s.Data = out
 	}
 	if sd, ok := doc["stringData"].(map[string]any); ok {
-		if wipeSecrets {
-			for k := range sd {
-				sd[k] = fmt.Sprintf(ValuePlaceholderTemplate, k)
+		out := make(map[string]any, len(sd))
+		for k, v := range sd {
+			if wipeSecrets {
+				out[k] = fmt.Sprintf(ValuePlaceholderTemplate, k)
+			} else {
+				out[k] = v
 			}
 		}
-		s.StringData = sd
+		s.StringData = out
 	}
 	return s, nil
 }

--- a/pkg/manifest/helmchartsource.go
+++ b/pkg/manifest/helmchartsource.go
@@ -22,11 +22,6 @@ func (h *HelmChartSource) Named() NamedResource {
 	return NamedResource{Kind: KindHelmChart, Namespace: h.Namespace, Name: h.Name}
 }
 
-// ResourceFullName is "<namespace>-<name>".
-func (h *HelmChartSource) ResourceFullName() string {
-	return h.Namespace + "-" + h.Name
-}
-
 // parseHelmChartSource decodes a standalone HelmChart CRD via the
 // source-controller typed schema.
 func parseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -25,12 +25,7 @@ type Kustomization struct {
 
 	kustomizev1.KustomizationSpec `json:",inline" yaml:",inline"`
 
-	HelmRepos        []*HelmRepository  `json:"helmRepos,omitempty"        yaml:"helmRepos,omitempty"`
-	OCIRepos         []*OCIRepository   `json:"ociRepos,omitempty"         yaml:"ociRepos,omitempty"`
-	HelmReleases     []*HelmRelease     `json:"helmReleases,omitempty"     yaml:"helmReleases,omitempty"`
-	ConfigMaps       []*ConfigMap       `json:"configMaps,omitempty"       yaml:"configMaps,omitempty"`
-	Secrets          []*Secret          `json:"secrets,omitempty"          yaml:"secrets,omitempty"`
-	HelmChartSources []*HelmChartSource `json:"helmChartSources,omitempty" yaml:"helmChartSources,omitempty"`
+	Secrets []*Secret `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 
 	// SourcePath is the location on disk this Kustomization was loaded
 	// from (config.kubernetes.io/path annotation).
@@ -105,14 +100,14 @@ func (k *Kustomization) Clone() *Kustomization {
 	return &out
 }
 
-// FilterDependsOn returns a copy of deps with any entries whose target
+// filterDependsOn returns a copy of deps with any entries whose target
 // is not present in known removed. known is a set of "namespace/name"
 // identifiers. The second return value is the count of dropped
 // entries. Pure function — does not mutate deps. Callers updating a
 // stored object should follow the Store's immutability contract:
 // shallow-copy the object, set the new DependsOn on the copy, then
 // re-AddObject the copy.
-func FilterDependsOn(deps []DependencyRef, known map[string]struct{}) ([]DependencyRef, int) {
+func filterDependsOn(deps []DependencyRef, known map[string]struct{}) ([]DependencyRef, int) {
 	if len(deps) == 0 {
 		return deps, 0
 	}

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -981,16 +981,16 @@ spec:
 		t.Errorf("substitute = %+v", k.PostBuildSubstitute)
 	}
 
-	kept, dropped := FilterDependsOn(k.DependsOn, map[string]struct{}{"flux-system/infra": {}})
+	kept, dropped := filterDependsOn(k.DependsOn, map[string]struct{}{"flux-system/infra": {}})
 	if len(kept) != 1 || kept[0].NamespacedName() != "flux-system/infra" {
-		t.Errorf("FilterDependsOn kept = %v", kept)
+		t.Errorf("filterDependsOn kept = %v", kept)
 	}
 	if dropped == 0 {
 		t.Errorf("expected at least one dropped entry")
 	}
 }
 
-// FilterDependsOn is the free function shared by KS and HR pruning;
+// filterDependsOn is the free function shared by KS and HR pruning;
 // verify it works on a synthetic HR-style dep list too.
 func TestFilterDependsOn_AcrossKinds(t *testing.T) {
 	deps := []DependencyRef{
@@ -998,7 +998,7 @@ func TestFilterDependsOn_AcrossKinds(t *testing.T) {
 		{NamedResource: NamedResource{Kind: KindHelmRelease, Namespace: "media", Name: "gone"}},
 	}
 	known := map[string]struct{}{"media/plex": {}}
-	kept, dropped := FilterDependsOn(deps, known)
+	kept, dropped := filterDependsOn(deps, known)
 	if len(kept) != 1 || kept[0].NamespacedName() != "media/plex" {
 		t.Errorf("kept = %v", kept)
 	}
@@ -1007,13 +1007,13 @@ func TestFilterDependsOn_AcrossKinds(t *testing.T) {
 	}
 
 	// nil-known: every dep dropped.
-	_, dropped = FilterDependsOn(deps, nil)
+	_, dropped = filterDependsOn(deps, nil)
 	if dropped != 2 {
 		t.Errorf("nil-known dropped = %d, want 2", dropped)
 	}
 
 	// empty deps: no work, no allocation.
-	out, dropped := FilterDependsOn(nil, known)
+	out, dropped := filterDependsOn(nil, known)
 	if out != nil || dropped != 0 {
 		t.Errorf("empty deps: out=%v dropped=%d", out, dropped)
 	}
@@ -1087,6 +1087,50 @@ stringData:
 			t.Errorf("data was wiped despite false: %v", s.Data["password"])
 		}
 	})
+}
+
+// TestParseSecret_Idempotent pins the copy-before-mutate fix: parseSecret
+// must not write placeholders back into the caller-owned doc map.
+// Previously the wipe loop mutated doc["data"] in place, so a second
+// parse on the same doc would re-encode an already-encoded placeholder,
+// producing base64(PLACEHOLDER_<base64(PLACEHOLDER_key)>) and causing
+// spurious EventObjectAdded on every cache-hit reconcile.
+func TestParseSecret_Idempotent(t *testing.T) {
+	const yamlDoc = `
+apiVersion: v1
+kind: Secret
+metadata: {name: s, namespace: ns}
+data:
+  token: c2VjcmV0
+stringData:
+  apiKey: plaintext
+`
+	doc := mustYAML(t, yamlDoc)
+
+	s1, err := parseSecret(doc, true)
+	if err != nil {
+		t.Fatalf("first parse: %v", err)
+	}
+	s2, err := parseSecret(doc, true)
+	if err != nil {
+		t.Fatalf("second parse: %v", err)
+	}
+
+	// Both parses must yield identical placeholder values.
+	if s1.Data["token"] != s2.Data["token"] {
+		t.Errorf("data not idempotent: first=%q second=%q", s1.Data["token"], s2.Data["token"])
+	}
+	if s1.StringData["apiKey"] != s2.StringData["apiKey"] {
+		t.Errorf("stringData not idempotent: first=%q second=%q", s1.StringData["apiKey"], s2.StringData["apiKey"])
+	}
+
+	// The original doc must be unmodified: still the raw base64 value.
+	if got := doc["data"].(map[string]any)["token"]; got != "c2VjcmV0" {
+		t.Errorf("parseSecret mutated doc[\"data\"]: got %q want %q", got, "c2VjcmV0")
+	}
+	if got := doc["stringData"].(map[string]any)["apiKey"]; got != "plaintext" {
+		t.Errorf("parseSecret mutated doc[\"stringData\"]: got %q want %q", got, "plaintext")
+	}
 }
 
 func TestParseDoc_Dispatch(t *testing.T) {

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -37,6 +37,9 @@ func (r *ResourceSet) Named() NamedResource {
 	return NamedResource{Kind: KindResourceSet, Namespace: r.Namespace, Name: r.Name}
 }
 
+// GetLabels returns the ResourceSet's metadata.labels.
+func (r *ResourceSet) GetLabels() map[string]string { return r.Labels }
+
 // parseResourceSet decodes a ResourceSet CR via the flux-operator
 // typed schema (controlplane.io/v1).
 func parseResourceSet(doc map[string]any) (*ResourceSet, error) {
@@ -82,6 +85,9 @@ type ResourceSetInputProvider struct {
 func (p *ResourceSetInputProvider) Named() NamedResource {
 	return NamedResource{Kind: KindResourceSetInputProvider, Namespace: p.Namespace, Name: p.Name}
 }
+
+// GetLabels returns the ResourceSetInputProvider's metadata.labels.
+func (p *ResourceSetInputProvider) GetLabels() map[string]string { return p.Labels }
 
 // parseResourceSetInputProvider decodes a ResourceSetInputProvider CR.
 func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvider, error) {

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -40,15 +40,8 @@ func (m Metadata) Matches(obj manifest.BaseManifest) bool {
 }
 
 func labelsOf(obj manifest.BaseManifest) map[string]string {
-	switch o := obj.(type) {
-	case *manifest.Kustomization:
-		return o.Labels
-	case *manifest.HelmRelease:
-		return o.Labels
-	case *manifest.ResourceSet:
-		return o.Labels
-	case *manifest.ResourceSetInputProvider:
-		return o.Labels
+	if o, ok := obj.(interface{ GetLabels() map[string]string }); ok {
+		return o.GetLabels()
 	}
 	return nil
 }

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -295,18 +295,6 @@ func (s *Slot) Stage() error {
 	return nil
 }
 
-// Refresh wipes the final slot and allocates a fresh staging directory
-// in one step. It is equivalent to calling Reset followed by Stage and
-// is intended for callers that detect a stale immutable cache hit and
-// need to re-fetch from scratch. The Reset+Stage sequence is preserved
-// unchanged; this method exists only to avoid repeating the pair.
-func (s *Slot) Refresh() error {
-	if err := s.Reset(); err != nil {
-		return err
-	}
-	return s.Stage()
-}
-
 // StageRefresh allocates a staging directory while preserving the
 // current final slot until Commit. It is for interval-based refreshes:
 // readers keep a usable old artifact if the fetch fails before commit,


### PR DESCRIPTION
## Summary

PR #460 was titled \"manifest...\" but actually shipped source-blob/cache content (the squash merge ate the wrong branch HEAD). The intended manifest changes never landed on main. This PR redoes them.

Applies the iter-10 + iter-11 manifest agent findings end-to-end:

1. **parseSecret no longer mutates input doc** (bug fix) — copy data/stringData into fresh maps; eliminates spurious AddObject events on cache-hit reconciles where the second parse would double-encode the placeholder. TestParseSecret_Idempotent pins it.
2. **Drop 5 dead Kustomization fields** (HelmReleases, HelmRepos, OCIRepos, ConfigMaps, HelmChartSources) — verified zero callers across the repo.
3. **Unexport FilterDependsOn → filterDependsOn** — only used inside pkg/manifest.
4. **Drop HelmChartSource.ResourceFullName()** — never called.
5. **Add GetLabels() to ResourceSet and ResourceSetInputProvider** — symmetry with Kustomization/HelmRelease.
6. **Simplify pkg/selector labelsOf** to one interface assertion (4-case switch dropped).

Also includes the duplicate Slot.Refresh removal from the local worktree base (already proposed separately in #471 — once that lands first, this becomes a no-op for that file).

## Test plan
- [x] go vet ./pkg/manifest/... ./pkg/selector/...
- [x] go test -count=1 -race -timeout=180s ./pkg/manifest/... ./pkg/selector/...
- [x] Whole-repo go test ./... — green
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)