### PR TITLE
refactor(format): drop dead ParseOutput and ValidOutputs

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -5,9 +5,7 @@ package format
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
-	"strings"
 	"unicode/utf8"
 
 	"sigs.k8s.io/yaml"
@@ -23,22 +21,6 @@ const (
 	OutputJSON  Output = "json"
 	OutputName  Output = "name"
 )
-
-// ValidOutputs returns the supported -o values, suitable for help text
-// and CLI validation.
-func ValidOutputs() []string {
-	return []string{string(OutputTable), string(OutputYAML), string(OutputJSON), string(OutputName)}
-}
-
-// ParseOutput validates a user-supplied -o value. Returns an error
-// listing the supported values when unrecognized.
-func ParseOutput(s string) (Output, error) {
-	switch Output(s) {
-	case OutputTable, OutputYAML, OutputJSON, OutputName:
-		return Output(s), nil
-	}
-	return "", fmt.Errorf("invalid -o %q: want one of %s", s, strings.Join(ValidOutputs(), ", "))
-}
 
 // Column describes a single table column.
 type Column struct {


### PR DESCRIPTION
## Summary

After iter-10 consolidated output validation into commonFlags.requireOutput + outputOrDefault, \`format.ParseOutput\` has zero callers across the repo (verified via grep). \`format.ValidOutputs\` was only used by \`ParseOutput\`. Both removed together. \`fmt\` and \`strings\` imports follow (they were only used by these functions).

## Test plan
- [x] grep -rn 'format\.ParseOutput\|format\.ValidOutputs' returned zero results
- [x] go vet + go test -race ./internal/format/...
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)