### PR TITLE
fix: keep substituteFrom producer Kustomizations in changed-only mode

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -71,6 +71,18 @@ type Filter struct {
 	// keepByName: (Kind, Name) presence set used as an O(1) fallback
 	// when either side of a lookup has an empty namespace.
 	keepByName map[nameKey]struct{}
+
+	// producersByID and producersByName map file-backed data resources
+	// (ConfigMap/Secret) to the Flux Kustomizations whose spec.path
+	// renders them. Two maps mirror the keepByName empty-namespace
+	// bridge: DiscoveryOnly indexes the raw on-disk ConfigMap before
+	// kustomize's namespace directive has rendered, but consumers wait
+	// on the namespaced form. Built once during resolve() and read-only
+	// after — so the BFS-local lookup in resolve() and the lock-held
+	// runtime lookups can both share the same maps without copying.
+	// See #418.
+	producersByID   map[manifest.NamedResource][]manifest.NamedResource
+	producersByName map[nameKey][]manifest.NamedResource
 }
 
 type nameKey struct{ kind, name string }
@@ -136,6 +148,45 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 		return true
 	}
 	return false
+}
+
+// ProducersFor returns Flux Kustomizations that render the file-backed
+// data resource id. Populated only for Enabled filters; used by
+// controllers to add ordering edges for data deps that arrive via
+// another KS's render — e.g. a postBuild.substituteFrom ConfigMap
+// rendered by an unchanged producer KS in changed-only mode. See
+// #418.
+//
+// Returns a copy — callers append-without-aliasing the filter's
+// internal state.
+func (f *Filter) ProducersFor(id manifest.NamedResource) []manifest.NamedResource {
+	if !f.Enabled() {
+		return nil
+	}
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return slices.Clone(f.producersFor(id))
+}
+
+// producersFor returns Flux Kustomizations that render the file-backed
+// data resource id. Read-only after resolve(); caller must already
+// hold f.mu (when called from runtime paths) or be inside resolve()
+// (read-only construction).
+//
+// The id-namespace asymmetry mirrors ShouldReconcile / keepByName:
+// the byName fallback fires only when the lookup id IS namespaced,
+// so a fully-namespaced producer entry can't silently match an
+// unrelated fully-namespaced consumer that happens to share
+// (Kind, Name).
+func (f *Filter) producersFor(id manifest.NamedResource) []manifest.NamedResource {
+	if f == nil {
+		return nil
+	}
+	out := f.producersByID[id]
+	if id.Namespace != "" {
+		out = appendUniqueProducers(out, f.producersByName[nameKey{id.Kind, id.Name}])
+	}
+	return out
 }
 
 // AddEmitted extends the keep set with child when emitter is a
@@ -289,6 +340,57 @@ func (f *Filter) addRecursiveLocked(id manifest.NamedResource) []manifest.NamedR
 			if _, ok := f.primary[dep]; !ok {
 				stack = append(stack, dep)
 			}
+			// Producers of a runtime-discovered substituteFrom CM
+			// must reconcile so the CM materializes, but they stay
+			// dependency-only — promoting them to primary would
+			// re-introduce the #204 keep cascade (an unchanged
+			// producer's render output for unrelated siblings is
+			// identical to baseline). See #418.
+			added = append(added, f.addDependencyOnlyRecursiveLocked(f.producersFor(dep)...)...)
+		}
+	}
+	return added
+}
+
+// addDependencyOnlyRecursiveLocked extends the keep set with ids
+// (and their transitive sourceRef/chartRef/valuesFrom deps AND any
+// producers of those deps) at runtime WITHOUT marking the entries
+// primary. The caller MUST hold f.mu.Lock().
+//
+// Used for runtime substituteFrom-producer promotion: a primary
+// consumer reaches a CM whose producing KS is unchanged. The
+// producer must reconcile so the CM materializes, but its render
+// output for unrelated siblings matches baseline — promoting it
+// to primary would re-introduce the #204 keep cascade.
+//
+// Chained producers are walked: a producer that itself has a
+// substituteFrom CM produced by another KS pulls that KS in too,
+// again ancestor-only. See #418.
+func (f *Filter) addDependencyOnlyRecursiveLocked(ids ...manifest.NamedResource) []manifest.NamedResource {
+	var added []manifest.NamedResource
+	stack := slices.Clone(ids)
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if _, alreadyKeep := f.keep[cur]; alreadyKeep {
+			continue
+		}
+		f.keep[cur] = struct{}{}
+		if cur.Namespace == "" {
+			f.keepByName[nameKey{cur.Kind, cur.Name}] = struct{}{}
+		}
+		added = append(added, cur)
+		if f.objs == nil {
+			continue
+		}
+		for _, dep := range transitiveDeps(f.objs, cur) {
+			stack = append(stack, dep)
+			for _, producer := range f.producersFor(dep) {
+				if producer == cur {
+					continue
+				}
+				stack = append(stack, producer)
+			}
 		}
 	}
 	return added
@@ -335,6 +437,7 @@ func (f *Filter) resolve(objs ObjectLister) {
 	}
 
 	owners := buildOwnership(objs, f.repoRoot)
+	f.producersByID, f.producersByName = buildProducerIndex(f.sourceFiles, owners)
 	ownersHit := make(map[manifest.NamedResource]struct{})
 
 	for _, file := range f.changes.Paths() {
@@ -376,6 +479,26 @@ func (f *Filter) resolve(objs ObjectLister) {
 				enqueuePrimary(d)
 			} else {
 				enqueueAncestor(d)
+			}
+			// If a data dependency is rendered by another Flux
+			// Kustomization, that producer must run so the data
+			// object materializes. Producers are ancestor-only —
+			// their output is needed, but an unchanged producer
+			// should NOT become a primary emitter that cascades
+			// unrelated children into changed-only scope (the #204
+			// cascade rationale applies). Skip the self-producer
+			// case (a KS that produces its own substituteFrom CM —
+			// bjw-s self-substitute pattern). See #418.
+			//
+			// Read producersByID/producersByName directly via the
+			// unlocked producersFor: resolve() runs pre-publication
+			// (f.keep / f.primary not yet set), so the public
+			// ProducersFor's RLock contract is not established here.
+			for _, producer := range f.producersFor(d) {
+				if producer == queue[head] {
+					continue
+				}
+				enqueueAncestor(producer)
 			}
 		}
 		// Also walk the structural-parent chain of any Flux
@@ -487,8 +610,55 @@ type ObjectLister interface {
 	ListObjects(kind string) []manifest.BaseManifest
 }
 
