### PR TITLE
refactor: drop test-only AllReady, trim stale comments

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -56,7 +56,7 @@ type commonFlags struct {
 	// constructor.
 	helmTemplateCacheMB int
 	// helmRenderCacheMB caps the persistent on-disk helm template-
-	// output cache in megabytes (Phase 3.4a). Default 1024; 0
+	// output cache in megabytes. Default 1024; 0
 	// disables. Plumbed through orchestrator.Config.HelmRenderCacheBytes
 	// into the helm.Client constructor. Cross-process: repeat `flate
 	// build` / `flate diff` runs against the same checkout reuse

--- a/pkg/depwait/bench_test.go
+++ b/pkg/depwait/bench_test.go
@@ -33,7 +33,7 @@ func BenchmarkWatchReady_ManyDeps(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		sum := WaitAll(w.Watch(ctx, deps))
-		if !sum.AllReady() {
+		if sum.AnyFailed() {
 			b.Fatalf("expected all ready: %+v", sum)
 		}
 	}

--- a/pkg/depwait/cel_test.go
+++ b/pkg/depwait/cel_test.go
@@ -28,7 +28,7 @@ func TestReadyExpr_ProjectsObservedGeneration(t *testing.T) {
 		// Common Flux readiness idiom.
 		ReadyExpr: `dep.status.observedGeneration == dep.metadata.generation`,
 	}}))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("observedGeneration projection should match metadata.generation: %+v", sum)
 	}
 }
@@ -48,7 +48,7 @@ func TestReadyExpr_NonAdditive_PassesOnTrue(t *testing.T) {
 		NamedResource: dep,
 		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("non-additive ReadyExpr should override Failed Ready: %+v", sum)
 	}
 }
@@ -75,7 +75,7 @@ func TestReadyExpr_NonAdditive_FlipsOnStatusUpdate(t *testing.T) {
 		NamedResource: dep,
 		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("expected to satisfy after status update: %+v", sum)
 	}
 }
@@ -93,7 +93,7 @@ func TestReadyExpr_NonAdditive_TimesOutOnFalse(t *testing.T) {
 		NamedResource: dep,
 		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
-	if sum.AllReady() {
+	if !sum.AnyFailed() {
 		t.Fatalf("expected timeout: %+v", sum)
 	}
 	if !strings.Contains(sum.Messages[dep], "readyExpr timeout") {
@@ -116,8 +116,8 @@ func TestReadyExpr_Additive_BothMustPass(t *testing.T) {
 		NamedResource: dep,
 		ReadyExpr:     `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`,
 	}}))
-	if !sum.AllReady() {
-		t.Errorf("expected AllReady when both checks pass: %+v", sum)
+	if sum.AnyFailed() {
+		t.Errorf("expected all ready when both checks pass: %+v", sum)
 	}
 }
 
@@ -207,7 +207,7 @@ func TestReadyExpr_TransientEvalErrorPolls(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		s.SetCondition(dep, store.Condition{Type: "Ready", Status: metav1.ConditionTrue})
 	}()
-	if sum := WaitAll(ch); !sum.AllReady() {
+	if sum := WaitAll(ch); sum.AnyFailed() {
 		t.Errorf("dep should go Ready once conditions[0] populates: %+v", sum)
 	}
 }
@@ -237,7 +237,7 @@ func TestReadyExpr_ReadsLabelsAndAnnotations(t *testing.T) {
 			NamedResource: dep,
 			ReadyExpr:     expr,
 		}}))
-		if !sum.AllReady() {
+		if sum.AnyFailed() {
 			t.Errorf("expr %q: not Ready: %+v", expr, sum)
 		}
 	}
@@ -262,7 +262,7 @@ func TestReadyExpr_BindsSelfAndDep(t *testing.T) {
 		// `object`-only binding.
 		ReadyExpr: `self.metadata.namespace == dep.metadata.namespace`,
 	}}))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("expected self/dep CEL to evaluate true: %+v", sum)
 	}
 }
@@ -276,7 +276,7 @@ func TestReadyExpr_Empty_UsesBuiltin(t *testing.T) {
 
 	w := &Waiter{Store: s, Timeout: time.Second}
 	sum := WaitAll(w.Watch(context.Background(), []manifest.DependencyRef{{NamedResource: dep}}))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("plain dep with Ready status should pass: %+v", sum)
 	}
 }

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -87,9 +87,6 @@ type Summary struct {
 	Messages map[manifest.NamedResource]string
 }
 
