### PR TITLE
feat(action): default version to the action's pinned ref

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -4,9 +4,10 @@ Install the [flate](https://github.com/home-operations/flate) CLI on Linux, macO
 
 ```yaml
 steps:
-  - uses: home-operations/flate/action@main
+  # Installs flate 0.1.26 (matches the pinned action ref) and reuses its
+  # XDG cache across runs.
+  - uses: home-operations/flate/action@0.1.26
     with:
-      version: latest
       cache: true
   - run: flate get ks --path ./kubernetes
 ```
@@ -15,11 +16,11 @@ Installation is handled by [`jdx/mise-action`](https://github.com/jdx/mise-actio
 
 ## Inputs
 
-| Name      | Description                                                                         | Default               |
-| --------- | ----------------------------------------------------------------------------------- | --------------------- |
-| `version` | flate version to install (e.g. `0.1.25`), or `latest`                               | `latest`              |
-| `token`   | GitHub token mise uses to resolve and download releases (avoids unauth rate limits) | `${{ github.token }}` |
-| `cache`   | Restore and save flate's XDG cache between runs                                     | `false`               |
+| Name      | Description                                                                         | Default                |
+| --------- | ----------------------------------------------------------------------------------- | ---------------------- |
+| `version` | flate version to install (e.g. `0.1.25`) or `latest`                                | _see [Version](#version)_ |
+| `token`   | GitHub token mise uses to resolve and download releases (avoids unauth rate limits) | `${{ github.token }}`  |
+| `cache`   | Restore and save flate's XDG cache between runs                                     | `false`                |
 
 ## Outputs
 
@@ -28,6 +29,25 @@ Installation is handled by [`jdx/mise-action`](https://github.com/jdx/mise-actio
 | `version`   | Resolved flate version (without the leading `v`)                               |
 | `cache-dir` | On-disk path flate uses for its persistent cache on this runner                |
 | `cache-hit` | `'true'` when a previous flate cache was restored (only set when `cache=true`) |
+
+## Version
+
+When `version` is not set, the action inspects the ref it was pinned to (`github.action_ref`) and resolves it to a flate release. Explicit `version:` always wins; otherwise:
+
+1. If the ref is a SemVer tag (e.g. `@0.1.26`, `@v0.1.26`), that version is installed.
+2. If the ref is a commit SHA (full or short), the action queries the GitHub `/tags` API for its own repo and installs the SemVer tag whose commit matches — this is the path used by workflows that pin actions to immutable digests for supply-chain security.
+3. Otherwise (branches, dangling SHAs), the action falls back to `latest`.
+
+| Pinned as                                              | Installed version |
+| ------------------------------------------------------ | ----------------- |
+| `home-operations/flate/action@0.1.26`                  | `0.1.26`          |
+| `home-operations/flate/action@v0.1.26`                 | `0.1.26`          |
+| `home-operations/flate/action@2e8f4c8…` (release SHA)  | matching tag      |
+| `home-operations/flate/action@main`                    | `latest`          |
+| `home-operations/flate/action@<non-release-sha>`       | `latest`          |
+| any of the above, with `version: 0.1.20`               | `0.1.20`          |
+
+The SHA-to-tag lookup uses `inputs.token` (defaulted to `${{ github.token }}`) and degrades to `latest` if the API call fails or `jq` isn't available.
 
 ## Caching
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,9 +9,12 @@ branding:
 
 inputs:
   version:
-    description: flate version to install (e.g. "0.1.25"), or "latest"
+    description: |
+      flate version to install (e.g. "0.1.25") or "latest". When unset, the action
+      installs the version matching the ref it was pinned to (e.g. @0.1.26 → 0.1.26);
+      branches and SHAs fall back to "latest".
     required: false
-    default: latest
+    default: ""
   token:
     description: GitHub token used by mise to resolve and download releases without hitting unauthenticated rate limits
     required: false
@@ -36,17 +39,68 @@ runs:
   using: composite
   steps:
     - id: resolve
-      name: Resolve flate cache dir
+      name: Resolve flate target
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        ACTION_REF: ${{ github.action_ref }}
+        ACTION_REPO: ${{ github.action_repository }}
       run: |
         set -euo pipefail
-        # Mirrors Go's os.UserCacheDir() — the path flate's cacheroot.Default() resolves to.
+
+        # SemVer pattern — used both to recognize tag-style refs and to filter
+        # candidate tags when a SHA-pin is mapped back to a release.
+        semver='^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+
+        # Resolve which flate version to install. Precedence:
+        #   1. explicit `version:` input
+        #   2. action ref is a SemVer tag (@0.1.26, @v0.1.26)
+        #   3. action ref is a commit SHA whose commit a SemVer tag points at
+        #      (looked up via the GitHub tags API on the action's own repo —
+        #       supports the SHA-pinning security pattern)
+        #   4. "latest"
+        version="${INPUT_VERSION}"
+        from=""
+
+        if [[ -n "${version}" ]]; then
+          from="input"
+        elif [[ "${ACTION_REF:-}" =~ ${semver} ]]; then
+          version="${ACTION_REF#v}"
+          from="action ref ${ACTION_REF}"
+        elif [[ "${ACTION_REF:-}" =~ ^[0-9a-f]{7,40}$ ]] && command -v jq >/dev/null; then
+          auth=()
+          [[ -n "${INPUT_TOKEN}" ]] && auth=(-H "Authorization: Bearer ${INPUT_TOKEN}")
+          tag=$(curl -fsSL --max-time 10 \
+                -H "Accept: application/vnd.github+json" \
+                "${auth[@]}" \
+                "https://api.github.com/repos/${ACTION_REPO}/tags?per_page=100" 2>/dev/null \
+            | jq -r --arg sha "${ACTION_REF}" --arg re "${semver}" '
+                [.[] | select(.commit.sha | startswith($sha)) | .name | select(test($re))] | first // ""
+              ' 2>/dev/null || true)
+          if [[ -n "${tag}" ]]; then
+            version="${tag#v}"
+            from="action ref ${ACTION_REF} → tag ${tag}"
+          fi
+        fi
+
+        if [[ -z "${version}" ]]; then
+          version="latest"
+          from="default (action ref \"${ACTION_REF:-<none>}\" is not a release tag)"
+        fi
+        echo "resolved flate version: ${version} (from ${from})"
+
+        # Cache dir: mirrors Go's os.UserCacheDir() — the path flate's cacheroot.Default() resolves to.
         case "${RUNNER_OS}" in
           Linux)   dir="${XDG_CACHE_HOME:-${HOME}/.cache}/flate" ;;
           macOS)   dir="${HOME}/Library/Caches/flate" ;;
           Windows) dir="${LOCALAPPDATA}/flate" ;;
         esac
-        echo "cache-dir=${dir}" >> "${GITHUB_OUTPUT}"
+
+        {
+          echo "version=${version}"
+          echo "cache-dir=${dir}"
+        } >> "${GITHUB_OUTPUT}"
 
     - id: cache
       if: ${{ inputs.cache == 'true' }}
@@ -65,7 +119,7 @@ runs:
       with:
         cache: false
         tool_versions: |
-          github:home-operations/flate ${{ inputs.version }}
+          github:home-operations/flate ${{ steps.resolve.outputs.version }}
 
     - id: verify
       name: Verify flate


### PR DESCRIPTION
## Summary

When `version:` is not set, derive it from `github.action_ref` (the ref the consumer pinned the action to):

| Pinned as                                              | Installed version          |
| ------------------------------------------------------ | -------------------------- |
| `home-operations/flate/action@0.1.26`                  | `0.1.26`                   |
| `home-operations/flate/action@v0.1.26`                 | `0.1.26`                   |
| `home-operations/flate/action@<release-sha>`           | matching tag (via API)     |
| `home-operations/flate/action@main`                    | `latest`                   |
| `home-operations/flate/action@<non-release-sha>`       | `latest`                   |
| any of the above, with `version: 0.1.20`               | `0.1.20`                   |

The SHA-pin path supports the security-conscious pattern of pinning actions to immutable digests rather than mutable tags. Lookup uses the GitHub `/repos/{action_repo}/tags` API with `inputs.token` (defaults to `${{ github.token }}`), filters candidates to strict SemVer, and degrades cleanly to `latest` if the API call fails or `jq` isn't available.

The resolved version + the source it came from is echoed to the step log to keep troubleshooting trivial.

Locally validated all 9 resolution cases (explicit-wins, semver-with-and-without-v, full-SHA, short-SHA, branch, non-matching SHA, empty ref).

## Test plan

- [ ] Tag the action repo at a release version and verify `home-operations/flate/action@<that-version>` installs the matching flate without setting `version:`
- [ ] Verify `home-operations/flate/action@<sha-of-that-release>` resolves to the same version
- [ ] Verify `home-operations/flate/action@main` still installs `latest`
- [ ] Verify `home-operations/flate/action@0.1.26` + `with: { version: 0.1.20 }` honors the explicit override

🤖 Generated with [Claude Code](https://claude.com/claude-code)