+// buildProducerIndex maps file-backed data resources to the
+// Kustomization(s) that render their files. Exact id matches cover
+// namespaced resources and finalized generators; the name map covers
+// the common kustomize-namespace case where DiscoveryOnly indexed a
+// raw ConfigMap/Secret with namespace="" but the consuming KS waits
+// on the rendered namespace.
+//
+// Indexing by name only for empty-namespace ids mirrors keepByName's
+// asymmetric rule (see ShouldReconcile / keepByName comments) —
+// without it, a producer of ConfigMap/cluster-infra/shared would
+// silently match a ConfigMap/database/shared consumer lookup. See
+// #418.
+func buildProducerIndex(sourceFiles map[manifest.NamedResource]string, owners ownershipIndex) (map[manifest.NamedResource][]manifest.NamedResource, map[nameKey][]manifest.NamedResource) {
+	byID := make(map[manifest.NamedResource][]manifest.NamedResource)
+	byName := make(map[nameKey][]manifest.NamedResource)
+	for id, file := range sourceFiles {
+		if id.Kind != manifest.KindConfigMap && id.Kind != manifest.KindSecret {
+			continue
+		}
+		producers := owners.ownersOf(file)
+		if len(producers) == 0 {
+			continue
+		}
+		byID[id] = appendUniqueProducers(byID[id], producers)
+		if id.Namespace == "" {
+			key := nameKey{id.Kind, id.Name}
+			byName[key] = appendUniqueProducers(byName[key], producers)
+		}
+	}
+	return byID, byName
+}
+
+// appendUniqueProducers extends dst with the producer ids in src,
+// deduping against dst. Used during producer-index construction and
+// at producersFor merge time; the slices are short (typically a
+// single owner KS per data file) so the linear scan is cheaper than
+// a map intermediary.
+func appendUniqueProducers(dst []manifest.NamedResource, src []manifest.NamedResource) []manifest.NamedResource {
+	for _, id := range src {
+		if !slices.Contains(dst, id) {
+			dst = append(dst, id)
+		}
+	}
+	return dst
+}
+
 // transitiveDeps returns the references id needs to render — chart
-// sources, KS sourceRef, valuesFrom. dependsOn is intentionally
+// sources, KS sourceRef, valuesFrom, and non-Optional
+// postBuild.substituteFrom ConfigMaps. dependsOn is intentionally
 // excluded: it's a reconcile-ordering signal in real Flux, not a
 // content dependency, so it adds nothing to an offline render.
 // Skipped resources still get marked Ready by their controllers, so
@@ -515,12 +685,25 @@ func transitiveDeps(objs ObjectLister, id manifest.NamedResource) []manifest.Nam
 		if ks == nil {
 			return nil
 		}
-		if ks.SourceKind == "" || ks.SourceName == "" {
-			return nil
+		var out []manifest.NamedResource
+		if ks.SourceKind != "" && ks.SourceName != "" {
+			out = append(out, manifest.NamedResource{
+				Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
+			})
 		}
-		return []manifest.NamedResource{{
-			Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
-		}}
+		for _, ref := range ks.PostBuildSubstituteFrom {
+			// Mirrors collectDeps in pkg/controllers/kustomization:
+			// Optional refs are best-effort; Secrets are SOPS/ExternalSecret-
+			// managed and can't be materialized offline; empty Name is
+			// malformed. See #418.
+			if ref.Optional || ref.Kind != manifest.KindConfigMap || ref.Name == "" {
+				continue
+			}
+			out = append(out, manifest.NamedResource{
+				Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name,
+			})
+		}
+		return out
 
 	case manifest.KindHelmChart:
 		// A HelmRelease chartRef pointing at a HelmChart CRD lands the

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -655,3 +655,352 @@ func TestFilter_TransitiveDepsHelmReleaseViaHelmChartCRD(t *testing.T) {
 		t.Errorf("HelmChart's sourceRef OCIRepository not pulled in; keep=%v", f.KeepNames())
 	}
 }
