### PR TITLE
fix(diff): redact ConfigMap binaryData

### DIFF
--- a/pkg/diff/bench_test.go
+++ b/pkg/diff/bench_test.go
@@ -25,11 +25,13 @@ func BenchmarkDiff_LargeTree(b *testing.B) {
 	}
 }
 
-// BenchmarkApplyStrip measures applyStrip against a 100-doc set with
-// 5 strip attrs — the pre-diff sanitization pass that pulls common
+// BenchmarkNormalizeDocs measures normalizeDocs against a 100-doc set
+// with 5 strip attrs — the pre-diff sanitization pass that pulls
 // chart-bump noise (helm.sh/chart, checksum/config, …) out of every
-// resource's metadata before dyff sees it.
-func BenchmarkApplyStrip(b *testing.B) {
+// resource's metadata and redacts ConfigMap.binaryData before dyff
+// sees them. The corpus carries no binaryData, so this exercises the
+// strip path plus the docsContainBinaryData short-circuit walk.
+func BenchmarkNormalizeDocs(b *testing.B) {
 	const n = 100
 	docs := make([]Doc, 0, n)
 	for i := range n {
@@ -46,7 +48,7 @@ func BenchmarkApplyStrip(b *testing.B) {
 						"app.kubernetes.io/name": fmt.Sprintf("app-%d", i),
 					},
 					"annotations": map[string]any{
-						"checksum/config":   fmt.Sprintf("%d", i*31),
+						"checksum/config":                   fmt.Sprintf("%d", i*31),
 						"deployment.kubernetes.io/revision": "1",
 					},
 				},
@@ -78,7 +80,7 @@ func BenchmarkApplyStrip(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_ = applyStrip(docs, attrs)
+		_ = normalizeDocs(docs, attrs)
 	}
 }
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -3,6 +3,9 @@ package diff
 import (
 	"bytes"
 	"cmp"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -101,8 +104,8 @@ func joinNS(ns, name string) string {
 // HelmRelease A doesn't accidentally diff against the same-named
 // Deployment from HelmRelease B.
 func Run(left, right []Doc, opts Options) ([]ResourceDiff, error) {
-	left = applyStrip(left, opts.StripAttrs)
-	right = applyStrip(right, opts.StripAttrs)
+	left = normalizeDocs(left, opts.StripAttrs)
+	right = normalizeDocs(right, opts.StripAttrs)
 	pairs := pair(left, right)
 	out := make([]ResourceDiff, 0, len(pairs))
 	for _, p := range pairs {
@@ -224,9 +227,9 @@ type pairKey struct {
 	// pPath disambiguates two KS parents with the same (kind, ns, name)
 	// but different spec.path — a real-world collision in repos where
 	// the same KS is rendered twice from different overlays.
-	pKind, pNS, pName, pPath  string
-	apiVersion                string
-	kind, ns, name            string
+	pKind, pNS, pName, pPath string
+	apiVersion               string
+	kind, ns, name           string
 }
 
 func pair(left, right []Doc) []pairedResource {
@@ -271,19 +274,80 @@ func pair(left, right []Doc) []pairedResource {
 	return out
 }
 
-// applyStrip clones each Doc's manifest and removes the listed
-// annotation/label keys before the diff runs. Deep-copies so the
-// original tree (used by other consumers in the same orchestrator
-// run) is untouched.
-func applyStrip(docs []Doc, attrs []string) []Doc {
-	if len(attrs) == 0 {
+// normalizeDocs clones each Doc's manifest and rewrites fields that
+// should not participate verbatim in human-facing diffs: the listed
+// annotation/label keys (chart-bump noise like helm.sh/chart,
+// checksum/config, …) and ConfigMap.binaryData values (opaque base64
+// blobs whose verbatim diff is gibberish to a reviewer and
+// pathologically expensive for dyff to render on large hook payloads
+// like kube-prometheus-stack's CRD upgrade bundle). Deep-copies so
+// the original tree (shared with other consumers in the same
+// orchestrator run) is untouched.
+func normalizeDocs(docs []Doc, attrs []string) []Doc {
+	if len(attrs) == 0 && !docsContainBinaryData(docs) {
 		return docs
 	}
 	out := make([]Doc, len(docs))
 	for i, d := range docs {
 		copyDoc := manifest.DeepCopyMap(d.Manifest)
 		manifest.StripResourceAttributes(copyDoc, attrs)
+		redactBinaryData(copyDoc)
 		out[i] = Doc{Manifest: copyDoc, Parent: d.Parent}
 	}
 	return out
+}
+
+// docsContainBinaryData reports whether any doc is a ConfigMap
+// carrying a non-empty binaryData field — the only shape
+// redactBinaryData would touch. Used so the zero-input fast path in
+// normalizeDocs stays allocation-free when neither strip attrs nor
+// binary payloads are present.
+func docsContainBinaryData(docs []Doc) bool {
+	for _, d := range docs {
+		if manifest.DocKind(d.Manifest) != manifest.KindConfigMap {
+			continue
+		}
+		if _, ok := d.Manifest["binaryData"].(map[string]any); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// redactBinaryData rewrites each ConfigMap.binaryData value to a
+// content-derived summary. binaryData is, by Kubernetes convention,
+// opaque bytes; the useful review signal is "did the content change"
+// not "which base64 character flipped." Hash-prefix summaries
+// preserve that signal while keeping the diff legible.
+func redactBinaryData(doc map[string]any) {
+	if manifest.DocKind(doc) != manifest.KindConfigMap {
+		return
+	}
+	binaryData, ok := doc["binaryData"].(map[string]any)
+	if !ok {
+		return
+	}
+	for k, v := range binaryData {
+		binaryData[k] = binaryDataSummary(v)
+	}
+}
+
+// binaryDataSummary returns a stable, content-derived placeholder for
+// a single binaryData value. base64-decode is the happy path
+// (binaryData is spec'd as base64); the trim handles YAML's trailing
+// newline on multi-line scalars. On decode failure we still produce a
+// content hash over the raw string so unequal-but-malformed values
+// don't collapse to a single summary.
+func binaryDataSummary(v any) string {
+	s, ok := v.(string)
+	if !ok {
+		return "<redacted binary data>"
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(s))
+	if err != nil {
+		sum := sha256.Sum256([]byte(s))
+		return fmt.Sprintf("<redacted binary data: %d base64 chars sha256:%s>", len(s), hex.EncodeToString(sum[:8]))
+	}
+	sum := sha256.Sum256(decoded)
+	return fmt.Sprintf("<redacted binary data: %d bytes sha256:%s>", len(decoded), hex.EncodeToString(sum[:8]))
 }

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -398,6 +398,61 @@ func TestRun_StripAttrsRemovesNoise(t *testing.T) {
 	}
 }
 
+// TestRun_RedactsConfigMapBinaryData locks the ConfigMap.binaryData
+// redaction: each value is replaced with a content-derived summary
+// before dyff sees the manifest, so a chart bump that only rotates a
+// 200 KB binary hook payload (kube-prometheus-stack's CRD upgrade
+// bundle is the canonical case) still surfaces as a one-line "this
+// changed" diff instead of two walls of base64. Sibling text fields
+// in `data` keep their normal line-by-line diff.
+func TestRun_RedactsConfigMapBinaryData(t *testing.T) {
+	mk := func(blob, data string) []Doc {
+		return []Doc{{
+			Manifest: map[string]any{
+				"kind": "ConfigMap",
+				"metadata": map[string]any{
+					"name": "binary", "namespace": "ns",
+				},
+				"binaryData": map[string]any{"payload.bin": blob},
+				"data":       map[string]any{"visible": data},
+			},
+		}}
+	}
+
+	diffs, err := Run(mk("QUFBQQ==", "same"), mk("QkJCQg==", "same"), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("binaryData-only change should surface as a redacted diff, got %d diff(s)", len(diffs))
+	}
+	body := diffs[0].Diff
+	if !strings.Contains(body, "@@ binaryData.payload.bin @@") {
+		t.Errorf("expected binaryData path to remain; got:\n%s", body)
+	}
+	if !strings.Contains(body, "redacted binary data") {
+		t.Errorf("expected redaction marker; got:\n%s", body)
+	}
+	if strings.Contains(body, "QUFBQQ==") || strings.Contains(body, "QkJCQg==") {
+		t.Errorf("raw binaryData leaked into diff body:\n%s", body)
+	}
+
+	diffs, err = Run(mk("QUFBQQ==", "old"), mk("QkJCQg==", "new"), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diffs) != 1 {
+		t.Fatalf("mixed data + binaryData change should surface as one diff, got %d diff(s)", len(diffs))
+	}
+	body = diffs[0].Diff
+	if strings.Contains(body, "QUFBQQ==") || strings.Contains(body, "QkJCQg==") {
+		t.Errorf("raw binaryData leaked into diff body:\n%s", body)
+	}
+	if !strings.Contains(body, "@@ data.visible @@") {
+		t.Errorf("expected visible data change to remain; got:\n%s", body)
+	}
+}
+
 // TestRun_DistinguishesByParent locks the parent-aware pairing: two
 // HelmReleases each rendering a same-named Deployment are tracked
 // independently — a change to HR/a's copy doesn't leak into a phantom


### PR DESCRIPTION
## Summary

- ConfigMaps shipping large base64 `binaryData` payloads — kube-prometheus-stack's `kube-prometheus-stack-crds-upgrade` hook is the canonical case at ~200 KB — produced diff bodies that were two walls of base64. Reviewers couldn't tell whether anything meaningful changed, and dyff's value-change rendering is pathologically slow on strings that size.
- `applyStrip` is broadened to `normalizeDocs`: on top of the existing label/annotation strip, each `ConfigMap.binaryData` value is replaced with a content-derived summary. Equal payloads collapse to identical summaries (no spurious diff); different payloads produce distinct summaries so the change signal survives.
- Scope is `ConfigMap` only. `Secret.data` is already wiped to a placeholder upstream of the diff path; `ConfigMap.data` (intended for review — scripts, dashboards, configs) is unchanged.

## Example output

Before — two ~200 KB walls of base64 per chart bump. After:

```diff
# HelmRelease: o11y/kube-prometheus-stack ConfigMap: o11y/kube-prometheus-stack-crds-upgrade

@@ binaryData.crds.bz2 @@
! ± value change
- <redacted binary data: 197482 bytes sha256:13c348f8b955ef60>
+ <redacted binary data: 199495 bytes sha256:0ddb25907a6450c1>
```

## Test plan

- [x] `go test ./...` — passes repo-wide, including new `TestRun_RedactsConfigMapBinaryData`
- [x] `go vet ./...` clean
- [x] `gofmt -l pkg/diff/` clean
- [x] `go test -bench=BenchmarkNormalizeDocs -benchmem ./pkg/diff` — no regression vs. prior `BenchmarkApplyStrip` on the no-binaryData corpus
- [ ] Manual end-to-end: render a flux tree containing kube-prometheus-stack across two chart versions and confirm the `kube-prometheus-stack-crds-upgrade` ConfigMap diff shows the redacted summary

Ported from https://github.com/tjwallace/flate/pull/2.