### PR TITLE
fix: idempotency bugs + Go 1.22-1.26 modernization + lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,10 +7,13 @@ linters:
   default: standard
   enable:
     - gosec
+    - intrange
     - misspell
+    - modernize
     - revive
     - unconvert
     - unparam
+    - usestdlibvars
   exclusions:
     rules:
       - path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,3 +20,11 @@ linters:
         linters:
           - errcheck
           - unparam
+      # SA5011 trips on `if x == nil { t.Fatal(...) }` followed by
+      # `x.Field`. testing.T.Fatal* calls runtime.Goexit, so the
+      # deref is unreachable — but the staticcheck build bundled in
+      # some golangci-lint platform binaries doesn't recognize it as
+      # terminating. Suppress for test files where this idiom is
+      # canonical.
+      - path: _test\.go
+        text: "SA5011"

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -497,7 +497,10 @@ func (f *Filter) resolve(objs ObjectLister) {
 		}
 	}
 
-	for head := 0; head < len(queue); head++ {
+	// NOTE: queue grows inside the loop via enqueuePrimary/enqueueAncestor.
+	// Re-evaluate len(queue) each iteration; do NOT convert to `range queue`
+	// (intrange linter must not auto-fix this — see //nolint above).
+	for head := 0; head < len(queue); head++ { //nolint:intrange // queue grows during iteration
 		_, headPrimary := primary[queue[head]]
 		for _, d := range transitiveDeps(objs, queue[head]) {
 			if headPrimary {

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -56,6 +56,14 @@ type Controller struct {
 	coal    *task.Coalescer[manifest.NamedResource]
 	filter  *change.Filter
 
+	// closed is set by Close so any later AddListener short-circuits
+	// rather than appending into a slice nobody will drain. The flag
+	// is checked once on the fast path (no lock) and re-checked under
+	// unsubMu before the append so a Close racing AddListener cannot
+	// snapshot c.unsub and miss a registration landing just after.
+	// Matches the started lifecycle-gate pattern above.
+	closed atomic.Bool
+
 	// unsubMu guards unsub so AddListener and Close can be called
 	// concurrently (e.g. shutdown racing a listener-triggered Submit).
 	// The slice is short-lived (registered at Start, drained at Close)
@@ -187,19 +195,42 @@ func (c *Controller) StartLifecycle(kindLabel string) {
 // AddListener registers a store listener and records it so Close can
 // unsubscribe. snapshot=true matches every concrete controller's needs
 // (deliver the current store state on subscribe). Safe to call
-// concurrently with Close.
+// concurrently with Close — once Close has flipped the closed gate,
+// any in-flight or later AddListener is refused and the registration
+// is rolled back so the underlying store does not retain a listener
+// the controller will never unsubscribe.
 func (c *Controller) AddListener(event store.EventKind, l store.Listener) {
+	// Fast path: avoid the store registration entirely when Close has
+	// already started. The post-lock re-check below catches the TOCTOU
+	// window where Close flips closed between this load and the lock.
+	if c.closed.Load() {
+		return
+	}
 	u := c.Store.AddListener(event, l, true)
 	c.unsubMu.Lock()
+	if c.closed.Load() {
+		// Close set the flag and drained c.unsub between our fast-path
+		// check and the lock — releasing the store registration here
+		// matches what Close would have done with our entry.
+		c.unsubMu.Unlock()
+		u()
+		return
+	}
 	c.unsub = append(c.unsub, u)
 	c.unsubMu.Unlock()
 }
 
-// Close removes every registered listener. Idempotent. Safe to call
-// concurrently with AddListener — though typical use registers all
-// listeners during Start and never adds more.
+// Close removes every registered listener and refuses any later
+// AddListener so a late call from a shutdown-racing goroutine cannot
+// leak a registration past us. Idempotent: a second Close is a no-op
+// because the closed flag is set via Swap.
 func (c *Controller) Close() {
 	c.unsubMu.Lock()
+	if c.closed.Swap(true) {
+		// Another Close already drained and marked us closed.
+		c.unsubMu.Unlock()
+		return
+	}
 	unsubs := c.unsub
 	c.unsub = nil
 	c.unsubMu.Unlock()

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -148,5 +150,130 @@ func TestRunWithStatus_PreservesExternalFailure(t *testing.T) {
 	}
 	if got.Message != "dependency cycle detected" {
 		t.Errorf("external failure message was clobbered: %q", got.Message)
+	}
+}
+
+// TestController_CloseDrainsConcurrentAddListener exercises the
+// Close-vs-AddListener race. Many goroutines register listeners while
+// a single goroutine runs Close. The contract is that exactly ONE
+// Close call must leave no listener registered against the store —
+// either Close drained the listener directly OR the closed flag
+// caused AddListener to refuse / roll back. A listener that registers
+// AFTER Close's snapshot but BEFORE Close releases the unsubMu lock
+// must NOT leak.
+//
+// We verify by firing EventObjectAdded AFTER Close returns and
+// counting handler invocations; we deliberately do NOT call Close
+// twice (a second Close would mask the leak by draining the slice
+// that grew between the first Close's snapshot and its lock release).
+// Run under -race over many iterations to catch the snapshot-after-
+// append window that the closed flag closes.
+func TestController_CloseDrainsConcurrentAddListener(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 256
+
+	for iter := range 100 {
+		s := store.New()
+		c := base.New(s, nil)
+
+		var fired atomic.Int64
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		closeDone := make(chan struct{})
+
+		for range goroutines {
+			wg.Go(func() {
+				<-start
+				c.AddListener(store.EventObjectAdded, func(manifest.NamedResource, any) {
+					fired.Add(1)
+				})
+			})
+		}
+
+		// Release goroutines and run a single Close concurrently. Wait
+		// for both the Close and every AddListener to finish before
+		// firing the post-close event — that way the test asks "after
+		// the dust settles, has Close drained everything that managed
+		// to register?". A pre-fix run that snapshotted before an
+		// AddListener landed leaves that listener registered, and the
+		// post-close event will fire it.
+		close(start)
+		go func() {
+			c.Close()
+			close(closeDone)
+		}()
+		wg.Wait()
+		<-closeDone
+
+		// Snapshot-replay during AddListener may have fired the handler
+		// at registration time. Only NEW events after Close matter for
+		// the leak check.
+		fired.Store(0)
+
+		hr := &manifest.HelmRelease{Name: "post-close", Namespace: "ns"}
+		s.AddObject(hr)
+
+		if got := fired.Load(); got != 0 {
+			t.Fatalf("iter %d: %d listeners still active after Close — leak", iter, got)
+		}
+	}
+}
+
+// TestController_AddListenerAfterCloseIsNoOp pins the post-Close
+// refusal: a fresh AddListener once Close has returned must register
+// nothing in the underlying store.
+func TestController_AddListenerAfterCloseIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	s := store.New()
+	c := base.New(s, nil)
+
+	c.Close()
+
+	var fired atomic.Int64
+	c.AddListener(store.EventObjectAdded, func(manifest.NamedResource, any) {
+		fired.Add(1)
+	})
+
+	// Fire an event. The refused listener must not run.
+	hr := &manifest.HelmRelease{Name: "after-close", Namespace: "ns"}
+	s.AddObject(hr)
+
+	if got := fired.Load(); got != 0 {
+		t.Fatalf("AddListener after Close fired %d times; want 0 (registration must be refused)", got)
+	}
+}
+
+// TestController_DoubleCloseIsSafe pins the Swap-based double-Close
+// idempotency: a second Close must not re-iterate an already-drained
+// slice (which would call each unsub twice) and must not panic.
+func TestController_DoubleCloseIsSafe(t *testing.T) {
+	t.Parallel()
+
+	s := store.New()
+	c := base.New(s, nil)
+
+	var fired atomic.Int64
+	c.AddListener(store.EventObjectAdded, func(manifest.NamedResource, any) {
+		fired.Add(1)
+	})
+
+	// First Close drains the registered listener.
+	c.Close()
+	// Second Close must be a no-op — Swap-on-closed returns true so
+	// the drain loop is skipped entirely. If the slice were re-iterated
+	// after c.unsub = nil, this would be a benign nil-range; the real
+	// regression we are guarding against is a future refactor that
+	// captures the slice outside the Swap branch and double-fires.
+	c.Close()
+
+	// Fire an event to confirm the listener was unsubscribed exactly
+	// once (the post-Close store has no listener and won't fire).
+	hr := &manifest.HelmRelease{Name: "double-close", Namespace: "ns"}
+	s.AddObject(hr)
+
+	if got := fired.Load(); got != 0 {
+		t.Fatalf("listener fired %d times after double Close; want 0", got)
 	}
 }

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -215,8 +215,8 @@ func warnIfMultipleBootstrapAliases(aliased []manifest.NamedResource, repoRoot s
 		return
 	}
 	names := make([]string, len(aliased))
-	for i := range len(aliased) {
-		names[i] = aliased[i].String()
+	for i, a := range aliased {
+		names[i] = a.String()
 	}
 	slog.Warn("discovery: aliased multiple bootstrap sources to the working tree; cross-repo refs render against the wrong tree",
 		"count", len(aliased), "ids", names, "localPath", repoRoot)

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -160,6 +160,10 @@ func (c *diskRenderCache) Put(key string, payload []byte) {
 	// syncDir=false: a render cache miss is cheap to re-derive on the
 	// next invocation, so we trade durability for write throughput.
 	// Mirrors atomic.WriteFile's documented "high-churn cache" mode.
+	//
+	// atomic.WriteFile removes its staged tmpfile on any error path
+	// (see pkg/source/atomic/file.go's committed-bool defer guard),
+	// so a failed Put can't leak partial state into the cache root.
 	if err := atomic.WriteFile(p, buf.Bytes(), 0o600, false); err != nil {
 		slog.Debug("helm render cache: write", "path", p, "err", err)
 		return

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"bytes"
+	"cmp"
 	"compress/gzip"
 	"errors"
 	"io"
@@ -9,7 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"sync"
 	atomicflag "sync/atomic"
 	"time"
@@ -248,11 +249,11 @@ func (c *diskRenderCache) sweep() {
 	// against ties (sort by mtime then path) so two test entries
 	// written within the same nanosecond don't evict in
 	// platform-dependent order.
-	sort.Slice(entries, func(i, j int) bool {
-		if entries[i].mtime != entries[j].mtime {
-			return entries[i].mtime < entries[j].mtime
+	slices.SortFunc(entries, func(a, b entry) int {
+		if c := cmp.Compare(a.mtime, b.mtime); c != 0 {
+			return c
 		}
-		return entries[i].path < entries[j].path
+		return cmp.Compare(a.path, b.path)
 	})
 
 	for _, e := range entries {

--- a/pkg/helm/template_cache_test.go
+++ b/pkg/helm/template_cache_test.go
@@ -179,15 +179,13 @@ func TestTemplateCache_ConcurrentSafety(t *testing.T) {
 	c := newTemplateCache(64 << 10, nil)
 	var wg sync.WaitGroup
 	for i := range 32 {
-		wg.Add(1)
-		go func(seed int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range 200 {
-				key := string(rune('a' + (seed+j)%26))
+				key := string(rune('a' + (i+j)%26))
 				c.Put(key, strings.Repeat(key, 8))
 				_, _ = c.Get(key)
 			}
-		}(i)
+		})
 	}
 	wg.Wait()
 	// Size should never exceed the limit even under contention.

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -663,8 +663,8 @@ func sweepStageBySize(root string, maxBytes int64) error {
 		return nil
 	}
 	// Oldest first; evict until under cap.
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].mtime.Before(entries[j].mtime)
+	slices.SortFunc(entries, func(a, b stageEntry) int {
+		return a.mtime.Compare(b.mtime)
 	})
 	for _, e := range entries {
 		if total <= maxBytes {

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -354,6 +354,18 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 		return "", fmt.Errorf("stage parent: %w", err)
 	}
 
+	// Clear any partial stage left over from a crash window between
+	// rename and sentinel-write: the final dir exists but carries no
+	// sentinel. The rebuild rename below would otherwise hit
+	// ENOTEMPTY/EEXIST. Removing here is safe — the sentinel check
+	// above ran under fpLocks so we're not racing an in-process peer,
+	// and a cross-process peer that lands a complete tree+sentinel
+	// after our recheck would be observed below via the rename's
+	// adoption branch.
+	if _, err := os.Stat(dir); err == nil {
+		_ = os.RemoveAll(dir)
+	}
+
 	// Stage into a sibling tempdir + atomic rename so concurrent
 	// readers never observe a partial tree.
 	staging, err := os.MkdirTemp(filepath.Dir(dir), filepath.Base(dir)+".tmp.*")
@@ -364,13 +376,14 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 		_ = os.RemoveAll(staging)
 		return "", err
 	}
-	// Write the sentinel BEFORE rename so readers that observe the
-	// final dir always see a sentinel. The sentinel is empty; its
-	// presence alone is the signal.
-	if err := atomicfile.WriteFile(filepath.Join(staging, stageCompleteSentinel), nil, 0o600, false); err != nil {
-		_ = os.RemoveAll(staging)
-		return "", fmt.Errorf("stage sentinel: %w", err)
-	}
+	// Rename FIRST, sentinel AFTER. If we wrote the sentinel into the
+	// tmp dir and then crashed (or the rename failed mid-flight on a
+	// filesystem that doesn't truly fulfill POSIX atomicity), a
+	// subsequent reader could observe an incomplete tree with a
+	// sentinel inside it and skip the rebuild. By renaming the
+	// sentinel-free tree first and writing the sentinel into the
+	// renamed dir, any crash window leaves the dir without a sentinel,
+	// which the read path correctly treats as "not complete, rebuild."
 	if err := os.Rename(staging, dir); err != nil {
 		_ = os.RemoveAll(staging)
 		// A racing peer process beat us to it. Adopt the winner —
@@ -381,6 +394,18 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 			return dir, nil
 		}
 		return "", fmt.Errorf("stage finalize: %w", err)
+	}
+	// Sentinel is empty; its presence alone is the signal. Use
+	// atomic.WriteFile so a crash during this write doesn't leave a
+	// partially-named or zero-length sentinel that confuses a later
+	// reader — either the sentinel is fully present or it isn't.
+	if err := atomicfile.WriteFile(sentinel, nil, 0o600, false); err != nil {
+		// The tree is intact at dir; we just couldn't write the
+		// sentinel. Leave the tree in place — the next Stage call
+		// observes the sentinel-free dir and rebuilds via the
+		// partial-stage-clear path above. Returning an error here
+		// surfaces the underlying problem to the caller.
+		return "", fmt.Errorf("stage sentinel: %w", err)
 	}
 	c.cacheStagePromise(fingerprint, dir)
 	c.maybeKickSweep()

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -705,12 +705,12 @@ func BenchmarkStagingCache_PersistentRerun(b *testing.B) {
 	src := b.TempDir()
 	// Synthesize 200 small files under a handful of subdirs so the
 	// copyTree pass has measurable depth + breadth.
-	for d := 0; d < 10; d++ {
+	for d := range 10 {
 		dir := filepath.Join(src, fmt.Sprintf("d%02d", d))
 		if err := os.MkdirAll(dir, 0o750); err != nil {
 			b.Fatal(err)
 		}
-		for f := 0; f < 20; f++ {
+		for f := range 20 {
 			path := filepath.Join(dir, fmt.Sprintf("f%02d.yaml", f))
 			if err := os.WriteFile(path, []byte("kind: ConfigMap\n"), 0o600); err != nil {
 				b.Fatal(err)
@@ -731,8 +731,7 @@ func BenchmarkStagingCache_PersistentRerun(b *testing.B) {
 	}
 
 	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		if _, err := cache.Stage(context.Background(), src, fp); err != nil {
 			b.Fatalf("Stage: %v", err)
 		}

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -353,6 +353,118 @@ func TestStagingCache_PersistentSentinelWritten(t *testing.T) {
 	}
 }
 
+// TestStagingCache_PartialStageRebuildsOnNextRun pins the
+// post-rename-pre-sentinel crash recovery contract: if a process
+// renames the staging tree into place but crashes before writing the
+// .flate-stage-complete sentinel, the next Stage call for the same
+// fingerprint MUST rebuild (or otherwise re-emit the sentinel) rather
+// than adopt the incomplete tree.
+//
+// Pre-fix, the sentinel was written into the tmp dir BEFORE rename, so
+// any partial-rename or crash-after-sentinel-write would leave the
+// final dir with a sentinel inside it — making subsequent runs
+// short-circuit on a tree they couldn't trust. Post-fix, the sentinel
+// is only written after the rename succeeds, so a crash window leaves
+// the dir sentinel-free and the next Stage call rebuilds.
+func TestStagingCache_PartialStageRebuildsOnNextRun(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+
+	root := t.TempDir()
+	cache1, err := NewStagingCache(root, 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache 1: %v", err)
+	}
+
+	const fp = "deadbeef11111111000000000000000000000000000000000000000000000000"
+	staged, err := cache1.Stage(context.Background(), src, fp)
+	if err != nil {
+		t.Fatalf("Stage 1: %v", err)
+	}
+	sentinel := filepath.Join(staged, stageCompleteSentinel)
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("sentinel missing after initial Stage: %v", err)
+	}
+	if err := cache1.Close(); err != nil {
+		t.Fatalf("cache1.Close: %v", err)
+	}
+
+	// Simulate the post-rename-pre-sentinel crash window: the tree is
+	// fully renamed into the final slot, but the sentinel was never
+	// written (or was lost). A correct implementation must observe
+	// "no sentinel" and rebuild on the next Stage call.
+	if err := os.Remove(sentinel); err != nil {
+		t.Fatalf("simulate crash (remove sentinel): %v", err)
+	}
+
+	// Fresh cache instance — the in-process promise from cache1 is gone,
+	// so the reattempt has to take the on-disk path.
+	cache2, err := NewStagingCache(root, 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache 2: %v", err)
+	}
+	t.Cleanup(func() { _ = cache2.Close() })
+
+	staged2, err := cache2.Stage(context.Background(), src, fp)
+	if err != nil {
+		t.Fatalf("Stage 2 (after simulated crash): %v", err)
+	}
+	if staged2 != staged {
+		t.Errorf("Stage 2 landed at %q, want %q", staged2, staged)
+	}
+	// The sentinel MUST be present again — either rebuilt or rewritten.
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Errorf("sentinel not restored after rebuild: %v", err)
+	}
+	// And the tree contents survived.
+	if _, err := os.Stat(filepath.Join(staged2, "kustomization.yaml")); err != nil {
+		t.Errorf("kustomization.yaml missing after rebuild: %v", err)
+	}
+}
+
+// TestStagingCache_SentinelWrittenAfterRename is the regression fence
+// for the post-fix ordering: stage a fingerprint, then assert that the
+// final dir exists, contains the sentinel, and has no `.tmp.*`
+// siblings lingering in the prefix dir. Together with the partial-stage
+// recovery test above, this pins the rename-then-sentinel invariant.
+func TestStagingCache_SentinelWrittenAfterRename(t *testing.T) {
+	src := t.TempDir()
+	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+
+	root := t.TempDir()
+	cache, err := NewStagingCache(root, 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	const fp = "abcdef9876543210000000000000000000000000000000000000000000000000"
+	staged, err := cache.Stage(context.Background(), src, fp)
+	if err != nil {
+		t.Fatalf("Stage: %v", err)
+	}
+
+	// Final dir exists and carries the sentinel.
+	if _, err := os.Stat(staged); err != nil {
+		t.Fatalf("final dir missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(staged, stageCompleteSentinel)); err != nil {
+		t.Errorf("sentinel missing from final dir: %v", err)
+	}
+
+	// No `.tmp.*` siblings remain in the prefix shard.
+	prefixDir := filepath.Dir(staged)
+	entries, err := os.ReadDir(prefixDir)
+	if err != nil {
+		t.Fatalf("read prefix dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp.") {
+			t.Errorf("leftover staging tmpdir in prefix: %q", e.Name())
+		}
+	}
+}
+
 // TestStagingCache_PersistentSameFingerprintSkipsRebuild proves that
 // a second Stage call for the same fingerprint is a no-op: no
 // additional copyTree pass fires, and the existing sentinel mtime is

--- a/pkg/manifest/envsubst.go
+++ b/pkg/manifest/envsubst.go
@@ -35,7 +35,7 @@ func ResolveEnvsubstDefaults(s string) string {
 // maybeHasEnvsubst is a cheap precheck — most strings have no `${`
 // at all, and ReplaceAllString allocates even when nothing matches.
 func maybeHasEnvsubst(s string) bool {
-	for i := 0; i < len(s)-1; i++ {
+	for i := range len(s) - 1 {
 		if s[i] == '$' && s[i+1] == '{' {
 			return true
 		}

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -76,7 +76,7 @@ type ResourceSetInputProvider struct {
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 
 	fluxopv1.ResourceSetInputProviderSpec `json:",inline" yaml:",inline"`
-	Status                                fluxopv1.ResourceSetInputProviderStatus `json:"status,omitempty" yaml:"status,omitempty"`
+	Status                                fluxopv1.ResourceSetInputProviderStatus `json:"status,omitzero" yaml:"status,omitempty"`
 
 	Labels map[string]string `json:"-" yaml:"-"`
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -876,7 +876,6 @@ func (o *Orchestrator) prewarmGitMirrors(ctx context.Context) {
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(limit)
 	for _, repo := range repos {
-		repo := repo
 		g.Go(func() error {
 			if err := o.gitFetcher.Prewarm(gctx, repo); err != nil {
 				slog.Debug("git: mirror prewarm failed (source controller will retry)",

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -221,6 +221,19 @@ type Orchestrator struct {
 	// miss any source CR discovery already reconciled.
 	bootstrapped bool
 
+	// renderOnce serializes the Run + Result-collection phase so a
+	// second Render returns the cached Result/err pair instead of
+	// re-driving the controllers. The underlying controllers' Configure
+	// hooks panic if invoked after Start (the "reconcile-shaping config
+	// is frozen once dispatch begins" invariant), so a naive re-Run
+	// would panic even with Bootstrap idempotent. Caching at the Render
+	// boundary is the embed-friendly answer: embedders that retry
+	// Render get back the original artifacts without paying the
+	// controller-restart cost.
+	renderOnce   sync.Once
+	renderResult *Result
+	renderErr    error
+
 	// stopOnce guards Stop so a New+Bootstrap-then-abort caller's
 	// manual Stop and Run's deferred Stop don't double-close the
 	// staging cache / controller unsubs.
@@ -390,7 +403,20 @@ func (o *Orchestrator) Filter() *change.Filter { return o.filter }
 // existence-only sources Ready, and prepares the change filter.
 // Delegates the load / expand / alias phase to pkg/discovery; the
 // remainder is dependency validation + change-filter construction.
+//
+// Idempotent: a second call returns nil without re-running discovery.
+// Bootstrap mutates orchestrator state (sourceFiles, parentOf,
+// existence, depGraph, componentCache, filter); replaying it would
+// rebuild the change.Filter from scratch, dropping any OnAdd hook
+// already wired into the store's listener set. Centralizing the
+// guard here means Render, embedders, and test harnesses all get
+// the invariant for free. A partial-failure path that returns before
+// flipping bootstrapped=true leaves the orchestrator eligible for a
+// clean retry on the next call.
 func (o *Orchestrator) Bootstrap(ctx context.Context) error {
+	if o.bootstrapped {
+		return nil
+	}
 	res, err := discovery.Run(ctx, discovery.Config{
 		Path: o.cfg.Path, Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
 		ComponentCache: o.componentCache,
@@ -874,8 +900,33 @@ func (o *Orchestrator) prewarmGitMirrors(ctx context.Context) {
 // so the caller sees both the partial output and the failure list.
 // An error from Bootstrap (the load phase) is fatal and returns
 // (nil, err); errors from Run yield (result, err).
+//
+// On any returned error, render defers Stop so embedders that receive
+// (nil, err) — Bootstrap failure paths in particular — don't leak the
+// staging cache tempdir and helm client until process exit. Stop is
+// sync.Once-guarded so the deferred call composes safely with Run's
+// own deferred Stop and any explicit caller Stop.
+//
+// Idempotent: a second call returns the cached Result/err pair from
+// the first. The controllers' Configure hooks panic if invoked after
+// Start (reconcile-shaping config is frozen once dispatch begins), so
+// a re-Run would panic. Caching at this boundary lets embedders retry
+// Render without restarting controllers — pair with Bootstrap's same
+// guarantee guard above.
 func (o *Orchestrator) Render(ctx context.Context) (*Result, error) {
-	if err := o.Bootstrap(ctx); err != nil {
+	o.renderOnce.Do(func() {
+		o.renderResult, o.renderErr = o.render(ctx)
+	})
+	return o.renderResult, o.renderErr
+}
+
+func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
+	defer func() {
+		if err != nil {
+			o.Stop()
+		}
+	}()
+	if err = o.Bootstrap(ctx); err != nil {
 		return nil, err
 	}
 	runErr := o.Run(ctx)

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -920,3 +920,222 @@ spec:
 		t.Errorf("rendered %s missing after Run; producer reconcile did not materialize the substituteFrom CM", cmID)
 	}
 }
+
+// TestOrchestrator_BootstrapIsIdempotent locks the A.1 invariant:
+// Bootstrap mutates orchestrator state (sourceFiles, parentOf,
+// existence, depGraph, componentCache, filter). A second call must
+// be a no-op so any caller (Render, embedders, test harnesses) that
+// runs through Bootstrap twice doesn't replay discovery and double-
+// mutate those indexes.
+//
+// Probes via three signals that differ pre/post fix:
+//  1. Store object counts must not change. Discovery's AddObject is
+//     idempotent today but this is the hard fence against future
+//     accumulation logic.
+//  2. The change.Filter pointer must be stable. Pre-fix,
+//     buildChangeFilter ran twice and replaced o.filter with a brand-
+//     new instance — the second filter dropped any OnAdd hook the
+//     first pass wired into the store's listener set.
+//  3. o.bootstrapped must already be true before the second call,
+//     pinning the guard's read site.
+func TestOrchestrator_BootstrapIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	origDir := t.TempDir()
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello
+data: {k: v}
+`)
+	// Baseline with different content forces changed-only mode, which
+	// makes buildChangeFilter actually construct a filter we can pin
+	// across the two Bootstrap calls.
+	testutil.WriteFile(t, origDir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./other
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+
+	o, err := New(Config{Path: dir, PathOrig: origDir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(o.Stop)
+
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap (1st): %v", err)
+	}
+	if !o.bootstrapped {
+		t.Fatal("orchestrator.bootstrapped must be true after first Bootstrap")
+	}
+	ksCount1 := len(o.Store().ListObjects(manifest.KindKustomization))
+	cmCount1 := len(o.Store().ListObjects(manifest.KindConfigMap))
+	filter1 := o.Filter()
+	if filter1 == nil {
+		t.Fatal("expected non-nil change filter when PathOrig differs from Path")
+	}
+
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap (2nd): %v", err)
+	}
+	ksCount2 := len(o.Store().ListObjects(manifest.KindKustomization))
+	cmCount2 := len(o.Store().ListObjects(manifest.KindConfigMap))
+	filter2 := o.Filter()
+
+	if ksCount1 != ksCount2 {
+		t.Errorf("Kustomization count differs across Bootstrap calls: %d -> %d", ksCount1, ksCount2)
+	}
+	if cmCount1 != cmCount2 {
+		t.Errorf("ConfigMap count differs across Bootstrap calls: %d -> %d", cmCount1, cmCount2)
+	}
+	if filter1 != filter2 {
+		t.Errorf("change filter pointer must be stable across Bootstrap calls; "+
+			"got %p -> %p (pre-fix buildChangeFilter re-ran and constructed a fresh filter)",
+			filter1, filter2)
+	}
+	// Sentinel: the apps KS must be present after both passes — never
+	// duplicated, never dropped. The Store is keyed by NamedResource
+	// so a true duplicate would be a no-op; this check pins that the
+	// canonical id is reachable post second-Bootstrap.
+	appsID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	if got := o.Store().GetObject(appsID); got == nil {
+		t.Errorf("apps KS missing after second Bootstrap")
+	}
+}
+
+// TestOrchestrator_RenderCalledTwiceProducesIdenticalArtifacts pins
+// the embedder contract: a second Render on the same orchestrator
+// returns the same Result.Manifests. Render itself is sync.Once-
+// guarded since the controllers' Configure hooks panic if invoked
+// after Start; the cache returns the first call's Result/err pair.
+func TestOrchestrator_RenderCalledTwiceProducesIdenticalArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello
+data: {k: v}
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(o.Stop)
+
+	res1, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render (1st): %v", err)
+	}
+	res2, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render (2nd): %v", err)
+	}
+
+	if len(res1.Manifests) != len(res2.Manifests) {
+		t.Fatalf("Render.Manifests key count differs: %d -> %d", len(res1.Manifests), len(res2.Manifests))
+	}
+	for id, mans1 := range res1.Manifests {
+		mans2, ok := res2.Manifests[id]
+		if !ok {
+			t.Errorf("second Render dropped key %s", id)
+			continue
+		}
+		if len(mans1) != len(mans2) {
+			t.Errorf("Render.Manifests[%s] doc count differs: %d -> %d", id, len(mans1), len(mans2))
+			continue
+		}
+		for i := range mans1 {
+			k1, _ := mans1[i]["kind"].(string)
+			k2, _ := mans2[i]["kind"].(string)
+			md1, _ := mans1[i]["metadata"].(map[string]any)
+			md2, _ := mans2[i]["metadata"].(map[string]any)
+			n1, _ := md1["name"].(string)
+			n2, _ := md2["name"].(string)
+			if k1 != k2 || n1 != n2 {
+				t.Errorf("Render.Manifests[%s][%d] differs: (%s/%s) -> (%s/%s)",
+					id, i, k1, n1, k2, n2)
+			}
+		}
+	}
+	if len(res1.Failed) != len(res2.Failed) {
+		t.Errorf("Render.Failed count differs: %d -> %d", len(res1.Failed), len(res2.Failed))
+	}
+	if len(res1.Orphans) != len(res2.Orphans) {
+		t.Errorf("Render.Orphans count differs: %d -> %d", len(res1.Orphans), len(res2.Orphans))
+	}
+}
+
+// TestOrchestrator_RenderErrorPathStopsCleanly pins the A.5 invariant:
+// when Render returns (nil, err) the orchestrator's Stop has already
+// fired, so the staging cache + helm client + controller listeners
+// don't survive in memory until process exit.
+//
+// Detects the bug by probing o.stopOnce: if Render fired Stop, our
+// follow-up stopOnce.Do is a no-op (sync.Once already triggered).
+// Pre-fix the deferred Stop didn't exist, so the probe would still
+// run and flip `probeFired` to true — flagging the leak.
+func TestOrchestrator_RenderErrorPathStopsCleanly(t *testing.T) {
+	// Non-existent path forces Bootstrap -> discovery.Run -> os.Stat
+	// to fail, which is the canonical (nil, err) embed path.
+	o, err := New(Config{Path: "/nonexistent/orchestrator-render-cleanup", WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := o.Render(context.Background())
+	if err == nil {
+		t.Fatal("expected Render error for non-existent path")
+	}
+	if res != nil {
+		t.Errorf("Render returned non-nil Result on Bootstrap error: %+v", res)
+	}
+
+	// Probe: if Render's deferred Stop fired, stopOnce is already
+	// triggered and this Do is a no-op. Pre-fix the deferred Stop
+	// didn't exist, the orchestrator's staging cache + helm client
+	// would survive in memory, and probeFired would flip true.
+	probeFired := false
+	o.stopOnce.Do(func() { probeFired = true })
+	if probeFired {
+		t.Fatal("Render error path did not fire Stop; staging cache + helm client leaked")
+	}
+
+	// And a separate Stop call must still be a true no-op — the
+	// sync.Once guard composes safely with the deferred Stop above
+	// and any explicit caller Stop. No panic from double-Close.
+	o.Stop()
+}

--- a/pkg/source/ignore.go
+++ b/pkg/source/ignore.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/fluxcd/pkg/sourceignore"
@@ -125,12 +126,12 @@ func pruneEmptyDirs(root string) error {
 		return fmt.Errorf("sourceignore prune walk: %w", err)
 	}
 	// Bottom-up by path length: deepest first.
-	for i := len(dirs) - 1; i >= 0; i-- {
-		entries, err := os.ReadDir(dirs[i])
+	for _, v := range slices.Backward(dirs) {
+		entries, err := os.ReadDir(v)
 		if err != nil || len(entries) > 0 {
 			continue
 		}
-		_ = os.Remove(dirs[i])
+		_ = os.Remove(v)
 	}
 	return nil
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -900,7 +900,6 @@ func TestStore_ListenerSnapshotPool_NoLostEvents(t *testing.T) {
 
 	counts := make([]atomic.Int64, numListeners)
 	for i := range numListeners {
-		i := i
 		s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) {
 			counts[i].Add(1)
 		}, false)
@@ -1017,9 +1016,7 @@ func TestStore_ShardedConcurrentDifferentKinds(t *testing.T) {
 
 	// 4 goroutines on Kustomizations, 4 on HelmReleases.
 	for w := range workers {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
+		wg.Go(func() {
 			isKS := w%2 == 0
 			for i := range N {
 				if isKS {
@@ -1034,7 +1031,7 @@ func TestStore_ShardedConcurrentDifferentKinds(t *testing.T) {
 					_ = s.GetObject(hr.Named())
 				}
 			}
-		}(w)
+		})
 	}
 	wg.Wait()
 
@@ -1070,9 +1067,7 @@ func TestStore_CrossKindOperationDoesntDeadlock(t *testing.T) {
 	done := make(chan struct{})
 	var wg sync.WaitGroup
 	for w := range goroutines {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range ops {
 				switch (w + i) % 5 {
 				case 0:
@@ -1092,7 +1087,7 @@ func TestStore_CrossKindOperationDoesntDeadlock(t *testing.T) {
 					s.SetArtifact(hr.Named(), &HelmReleaseArtifact{Manifests: nil, Fingerprint: "x"})
 				}
 			}
-		}(w)
+		})
 	}
 	go func() { wg.Wait(); close(done) }()
 	select {

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -437,10 +437,9 @@ func TestReplaceValueAtPath_TypeCoercion(t *testing.T) {
 func walkPath(t *testing.T, m map[string]any, path string) any {
 	t.Helper()
 	cur := any(m)
-	parts := strings.Split(path, ".")
-	for _, p := range parts {
-		if idx := strings.IndexByte(p, '['); idx >= 0 {
-			key := p[:idx]
+	parts := strings.SplitSeq(path, ".")
+	for p := range parts {
+		if key, _, ok := strings.Cut(p, "["); ok {
 			if cm, ok := cur.(map[string]any); ok {
 				cur = cm[key]
 			}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -555,7 +555,7 @@ func TestE2E_SubstituteDisabledAnnotation(t *testing.T) {
 
 func mustExtractLine(t *testing.T, haystack, needle string) string {
 	t.Helper()
-	for _, line := range strings.Split(haystack, "\n") {
+	for line := range strings.SplitSeq(haystack, "\n") {
 		if strings.Contains(line, needle) && (strings.Contains(line, "PASSED") || strings.Contains(line, "FAILED")) {
 			return line
 		}


### PR DESCRIPTION
## Summary

Three latent idempotency bugs found by an audit after PR #488, plus modernization linter enablement and the tactical cleanups it surfaced.

### Phase A — Latent bug fixes

- **`8d4c74c` Orchestrator Bootstrap idempotency + Render Stop-on-error** — `Bootstrap` now returns nil early when `o.bootstrapped`. `Render` was split into a public `sync.Once`-guarded wrapper and a private body that defers `Stop()` on error. Embedders calling `Render` twice now get identical artifacts; embedders that hit a Bootstrap or Run error no longer leak the staging cache + helm client.

- **`415bcae` Controller.Close vs concurrent AddListener** — `Close` would snapshot `c.unsub`, drop the lock, then iterate; a concurrent `AddListener` could append after the snapshot, leaking a listener. Added an `atomic.Bool closed` flag mirroring the existing `started` lifecycle gate. `AddListener` fast-checks `closed` before the store registration and re-checks under `unsubMu`. `Close` uses `Swap(true)` so double-Close is a no-op.

- **`193adc2` Stage cache sentinel ordering** — `pkg/kustomize/stage.go` wrote `.flate-stage-complete` into the `.tmp` dir BEFORE rename-to-final. A crash mid-rename could leave the sentinel adjacent to a partial tree. Inverted: rename first, then write the sentinel into the renamed dir. Recovery path explicitly cleans up sentinel-less leftover dirs under `fpLocks` before retrying. Also documented the `atomic.WriteFile` cleanup-on-error contract at the helm disk render cache call site (no fix needed there — it's already correct).

### Phase B — Lint config + auto-modernization

- **`ff88f69` Enable Go 1.22-1.26 modernization linters** in `.golangci.yml`: `modernize` (umbrella covering `bloop`, `stringscut`, `stringsseq`, `forvar`, `slicesbackward`, `omitzero`), `intrange`, `usestdlibvars`.

- **`fce8688` Apply `golangci-lint run --fix` and hand-fixes**:
  - 4 `for i := 0; i < N; i++` → `for range N` / `for i := range N`
  - 2 `forvar` redundant-shadow drops (Go 1.22 per-iteration scope)
  - 2 `range strings.Split` → `range strings.SplitSeq`
  - 1 `strings.IndexByte`+slice → `strings.Cut`
  - 1 `range slices.Reversed(...)` (Go 1.23 `slicesbackward`)
  - 1 `json:"...,omitempty"` → `omitzero` on a non-pointer struct field
  - 1 `for range b.N` → `for b.Loop()` in a Phase 3.4b bench
  - 2 `sort.Slice` → `slices.SortFunc` (one with `cmp.Compare` for two-key)
  - 3 `wg.Add(1); go func() { defer wg.Done() }()` → `wg.Go()` (Go 1.25)

One auto-fix reverted: `intrange` proposed `for head := range queue` in `pkg/change/filter.go`'s BFS where the body appends to `queue` (snapshot semantics would terminate too early). Marked `//nolint:intrange` with explanation; caught by the existing chained-producer tests.

### Phase C — Cleanliness nits

- `pkg/source/cache.go` receiver drift didn't exist (the explore agent's flag was a false alarm — `m` was for `pkg/source/git/mirror`, a different package).
- `filter.resolve` closure extraction skipped — closures capture three local maps that exist purely for BFS scope; lifting to struct fields would pollute `Filter` with resolve-only state.

## Validation

- `mise run vet`, `mise run lint`, `mise run test` — all clean.
- `go test -race ./pkg/orchestrator ./pkg/controllers/base ./pkg/kustomize ./pkg/helm -count=1` — clean.
- All three idempotency-fix tests were verified to **fail on pre-fix state** (via `git stash` round-trip), then pass after.
- E2E smoke against `buroa/k8s-gitops`: cold 3.21s, warm 0.65s, output byte-identical to PR #488 baseline. No perf regression.

## Stacked commits

```
fce8688 chore: apply golangci-lint --fix and cleanup nits
ff88f69 chore(lint): enable Go 1.22-1.26 modernization linters
415bcae fix(controllers/base): refuse AddListener after Close starts
193adc2 fix(kustomize,helm): write stage sentinel after rename; document cache cleanup
8d4c74c perf(orchestrator): guard Bootstrap re-entry and Stop on Render error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)