+
+// TestFilter_SubstituteFromConfigMapKeepsProducerKustomization pins
+// issue #418: a kept Kustomization with a non-Optional
+// postBuild.substituteFrom ConfigMap must pull the producer KS that
+// renders that CM into keep, even when the producer's own files
+// didn't change. Without this, changed-only mode fails reconcile
+// with "ConfigMap/flux-system/cluster-settings: dependency not found"
+// because the producer never runs and the CM never materializes.
+//
+// The producer joins keep as ancestor-only — NOT primary — so its
+// render output for unrelated siblings can't cascade into changed-
+// only scope (the #204 keep-cascade rationale).
+func TestFilter_SubstituteFromConfigMapKeepsProducerKustomization(t *testing.T) {
+	clusterAppsObj := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "kubernetes/apps",
+		},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "cluster-settings"},
+		},
+	}
+	clusterVarsObj := &manifest.Kustomization{
+		Name: "cluster-vars", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "kubernetes/flux/vars",
+			// The CM lives in a shared Component referenced by
+			// cluster-vars — ownersOf returns cluster-vars for any
+			// file under the resolved component path.
+			Components: []string{"../../components/cluster-settings"},
+		},
+	}
+	ntfyObj := &manifest.Kustomization{
+		Name: "ntfy", Namespace: "communication",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "kubernetes/apps/communication/ntfy/app",
+		},
+	}
+	hrObj := &manifest.HelmRelease{Name: "ntfy", Namespace: "communication"}
+	// rawSettings is the DiscoveryOnly-indexed pre-render form:
+	// Namespace="" because kustomize's namespace directive hasn't
+	// run yet at file-walk time.
+	rawSettings := &manifest.ConfigMap{Name: "cluster-settings", Namespace: ""}
+	rawSettingsID := rawSettings.Named()
+
+	clusterApps := clusterAppsObj.Named()
+	clusterVars := clusterVarsObj.Named()
+	ntfy := ntfyObj.Named()
+	hr := hrObj.Named()
+	// renderedSettings is the form the consumer KS waits on once
+	// kustomize's namespace directive has stamped flux-system onto
+	// the rendered CM.
+	renderedSettings := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings"}
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/apps/communication/ntfy/app/helmrelease.yaml"}),
+		map[manifest.NamedResource]string{
+			clusterApps:   "kubernetes/flux/cluster-apps.yaml",
+			clusterVars:   "kubernetes/flux/cluster-vars.yaml",
+			ntfy:          "kubernetes/apps/communication/ntfy/ks.yaml",
+			hr:            "kubernetes/apps/communication/ntfy/app/helmrelease.yaml",
+			rawSettingsID: "kubernetes/components/cluster-settings/cluster-settings.yaml",
+		},
+		"",
+		mapLister{
+			clusterApps:   clusterAppsObj,
+			clusterVars:   clusterVarsObj,
+			ntfy:          ntfyObj,
+			hr:            hrObj,
+			rawSettingsID: rawSettings,
+		},
+	)
+
+	// The leaf HR's file changed, so ntfy + the cluster-apps
+	// ancestor are pulled in; the rendered ConfigMap is a
+	// substituteFrom dep of cluster-apps; and cluster-vars is the
+	// producer of that ConfigMap.
+	for _, id := range []manifest.NamedResource{clusterApps, ntfy, hr, renderedSettings, clusterVars} {
+		if !f.ShouldReconcile(id) {
+			t.Errorf("expected %s in keep; keep=%v", id, f.KeepNames())
+		}
+	}
+	// The producer is ancestor-only: AddEmitted from cluster-vars
+	// to a sentinel child must reject (producer is NOT primary).
+	sentinel := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "unrelated", Name: "sentinel"}
+	f.AddEmitted(clusterVars, sentinel)
+	if f.ShouldReconcile(sentinel) {
+		t.Errorf("producer cluster-vars must be ancestor-only (NOT primary) — AddEmitted leaked sentinel into keep; keep=%v", f.KeepNames())
+	}
+}
+
+// TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly
+// covers the runtime AddEmitted path: a primary parent KS emits a
+// child KS at render time, and that child has a substituteFrom CM
+// produced by an unchanged third KS. The producer must land in keep
+// (so the CM materializes) but stay dependency-only — its render
+// output for unrelated siblings is unchanged, so promoting it would
+// re-introduce the #204 cascade. See #418.
+func TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly(t *testing.T) {
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "parent-apps"}
+	childObj := &manifest.Kustomization{
+		Name: "child-app", Namespace: "apps",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "kubernetes/apps/child",
+		},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "shared-settings"},
+		},
+	}
+	child := childObj.Named()
+	producerObj := &manifest.Kustomization{
+		Name: "settings-producer", Namespace: "apps",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "kubernetes/apps/settings",
+		},
+	}
+	producer := producerObj.Named()
+	// CM with namespace="" mirrors the DiscoveryOnly pre-render form.
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "", Name: "shared-settings"}
+	cmObj := &manifest.ConfigMap{Name: cmID.Name, Namespace: cmID.Namespace}
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/parent/parent.yaml"}),
+		map[manifest.NamedResource]string{
+			parent:   "kubernetes/parent/parent.yaml",
+			producer: "kubernetes/apps/settings/ks.yaml",
+			cmID:     "kubernetes/apps/settings/cm.yaml",
+		},
+		"",
+		mapLister{producer: producerObj, child: childObj, cmID: cmObj},
+	)
+
+	if !f.ShouldReconcile(parent) {
+		t.Fatalf("parent must be primary from direct file change; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(producer) {
+		t.Fatalf("precondition: producer must NOT be in keep before AddEmitted runs; keep=%v", f.KeepNames())
+	}
+
+	// Primary parent emits child at render time. AddEmitted walks
+	// child's transitiveDeps, hits the substituteFrom CM, and pulls
+	// the producer in dependency-only.
+	f.AddEmitted(parent, child)
+
+	if !f.ShouldReconcile(child) {
+		t.Errorf("child must be in keep after AddEmitted from primary parent; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(producer) {
+		t.Errorf("producer of child's substituteFrom CM must be in keep; keep=%v", f.KeepNames())
+	}
+	// Producer is dependency-only: AddEmitted from producer to a
+	// sentinel child must reject because producer is not primary.
+	sentinel := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "unrelated", Name: "sentinel"}
+	f.AddEmitted(producer, sentinel)
+	if f.ShouldReconcile(sentinel) {
+		t.Errorf("producer must be dependency-only (NOT primary) — AddEmitted leaked sentinel into keep; keep=%v", f.KeepNames())
+	}
+}
+
+// TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer pins that
+// a runtime-added producer KS is delivered to OnAdd. The orchestrator
+// wires OnAdd → Store.Refire for KindKustomization (#418); without
+// the OnAdd dispatch, an unchanged producer joining keep at runtime
+// would stay PreGate-skipped and its CM would never materialize.
+func TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer(t *testing.T) {
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "parent-apps"}
+	childObj := &manifest.Kustomization{
+		Name: "child-app", Namespace: "apps",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/child"},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "shared-settings"},
+		},
+	}
+	child := childObj.Named()
+	producerObj := &manifest.Kustomization{
+		Name: "settings-producer", Namespace: "apps",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/settings"},
+	}
+	producer := producerObj.Named()
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "", Name: "shared-settings"}
+	cmObj := &manifest.ConfigMap{Name: cmID.Name, Namespace: cmID.Namespace}
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/parent/parent.yaml"}),
+		map[manifest.NamedResource]string{
+			parent:   "kubernetes/parent/parent.yaml",
+			producer: "kubernetes/apps/settings/ks.yaml",
+			cmID:     "kubernetes/apps/settings/cm.yaml",
+		},
+		"",
+		mapLister{producer: producerObj, child: childObj, cmID: cmObj},
+	)
+
+	var added []manifest.NamedResource
+	f.OnAdd = func(id manifest.NamedResource) {
+		added = append(added, id)
+	}
+
+	f.AddEmitted(parent, child)
+
+	if !slices.Contains(added, producer) {
+		t.Errorf("OnAdd must fire for the runtime-added producer KS; added=%v", added)
+	}
+}
+
+// TestFilter_ChainedSubstituteFromProducers covers the chained
+// producer case: KS A has substituteFrom CM-a (produced by KS B);
+// KS B has substituteFrom CM-b (produced by KS C). C must land in
+// keep as ancestor — without the chain walk, an unchanged C would
+// silently be skipped and B's render would fail. See #418.
+func TestFilter_ChainedSubstituteFromProducers(t *testing.T) {
+	aObj := &manifest.Kustomization{
+		Name: "consumer", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/consumer"},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "cm-a"},
+		},
+	}
+	bObj := &manifest.Kustomization{
+		Name: "producer-b", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/b"},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "cm-b"},
+		},
+	}
+	cObj := &manifest.Kustomization{
+		Name: "producer-c", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/c"},
+	}
+	a, b, c := aObj.Named(), bObj.Named(), cObj.Named()
+
+	cmA := &manifest.ConfigMap{Name: "cm-a", Namespace: ""}
+	cmAID := cmA.Named()
+	cmB := &manifest.ConfigMap{Name: "cm-b", Namespace: ""}
+	cmBID := cmB.Named()
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/consumer/file.yaml"}),
+		map[manifest.NamedResource]string{
+			a:     "kubernetes/consumer/ks.yaml",
+			b:     "kubernetes/b/ks.yaml",
+			c:     "kubernetes/c/ks.yaml",
+			cmAID: "kubernetes/b/cm-a.yaml",
+			cmBID: "kubernetes/c/cm-b.yaml",
+		},
+		"",
+		mapLister{a: aObj, b: bObj, c: cObj, cmAID: cmA, cmBID: cmB},
+	)
+
+	if !f.ShouldReconcile(a) {
+		t.Fatalf("consumer A must be in keep (file change); keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(b) {
+		t.Errorf("producer B (renders cm-a) must be in keep; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(c) {
+		t.Errorf("chained producer C (renders cm-b consumed by B) must be in keep; keep=%v", f.KeepNames())
+	}
+}
+
+// TestFilter_SelfProducerSkippedInResolve pins the bjw-s
+// self-substitute pattern: a KS may produce its own
+// postBuild.substituteFrom CM. The BFS must NOT enqueue the KS as
+// its own ancestor (would infinite-loop or self-edge). See #418.
+func TestFilter_SelfProducerSkippedInResolve(t *testing.T) {
+	selfObj := &manifest.Kustomization{
+		Name: "self", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/self"},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "self-settings"},
+		},
+	}
+	self := selfObj.Named()
+	// CM lives at spec.path of self — so ownersOf returns self.
+	cmObj := &manifest.ConfigMap{Name: "self-settings", Namespace: ""}
+	cmID := cmObj.Named()
+
+	f := NewFilter(
+		NewSet([]string{"kubernetes/self/changed.yaml"}),
+		map[manifest.NamedResource]string{
+			self: "kubernetes/self/ks.yaml",
+			cmID: "kubernetes/self/cm.yaml",
+		},
+		"",
+		mapLister{self: selfObj, cmID: cmObj},
+	)
+
+	if !f.ShouldReconcile(self) {
+		t.Errorf("self KS must be in keep; keep=%v", f.KeepNames())
+	}
+	// Sanity: no infinite loop happened (we made it here). Also
+	// confirm self only appears once in the producer index — not as
+	// its own ancestor via enqueueAncestor.
+	prods := f.ProducersFor(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "self-settings"})
+	if !slices.Contains(prods, self) {
+		t.Errorf("producers index should still contain self for cm-by-name lookup; got=%v", prods)
+	}
+}
+
+// TestFilter_ProducerByNameDoesNotLeakAcrossNamespaces pins the
+// asymmetric producer-byName rule, mirroring
+// TestFilter_KeepByNameDoesNotLeakAcrossNamespaces. A producer KS
+// renders a CM in namespace ns1; an unrelated producer in ns2
+// renders a same-named CM in ns2. A ProducersFor lookup on
+// CM/ns1/shared MUST return only the ns1 producer — never the ns2
+// one. See #418.
+func TestFilter_ProducerByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
+	// Both producer KSes spec a CM named "shared". The CMs land at
+	// distinct on-disk paths, so ownersOf attributes each producer
+	// only to its own CM file.
+	aObj := &manifest.Kustomization{
+		Name: "producer-a", Namespace: "ns1",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "p1"},
+	}
+	bObj := &manifest.Kustomization{
+		Name: "producer-b", Namespace: "ns2",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "p2"},
+	}
+	a, b := aObj.Named(), bObj.Named()
+
+	// The DiscoveryOnly-indexed CMs are in their respective on-disk
+	// paths but have explicit namespace already (so they land in
+	// producersByID only — NOT producersByName).
+	cmNS1 := &manifest.ConfigMap{Name: "shared", Namespace: "ns1"}
+	cmNS1ID := cmNS1.Named()
+	cmNS2 := &manifest.ConfigMap{Name: "shared", Namespace: "ns2"}
+	cmNS2ID := cmNS2.Named()
+
+	f := NewFilter(
+		NewSet([]string{"unrelated.yaml"}),
+		map[manifest.NamedResource]string{
+			a:       "p1/ks.yaml",
+			b:       "p2/ks.yaml",
+			cmNS1ID: "p1/cm.yaml",
+			cmNS2ID: "p2/cm.yaml",
+		},
+		"",
+		mapLister{a: aObj, b: bObj, cmNS1ID: cmNS1, cmNS2ID: cmNS2},
+	)
+
+	gotNS1 := f.ProducersFor(cmNS1ID)
+	if !slices.Equal(gotNS1, []manifest.NamedResource{a}) {
+		t.Errorf("ProducersFor(CM/ns1/shared) leaked across namespaces: got %v, want [%v]", gotNS1, a)
+	}
+	gotNS2 := f.ProducersFor(cmNS2ID)
+	if !slices.Equal(gotNS2, []manifest.NamedResource{b}) {
+		t.Errorf("ProducersFor(CM/ns2/shared) leaked across namespaces: got %v, want [%v]", gotNS2, b)
+	}
+}

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -275,14 +275,16 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 // CEL ReadyExpr), the source ref, the implicit structural parent (the
 // enclosing Flux KS that renders us — must finish first so any
 // parent-render-time spec injections land before our reconcile), and
