### PR TITLE
feat: --output markdown for build, diff, test, get

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -58,7 +58,7 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 			applyBuildFlags(c, b)
 			// build only emits manifest streams; reject -o values that
 			// don't make sense (e.g. name, which is a get-only concept).
-			if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+			if err := c.requireOutput(format.OutputYAML, format.OutputJSON, format.OutputMarkdown); err != nil {
 				return err
 			}
 			stopProfile, err := startProfile(c.profileMode, c.profileOut)
@@ -170,12 +170,15 @@ func collectRendered(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 }
 
 // emitDocs writes a sequence of rendered docs as either multi-doc YAML
-// (the default for `flate build`) or a single JSON array. Other -o
-// values are rejected earlier by requireOutput.
+// (the default for `flate build`), a single JSON array, or a
+// GitHub-flavored Markdown stream (H3 header + fenced YAML per doc).
+// Other -o values are rejected earlier by requireOutput.
 func emitDocs(w io.Writer, docs []map[string]any, out format.Output) error {
 	switch out {
 	case format.OutputJSON:
 		return format.JSON(w, docs)
+	case format.OutputMarkdown:
+		return format.MarkdownDocs(w, docs)
 	default:
 		return format.YAMLMulti(w, docs)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -565,6 +565,103 @@ func TestRun_DiffImages_RespectsNamespaceFailures(t *testing.T) {
 	}
 }
 
+// TestBuild_OutputMarkdown pins the build → markdown shape: every
+// rendered doc lands under an `### <kind>/...` heading wrapping a
+// fenced YAML block (the Layer A MarkdownDocs contract).
+func TestBuild_OutputMarkdown(t *testing.T) {
+	path := writeFixture(t)
+	stdout, stderr, code := runCLI(t, "build", "all", "-o", "markdown", "--path", path)
+	if code != 0 {
+		t.Fatalf("build all -o markdown exited %d: %s", code, stderr)
+	}
+	for _, want := range []string{"```yaml", "### "} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("missing %q in markdown output:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestGet_OutputMarkdown pins the get → markdown shape: a GFM pipe
+// table with the standard header/separator/data rows the format
+// package emits.
+func TestGet_OutputMarkdown(t *testing.T) {
+	path := writeFixture(t)
+	stdout, stderr, code := runCLI(t, "get", "ks", "-o", "markdown", "--path", path)
+	if code != 0 {
+		t.Fatalf("get ks -o markdown exited %d: %s", code, stderr)
+	}
+	for _, want := range []string{"| ", "| --- "} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("missing %q in markdown table:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestGetAll_OutputMarkdown covers the cluster-summary path:
+// `## Cluster summary` heading + a two-row pipe table.
+func TestGetAll_OutputMarkdown(t *testing.T) {
+	path := writeFixture(t)
+	stdout, stderr, code := runCLI(t, "get", "all", "-o", "markdown", "--path", path)
+	if code != 0 {
+		t.Fatalf("get all -o markdown exited %d: %s", code, stderr)
+	}
+	for _, want := range []string{"## Cluster summary", "Kustomizations", "HelmReleases", "| --- "} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("missing %q in cluster summary markdown:\n%s", want, stdout)
+		}
+	}
+}
+
+// TestTest_OutputMarkdown pins the test → markdown shape: the
+// pipe-table summary header that testrunner.Report.WriteMarkdown
+// emits, plus the per-outcome H2 section for the only outcome the
+// fixture can produce (Passed).
+func TestTest_OutputMarkdown(t *testing.T) {
+	path := writeFixture(t)
+	stdout, stderr, code := runCLI(t, "test", "ks", "-o", "markdown", "--path", path)
+	if code != 0 {
+		t.Fatalf("test ks -o markdown exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "| Passed | Skipped | Failed | Matched |") {
+		t.Errorf("missing summary header:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "## Passed") &&
+		!strings.Contains(stdout, "## Skipped") &&
+		!strings.Contains(stdout, "## Failed") {
+		t.Errorf("missing at least one outcome section:\n%s", stdout)
+	}
+}
+
+// TestDiff_OutputMarkdown drives a non-trivial diff (baseline tree
+// has a ConfigMap with different data than current) and asserts the
+// Layer B markdown render: the `# Diff` heading, an `### <header>`
+// per resource, and the ```diff fence wrapping the dyff body.
+func TestDiff_OutputMarkdown(t *testing.T) {
+	current := writeFixture(t)
+	orig := t.TempDir()
+	copyTree(t, current, filepath.Join(orig, "kubernetes"))
+	// Mutate the baseline ConfigMap so the diff renders a non-empty
+	// hunk. Without the delta `diff.Render` returns the empty-set
+	// "_No changes._" body and the ```diff fence assertion misses.
+	mustWrite(t, filepath.Join(orig, "kubernetes", "apps", "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: apps}
+data:
+  greeting: hola
+`)
+	stdout, stderr, code := runCLI(t, "diff", "ks", "-o", "markdown",
+		"--path", current, "--path-orig", filepath.Join(orig, "kubernetes"))
+	if code != 0 {
+		t.Fatalf("diff ks -o markdown exited %d: %s", code, stderr)
+	}
+	for _, want := range []string{"# Diff", "### ", "```diff"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("missing %q in diff markdown:\n%s", want, stdout)
+		}
+	}
+}
+
 func copyTree(t *testing.T, src, dst string) {
 	t.Helper()
 	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -79,7 +79,7 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags) {
 			"that only materialize in the live cluster. "+
 			"Verify/cert/proxy secretRefs still fail loud.")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")
-	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, yaml, json, name")
+	fs.StringVarP(&f.output, "output", "o", "table", "output format: table, yaml, json, name, markdown")
 	fs.BoolVar(&f.enableOCI, "enable-oci", true, "reconcile OCIRepository objects")
 	fs.StringVar(&f.registryConfig, "registry-config", "", "docker config.json for OCI authentication")
 	fs.StringVar(&f.cacheDir, "cache-dir", "",

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -157,10 +157,12 @@ func imageSetDiff(orig, current map[string]struct{}, includeRemoved bool) []stri
 }
 
 func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kind, name string) error {
-	// diff has no `name` output mode; only diff/yaml/json are
+	// diff has no `name` output mode; only diff/yaml/json/markdown are
 	// meaningful. Reject early so the user sees a clear error instead
-	// of "unknown diff format" from pkg/diff.
-	if err := c.requireOutput(format.Output(diff.FormatDiff), format.OutputYAML, format.OutputJSON); err != nil {
+	// of "unknown diff format" from pkg/diff. OutputMarkdown's string
+	// value matches diff.FormatMarkdown so the cast below routes it to
+	// the markdown renderer without an extra switch.
+	if err := c.requireOutput(format.Output(diff.FormatDiff), format.OutputYAML, format.OutputJSON, format.OutputMarkdown); err != nil {
 		return err
 	}
 	stopProfile, err := startProfile(c.profileMode, c.profileOut)

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -156,6 +156,22 @@ func TestEnv_HelpAdvertisesEnvVars(t *testing.T) {
 			t.Errorf("--help should not advertise %q — env binding is skipped for it", banned)
 		}
 	}
+	// The `-o`/`--output` flag's description line must mention
+	// markdown so users discover the format alongside the existing
+	// table/yaml/json/name set.
+	var outputLine string
+	for line := range strings.SplitSeq(stdout, "\n") {
+		if strings.Contains(line, "--output") {
+			outputLine = line
+			break
+		}
+	}
+	if outputLine == "" {
+		t.Fatalf("--help missing --output line:\n%s", stdout)
+	}
+	if !strings.Contains(outputLine, "markdown") {
+		t.Errorf("--output description should advertise markdown: %q", outputLine)
+	}
 }
 
 // TestEnvKey pins the kebab→snake transform so future refactors don't

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"slices"
+	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -118,10 +119,10 @@ func newGetAllCmd() *cobra.Command {
 		Use:   "all",
 		Short: "Summarize every Kustomization and HelmRelease",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// printCluster emits a key/value summary; only yaml/json
+			// printCluster emits a key/value summary; yaml/json/markdown
 			// shape it. Reject `-o name` (which printCluster used to
 			// silently coerce to yaml) for parity with build/diff.
-			if err := c.requireOutput(format.OutputYAML, format.OutputJSON); err != nil {
+			if err := c.requireOutput(format.OutputYAML, format.OutputJSON, format.OutputMarkdown); err != nil {
 				return err
 			}
 			o, res, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
@@ -151,9 +152,9 @@ func newGetImagesCmd() *cobra.Command {
 		Short: "List container images across the cluster",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			// Mirrors `diff images`: name is the natural default
-			// (one image per line); yaml/json are the structured
-			// alternatives. Reject anything else loudly.
-			if err := c.requireOutput(format.OutputYAML, format.OutputJSON, format.OutputName); err != nil {
+			// (one image per line); yaml/json/markdown are the
+			// structured alternatives. Reject anything else loudly.
+			if err := c.requireOutput(format.OutputYAML, format.OutputJSON, format.OutputName, format.OutputMarkdown); err != nil {
 				return err
 			}
 			o, res, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
@@ -266,6 +267,8 @@ func printResources[T manifest.BaseManifest](
 		return format.JSON(w, docs)
 	case format.OutputName:
 		return format.Name(w, rows, "name")
+	case format.OutputMarkdown:
+		return format.MarkdownTable(w, cols, rows)
 	}
 	return format.Table(w, cols, rows)
 }
@@ -286,12 +289,31 @@ var (
 )
 
 func printCluster(w io.Writer, o *orchestrator.Orchestrator, c *commonFlags, out string) error {
+	ksCount := countObjects(o, c, manifest.KindKustomization)
+	hrCount := countObjects(o, c, manifest.KindHelmRelease)
 	summary := map[string]any{
-		"kustomizations": countObjects(o, c, manifest.KindKustomization),
-		"helmReleases":   countObjects(o, c, manifest.KindHelmRelease),
+		"kustomizations": ksCount,
+		"helmReleases":   hrCount,
 	}
-	if format.Output(out) == format.OutputJSON {
+	switch format.Output(out) {
+	case format.OutputJSON:
 		return format.JSON(w, summary)
+	case format.OutputMarkdown:
+		// Two-row pipe table fronted by an H2 — slots into PR
+		// comments and step summaries without further massaging.
+		if _, err := io.WriteString(w, "## Cluster summary\n\n"); err != nil {
+			return err
+		}
+		return format.MarkdownTable(w,
+			[]format.Column{
+				{Header: "Resource", Key: "resource"},
+				{Header: "Count", Key: "count"},
+			},
+			[]map[string]string{
+				{"resource": "Kustomizations", "count": strconv.Itoa(ksCount)},
+				{"resource": "HelmReleases", "count": strconv.Itoa(hrCount)},
+			},
+		)
 	}
 	return format.YAML(w, summary)
 }

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -33,13 +33,25 @@ func collectImages(o *orchestrator.Orchestrator, res *orchestrator.Result, c *co
 }
 
 // emitImageList writes a sorted image list — JSON / YAML when
-// requested, otherwise one image per line.
+// requested, a GitHub-flavored bulleted list with `code`-fenced refs
+// under markdown, otherwise one image per line.
 func emitImageList(w io.Writer, imgs []string, out string) error {
 	switch format.Output(out) {
 	case format.OutputJSON:
 		return format.JSON(w, imgs)
 	case format.OutputYAML:
 		return format.YAML(w, imgs)
+	case format.OutputMarkdown:
+		// Bulleted list — the image refs are flat strings, so a pipe
+		// table buys nothing over `- \`ref\`` which renders inline
+		// code in PR comments and is the natural counterpart to the
+		// one-per-line plain-text shape.
+		for _, img := range imgs {
+			if _, err := io.WriteString(w, "- `"+img+"`\n"); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	for _, img := range imgs {
 		if _, err := io.WriteString(w, img+"\n"); err != nil {

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -3,17 +3,21 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
+	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/internal/testrunner"
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-// `test` emits a human-readable reconcile report. No structured-output
-// support yet; reject any non-default `-o` so users don't silently get
-// the same plain-text output regardless of what they ask for. When
-// adding json/yaml here later, pass them through requireOutput.
+// `test` emits a human-readable reconcile report. Plain text is the
+// default; `-o markdown` swaps in the GitHub-flavored report shape
+// (pipe-table summary + per-outcome task-list sections) for PR
+// comments. Any other `-o` value is rejected so users don't silently
+// get the same plain-text output regardless of what they ask for.
+// When adding json/yaml here later, pass them through requireOutput.
 
 func newTestCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -50,7 +54,7 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 		Short:   short,
 		Args:    args,
 		RunE: func(cmd *cobra.Command, argv []string) error {
-			if err := c.requireOutput(); err != nil {
+			if err := c.requireOutput(format.OutputMarkdown); err != nil {
 				return err
 			}
 			stopProfile, err := startProfile(c.profileMode, c.profileOut)
@@ -79,7 +83,7 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 			if name != "" && report.Matched == 0 {
 				return errors.Join(fmt.Errorf("no %s named %q in --path", testKindName(kinds), name), runErr)
 			}
-			if err := report.Write(cmd.OutOrStdout()); err != nil {
+			if err := emitTestReport(cmd.OutOrStdout(), report, c.outputOrDefault(format.OutputText)); err != nil {
 				return errors.Join(err, runErr)
 			}
 			if report.AnyFailed() {
@@ -98,4 +102,17 @@ func testKindName(kinds []string) string {
 		return kinds[0]
 	}
 	return "resource"
+}
+
+// emitTestReport dispatches the report to the renderer that matches
+// the requested -o. The text path (default) keeps the pytest-style
+// output testrunner.Report.Write produces; the markdown path emits
+// the GitHub-flavored shape from testrunner.Report.WriteMarkdown.
+func emitTestReport(w io.Writer, r testrunner.Report, out format.Output) error {
+	switch out {
+	case format.OutputMarkdown:
+		return r.WriteMarkdown(w)
+	default:
+		return r.Write(w)
+	}
 }

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -5,7 +5,9 @@ package format
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"strings"
 	"unicode/utf8"
 
 	"sigs.k8s.io/yaml"
@@ -16,11 +18,32 @@ type Output string
 
 // Output values understood by the -o flag.
 const (
-	OutputTable Output = "table"
-	OutputYAML  Output = "yaml"
-	OutputJSON  Output = "json"
-	OutputName  Output = "name"
+	OutputTable    Output = "table"
+	OutputYAML     Output = "yaml"
+	OutputJSON     Output = "json"
+	OutputName     Output = "name"
+	OutputMarkdown Output = "markdown"
+	// OutputText is the implicit default for `flate test`. The constant
+	// exists so test.go can dispatch on it explicitly rather than relying
+	// on a string literal; the rendered output is the existing pytest-
+	// style report from testrunner.Report.Write.
+	OutputText Output = "text"
 )
+
+// TaskItem is one entry in a GitHub-flavored task list. Checked
+// drives `- [x]` vs `- [ ]`. When Detail is non-empty, it's wrapped
+// in a <details><summary>…</summary> block under the bullet so long
+// failure bodies stay collapsed in PR comments.
+type TaskItem struct {
+	Label   string
+	Checked bool
+	// Summary is the short label shown in the <details>'s <summary>
+	// tag — typically a one-line failure reason.
+	Summary string
+	// Detail is the long body shown when the <details> is expanded.
+	// Empty Detail suppresses the <details> block entirely.
+	Detail string
+}
 
 // Column describes a single table column.
 type Column struct {
@@ -127,6 +150,137 @@ func Name(w io.Writer, items []map[string]string, key string) error {
 	for _, it := range items {
 		b.WriteString(it[key])
 		b.WriteByte('\n')
+	}
+	_, err := w.Write(b.Bytes())
+	return err
+}
+
+// MarkdownTable renders rows as a GitHub-flavored Markdown pipe table.
+// Pipes inside cell values are escaped to keep the table well-formed
+// when the output is embedded in PR comments or release notes.
+func MarkdownTable(w io.Writer, cols []Column, rows []map[string]string) error {
+	var b bytes.Buffer
+	// Rough sizing: header + separator + one line per row, ~16 bytes per cell.
+	b.Grow((2 + len(rows)) * (len(cols)*16 + 4))
+	// Header row.
+	b.WriteByte('|')
+	for _, c := range cols {
+		b.WriteByte(' ')
+		b.WriteString(escapeMarkdownCell(c.Header))
+		b.WriteString(" |")
+	}
+	b.WriteByte('\n')
+	// Separator row.
+	b.WriteByte('|')
+	for range cols {
+		b.WriteString(" --- |")
+	}
+	b.WriteByte('\n')
+	// Data rows.
+	for _, r := range rows {
+		b.WriteByte('|')
+		for _, c := range cols {
+			b.WriteByte(' ')
+			b.WriteString(escapeMarkdownCell(r[c.Key]))
+			b.WriteString(" |")
+		}
+		b.WriteByte('\n')
+	}
+	_, err := w.Write(b.Bytes())
+	return err
+}
+
+// escapeMarkdownCell escapes characters that would break a GFM pipe
+// table cell — currently just `|`. Newlines inside cells are replaced
+// with `<br>` so multi-line values don't terminate the row.
+func escapeMarkdownCell(s string) string {
+	if !strings.ContainsAny(s, "|\n") {
+		return s
+	}
+	r := strings.NewReplacer("|", `\|`, "\n", "<br>")
+	return r.Replace(s)
+}
+
+// MarkdownDocs emits each doc as a fenced YAML block, preceded by an
+// H3 header derived from kind/namespace/name. Cluster-scoped docs
+// (empty namespace) render `### Kind/name`; namespaced docs render
+// `### Kind/namespace/name`. Docs missing any of those fields fall
+// back to a generic `### Document N` header.
+func MarkdownDocs(w io.Writer, docs []map[string]any) error {
+	var b bytes.Buffer
+	for i, d := range docs {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(markdownDocHeader(d, i))
+		b.WriteString("\n\n")
+		b.WriteString("```yaml\n")
+		out, err := yaml.Marshal(d)
+		if err != nil {
+			return err
+		}
+		b.Write(out)
+		// yaml.Marshal already terminates with '\n'; close the fence.
+		b.WriteString("```\n")
+	}
+	_, err := w.Write(b.Bytes())
+	return err
+}
+
+func markdownDocHeader(d map[string]any, idx int) string {
+	kind, _ := d["kind"].(string)
+	var ns, name string
+	if md, ok := d["metadata"].(map[string]any); ok {
+		name, _ = md["name"].(string)
+		ns, _ = md["namespace"].(string)
+	}
+	if kind == "" || name == "" {
+		return fmt.Sprintf("### Document %d", idx+1)
+	}
+	if ns == "" {
+		return fmt.Sprintf("### %s/%s", kind, name)
+	}
+	return fmt.Sprintf("### %s/%s/%s", kind, ns, name)
+}
+
+// MarkdownTaskList emits a GitHub-flavored task list. Each item is a
+// bullet with a checked/unchecked box. When Detail is non-empty, the
+// item carries a collapsible <details> block (with Summary in the
+// <summary> tag and Detail in a fenced code block). When Detail is
+// empty but Summary is non-empty, Summary is appended inline after
+// an em dash — the skip-case shorthand.
+func MarkdownTaskList(w io.Writer, items []TaskItem) error {
+	var b bytes.Buffer
+	b.Grow(len(items) * 64)
+	for _, it := range items {
+		box := "[ ]"
+		if it.Checked {
+			box = "[x]"
+		}
+		b.WriteString("- ")
+		b.WriteString(box)
+		b.WriteByte(' ')
+		b.WriteString(it.Label)
+		switch {
+		case it.Detail != "":
+			b.WriteByte('\n')
+			b.WriteString("  <details><summary>")
+			b.WriteString(it.Summary)
+			b.WriteString("</summary>\n\n")
+			b.WriteString("  ```\n")
+			b.WriteString(it.Detail)
+			if !strings.HasSuffix(it.Detail, "\n") {
+				b.WriteByte('\n')
+			}
+			b.WriteString("  ```\n")
+			b.WriteString("  </details>\n")
+		case it.Summary != "":
+			b.WriteString(" — ")
+			b.WriteString(it.Summary)
+			b.WriteByte('\n')
+		default:
+			b.WriteByte('\n')
+		}
 	}
 	_, err := w.Write(b.Bytes())
 	return err

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -48,3 +48,205 @@ func TestJSON(t *testing.T) {
 		t.Errorf("json output: %s", b.String())
 	}
 }
+
+func TestMarkdownTable(t *testing.T) {
+	tests := []struct {
+		name        string
+		cols        []Column
+		rows        []map[string]string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "basic three columns",
+			cols: []Column{{"NAME", "name"}, {"KIND", "kind"}, {"NS", "ns"}},
+			rows: []map[string]string{
+				{"name": "app1", "kind": "Kustomization", "ns": "flux-system"},
+				{"name": "app2", "kind": "HelmRelease", "ns": "default"},
+			},
+			wantContain: []string{
+				"| NAME | KIND | NS |",
+				"| --- | --- | --- |",
+				"| app1 | Kustomization | flux-system |",
+				"| app2 | HelmRelease | default |",
+			},
+		},
+		{
+			name: "cell with pipe character",
+			cols: []Column{{"NAME", "name"}, {"EXPR", "expr"}},
+			rows: []map[string]string{
+				{"name": "rule", "expr": "a | b"},
+			},
+			wantContain: []string{`| rule | a \| b |`},
+			wantAbsent:  []string{"| rule | a | b |"},
+		},
+		{
+			name: "empty rows renders header only",
+			cols: []Column{{"NAME", "name"}, {"PATH", "path"}},
+			rows: nil,
+			wantContain: []string{
+				"| NAME | PATH |",
+				"| --- | --- |",
+			},
+			wantAbsent: []string{"| app"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			if err := MarkdownTable(&b, tc.cols, tc.rows); err != nil {
+				t.Fatalf("MarkdownTable: %v", err)
+			}
+			got := b.String()
+			for _, want := range tc.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("missing %q in:\n%s", want, got)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("unexpected %q in:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMarkdownDocs(t *testing.T) {
+	tests := []struct {
+		name        string
+		docs        []map[string]any
+		wantContain []string
+	}{
+		{
+			name: "two namespaced docs",
+			docs: []map[string]any{
+				{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": "cm1", "namespace": "default"},
+				},
+				{
+					"apiVersion": "v1",
+					"kind":       "Secret",
+					"metadata":   map[string]any{"name": "s1", "namespace": "kube-system"},
+				},
+			},
+			wantContain: []string{
+				"### ConfigMap/default/cm1",
+				"### Secret/kube-system/s1",
+				"```yaml",
+				"kind: ConfigMap",
+				"kind: Secret",
+				"```\n",
+			},
+		},
+		{
+			name: "cluster-scoped doc omits namespace segment",
+			docs: []map[string]any{
+				{
+					"apiVersion": "rbac.authorization.k8s.io/v1",
+					"kind":       "ClusterRole",
+					"metadata":   map[string]any{"name": "view"},
+				},
+			},
+			wantContain: []string{
+				"### ClusterRole/view",
+				"kind: ClusterRole",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			if err := MarkdownDocs(&b, tc.docs); err != nil {
+				t.Fatalf("MarkdownDocs: %v", err)
+			}
+			got := b.String()
+			for _, want := range tc.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("missing %q in:\n%s", want, got)
+				}
+			}
+		})
+	}
+	// Cluster-scoped also asserts the namespaced segment is absent.
+	var b bytes.Buffer
+	if err := MarkdownDocs(&b, []map[string]any{
+		{"kind": "ClusterRole", "metadata": map[string]any{"name": "view"}},
+	}); err != nil {
+		t.Fatalf("MarkdownDocs: %v", err)
+	}
+	if strings.Contains(b.String(), "ClusterRole//view") {
+		t.Errorf("cluster-scoped header leaked empty namespace: %s", b.String())
+	}
+}
+
+func TestMarkdownTaskList(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []TaskItem
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "mix of checked and unchecked",
+			items: []TaskItem{
+				{Label: "passing-resource", Checked: true},
+				{Label: "pending-resource", Checked: false},
+			},
+			wantContain: []string{
+				"- [x] passing-resource",
+				"- [ ] pending-resource",
+			},
+		},
+		{
+			name: "summary-only renders inline em dash",
+			items: []TaskItem{
+				{Label: "skipped-test", Checked: true, Summary: "no fixtures"},
+			},
+			wantContain: []string{
+				"- [x] skipped-test — no fixtures",
+			},
+			wantAbsent: []string{"<details>", "<summary>"},
+		},
+		{
+			name: "detail wraps in collapsible block with code fence",
+			items: []TaskItem{
+				{
+					Label:   "failing-resource",
+					Checked: false,
+					Summary: "diff mismatch",
+					Detail:  "expected: foo\nactual: bar",
+				},
+			},
+			wantContain: []string{
+				"- [ ] failing-resource",
+				"<details><summary>diff mismatch</summary>",
+				"  ```",
+				"expected: foo",
+				"actual: bar",
+				"</details>",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var b bytes.Buffer
+			if err := MarkdownTaskList(&b, tc.items); err != nil {
+				t.Fatalf("MarkdownTaskList: %v", err)
+			}
+			got := b.String()
+			for _, want := range tc.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("missing %q in:\n%s", want, got)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("unexpected %q in:\n%s", absent, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -87,6 +87,72 @@ func (r Report) Write(w io.Writer) error {
 	return err
 }
 
+// WriteMarkdown renders the report as GitHub-flavored markdown to w:
+// a pipe-table summary of counts followed by per-outcome task-list
+// sections. Empty sections are omitted. Failure bodies are wrapped in
+// a collapsible <details> block when present.
+func (r Report) WriteMarkdown(w io.Writer) error {
+	var b strings.Builder
+	fmt.Fprintln(&b, "| Passed | Skipped | Failed | Matched |")
+	fmt.Fprintln(&b, "| ---: | ---: | ---: | ---: |")
+	fmt.Fprintf(&b, "| %d | %d | %d | %d |\n", r.Passed, r.Skipped, r.Failed, r.Matched)
+
+	var passed, skipped, failed []Case
+	for _, c := range r.Cases {
+		switch c.Outcome {
+		case OutcomePassed:
+			passed = append(passed, c)
+		case OutcomeSkipped:
+			skipped = append(skipped, c)
+		case OutcomeFailed:
+			failed = append(failed, c)
+		}
+	}
+
+	if len(passed) > 0 {
+		fmt.Fprint(&b, "\n## Passed\n\n")
+		for _, c := range passed {
+			fmt.Fprintf(&b, "- [x] %s\n", c.ID.NamespacedName())
+		}
+	}
+
+	if len(skipped) > 0 {
+		fmt.Fprint(&b, "\n## Skipped\n\n")
+		for _, c := range skipped {
+			if c.Reason != "" {
+				fmt.Fprintf(&b, "- [x] %s — %s\n", c.ID.NamespacedName(), c.Reason)
+			} else {
+				fmt.Fprintf(&b, "- [x] %s\n", c.ID.NamespacedName())
+			}
+		}
+	}
+
+	if len(failed) > 0 {
+		fmt.Fprint(&b, "\n## Failed\n\n")
+		for _, c := range failed {
+			if c.Reason == "" {
+				fmt.Fprintf(&b, "- [ ] %s\n", c.ID.NamespacedName())
+				continue
+			}
+			lines := strings.Split(c.Reason, "\n")
+			summary := lines[0]
+			rest := lines[1:]
+			if len(rest) == 0 {
+				fmt.Fprintf(&b, "- [ ] %s\n  <details><summary>%s</summary></details>\n", c.ID.NamespacedName(), summary)
+				continue
+			}
+			fmt.Fprintf(&b, "- [ ] %s\n  <details><summary>%s</summary>\n\n  ```\n", c.ID.NamespacedName(), summary)
+			for _, line := range rest {
+				fmt.Fprintf(&b, "  %s\n", line)
+			}
+			fmt.Fprint(&b, "  ```\n  </details>\n")
+		}
+	}
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
 // Run inspects the store and produces a Report. When j.Kinds is empty,
 // both reconciler-driven kinds (Kustomization, HelmRelease) are
 // reported on.

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -188,3 +188,124 @@ type errWriter struct {
 func (w errWriter) Write(_ []byte) (int, error) {
 	return 0, w.err
 }
+
+func TestReport_WriteMarkdown(t *testing.T) {
+	t.Run("mixed pass/skip/fail", func(t *testing.T) {
+		rep := Report{
+			Passed:  2,
+			Skipped: 1,
+			Failed:  1,
+			Matched: 4,
+			Cases: []Case{
+				{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "alpha"}, Outcome: OutcomePassed},
+				{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "beta"}, Outcome: OutcomePassed},
+				{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "untouched"}, Outcome: OutcomeSkipped, Reason: "unchanged"},
+				{ID: manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "apps", Name: "broken"}, Outcome: OutcomeFailed, Reason: "boom\nstack frame 1\nstack frame 2"},
+			},
+		}
+
+		var b bytes.Buffer
+		if err := rep.WriteMarkdown(&b); err != nil {
+			t.Fatalf("WriteMarkdown: %v", err)
+		}
+		out := b.String()
+
+		wantSubstrings := []string{
+			"| Passed | Skipped | Failed | Matched |",
+			"| 2 | 1 | 1 | 4 |",
+			"## Passed",
+			"## Skipped",
+			"## Failed",
+			"- [x] ns/alpha",
+			"- [x] ns/beta",
+			"- [x] ns/untouched — unchanged",
+			"- [ ] apps/broken",
+			"<details><summary>boom</summary>",
+			"stack frame 1",
+			"stack frame 2",
+			"</details>",
+		}
+		for _, want := range wantSubstrings {
+			if !strings.Contains(out, want) {
+				t.Errorf("markdown output missing %q:\n%s", want, out)
+			}
+		}
+	})
+
+	t.Run("only passes omits empty headers", func(t *testing.T) {
+		rep := Report{
+			Passed:  1,
+			Matched: 1,
+			Cases: []Case{
+				{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "only"}, Outcome: OutcomePassed},
+			},
+		}
+
+		var b bytes.Buffer
+		if err := rep.WriteMarkdown(&b); err != nil {
+			t.Fatalf("WriteMarkdown: %v", err)
+		}
+		out := b.String()
+
+		if !strings.Contains(out, "## Passed") {
+			t.Errorf("expected ## Passed header: %s", out)
+		}
+		if strings.Contains(out, "## Skipped") {
+			t.Errorf("must not emit ## Skipped header for empty bucket: %s", out)
+		}
+		if strings.Contains(out, "## Failed") {
+			t.Errorf("must not emit ## Failed header for empty bucket: %s", out)
+		}
+	})
+
+	t.Run("single-line failure reason", func(t *testing.T) {
+		rep := Report{
+			Failed:  1,
+			Matched: 1,
+			Cases: []Case{
+				{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}, Outcome: OutcomeFailed, Reason: "single-line boom"},
+			},
+		}
+
+		var b bytes.Buffer
+		if err := rep.WriteMarkdown(&b); err != nil {
+			t.Fatalf("WriteMarkdown: %v", err)
+		}
+		out := b.String()
+
+		if !strings.Contains(out, "<details><summary>single-line boom</summary></details>") {
+			t.Errorf("single-line reason should collapse to one-line details: %s", out)
+		}
+	})
+
+	t.Run("empty failure reason emits bare bullet", func(t *testing.T) {
+		rep := Report{
+			Failed:  1,
+			Matched: 1,
+			Cases: []Case{
+				{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}, Outcome: OutcomeFailed},
+			},
+		}
+
+		var b bytes.Buffer
+		if err := rep.WriteMarkdown(&b); err != nil {
+			t.Fatalf("WriteMarkdown: %v", err)
+		}
+		out := b.String()
+
+		if !strings.Contains(out, "- [ ] ns/x\n") {
+			t.Errorf("expected bare failure bullet: %s", out)
+		}
+		if strings.Contains(out, "<details>") {
+			t.Errorf("must not emit <details> when reason is empty: %s", out)
+		}
+	})
+
+	t.Run("propagates writer error", func(t *testing.T) {
+		want := errors.New("write failed")
+		rep := Report{Passed: 1, Cases: []Case{{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "x"}, Outcome: OutcomePassed}}}
+		if err := rep.WriteMarkdown(errWriter{err: want}); !errors.Is(err, want) {
+			t.Fatalf("WriteMarkdown error = %v, want %v", err, want)
+		}
+	})
+}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -24,9 +24,10 @@ const (
 	// fence. K8s-aware: list entries are matched by identifier
 	// (container name, env-var name, etc.), so reordering a list
 	// produces no diff churn.
-	FormatDiff Format = "diff"
-	FormatYAML Format = "yaml"
-	FormatJSON Format = "json"
+	FormatDiff     Format = "diff"
+	FormatYAML     Format = "yaml"
+	FormatJSON     Format = "json"
+	FormatMarkdown Format = "markdown"
 )
 
 // Options tunes Run behavior.
@@ -147,8 +148,69 @@ func Render(diffs []ResourceDiff, format Format) ([]byte, error) {
 		return yaml.Marshal(diffs)
 	case FormatJSON:
 		return json.MarshalIndent(diffs, "", "  ")
+	case FormatMarkdown:
+		return renderMarkdown(diffs), nil
 	}
 	return nil, fmt.Errorf("unknown diff format %q", format)
+}
+
+// renderMarkdown emits a PR-comment-friendly view of the diff set:
+// a `# Diff` heading, a pipe-table summary by classification
+// (added/modified/removed), and one H3 + ```diff fence per
+// ResourceDiff wrapping the dyff body verbatim. Classification is
+// inferred from the dyff body's root-level markers — `! + ` for
+// wholesale additions, `! - ` for wholesale removals, anything else
+// is treated as a modification.
+func renderMarkdown(diffs []ResourceDiff) []byte {
+	var b bytes.Buffer
+	b.WriteString("# Diff\n")
+	if len(diffs) == 0 {
+		b.WriteString("\n_No changes._\n")
+		return b.Bytes()
+	}
+	var added, modified, removed int
+	for _, d := range diffs {
+		switch classifyDiff(d.Diff) {
+		case "added":
+			added++
+		case "removed":
+			removed++
+		default:
+			modified++
+		}
+	}
+	fmt.Fprintf(&b, "\n| Added | Modified | Removed | Total |\n")
+	b.WriteString("| --- | --- | --- | --- |\n")
+	fmt.Fprintf(&b, "| %d | %d | %d | %d |\n\n", added, modified, removed, len(diffs))
+	for _, d := range diffs {
+		fmt.Fprintf(&b, "### %s\n\n", d.Header())
+		b.WriteString("```diff\n")
+		b.WriteString(d.Diff)
+		if !strings.HasSuffix(d.Diff, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteString("```\n\n")
+	}
+	return b.Bytes()
+}
+
+// classifyDiff inspects a dyff body and returns one of "added",
+// "removed", or "modified". Wholesale additions/removals from
+// Run() emit a `(root level)` header followed by an `! + ` /
+// `! - ` map-entries marker; anything else is a per-path
+// modification.
+func classifyDiff(body string) string {
+	if !strings.Contains(body, "@@ (root level) @@") {
+		return "modified"
+	}
+	switch {
+	case strings.Contains(body, "\n! + "):
+		return "added"
+	case strings.Contains(body, "\n! - "):
+		return "removed"
+	default:
+		return "modified"
+	}
 }
 
 type pairedResource struct {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -245,6 +245,87 @@ func TestRender_DiffHeaderAlwaysEmitted(t *testing.T) {
 	})
 }
 
+// TestRender_Markdown pins the FormatMarkdown shape:
+//   - Top-level `# Diff` heading,
+//   - A pipe-table summary classifying entries as added/modified/removed
+//     (derived from the dyff body),
+//   - One H3 + ```diff fence per ResourceDiff, with the dyff body
+//     passed through verbatim inside the fence,
+//   - The "no changes" sentinel for an empty diff set.
+func TestRender_Markdown(t *testing.T) {
+	t.Run("empty diffs emits no-changes sentinel", func(t *testing.T) {
+		out, err := Render(nil, FormatMarkdown)
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		s := string(out)
+		if !strings.Contains(s, "# Diff") {
+			t.Errorf("missing top-level heading; got:\n%s", s)
+		}
+		if !strings.Contains(s, "_No changes._") {
+			t.Errorf("missing no-changes sentinel; got:\n%s", s)
+		}
+		if strings.Contains(s, "```diff") {
+			t.Errorf("empty diff should not emit any code fence; got:\n%s", s)
+		}
+	})
+
+	t.Run("mixed added/modified/removed", func(t *testing.T) {
+		// Modified resource: same name in both, value differs.
+		left := []Doc{
+			cm("modme", "ns", "owner", "v1"),
+			cm("removeme", "ns", "owner", "v1"), // removal: only on left
+		}
+		right := []Doc{
+			cm("modme", "ns", "owner", "v2"),
+			cm("addme", "ns", "owner", "v1"), // addition: only on right
+		}
+		diffs, err := Run(left, right, Options{})
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if len(diffs) != 3 {
+			t.Fatalf("expected 3 diff entries (add + mod + remove), got %d:\n%+v", len(diffs), diffs)
+		}
+		out, err := Render(diffs, FormatMarkdown)
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		s := string(out)
+
+		// Top-level heading.
+		if !strings.Contains(s, "# Diff") {
+			t.Errorf("missing top-level heading; got:\n%s", s)
+		}
+
+		// Summary table classifying one of each.
+		if !strings.Contains(s, "| Added | Modified | Removed | Total |") {
+			t.Errorf("missing summary table header; got:\n%s", s)
+		}
+		if !strings.Contains(s, "| 1 | 1 | 1 | 3 |") {
+			t.Errorf("missing/incorrect summary row (expected 1 added, 1 modified, 1 removed, 3 total); got:\n%s", s)
+		}
+
+		// Per-resource sections: one H3 heading + ```diff fence each.
+		for _, d := range diffs {
+			heading := "### " + d.Header()
+			if !strings.Contains(s, heading) {
+				t.Errorf("missing per-resource heading %q; got:\n%s", heading, s)
+			}
+			// Body must appear verbatim inside the fence.
+			if !strings.Contains(s, d.Diff) {
+				t.Errorf("dyff body for %s missing from output; got:\n%s", d.Header(), s)
+			}
+		}
+		if !strings.Contains(s, "```diff\n") {
+			t.Errorf("missing ```diff fence opener; got:\n%s", s)
+		}
+		if !strings.Contains(s, "\n```\n") {
+			t.Errorf("missing closing fence; got:\n%s", s)
+		}
+	})
+}
+
 func TestFormat_JSON(t *testing.T) {
 	diffs := []ResourceDiff{{Kind: "ConfigMap", Name: "a", Diff: "..."}}
 	out, err := Render(diffs, FormatJSON)


### PR DESCRIPTION
## Summary

Adds `-o markdown` (and `FLATE_OUTPUT=markdown`) to every main subcommand, rendering GitHub-flavored markdown that pastes cleanly into PR comments, issues, and CI summaries.

### What each subcommand emits

- **`build -o markdown`** — one `### Kind/namespace/name` heading + ` ```yaml` fence per rendered doc.
- **`diff -o markdown`** — `# Diff` header, an `| Added | Modified | Removed | Total |` summary pipe-table, then `### <resource header>` + ` ```diff` fence per changed resource. Wraps the existing dyff output unchanged.
- **`test -o markdown`** — `| Passed | Skipped | Failed | Matched |` counts table at the top, then per-outcome task-list sections (`- [x]` for pass/skip, `- [ ]` for fail) with `<details><summary>reason</summary>` blocks around multi-line failure bodies.
- **`get ks/hr -o markdown`** — GFM pipe-tables (replaces the fixed-width table layout).
- **`get all -o markdown`** — `## Cluster summary` heading + 2-column counts pipe-table.
- **`get images -o markdown`** — bulleted list of `` `image:tag` `` refs.

### Architecture (matches existing decentralized format dispatch)

Stacked into four small commits:

1. `feat(format): OutputMarkdown + MarkdownTable/Docs/TaskList helpers` — new constants (`OutputMarkdown`, `OutputText`), `TaskItem` type, and three `io.Writer`-based emitters alongside the existing `Table`/`YAMLMulti`/`JSON`/`Name`.
2. `feat(diff): FormatMarkdown render case` — new `diff.FormatMarkdown` + a `Render()` case that classifies each `ResourceDiff` as added/modified/removed for the summary table, then emits H3-headed `\`\`\`diff` blocks.
3. `feat(testrunner): Report.WriteMarkdown` — new method alongside the unchanged `Write(w)`; the default text output is preserved for users who don't pass `-o`.
4. `feat(cli): wire --output markdown through build, diff, test, get` — each subcommand's existing `requireOutput` allow-list gains `format.OutputMarkdown`; the emit switches dispatch to the helpers from layers 1-3.

No new abstractions, no API churn for non-markdown users.

## Test plan

- [x] `mise run vet` — clean
- [x] `mise run lint` — 0 issues
- [x] `mise run test` — full suite green
- [x] `go test -race ./internal/format ./pkg/diff ./internal/testrunner ./internal/cli -count=1` — clean
- [x] Per-subcommand end-to-end tests: `TestBuild_OutputMarkdown`, `TestDiff_OutputMarkdown`, `TestTest_OutputMarkdown`, `TestGet_OutputMarkdown`, `TestGetAll_OutputMarkdown`.
- [x] `TestEnv_HelpAdvertisesEnvVars` extended to pin `markdown` in the `-o` flag description.
- [x] Manual smoke against `testdata/simple` for all four subcommands.

### Sample output

`flate test ks -o markdown`:

```
| Passed | Skipped | Failed | Matched |
| ---: | ---: | ---: | ---: |
| 1 | 0 | 0 | 1 |

## Passed

- [x] flux-system/apps
```

`flate diff ks -o markdown` (with a value change):

````
# Diff

| Added | Modified | Removed | Total |
| --- | --- | --- | --- |
| 0 | 1 | 0 | 1 |

### apps Kustomization: flux-system/apps ConfigMap: apps/hello

\`\`\`diff

@@ data.greeting @@
! ± value change
- hola-from-flate
+ hello-from-flate
\`\`\`
````

🤖 Generated with [Claude Code](https://claude.com/claude-code)