### PR TITLE
feat(cli): expose --cache-dir on build/diff/test/get

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -82,6 +82,11 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, yaml, json, name")
 	fs.BoolVar(&f.enableOCI, "enable-oci", true, "reconcile OCIRepository objects")
 	fs.StringVar(&f.registryConfig, "registry-config", "", "docker config.json for OCI authentication")
+	fs.StringVar(&f.cacheDir, "cache-dir", "",
+		"on-disk cache root for source artifacts, helm charts, kustomize stages, "+
+			"and persistent render output. Defaults to $XDG_CACHE_HOME/flate "+
+			"(Linux), ~/Library/Caches/flate (macOS), %LocalAppData%/flate "+
+			"(Windows), falling back to $TMPDIR/flate-cache if those error.")
 	fs.IntVar(&f.concurrency, "concurrency", runtime.NumCPU()*4,
 		"max parallel reconcile bodies (0 = unbounded)")
 	fs.StringVar(&f.profileMode, "profile", "",

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -3,8 +3,12 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
 
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/change"
@@ -12,6 +16,63 @@ import (
 	"github.com/home-operations/flate/pkg/orchestrator"
 	"github.com/home-operations/flate/pkg/store"
 )
+
+// TestBindCommon_CacheDirFlag pins that --cache-dir is wired on every
+// commonFlags subcommand and ends up on commonFlags.cacheDir for the
+// downstream buildOrchCfg → orchestrator.Config.CacheDir handoff.
+func TestBindCommon_CacheDirFlag(t *testing.T) {
+	var f commonFlags
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	bindCommon(fs, &f)
+	if err := fs.Parse([]string{"--cache-dir", "/tmp/explicit"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if f.cacheDir != "/tmp/explicit" {
+		t.Errorf("cacheDir = %q, want /tmp/explicit", f.cacheDir)
+	}
+}
+
+// TestCacheDir_FlagAndEnvPopulateRoot runs build all twice — once via
+// --cache-dir and once via FLATE_CACHE_DIR — against fresh tempdirs
+// and asserts each one ends up non-empty. The kustomize stage cache
+// writes into <cacheDir>/stage even for the inline-ConfigMap fixture,
+// so a successful build populates the dir if the flag flowed through
+// to orchestrator.Config.CacheDir.
+func TestCacheDir_FlagAndEnvPopulateRoot(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		via  func(t *testing.T, root string) []string
+	}{
+		{
+			name: "flag",
+			via:  func(_ *testing.T, root string) []string { return []string{"--cache-dir", root} },
+		},
+		{
+			name: "env",
+			via: func(t *testing.T, root string) []string {
+				t.Setenv("FLATE_CACHE_DIR", root)
+				return nil
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeFixture(t)
+			cacheRoot := filepath.Join(t.TempDir(), "cache")
+			args := append([]string{"build", "all", "--path", path}, tc.via(t, cacheRoot)...)
+			_, stderr, code := runCLI(t, args...)
+			if code != 0 {
+				t.Fatalf("build all (%s) exited %d: %s", tc.name, code, stderr)
+			}
+			entries, err := os.ReadDir(cacheRoot)
+			if err != nil {
+				t.Fatalf("read cache root %q: %v", cacheRoot, err)
+			}
+			if len(entries) == 0 {
+				t.Errorf("cache root %q is empty after build — --cache-dir / FLATE_CACHE_DIR did not flow through", cacheRoot)
+			}
+		})
+	}
+}
 
 func TestScopedNamespaces_ExplicitNamespaceWins(t *testing.T) {
 	c := &commonFlags{namespace: "media"}

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -142,6 +142,7 @@ func TestEnv_HelpAdvertisesEnvVars(t *testing.T) {
 		"[env: FLATE_SKIP_CRDS]",
 		"[env: FLATE_SKIP_KINDS]",
 		"[env: FLATE_CONCURRENCY]",
+		"[env: FLATE_CACHE_DIR]",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("--help missing %q\n%s", want, stdout)


### PR DESCRIPTION
## Summary

`--cache-dir` was already available on `flate cache clear-render` and `flate cache gc`, but the main subcommands (`build`, `diff`, `test`, `get`) rejected it as an unknown flag. The plumbing was already there — `commonFlags.cacheDir`, `resolveCacheRoot`, and the `buildOrchCfg → orchestrator.Config.CacheDir` handoff — the only missing piece was the `fs.StringVar` binding inside `bindCommon`.

Adds one flag binding + tests pinning that (1) the flag is recognized on `commonFlags` subcommands, (2) `FLATE_CACHE_DIR` env var is auto-derived by `applyEnvVars`, and (3) the value actually flows through end-to-end (a fresh cache dir gets populated by a `build all` run).

Usage:

```
flate build all --cache-dir=/tmp/explicit ...
FLATE_CACHE_DIR=/tmp/env flate build all ...
```

Defaults are unchanged: `$XDG_CACHE_HOME/flate` (Linux), `~/Library/Caches/flate` (macOS), `%LocalAppData%/flate` (Windows), falling back to `$TMPDIR/flate-cache` if those error.

## Test plan

- [x] `mise run vet` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — full suite green
- [x] `flate build all --help | grep cache-dir` — shows the flag with `[env: FLATE_CACHE_DIR]`
- [x] New tests:
  - `TestBindCommon_CacheDirFlag` — flag parses to `commonFlags.cacheDir`
  - `TestCacheDir_FlagAndEnvPopulateRoot` — runs `build all` via `--cache-dir` and `FLATE_CACHE_DIR`, asserts each fresh tempdir gets populated
  - `TestEnv_HelpAdvertisesEnvVars` — now also pins `[env: FLATE_CACHE_DIR]` in `build all --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)