-// every non-Optional postBuild.substituteFrom ConfigMap.
+// every non-Optional postBuild.substituteFrom ConfigMap (or, in
+// changed-only mode, the unchanged producer Kustomization that renders
+// that ConfigMap).
 //
-// substituteFrom ConfigMap edges fix the race where the referenced CM
-// is emitted by another KS's render: without the edge, KS-A would
-// race KS-B and Prepare would silently expand with empty values for
-// vars that should have come from KS-B's CM. Flux's eventual-
-// consistency reconcile loop self-heals; flate is one-shot, so a
-// missed substitution shows up as broken rendered output.
+// substituteFrom ConfigMap/producer edges fix the race where the
+// referenced CM is emitted by another KS's render: without the edge,
+// KS-A would race KS-B and Prepare would silently expand with empty
+// values for vars that should have come from KS-B's CM. Flux's
+// eventual-consistency reconcile loop self-heals; flate is one-shot,
+// so a missed substitution shows up as broken rendered output.
 //
 // Secret refs are deliberately NOT added as depwait edges. In real
 // repos substituteFrom Secrets are almost always SOPS-encrypted or
@@ -316,11 +318,26 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 		if ref.Name == "" {
 			continue
 		}
-		deps = append(deps, manifest.DependencyRef{
-			NamedResource: manifest.NamedResource{
-				Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name,
-			},
-		})
+		depID := manifest.NamedResource{Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name}
+		deps = append(deps, manifest.DependencyRef{NamedResource: depID})
+		// In changed-only mode, when the substituteFrom CM is rendered
+		// by another Flux Kustomization (the producer), wait on that
+		// producer too — the CM dep alone doesn't gate ordering when
+		// the producer's reconcile is what materializes the CM. Only
+		// KS producers form depwait edges (generator-produced CMs have
+		// no controller to wait on); skip the self-producer case
+		// (bjw-s self-substitute pattern).
+		if f := c.Filter(); f != nil {
+			for _, producer := range f.ProducersFor(depID) {
+				if producer == ks.Named() {
+					continue
+				}
+				if producer.Kind != manifest.KindKustomization {
+					continue
+				}
+				deps = append(deps, manifest.DependencyRef{NamedResource: producer})
+			}
+		}
 	}
 	return deps
 }

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -3,6 +3,10 @@ package kustomization
 import (
 	"testing"
 
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -110,6 +114,104 @@ func TestCollectDeps_SubstituteFromIgnoresMalformedRefs(t *testing.T) {
 	c := New(store.New(), nil, nil, false)
 	if deps := c.collectDeps(ks); len(deps) != 0 {
 		t.Errorf("expected no deps from malformed substituteFrom refs; got %+v", deps)
+	}
+}
+
+// TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer pins the
+// changed-only producer-KS depwait edge: when the substituteFrom
+// ConfigMap is rendered by another Flux Kustomization, that producer
+// is appended as its own dep so the consumer waits for the producer's
+// reconcile (which materializes the CM) before rendering. See #418.
+func TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer(t *testing.T) {
+	consumerObj := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "cluster-settings"},
+		},
+	}
+	producerObj := &manifest.Kustomization{
+		Name: "cluster-vars", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/flux/vars"},
+	}
+	consumer := consumerObj.Named()
+	producer := producerObj.Named()
+	// DiscoveryOnly-indexed CM (Namespace="") — kustomize's namespace
+	// directive hasn't run yet at file-walk time.
+	cmObj := &manifest.ConfigMap{Name: "cluster-settings", Namespace: ""}
+	cmID := cmObj.Named()
+
+	f := change.NewFilter(
+		change.NewSet([]string{"kubernetes/apps/changed.yaml"}),
+		map[manifest.NamedResource]string{
+			consumer: "kubernetes/flux/cluster-apps.yaml",
+			producer: "kubernetes/flux/cluster-vars.yaml",
+			cmID:     "kubernetes/flux/vars/cluster-settings.yaml",
+		},
+		"",
+		testutil.MapLister{consumer: consumerObj, producer: producerObj, cmID: cmObj},
+	)
+
+	c := New(store.New(), nil, nil, false)
+	c.Configure(Options{Filter: f})
+	deps := c.collectDeps(consumerObj)
+
+	wantCM := manifest.NamedResource{
+		Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings",
+	}
+	var sawCM, sawProducer bool
+	for _, d := range deps {
+		if d.NamedResource == wantCM {
+			sawCM = true
+		}
+		if d.NamedResource == producer {
+			sawProducer = true
+		}
+	}
+	if !sawCM {
+		t.Errorf("expected substituteFrom CM dep %+v in deps %+v", wantCM, deps)
+	}
+	if !sawProducer {
+		t.Errorf("expected producer KS dep %+v in deps %+v", producer, deps)
+	}
+}
+
+// TestCollectDeps_SkipsSelfProducer pins the bjw-s self-substitute
+// pattern: a KS that produces its own substituteFrom ConfigMap must
+// NOT be appended as a dep on itself (would self-loop in depwait).
+// See #418.
+func TestCollectDeps_SkipsSelfProducer(t *testing.T) {
+	selfObj := &manifest.Kustomization{
+		Name: "app", Namespace: "foo",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/foo/app"},
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindConfigMap, Name: "settings"},
+		},
+	}
+	self := selfObj.Named()
+	// CM rendered by self — file lives under self's spec.path so
+	// ownersOf returns self in the producer index.
+	cmObj := &manifest.ConfigMap{Name: "settings", Namespace: ""}
+	cmID := cmObj.Named()
+
+	f := change.NewFilter(
+		change.NewSet([]string{"kubernetes/foo/app/changed.yaml"}),
+		map[manifest.NamedResource]string{
+			self: "kubernetes/foo/app/ks.yaml",
+			cmID: "kubernetes/foo/app/settings.yaml",
+		},
+		"",
+		testutil.MapLister{self: selfObj, cmID: cmObj},
+	)
+
+	c := New(store.New(), nil, nil, false)
+	c.Configure(Options{Filter: f})
+	deps := c.collectDeps(selfObj)
+
+	for _, d := range deps {
+		if d.NamedResource == self {
+			t.Errorf("self-producer must not appear as its own dep; got %+v", deps)
+		}
 	}
 }
 

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -178,6 +178,17 @@ func (w *walker) descend(ctx context.Context, dir string) (int, error) {
 		}
 		if k.isKustomizeComponent() {
 			slog.Debug("loader: skipping kustomize Component directory", "dir", dir)
+			// DiscoveryOnly callers still need the change filter's
+			// producer index to see ConfigMap/Secret data files that
+			// happen to live inside a Component subtree — a sibling
+			// KS's substituteFrom dep can't resolve to its producing
+			// KS otherwise. walkComponentData records those files
+			// without publishing Component-housed Flux CRs (which are
+			// frequently `${VAR}`-templated and not renderable
+			// standalone).
+			if w.loader.Options.DiscoveryOnly {
+				return w.walkComponentData(ctx, dir, k)
+			}
 			return 0, nil
 		}
 		return w.walkKustomize(ctx, dir, k)
