### PR TITLE
refactor(controllers): drop test-only resolveSourceRoot wrapper

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -359,14 +359,6 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 	return deps
 }
 
-// resolveSourceRoot returns the on-disk root the kustomization should
-// be built from — i.e. the source artifact's local path. The Flux
-// renderer then joins ks.Path onto this root.
-func (c *Controller) resolveSourceRoot(ks *manifest.Kustomization) (string, error) {
-	path, _, err := c.resolveSourceRootAndFingerprint(ks)
-	return path, err
-}
-
 // resolveSourceRootAndFingerprint returns the source's on-disk root
 // AND its content-addressed fingerprint. The fingerprint feeds the
 // persistent kustomize staging cache: when non-empty, repeat renders

--- a/pkg/controllers/kustomization/source_root_test.go
+++ b/pkg/controllers/kustomization/source_root_test.go
@@ -40,7 +40,7 @@ func TestResolveSourceRoot_FallsBackToBootstrapWhenSourceRefEmpty(t *testing.T) 
 			// render's `patches:` block.
 		},
 	}
-	got, err := c.resolveSourceRoot(ks)
+	got, _, err := c.resolveSourceRootAndFingerprint(ks)
 	if err != nil {
 		t.Fatalf("resolveSourceRoot: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 		SourceName:        "external",
 		SourceNamespace:   "flux-system",
 	}
-	got, err := c.resolveSourceRoot(ks)
+	got, _, err := c.resolveSourceRootAndFingerprint(ks)
 	if err != nil {
 		t.Fatalf("resolveSourceRoot: %v", err)
 	}
@@ -97,7 +97,7 @@ func TestResolveSourceRoot_NoBootstrapNoSourceRefErrors(t *testing.T) {
 		Name: "foo", Namespace: "flux-system",
 		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
 	}
-	_, err := c.resolveSourceRoot(ks)
+	_, _, err := c.resolveSourceRootAndFingerprint(ks)
 	if err == nil {
 		t.Fatalf("expected error when bootstrap source is absent")
 	}


### PR DESCRIPTION
## Summary
- Remove the test-only `resolveSourceRoot` method (no production callers; wrapped `resolveSourceRootAndFingerprint` discarding the fingerprint). Tests now call the underlying method directly.

Behavior-preserving; part of a code-cleanliness refactor set. Independent (base `main`).

## Test plan
- [ ] `go test -race ./pkg/controllers/...`
- [ ] `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)