### PR TITLE
feat(cli): bind every flag to a FLATE_* env var

### DIFF
--- a/internal/cli/env.go
+++ b/internal/cli/env.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// envPrefix is prepended to every flag name to form its env-var key.
+// `--path` ↦ FLATE_PATH, `--skip-kinds` ↦ FLATE_SKIP_KINDS, etc.
+const envPrefix = "FLATE_"
+
+// envSkipFlags lists flag names whose env-var binding would be useless
+// or actively harmful. `help` and `version` short-circuit normal
+// command execution when set, so `FLATE_HELP=true` would silently
+// disable every other invocation — better to leave them CLI-only.
+var envSkipFlags = map[string]bool{
+	"help":    true,
+	"version": true,
+}
+
+// envKey returns the env-var name corresponding to a cobra flag.
+// Identity transform: kebab → snake, uppercase, FLATE_ prefix.
+func envKey(flagName string) string {
+	return envPrefix + strings.ReplaceAll(strings.ToUpper(flagName), "-", "_")
+}
+
+// applyEnvVars fills any flag on cmd that wasn't explicitly set on
+// the command line from its FLATE_<UPPER_SNAKE> env var. CLI args
+// always win — env vars only cover the gap. Slice/map/bool/duration
+// values parse the same form pflag accepts on argv (CSV for slices,
+// `k=v,k=v` for maps, `true/false/1/0` for bools, `30m` for durations).
+// An invalid value fails loud with the offending env key named.
+func applyEnvVars(cmd *cobra.Command) error {
+	var firstErr error
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if firstErr != nil || f.Changed || envSkipFlags[f.Name] {
+			return
+		}
+		key := envKey(f.Name)
+		v, ok := os.LookupEnv(key)
+		if !ok {
+			return
+		}
+		if err := f.Value.Set(v); err != nil {
+			firstErr = fmt.Errorf("invalid %s %q: %w", key, v, err)
+			return
+		}
+		f.Changed = true
+	})
+	return firstErr
+}
+
+// annotateEnvUsage appends `[env: FLATE_X]` to every flag's Usage in
+// the command tree so the env-var surface is discoverable through
+// `--help`. cobra short-circuits on `--help` without running PreRun,
+// so the annotation must be baked into the usage string at command-
+// construction time.
+//
+// Walks LocalFlags() at every node: that's local-non-persistent +
+// own-persistent, which covers each flag exactly once across the
+// tree — root contributes its own persistent flags (e.g. log-level),
+// subcommands contribute their local flags, and inherited persistent
+// flags are picked up via cobra's shared *pflag.Flag pointer so
+// rendering inherited flags shows the annotation too. Using Flags()
+// here would miss root's own persistent flags (cobra only merges
+// persistent flags from *parents*, and root has none).
+func annotateEnvUsage(root *cobra.Command) {
+	var walk func(*cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		cmd.LocalFlags().VisitAll(func(f *pflag.Flag) {
+			if envSkipFlags[f.Name] {
+				return
+			}
+			f.Usage = strings.TrimRight(f.Usage, " ") + " [env: " + envKey(f.Name) + "]"
+		})
+		for _, sub := range cmd.Commands() {
+			walk(sub)
+		}
+	}
+	walk(root)
+}

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnv_FlagFromEnv covers the happy path: a flag the user did not
+// pass on the command line is filled from FLATE_<NAME>. We point
+// FLATE_PATH at the fixture and run `build all` without `--path`;
+// the build succeeds and emits the fixture's ConfigMap, proving the
+// orchestrator saw the env-supplied path.
+func TestEnv_FlagFromEnv(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_PATH", path)
+	stdout, stderr, code := runCLI(t, "build", "all")
+	if code != 0 {
+		t.Fatalf("build all (FLATE_PATH) exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "kind: ConfigMap") {
+		t.Errorf("expected ConfigMap in render via FLATE_PATH:\n%s", stdout)
+	}
+}
+
+// TestEnv_CLIFlagOverridesEnv pins the precedence rule: a CLI flag
+// always wins over the env var, even when env points at something
+// broken. Without that rule the user can't override an ambient
+// FLATE_PATH set in their shell rc.
+func TestEnv_CLIFlagOverridesEnv(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_PATH", "/nonexistent/path/here")
+	stdout, stderr, code := runCLI(t, "build", "all", "--path", path)
+	if code != 0 {
+		t.Fatalf("build all --path (vs FLATE_PATH) exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "kind: ConfigMap") {
+		t.Errorf("CLI --path should have won over bad FLATE_PATH:\n%s", stdout)
+	}
+}
+
+// TestEnv_BoolFlagParsed verifies pflag's bool Set is wired through:
+// FLATE_SKIP_CRDS=false flips a flag that defaults to true. We
+// exercise `--only-crds`'s applyBuildFlags pathway by checking that
+// the resulting render still includes the ConfigMap (i.e. nothing
+// regressed) — the boolean parse is on the silent path here, so the
+// stronger assertion comes from TestEnv_InvalidValueReportsKey,
+// which proves Value.Set is reached.
+func TestEnv_BoolFlagParsed(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_SKIP_CRDS", "false")
+	stdout, stderr, code := runCLI(t, "build", "all", "--path", path)
+	if code != 0 {
+		t.Fatalf("build all FLATE_SKIP_CRDS=false exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "kind: ConfigMap") {
+		t.Errorf("expected ConfigMap in render:\n%s", stdout)
+	}
+}
+
+// TestEnv_SliceFlagParsesCSV covers comma-separated parsing for
+// pflag.StringSliceVar (`--skip-kinds`). Setting FLATE_SKIP_KINDS to
+// "ConfigMap,Secret" should drop the fixture's only ConfigMap from
+// the render, leaving an empty stream.
+func TestEnv_SliceFlagParsesCSV(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_SKIP_KINDS", "ConfigMap,Secret")
+	stdout, stderr, code := runCLI(t, "build", "all", "--path", path)
+	if code != 0 {
+		t.Fatalf("build all FLATE_SKIP_KINDS=... exited %d: %s", code, stderr)
+	}
+	if strings.Contains(stdout, "kind: ConfigMap") {
+		t.Errorf("FLATE_SKIP_KINDS=ConfigMap,Secret should have filtered ConfigMap:\n%s", stdout)
+	}
+}
+
+// TestEnv_InvalidValueReportsKey covers the loud-failure path: an
+// env-supplied value that pflag rejects must surface the FLATE_*
+// key in the error so the user can find the offending shell export.
+// We use FLATE_CONCURRENCY (an int) with a non-integer to drive
+// IntVar.Set into its error branch — that path returns a typed
+// error, unlike --log-level's enum check which runs after env
+// binding.
+func TestEnv_InvalidValueReportsKey(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_CONCURRENCY", "notanint")
+	_, stderr, code := runCLI(t, "build", "all", "--path", path)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for invalid FLATE_CONCURRENCY")
+	}
+	if !strings.Contains(stderr, "FLATE_CONCURRENCY") {
+		t.Errorf("error should name the offending env key: %q", stderr)
+	}
+}
+
+// TestEnv_PersistentFlagFromEnv exercises the root-level persistent
+// flag path (FLATE_LOG_LEVEL). An invalid level surfaces through the
+// existing setLogLevel validator, proving env binding happens
+// before validation runs.
+func TestEnv_PersistentFlagFromEnv(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_LOG_LEVEL", "bogus")
+	_, stderr, code := runCLI(t, "build", "all", "--path", path)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for FLATE_LOG_LEVEL=bogus")
+	}
+	if !strings.Contains(stderr, "invalid --log-level") {
+		t.Errorf("env-bound log-level should still trip setLogLevel: %q", stderr)
+	}
+}
+
+// TestEnv_HelpVersionAreSkipped guards against the worst-case footgun:
+// FLATE_HELP=true must not silently turn every invocation into a help
+// printout. The skip list keeps cobra's `--help` and `--version`
+// short-circuits CLI-only.
+func TestEnv_HelpVersionAreSkipped(t *testing.T) {
+	path := writeFixture(t)
+	t.Setenv("FLATE_HELP", "true")
+	t.Setenv("FLATE_VERSION", "true")
+	stdout, stderr, code := runCLI(t, "build", "all", "--path", path)
+	if code != 0 {
+		t.Fatalf("FLATE_HELP/VERSION should be ignored, but build exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "kind: ConfigMap") {
+		t.Errorf("normal build output missing — env skip-list regressed:\n%s", stdout)
+	}
+}
+
+// TestEnv_HelpAdvertisesEnvVars pins the discoverability requirement:
+// every documented flag should advertise its env key in `--help`.
+// Persistent flags that bubble through every subcommand (--log-level,
+// --path) are checked at the leaf-command help so we exercise the
+// shared-pointer dedupe in annotateEnvUsage (each annotation should
+// land exactly once even though the flag is inherited by every leaf).
+func TestEnv_HelpAdvertisesEnvVars(t *testing.T) {
+	stdout, _, code := runCLI(t, "build", "all", "--help")
+	if code != 0 {
+		t.Fatalf("`build all --help` exited %d", code)
+	}
+	for _, want := range []string{
+		"[env: FLATE_PATH]",
+		"[env: FLATE_LOG_LEVEL]",
+		"[env: FLATE_SKIP_CRDS]",
+		"[env: FLATE_SKIP_KINDS]",
+		"[env: FLATE_CONCURRENCY]",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("--help missing %q\n%s", want, stdout)
+		}
+		if strings.Count(stdout, want) > 1 {
+			t.Errorf("--help duplicated %q (annotateEnvUsage dedupe regressed)", want)
+		}
+	}
+	for _, banned := range []string{"[env: FLATE_HELP]"} {
+		if strings.Contains(stdout, banned) {
+			t.Errorf("--help should not advertise %q — env binding is skipped for it", banned)
+		}
+	}
+}
+
+// TestEnvKey pins the kebab→snake transform so future refactors don't
+// silently change which env vars users export.
+func TestEnvKey(t *testing.T) {
+	for in, want := range map[string]string{
+		"path":         "FLATE_PATH",
+		"path-orig":    "FLATE_PATH_ORIG",
+		"log-level":    "FLATE_LOG_LEVEL",
+		"skip-kinds":   "FLATE_SKIP_KINDS",
+		"api-versions": "FLATE_API_VERSIONS",
+	} {
+		if got := envKey(in); got != want {
+			t.Errorf("envKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,12 @@ func New(version string) *cobra.Command {
 	}
 	root.PersistentFlags().String("log-level", "info", "log level (debug, info, warn, error)")
 	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		// Env binding runs first so FLATE_LOG_LEVEL is honored by the
+		// validation below, and downstream RunE bodies see flags that
+		// reflect the merged (CLI > env > default) view.
+		if err := applyEnvVars(cmd); err != nil {
+			return err
+		}
 		lvl, _ := cmd.Flags().GetString("log-level")
 		return setLogLevel(lvl, cmd.ErrOrStderr())
 	}
@@ -49,6 +55,7 @@ func New(version string) *cobra.Command {
 		newTestCmd(),
 		newCacheCmd(),
 	)
+	annotateEnvUsage(root)
 	return root
 }
 


### PR DESCRIPTION
## Summary
- Walk each command's flags in `PersistentPreRunE` and fill any flag the user didn't pass on the CLI from `FLATE_<UPPER_SNAKE>`, parsed through `pflag.Value.Set` so slices/bools/durations/maps share the on-argv form. CLI args always win; invalid values fail loud with the env key named in the error.
- Append `[env: FLATE_X]` to every flag's usage at construction time so `--help` advertises the env surface. Walks `LocalFlags()` rather than `Flags()` because cobra's `mergePersistentFlags` only pulls from parents — root's own persistent flags (`--log-level`) are never visited via a leaf's merged set.
- Skip `help`/`version` so `FLATE_HELP=true` can't hijack every invocation.

Resulting env keys: `FLATE_PATH`, `FLATE_NAMESPACE`, `FLATE_SKIP_CRDS`, `FLATE_SKIP_KINDS=Job,CronJob`, `FLATE_LOG_LEVEL`, etc.

## Test plan
- [x] `go test ./...` — full suite green
- [x] `go vet ./...` — clean
- [x] `env_test.go` covers: env supplies missing flag, CLI overrides env, bool parse, CSV slice parse, invalid value names the env key, persistent flag via env, `FLATE_HELP`/`FLATE_VERSION` ignored, `--help` advertises every flag exactly once, kebab→snake transform pinned.
- [x] Eyeballed `flate build all --help`: every flag carries `[env: FLATE_*]`, log-level annotated in Global Flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)