@@ -287,6 +298,75 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 	return count, nil
 }
 
+// walkComponentData records direct ConfigMap/Secret resources from
+// kustomize Components during DiscoveryOnly loads without publishing
+// templated Flux CRs as standalone objects. The change filter's
+// producer index needs the data files source-recorded so a downstream
+// substituteFrom consumer can resolve its producing KS, but a
+// Component's own `${VAR}`-templated Flux CRs are NOT renderable
+// standalone — publishing them would corrupt discovery.
+//
+// Component-of-Component graphs recurse via k.Components; w.visited
+// terminates Component cycles (same primitive descend uses for the
+// non-Component graph). We deliberately do NOT call descend() for
+// nested Components — that would re-enter the regular walk and load
+// any non-Component YAMLs from the Component subtree, defeating the
+// whole point of the skip. Stay limited to CM/Secret data-file
+// recording.
+func (w *walker) walkComponentData(ctx context.Context, dir string, k *kustomization) (int, error) {
+	for _, r := range k.Resources {
+		if cerr := ctx.Err(); cerr != nil {
+			return 0, cerr
+		}
+		abs, ok := resolveDataPath(dir, r)
+		if !ok || w.ignore.matches(abs, w.scanRoot, false) || !isManifestFile(abs) {
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil || info.IsDir() {
+			// Directories under a Component's `resources:` are sibling
+			// kustomize packages, not bare data files; the producer
+			// index is fed by files, so skip rather than recurse. A
+			// nested kustomize package authored inside a Component is
+			// vanishingly rare and would be loaded via its enclosing
+			// Flux KS spec.path instead.
+			continue
+		}
+		if err := w.loader.recordDataFile(abs); err != nil {
+			slog.Warn("loader: component data file failed to parse", "path", abs, "err", err)
+		}
+	}
+	for _, comp := range k.Components {
+		if cerr := ctx.Err(); cerr != nil {
+			return 0, cerr
+		}
+		abs, ok := resolveComponentPath(dir, comp)
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if _, seen := w.visited[abs]; seen {
+			continue
+		}
+		w.visited[abs] = struct{}{}
+		nested := readKustomization(abs)
+		if nested == nil || !nested.isKustomizeComponent() {
+			// A Component that points at a non-Component dir is
+			// malformed for kustomize purposes; skip rather than
+			// descend into walkKustomize, which would publish Flux
+			// CRs we deliberately keep hidden under Component subtrees.
+			continue
+		}
+		if _, err := w.walkComponentData(ctx, abs, nested); err != nil {
+			return 0, err
+		}
+	}
+	return 0, nil
+}
+
 // walkAdHoc handles entry points that aren't themselves kustomize
 // packages: walks the filesystem tree, loading every YAML, and
 // switching to walkKustomize when it encounters a sub-directory
@@ -317,6 +397,15 @@ func (w *walker) walkAdHoc(ctx context.Context, root string) (int, error) {
 			// descending again.
 			if k := readKustomization(path); k != nil {
 				if k.isKustomizeComponent() {
+					// Mirror descend's DiscoveryOnly gate: harvest
+					// CM/Secret data files from Component subtrees so
+					// the producer index can resolve substituteFrom
+					// deps even when the entry was the ad-hoc walk.
+					if w.loader.Options.DiscoveryOnly {
+						if _, err := w.walkComponentData(ctx, path, k); err != nil {
+							return err
+						}
+					}
 					return filepath.SkipDir
 				}
 				w.visited[path] = struct{}{}
@@ -375,6 +464,37 @@ func (l *Loader) loadFile(path string) (int, error) {
 		count++
 	}
 	return count, nil
+}
+
+// recordDataFile parses absPath and records any ConfigMap/Secret
+// objects into the Existence index and SourceFiles map without
+// adding them to the Store. Used by walkComponentData so the change
+// filter's producer index can resolve substituteFrom data deps to
+// their renderer KS without publishing untemplated Component-subtree
+// resources. Mirrors loadFile's PreferExisting + Existence + source
+// bookkeeping but skips AddObject and skips non-data kinds.
+func (l *Loader) recordDataFile(absPath string) error {
+	objs, err := parseFile(absPath, manifest.ParseDocOptions{WipeSecrets: l.Options.WipeSecrets})
+	if err != nil {
+		return err
+	}
+	for _, obj := range objs {
+		id := obj.Named()
+		if id.Kind != manifest.KindConfigMap && id.Kind != manifest.KindSecret {
+			// Non-data kinds (most commonly templated Flux CRs in a
+			// Component subtree) intentionally stay invisible — the
+			// producer-index use case is data-only.
+			continue
+		}
+		if l.PreferExisting && l.Store.GetObject(id) != nil {
+			continue
+		}
+		if l.Existence != nil {
+			l.Existence.Record(id, absPath)
+		}
+		l.recordSource(id, absPath)
+	}
+	return nil
 }
 
 // recordGenerators appends generator records observed during a walk.

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -472,6 +472,190 @@ spec:
 	}
 }
 