-// AllReady reports whether every dependency reached DepReady.
-func (s Summary) AllReady() bool { return len(s.Failed) == 0 }
-
 // AnyFailed reports whether at least one dependency ended in failure.
 func (s Summary) AnyFailed() bool { return len(s.Failed) > 0 }
 

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -76,7 +76,7 @@ func TestWaiter_AllReady(t *testing.T) {
 
 	w := &Waiter{Store: s, Timeout: time.Second}
 	sum := WaitAll(w.Watch(context.Background(), refs(dep1, dep2)))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("expected all ready: %+v", sum)
 	}
 }
@@ -105,7 +105,7 @@ func TestWaiter_Exists_NonStatusKind(t *testing.T) {
 
 	w := &Waiter{Store: s, Timeout: time.Second}
 	sum := WaitAll(w.Watch(context.Background(), refs(id)))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("expected ConfigMap to become ready: %+v", sum)
 	}
 }
@@ -173,7 +173,7 @@ func TestWaiter_ResolveMissingLazyPromotes(t *testing.T) {
 	if !resolveCalled {
 		t.Errorf("Existence.Promote was never invoked")
 	}
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("expected dep to clear after lazy promotion: %+v", sum)
 	}
 }
@@ -228,7 +228,7 @@ func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
 		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("render-only dep that arrived after grace should clear, not fail: %+v", sum)
 	}
 }
@@ -447,7 +447,7 @@ func TestWaiter_RenderInflightActiveHoldsTheWait(t *testing.T) {
 	}()
 
 	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("dep arrived after grace with Renders active; expected Ready: %+v", sum)
 	}
 }
@@ -508,7 +508,7 @@ func TestWaiter_ReadyExprCancelSurfacesCancelled(t *testing.T) {
 func TestWaiter_NoDeps(t *testing.T) {
 	w := &Waiter{Store: store.New()}
 	sum := WaitAll(w.Watch(context.Background(), nil))
-	if !sum.AllReady() {
+	if sum.AnyFailed() {
 		t.Errorf("expected vacuous ready: %+v", sum)
 	}
 }
@@ -578,7 +578,7 @@ func TestWaiter_ReadyExprWakesOnObjectAdded(t *testing.T) {
 
 	select {
 	case sum := <-done:
-		if sum.AnyFailed() || !sum.AllReady() {
+		if sum.AnyFailed() {
 			t.Fatalf("expected ready; got %+v", sum)
 		}
 	case <-time.After(2 * time.Second):

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -153,13 +153,8 @@ func (d *discoverer) applyNamespaces(repoRoot string) {
 }
 
 // mergeParents combines per-kind parent maps into one. NamedResource
-// keys are kind-segregated by construction (caller passes per-Kind
-// maps from BuildParentIndexForKind), so collisions are structurally
-// impossible. The previous "earlier wins on collision" clause was
-// dead defensive code that silently masked a programmer error if a
-// future caller leaked wrong-kind entries — drop it and let the
-// later-arguments-overwrite default surface the bug at the call
-// site instead.
+// keys are kind-segregated by construction (caller passes per-Kind maps
+// from BuildParentIndexForKind), so collisions are structurally impossible.
 func mergeParents(perKind ...map[manifest.NamedResource]manifest.NamedResource) map[manifest.NamedResource]manifest.NamedResource {
 	out := map[manifest.NamedResource]manifest.NamedResource{}
 	for _, m := range perKind {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -63,7 +63,7 @@ func newShard() *shard {
 
 // Store is the central in-memory state container.
 //
-// # Sharded layout (Phase 3.1)
+// # Sharded layout
 //
 // The Store's hot state is sharded across shardCount shards keyed by
 // the FNV-1a hash of id.Kind. Reads and writes on different Kinds no

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -368,6 +368,7 @@ func decodeBag(stringData, binaryData map[string]any) (map[string]string, error)
 // (string, []byte after future schema corrections, JSON-numeric
 // scalars) from the "garbage value" case which now returns an error
 // instead of silently rendering "[107 58]"-style Stringer output.
+// Also used by VarsMap for scalar postBuild substitution values.
 func bagValueAsString(v any) (string, error) {
 	switch t := v.(type) {
 	case string:


### PR DESCRIPTION
## Summary
- Remove the test-only `Summary.AllReady` (`pkg/depwait`); tests use `!AnyFailed()`.
- Doc note on `bagValueAsString` re its reuse by `VarsMap` (`pkg/values`).
- Trim an 8-line archaeology comment in `discovery.mergeParents` to the live invariant.
- Strip two stale internal phase tags (`internal/cli`, `pkg/store`).

Behavior-preserving; part of a code-cleanliness refactor set. Independent (base `main`).

## Test plan
- [ ] `go test -race ./pkg/depwait/... ./pkg/values/... ./pkg/discovery/...`
- [ ] `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)