### PR TITLE
perf(controllers/helmrelease): O(1) raw-producer index removes full-store scan from --allow-missing-secrets path

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -54,6 +55,19 @@ type Controller struct {
 
 	// renderTracker receives every source-kind child emitted during render.
 	renderTracker RenderTracker
+
+	// rawProducerIndex is an in-memory index populated by the store
+	// listener in Start. It maps the target NamedResource (the Secret
+	// that a producer generates) to the producer's own NamedResource
+	// (the ExternalSecret or SealedSecret in the store). This replaces
+	// the O(N) Store.ListObjects("") scan in generatedValuesProducer with
+	// an O(1) sync.Map lookup, eliminating the per-reconcile read-lock
+	// contention on the store when --allow-missing-secrets is active.
+	//
+	// Key:   manifest.NamedResource — the generated Secret's identity
+	//        (Kind=KindSecret, Namespace, Name)
+	// Value: manifest.NamedResource — the producer's identity
+	rawProducerIndex sync.Map
 }
 
 // ReconcileOptions carries the post-bootstrap state the orchestrator
@@ -125,7 +139,66 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 // the canonical Store. One fewer push-registry to keep in sync.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("helmrelease")
+	c.AddListener(store.EventObjectAdded, c.onRawProducerAdded())
 	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
+}
+
+// onRawProducerAdded returns a listener that indexes RawObject producers
+// (ExternalSecret, SealedSecret) into rawProducerIndex. Registered with
+// flush=true (via AddListener) so the index is populated with any objects
+// already in the store at Start time and kept current as new objects arrive.
+//
+// The index maps targetID → producer.Named(), mirroring the classification
+// logic in rawProducesValuesRef so generatedValuesProducer can be answered
+// in O(1) without a full-store scan.
+func (c *Controller) onRawProducerAdded() store.Listener {
+	return func(_ manifest.NamedResource, payload any) {
+		raw, ok := payload.(*manifest.RawObject)
+		if !ok {
+			return
+		}
+		targetID, ok := rawProducerTargetID(raw)
+		if !ok {
+			return
+		}
+		c.rawProducerIndex.Store(targetID, raw.Named())
+	}
+}
+
+// rawProducerTargetID returns the NamedResource of the Secret that raw
+// will produce, or (zero, false) when raw is not a recognised producer kind.
+// This mirrors the classification in rawProducesValuesRef but returns the
+// target identity rather than a boolean, so the index can be keyed by it.
+func rawProducerTargetID(raw *manifest.RawObject) (manifest.NamedResource, bool) {
+	switch raw.Kind {
+	case "ExternalSecret":
+		target, _ := raw.Spec["target"].(map[string]any)
+		targetName, _ := target["name"].(string)
+		if targetName == "" {
+			targetName = raw.Name
+		}
+		return manifest.NamedResource{
+			Kind:      manifest.KindSecret,
+			Namespace: raw.Namespace,
+			Name:      targetName,
+		}, true
+	case "SealedSecret":
+		targetName := raw.Name
+		if tmpl, _ := raw.Spec["template"].(map[string]any); tmpl != nil {
+			if metadata, _ := tmpl["metadata"].(map[string]any); metadata != nil {
+				if name, _ := metadata["name"].(string); name != "" {
+					targetName = name
+				}
+			}
+		}
+		return manifest.NamedResource{
+			Kind:      manifest.KindSecret,
+			Namespace: raw.Namespace,
+			Name:      targetName,
+		}, true
+	default:
+		return manifest.NamedResource{}, false
+	}
 }
 
 func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -396,6 +396,147 @@ func TestEmitRenderedChildren_NilTrackerAndNilFilterAreNoops(t *testing.T) {
 	}
 }
 