+// TestLoader_DiscoveryOnlyRecordsComponentDataResources pins the
+// Phase 1B contract: under DiscoveryOnly, kustomize Component
+// subtrees still skip publishing standalone Flux CRs (the templated
+// ones don't render outside their parent KS) but the loader walks
+// the Component's `resources:` for ConfigMap/Secret data files and
+// records them in Existence + SourceFiles. This is what lets the
+// change filter's producer index resolve a downstream KS's
+// substituteFrom dep to the unchanged renderer KS that owns the
+// Component (issue #418).
+func TestLoader_DiscoveryOnlyRecordsComponentDataResources(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "components/settings/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster-settings.yaml
+  - ./templated-ks.yaml
+`)
+	testutil.WriteFile(t, dir, "components/settings/cluster-settings.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  FOO: bar
+`)
+	testutil.WriteFile(t, dir, "components/settings/templated-ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: "${APP}-leak", namespace: ns}
+spec:
+  path: ./irrelevant
+  sourceRef: {kind: GitRepository, name: flux-system}
+  interval: 1h
+`)
+	s := store.New()
+	l := New(s)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	l.SourceFiles = map[manifest.NamedResource]string{}
+	l.SourceRoot = dir
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings"}
+	if _, ok := l.Existence.Get(cmID); !ok {
+		t.Errorf("Component-housed CM must be recorded in Existence under DiscoveryOnly")
+	}
+	if _, ok := l.SourceFiles[cmID]; !ok {
+		t.Errorf("Component-housed CM must be recorded in SourceFiles under DiscoveryOnly")
+	}
+	if s.GetObject(cmID) != nil {
+		t.Errorf("Component-housed CM must NOT be in Store under DiscoveryOnly (existence-only)")
+	}
+	// The templated KS would be filtered upstream by parseFile's
+	// envsubst guard even if walkComponentData tried to publish it,
+	// but this assertion pins the "Component CRs stay hidden" contract
+	// at the boundary the caller cares about: the Store.
+	leakID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "${APP}-leak"}
+	if s.GetObject(leakID) != nil {
+		t.Errorf("templated Flux CR inside a Component must NOT leak into the Store")
+	}
+}
+
+// TestLoader_DiscoveryOnlyRecordsNestedComponentData pins the
+// Component-of-Component recursion in walkComponentData: an outer
+// Component that references an inner Component via `components:`
+// must surface the inner Component's CM/Secret data files into the
+// producer index. The reference PR (tjwallace/flate#1) walked only
+// `resources:` and missed this graph shape — this test is the fence.
+func TestLoader_DiscoveryOnlyRecordsNestedComponentData(t *testing.T) {
+	dir := t.TempDir()
+	// Outer Component points at inner via `components:`. The path is
+	// relative to the outer Component's directory; resolveComponentPath
+	// allows the `..` escape that resolveDataPath forbids.
+	testutil.WriteFile(t, dir, "components/outer/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+components:
+  - ../inner
+`)
+	testutil.WriteFile(t, dir, "components/inner/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./shared.yaml
+`)
+	testutil.WriteFile(t, dir, "components/inner/shared.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shared-cm
+  namespace: flux-system
+data:
+  KEY: value
+`)
+	s := store.New()
+	l := New(s)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	l.SourceFiles = map[manifest.NamedResource]string{}
+	l.SourceRoot = dir
+	// Drive the loader at the outer Component directly — same shape
+	// as TestLoader_SkipsKustomizeComponentSubtree's entry pattern.
+	if _, err := l.Load(context.Background(), filepath.Join(dir, "components/outer")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "shared-cm"}
+	if _, ok := l.Existence.Get(id); !ok {
+		t.Errorf("inner Component CM reached via Component-of-Component must be recorded in Existence")
+	}
+	if _, ok := l.SourceFiles[id]; !ok {
+		t.Errorf("inner Component CM must be recorded in SourceFiles")
+	}
+}
+
+// TestLoader_DiscoveryOnlyComponentCycleTerminates pins the
+// w.visited cycle protection in walkComponentData: a pair of
+// Components that reference each other via `components:` must not
+// infinite-loop. The same primitive descend uses; verify here so a
+// future change can't drop it.
+func TestLoader_DiscoveryOnlyComponentCycleTerminates(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "components/a/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+components:
+  - ../b
+`)
+	testutil.WriteFile(t, dir, "components/b/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+components:
+  - ../a
+`)
+	s := store.New()
+	l := New(s)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	// No timeout context: if cycle protection fails, the test hangs
+	// and the test framework's overall timeout surfaces the bug.
+	if _, err := l.Load(context.Background(), filepath.Join(dir, "components/a")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+}
+
+// TestLoader_NonDiscoveryOnlyStillSkipsComponents is the pre-existing
+// behavior fence: when DiscoveryOnly is OFF, Component subtrees stay
+// fully invisible — no CM/Secret data files surface in Existence or
+// SourceFiles. Without this fence the new walkComponentData gate
+// could be loosened by mistake and silently leak Component-housed
+// CMs into non-DiscoveryOnly Store-loading consumers.
+func TestLoader_NonDiscoveryOnlyStillSkipsComponents(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "components/settings/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./cluster-settings.yaml
+`)
+	testutil.WriteFile(t, dir, "components/settings/cluster-settings.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  FOO: bar
+`)
+	s := store.New()
+	l := New(s)
+	// DiscoveryOnly intentionally OFF.
+	l.Existence = NewExistenceIndex()
+	l.SourceFiles = map[manifest.NamedResource]string{}
+	l.SourceRoot = dir
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings"}
+	if _, ok := l.Existence.Get(cmID); ok {
+		t.Errorf("non-DiscoveryOnly walk must not record Component-housed CMs in Existence")
+	}
+	if _, ok := l.SourceFiles[cmID]; ok {
+		t.Errorf("non-DiscoveryOnly walk must not record Component-housed CMs in SourceFiles")
+	}
+	if s.GetObject(cmID) != nil {
+		t.Errorf("non-DiscoveryOnly walk must not publish Component-housed CMs to the Store")
+	}
+}
+
 // TestLoader_RespectsCanceledContext asserts the walk bails out on
 // context cancellation. Useful when a stuck NFS mount or symlink
 // loop would otherwise block Bootstrap indefinitely.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -504,18 +504,28 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	// Issue #260. Refire owns the status reset that closes the
 	// depwait race — see Store.Refire.
 	//
