### PR TITLE
fix(diff): empty markdown is empty, drop KS path from header

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -72,13 +72,13 @@ type ResourceDiff struct {
 	Diff      string `json:"diff"                yaml:"diff"`
 }
 
-// Header returns the flux-local-style "[path] Parent: ns/name
-// Child: ns/name" prefix used in diff output.
+// Header returns the "Parent: ns/name Child: ns/name" prefix used
+// in diff output. The Kustomization source path is intentionally
+// omitted so KS-owned and HR-owned resources render symmetrically
+// — `Parent.Path` survives on the struct for JSON/YAML consumers
+// but never appears in the human-facing header.
 func (d ResourceDiff) Header() string {
-	parts := make([]string, 0, 3)
-	if d.Parent.Path != "" {
-		parts = append(parts, d.Parent.Path)
-	}
+	parts := make([]string, 0, 2)
 	if d.Parent.Kind != "" {
 		parts = append(parts, fmt.Sprintf("%s: %s", d.Parent.Kind, joinNS(d.Parent.Namespace, d.Parent.Name)))
 	}
@@ -160,14 +160,15 @@ func Render(diffs []ResourceDiff, format Format) ([]byte, error) {
 // ResourceDiff wrapping the dyff body verbatim. Classification is
 // inferred from the dyff body's root-level markers — `! + ` for
 // wholesale additions, `! - ` for wholesale removals, anything else
-// is treated as a modification.
+// is treated as a modification. An empty diff set renders as the
+// empty document so the markdown output can be dropped into a PR
+// comment unconditionally without a "no changes" placeholder.
 func renderMarkdown(diffs []ResourceDiff) []byte {
+	if len(diffs) == 0 {
+		return nil
+	}
 	var b bytes.Buffer
 	b.WriteString("# Diff\n")
-	if len(diffs) == 0 {
-		b.WriteString("\n_No changes._\n")
-		return b.Bytes()
-	}
 	var added, modified, removed int
 	for _, d := range diffs {
 		switch classifyDiff(d.Diff) {

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -251,22 +251,16 @@ func TestRender_DiffHeaderAlwaysEmitted(t *testing.T) {
 //     (derived from the dyff body),
 //   - One H3 + ```diff fence per ResourceDiff, with the dyff body
 //     passed through verbatim inside the fence,
-//   - The "no changes" sentinel for an empty diff set.
+//   - An empty diff set renders as the empty document so callers
+//     (e.g. PR-comment automation) can skip posting entirely.
 func TestRender_Markdown(t *testing.T) {
-	t.Run("empty diffs emits no-changes sentinel", func(t *testing.T) {
+	t.Run("empty diffs render as the empty document", func(t *testing.T) {
 		out, err := Render(nil, FormatMarkdown)
 		if err != nil {
 			t.Fatalf("Render: %v", err)
 		}
-		s := string(out)
-		if !strings.Contains(s, "# Diff") {
-			t.Errorf("missing top-level heading; got:\n%s", s)
-		}
-		if !strings.Contains(s, "_No changes._") {
-			t.Errorf("missing no-changes sentinel; got:\n%s", s)
-		}
-		if strings.Contains(s, "```diff") {
-			t.Errorf("empty diff should not emit any code fence; got:\n%s", s)
+		if len(out) != 0 {
+			t.Errorf("expected empty output for empty diff set, got:\n%s", out)
 		}
 	})
 
@@ -354,7 +348,10 @@ func TestResourceDiff_Header(t *testing.T) {
 		},
 		Kind: "HelmRelease", Namespace: "media", Name: "qui",
 	}
-	want = "kubernetes/apps/media/qui/app Kustomization: media/qui HelmRelease: media/qui"
+	// Parent.Path is preserved on the struct (for JSON/YAML
+	// consumers) but deliberately omitted from the human header so
+	// KS-owned and HR-owned entries render symmetrically.
+	want = "Kustomization: media/qui HelmRelease: media/qui"
 	if got := ksDiff.Header(); got != want {
 		t.Errorf("KS header:\n got %q\nwant %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- `FormatMarkdown` returns the empty document for an empty diff set instead of emitting `# Diff` + `_No changes._`. PR-comment automation can now skip posting unconditionally.
- `ResourceDiff.Header()` no longer prepends `Parent.Path` for Kustomization-owned entries, so KS-owned and HR-owned resources render symmetrically. `Parent.Path` stays on the struct, so JSON/YAML output is unchanged.

## Test plan
- [x] `go test ./pkg/diff/... ./internal/cli/...` (passes locally)
- [ ] Run `flate diff all -o markdown` on a tree with no drift — confirm zero output.
- [ ] Run `flate diff all -o markdown` on a tree with a Kustomization-owned ConfigMap change — confirm the `### ` header omits the source path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)