+// TestRawProducerIndex_ExternalSecretWithExplicitTarget verifies that an
+// ExternalSecret with spec.target.name set is indexed under that explicit
+// target name, and that generatedValuesProducer returns the producer identity
+// for a matching Secret ref.
+func TestRawProducerIndex_ExternalSecretWithExplicitTarget(t *testing.T) {
+	c, st := newTestControllerWithOptions(t, ReconcileOptions{})
+
+	producer := &manifest.RawObject{
+		Kind:       "ExternalSecret",
+		APIVersion: "external-secrets.io/v1",
+		Name:       "app-creds",
+		Namespace:  "default",
+		Spec: map[string]any{
+			"target": map[string]any{"name": "app-values"},
+		},
+	}
+	st.AddObject(producer)
+
+	target := manifest.NamedResource{
+		Kind:      manifest.KindSecret,
+		Namespace: "default",
+		Name:      "app-values",
+	}
+	got, ok := c.generatedValuesProducer(target)
+	if !ok {
+		t.Fatal("generatedValuesProducer returned false; expected producer to be indexed")
+	}
+	if got.Kind != "ExternalSecret" || got.Namespace != "default" || got.Name != "app-creds" {
+		t.Errorf("generatedValuesProducer returned %v; want ExternalSecret/default/app-creds", got)
+	}
+}
+
+// TestRawProducerIndex_ExternalSecretFallsBackToOwnName verifies that an
+// ExternalSecret with no spec.target.name is indexed under its own .metadata.name.
+func TestRawProducerIndex_ExternalSecretFallsBackToOwnName(t *testing.T) {
+	c, st := newTestControllerWithOptions(t, ReconcileOptions{})
+
+	producer := &manifest.RawObject{
+		Kind:       "ExternalSecret",
+		APIVersion: "external-secrets.io/v1",
+		Name:       "my-secret",
+		Namespace:  "staging",
+		Spec:       map[string]any{},
+	}
+	st.AddObject(producer)
+
+	target := manifest.NamedResource{
+		Kind:      manifest.KindSecret,
+		Namespace: "staging",
+		Name:      "my-secret",
+	}
+	got, ok := c.generatedValuesProducer(target)
+	if !ok {
+		t.Fatal("generatedValuesProducer returned false; expected producer to be indexed via own name")
+	}
+	if got.Name != "my-secret" || got.Namespace != "staging" {
+		t.Errorf("generatedValuesProducer returned %v; want ExternalSecret/staging/my-secret", got)
+	}
+}
+
+// TestRawProducerIndex_SealedSecretWithTemplateMetadataName verifies that a
+// SealedSecret with spec.template.metadata.name is indexed under that name.
+func TestRawProducerIndex_SealedSecretWithTemplateMetadataName(t *testing.T) {
+	c, st := newTestControllerWithOptions(t, ReconcileOptions{})
+
+	producer := &manifest.RawObject{
+		Kind:       "SealedSecret",
+		APIVersion: "bitnami.com/v1alpha1",
+		Name:       "sealed-db",
+		Namespace:  "prod",
+		Spec: map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{"name": "db-password"},
+			},
+		},
+	}
+	st.AddObject(producer)
+
+	target := manifest.NamedResource{
+		Kind:      manifest.KindSecret,
+		Namespace: "prod",
+		Name:      "db-password",
+	}
+	got, ok := c.generatedValuesProducer(target)
+	if !ok {
+		t.Fatal("generatedValuesProducer returned false for SealedSecret with template.metadata.name")
+	}
+	if got.Name != "sealed-db" || got.Namespace != "prod" {
+		t.Errorf("generatedValuesProducer returned %v; want SealedSecret/prod/sealed-db", got)
+	}
+}
+
+// TestRawProducerIndex_Missing verifies that generatedValuesProducer returns
+// false for a Secret that has no matching producer in the index.
+func TestRawProducerIndex_Missing(t *testing.T) {
+	c, _ := newTestControllerWithOptions(t, ReconcileOptions{})
+
+	target := manifest.NamedResource{
+		Kind:      manifest.KindSecret,
+		Namespace: "default",
+		Name:      "no-such-secret",
+	}
+	if _, ok := c.generatedValuesProducer(target); ok {
+		t.Error("generatedValuesProducer returned true for a non-existent producer; want false")
+	}
+}
+
+// TestRawProducerIndex_NamespaceIsolation verifies that a producer in
+// namespace A does not match a query for the same name in namespace B.
+func TestRawProducerIndex_NamespaceIsolation(t *testing.T) {
+	c, st := newTestControllerWithOptions(t, ReconcileOptions{})
+
+	st.AddObject(&manifest.RawObject{
+		Kind:       "ExternalSecret",
+		APIVersion: "external-secrets.io/v1",
+		Name:       "svc-creds",
+		Namespace:  "team-a",
+		Spec:       map[string]any{},
+	})
+
+	// Same name, different namespace — must not match.
+	crossNS := manifest.NamedResource{
+		Kind:      manifest.KindSecret,
+		Namespace: "team-b",
+		Name:      "svc-creds",
+	}
+	if _, ok := c.generatedValuesProducer(crossNS); ok {
+		t.Error("generatedValuesProducer matched a producer from a different namespace; want false")
+	}
+
+	// Same namespace — must match.
+	sameNS := manifest.NamedResource{
+		Kind:      manifest.KindSecret,
+		Namespace: "team-a",
+		Name:      "svc-creds",
+	}
+	if _, ok := c.generatedValuesProducer(sameNS); !ok {
+		t.Error("generatedValuesProducer did not match producer in same namespace; want true")
+	}
+}
+
 func TestController_CollectHRDepsClone(t *testing.T) {
 	c, _ := newTestController(t, nil)
 	hr := &manifest.HelmRelease{

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -80,46 +80,10 @@ func (c *Controller) valuesRefExists(id manifest.NamedResource) bool {
 }
 
 func (c *Controller) generatedValuesProducer(id manifest.NamedResource) (manifest.NamedResource, bool) {
-	for _, obj := range c.Store.ListObjects("") {
-		raw, ok := obj.(*manifest.RawObject)
-		if !ok || raw.Namespace != id.Namespace {
-			continue
-		}
-		if rawProducesValuesRef(raw, id) {
-			return raw.Named(), true
-		}
+	if v, ok := c.rawProducerIndex.Load(id); ok {
+		return v.(manifest.NamedResource), true
 	}
 	return manifest.NamedResource{}, false
-}
-
-func rawProducesValuesRef(raw *manifest.RawObject, id manifest.NamedResource) bool {
-	switch raw.Kind {
-	case "ExternalSecret":
-		if id.Kind != manifest.KindSecret {
-			return false
-		}
-		target, _ := raw.Spec["target"].(map[string]any)
-		targetName, _ := target["name"].(string)
-		if targetName == "" {
-			targetName = raw.Name
-		}
-		return targetName == id.Name
-	case "SealedSecret":
-		if id.Kind != manifest.KindSecret {
-			return false
-		}
-		targetName := raw.Name
-		if tmpl, _ := raw.Spec["template"].(map[string]any); tmpl != nil {
-			if metadata, _ := tmpl["metadata"].(map[string]any); metadata != nil {
-				if name, _ := metadata["name"].(string); name != "" {
-					targetName = name
-				}
-			}
-		}
-		return targetName == id.Name
-	default:
-		return false
-	}
 }
 
 func valuesRefID(hr *manifest.HelmRelease, ref manifest.ValuesReference) (manifest.NamedResource, bool) {


### PR DESCRIPTION
## Summary

Iter-12 final-convergence finding. \`generatedValuesProducer\` did \`Store.ListObjects(\"\")\` — an unfiltered scan over every object — once per non-optional unresolvable valuesFrom ref when \`--allow-missing-secrets\` is active. Called per-HR per-reconcile while holding \`s.mu.RLock\` for the walk. On larger repos this serialized concurrent store writes and inflated render latency.

### Change

- \`Controller.rawProducerIndex sync.Map\` (target \`NamedResource\` → producer \`NamedResource\`)
- New \`onRawProducerAdded\` listener wired in \`Start\` with flush=true so the index is hydrated atomically against pre-existing store contents
- \`generatedValuesProducer\` becomes an O(1) \`sync.Map.Load\`
- \`rawProducerTargetID\` carries the ExternalSecret/SealedSecret classification (replaces the now-dead \`rawProducesValuesRef\`)
- Five new tests: ExternalSecret with explicit target.name; fallback to own name; SealedSecret with template.metadata.name; missing producer; namespace isolation

### Why this is the loop's natural endpoint

After 12 iterations of progressively-finer review, the final convergence audit found exactly ONE actionable performance concern (this one) and one cosmetic readability note (left as-is — too marginal to ship). The codebase is otherwise architecturally settled.

## Test plan
- [x] go vet + go test -count=3 -race -timeout=300s ./pkg/controllers/helmrelease/...
- [x] Downstream (orchestrator, cli) green
- [x] golangci-lint clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)