### PR TITLE
refactor(source): dedup cacheKeyHash/allocStaging, strip stale tag

### DIFF
--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -291,9 +291,17 @@ func (s *Slot) Stage() error {
 	if err := os.MkdirAll(filepath.Dir(s.final), 0o750); err != nil {
 		return fmt.Errorf("cache slot stage parent: %w", err)
 	}
+	return s.allocStaging("stage")
+}
+
+// allocStaging creates the .tmp.* staging dir under the final slot's
+// parent and points Path at it. label distinguishes the wrapped error
+// between the Stage and refresh-stage callers. Assumes s.staging is
+// empty — callers guard that and the parent-dir creation themselves.
+func (s *Slot) allocStaging(label string) error {
 	staging, err := os.MkdirTemp(filepath.Dir(s.final), filepath.Base(s.final)+".tmp.*")
 	if err != nil {
-		return fmt.Errorf("cache slot stage: %w", err)
+		return fmt.Errorf("cache slot %s: %w", label, err)
 	}
 	s.staging = staging
 	s.Path = staging
@@ -313,13 +321,7 @@ func (s *Slot) StageRefresh() error {
 		s.Path = s.staging
 		return nil
 	}
-	staging, err := os.MkdirTemp(filepath.Dir(s.final), filepath.Base(s.final)+".tmp.*")
-	if err != nil {
-		return fmt.Errorf("cache slot refresh stage: %w", err)
-	}
-	s.staging = staging
-	s.Path = staging
-	return nil
+	return s.allocStaging("refresh stage")
 }
 
 func (s *Slot) lockFile(ctx context.Context) error {

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -65,7 +65,7 @@ const (
 	HelmCacheDir  = "helm-cache"
 	StageDir      = "stage"
 	// RenderHelmCacheDir holds the persisted helm template-output
-	// cache (Phase 3.4a). Entries are sharded `<root>/render/helm/<hex[:2]>/<hex>`
+	// cache. Entries are sharded `<root>/render/helm/<hex[:2]>/<hex>`
 	// where <hex> is the full sha256 of the template-cache key. Content
 	// is gzipped rendered manifest bytes. Cross-process safe via atomic
 	// rename; eviction is mtime-LRU bounded by the caller's byte cap.

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -15,9 +15,6 @@ package git
 import (
 	"cmp"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -244,7 +241,8 @@ func gitCacheKey(repo *manifest.GitRepository, refLabel string) string {
 		RecurseSubmodules: repo.RecurseSubmodules,
 		Verify:            gitVerifyCacheKey(repo.Namespace, repo.Verification),
 	}
-	return refLabel + "#opts:" + cacheKeyHash(payload)
+	h, _ := source.CacheKeyHash(payload, 8)
+	return refLabel + "#opts:" + h
 }
 
 func gitVerifyCacheKey(namespace string, v *manifest.GitRepositoryVerify) string {
@@ -252,12 +250,6 @@ func gitVerifyCacheKey(namespace string, v *manifest.GitRepositoryVerify) string
 		return ""
 	}
 	return string(v.GetMode()) + ":" + namespace + "/" + v.SecretRef.Name
-}
-
-func cacheKeyHash(v any) string {
-	b, _ := json.Marshal(v)
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:8])
 }
 
 func canUseCachedGitSlot(ref *manifest.GitRepositoryRef) bool {

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -3,10 +3,7 @@ package oci
 import (
 	"cmp"
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -294,13 +291,8 @@ func ociCacheKey(repo *manifest.OCIRepository, ref manifest.OCIRepositoryRef, re
 		LayerOperation: effectiveLayerOperation(repo.LayerSelector),
 		Ignore:         ignore,
 	}
-	return payload.Ref + "#opts:" + ociCacheKeyHash(payload)
-}
-
-func ociCacheKeyHash(v any) string {
-	b, _ := json.Marshal(v)
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:8])
+	h, _ := source.CacheKeyHash(payload, 8)
+	return payload.Ref + "#opts:" + h
 }
 
 // checkCacheHit applies the cache-hit gauntlet to a populated slot:

--- a/pkg/source/oci/marker.go
+++ b/pkg/source/oci/marker.go
@@ -1,9 +1,6 @@
 package oci
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +9,7 @@ import (
 	"time"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/atomic"
 )
 
@@ -94,14 +92,13 @@ func verifyFingerprint(v *manifest.OCIRepositoryVerify) string {
 	if v == nil {
 		return ""
 	}
-	b, err := json.Marshal(v)
+	h, err := source.CacheKeyHash(v, 16)
 	if err != nil {
 		// Marshal-of-typed-struct shouldn't fail; if it does we
 		// fingerprint as empty which forces re-verify (safe default).
 		return ""
 	}
-	sum := sha256.Sum256(b)
-	return hex.EncodeToString(sum[:16])
+	return h
 }
 
 // writeVerifyMarker persists the verify-policy fingerprint to the

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -15,6 +15,9 @@ package source
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -95,6 +98,20 @@ func (ExistenceFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*stor
 func ErrUnsupportedProvider(kind, namespace, name, got, want, hint string) error {
 	return fmt.Errorf("%s %s/%s provider %q is not implemented; flate currently supports only %q (%s)",
 		kind, namespace, name, got, want, hint)
+}
+
+// CacheKeyHash marshals v to JSON, sha256-hashes the bytes, and returns
+// the hex of the first n bytes — the shared cache-key fingerprint used
+// by the per-kind fetchers. Exported so subpackages (git, oci) can reuse
+// one implementation; each caller picks its own width (n) and decides how
+// to treat a marshal error.
+func CacheKeyHash(v any, n int) (string, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:n]), nil
 }
 
 // SecretGetter resolves a Secret CR by namespace + name. Fetchers


### PR DESCRIPTION
## Summary
- Collapse three copies of the json→sha256→hex cache-key hash into one exported `source.CacheKeyHash(v, n)`.
- Extract `Slot.allocStaging(label)` shared by `Stage`/`StageRefresh` (error strings preserved).
- Strip a stale internal phase tag from a comment.

Behavior-preserving; part of a code-cleanliness refactor set. Independent (base `main`).

## Test plan
- [ ] `go test -race ./pkg/source/...`
- [ ] `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)