+	// Kustomization is included for the symmetric substituteFrom
+	// producer case (#418): when a primary parent emits a child KS
+	// at render time and that child consumes a substituteFrom CM
+	// produced by an unchanged producer KS, addRecursive pulls the
+	// producer into keep dependency-only — but the producer's own
+	// listener already PreGate-skipped during Bootstrap, leaving no
+	// CM in the store. Refire re-runs the producer so the CM lands
+	// before the consuming KS's depwait expires.
+	//
 	// Kinds limited to the source-controller-managed set (those wired
-	// with a Fetcher in the constructor above). HelmChart resources
-	// are read directly by helm.storeResolver without a Fetcher, so
-	// Refire on a HelmChart id would write a Pending status that no
-	// controller transitions back to Ready.
+	// with a Fetcher in the constructor above) plus Kustomization.
+	// HelmChart resources are read directly by helm.storeResolver
+	// without a Fetcher, so Refire on a HelmChart id would write a
+	// Pending status that no controller transitions back to Ready.
 	f.OnAdd = func(id manifest.NamedResource) {
 		switch id.Kind {
 		case manifest.KindGitRepository,
 			manifest.KindOCIRepository,
 			manifest.KindHelmRepository,
 			manifest.KindBucket,
-			manifest.KindExternalArtifact:
+			manifest.KindExternalArtifact,
+			manifest.KindKustomization:
 			o.store.Refire(id)
 		}
 	}

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -12,6 +12,7 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -716,5 +717,151 @@ func TestOrchestrator_TypedListener(t *testing.T) {
 	s.UpdateStatus(id, store.StatusFailed, "boom")
 	if seen.Status != store.StatusFailed || seen.Message != "boom" {
 		t.Errorf("typed listener did not receive payload: %+v", seen)
+	}
+}
+
+// TestOrchestrator_ChangedOnlyKeepsSubstituteFromProducer is the
+// end-to-end regression fence for issue #418. A leaf HelmRelease
+// change under cluster-apps must NOT cause cluster-apps's reconcile
+// to fail with "ConfigMap/flux-system/cluster-settings: dependency
+// not found" because the producer Kustomization (cluster-vars) that
+// renders the substituteFrom ConfigMap was skipped from the keep set.
+//
+// Wiring under test:
+//   - cluster-apps (KS, flux-system) consumes ConfigMap/cluster-settings
+//     via spec.postBuild.substituteFrom.
+//   - cluster-vars (KS, flux-system) renders that CM through a kustomize
+//     Component subtree at kubernetes/components/cluster-settings.
+//   - cluster-apps's spec.path covers an ntfy subtree whose HR file is
+//     the only changed file. The HR is suspended so no chart pull is
+//     needed for this offline fixture.
+//
+// Expectations:
+//  1. cluster-vars is in the filter keep set (ancestor-only — the
+//     producer must reconcile but doesn't promote its other children).
+//  2. Run does NOT fail with "dependency not found" for the CM.
+//  3. The producer's artifact is materialized in the store.
+//  4. The rendered ConfigMap is materialized in the store.
+func TestOrchestrator_ChangedOnlyKeepsSubstituteFromProducer(t *testing.T) {
+	dir := t.TempDir()
+
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster-apps.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/apps
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+`)
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster-vars.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-vars
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./kubernetes/flux/vars
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "kubernetes/flux/vars/kustomization.yaml", `namespace: flux-system
+components:
+  - ../../components/cluster-settings
+`)
+	testutil.WriteFile(t, dir, "kubernetes/components/cluster-settings/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - cluster-settings.yaml
+`)
+	testutil.WriteFile(t, dir, "kubernetes/components/cluster-settings/cluster-settings.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+data:
+  CLUSTER_DOMAIN: example.test
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/kustomization.yaml", `resources:
+  - communication/ntfy/ks.yaml
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/communication/ntfy/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ntfy
+  namespace: communication
+spec:
+  interval: 10m
+  path: ./kubernetes/apps/communication/ntfy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/communication/ntfy/app/kustomization.yaml", `resources:
+  - helmrelease.yaml
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/communication/ntfy/app/helmrelease.yaml", `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ntfy
+  namespace: communication
+spec:
+  interval: 10m
+  suspend: true
+  chartRef:
+    kind: OCIRepository
+    name: ntfy
+    namespace: flux-system
+`)
+
+	o, err := New(Config{
+		Path:        dir,
+		WipeSecrets: true,
+		ExternalChanges: change.NewSet([]string{
+			"kubernetes/apps/communication/ntfy/app/helmrelease.yaml",
+		}),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+
+	producerID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-vars"}
+	f := o.Filter()
+	if f == nil {
+		t.Fatalf("Filter() returned nil; ExternalChanges should have activated changed-only mode")
+	}
+	if !f.ShouldReconcile(producerID) {
+		t.Fatalf("producer %s must be in keep set; keep=%v", producerID, f.KeepNames())
+	}
+
+	if err := o.Run(context.Background()); err != nil {
+		if strings.Contains(err.Error(), "ConfigMap/flux-system/cluster-settings: dependency not found") {
+			t.Fatalf("changed-only skipped unchanged substituteFrom producer: %v", err)
+		}
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := o.Store().GetArtifact(producerID); got == nil {
+		t.Errorf("producer %s artifact missing after Run; producer was kept but never reconciled", producerID)
+	}
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings"}
+	if got := o.Store().GetObject(cmID); got == nil {
+		t.Errorf("rendered %s missing after Run; producer reconcile did not materialize the substituteFrom CM", cmID)
 	}
 }


### PR DESCRIPTION
## Summary

- In changed-only mode, an unchanged Kustomization that produces a `ConfigMap` consumed by a kept Kustomization via `spec.postBuild.substituteFrom` was skipped, causing reconcile to fail with `dependency not found`.
- The `change.Filter` now tracks producers of file-backed CM/Secret resources (`producersByID` / `producersByName`, mirroring `keepByName`'s empty-namespace asymmetry) and pulls them into keep as dependency-only — never primary — so unrelated siblings don't cascade.
- The Kustomization controller appends the producer KS as a depwait edge alongside the existing substituteFrom CM dep.
- The loader records CM/Secret resources from kustomize `Component` subtrees under `DiscoveryOnly` (with `k.Components` recursion + `w.visited` cycle protection) so producers housed in Components are discoverable. Templated Flux CRs in Component subtrees are **not** published as standalone objects.
- The orchestrator's `Filter.OnAdd` switch now includes `KindKustomization` so a producer joining keep at runtime via `AddEmitted` is `Refire`d, mirroring the existing source-kind fix from #260.

Fixes #418. Approach borrowed from https://github.com/tjwallace/flate/pull/1 with these refinements:
- `walkComponentData` recurses into nested Components (the reference PR only walked `Resources`).
- BFS-local producer lookup in `resolve()` instead of the public `ProducersFor` (avoids the construction-time lock contract).
- Self-producer skip at the BFS site (bjw-s self-substitute pattern).
- `OnAdd` switch extended for `KindKustomization`.

## Test plan

- [x] `go test ./pkg/change ./pkg/loader ./pkg/orchestrator ./pkg/controllers/kustomization ./internal/testrunner -count=1` — green
- [x] `go test ./... -count=1` — green
- [x] `mise run vet` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — green
- [x] New regression coverage:
  - `TestFilter_SubstituteFromConfigMapKeepsProducerKustomization` — initial resolve
  - `TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly` — runtime AddEmitted
  - `TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer` — OnAdd contract
  - `TestFilter_ChainedSubstituteFromProducers` — producer-of-producer
  - `TestFilter_SelfProducerSkippedInResolve` — bjw-s self-substitute pattern
  - `TestFilter_ProducerByNameDoesNotLeakAcrossNamespaces` — cross-namespace leak fence
  - `TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer` — depwait edge
  - `TestCollectDeps_SkipsSelfProducer` — self-loop avoidance
  - `TestLoader_DiscoveryOnlyRecordsComponentDataResources` — Component CM recorded
  - `TestLoader_DiscoveryOnlyRecordsNestedComponentData` — Component-of-Component
  - `TestLoader_DiscoveryOnlyComponentCycleTerminates` — cycle termination
  - `TestLoader_NonDiscoveryOnlyStillSkipsComponents` — pre-existing behavior fence
  - `TestOrchestrator_ChangedOnlyKeepsSubstituteFromProducer` — e2e reproducer

🤖 Generated with [Claude Code](https://claude.com/claude-code)