### PR TITLE
refactor(helm): extract newInstallAction, move test-only hooks, fix name collision

### DIFF
--- a/pkg/helm/bench_test.go
+++ b/pkg/helm/bench_test.go
@@ -155,8 +155,8 @@ func BenchmarkMergeChartValuesFiles(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		if _, err := mergeChartValuesFiles(ch, names, false); err != nil {
-			b.Fatalf("mergeChartValuesFiles: %v", err)
+		if _, err := mergeChartValuesFilesUncached(ch, names, false); err != nil {
+			b.Fatalf("mergeChartValuesFilesUncached: %v", err)
 		}
 	}
 }

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -179,7 +179,7 @@ type ClientOptions struct {
 	TemplateCacheBytes int64
 
 	// RenderCacheBytes caps the persistent on-disk helm template-
-	// output cache (Phase 3.4a). <= 0 disables disk caching. Disk
+	// output cache. <= 0 disables disk caching. Disk
 	// caching is also disabled when RenderCacheRoot is empty even
 	// if RenderCacheBytes > 0 — the wiring requires both.
 	RenderCacheBytes int64

--- a/pkg/helm/export_test.go
+++ b/pkg/helm/export_test.go
@@ -1,0 +1,39 @@
+package helm
+
+import "time"
+
+// Size reports the running total of cached entry costs (sum of
+// value sizes). Used by tests to verify eviction accounting.
+func (c *templateCache) Size() int64 {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.size
+}
+
+// Len returns the number of currently-cached entries. Test affordance.
+func (c *templateCache) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.list.Len()
+}
+
+// SweepBlocking forces a synchronous eviction pass. Test affordance —
+// production callers use the async trigger inside Put. Useful for
+// asserting eviction ordering without flake.
+func (c *diskRenderCache) SweepBlocking() {
+	if c == nil {
+		return
+	}
+	// Wait for any in-flight async sweep to drain before kicking off
+	// our own so the synchronous call sees a stable view.
+	for !c.sweepBusy.CompareAndSwap(0, 1) {
+		time.Sleep(time.Millisecond)
+	}
+	c.sweep()
+}

--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -433,7 +433,7 @@ func TestMergeChartValuesFiles(t *testing.T) {
 			"first.yaml":  "a: first-only\nb: from-first\n",
 			"second.yaml": "b: from-second\nc: second-only\n",
 		})
-		got, err := mergeChartValuesFiles(c, []string{"first.yaml", "second.yaml"}, false)
+		got, err := mergeChartValuesFilesUncached(c, []string{"first.yaml", "second.yaml"}, false)
 		if err != nil {
 			t.Fatalf("merge: %v", err)
 		}
@@ -444,7 +444,7 @@ func TestMergeChartValuesFiles(t *testing.T) {
 
 	t.Run("MissingFileIgnored", func(t *testing.T) {
 		c := chartWith(map[string]string{"a.yaml": "k: v\n"})
-		got, err := mergeChartValuesFiles(c, []string{"a.yaml", "missing.yaml"}, true)
+		got, err := mergeChartValuesFilesUncached(c, []string{"a.yaml", "missing.yaml"}, true)
 		if err != nil {
 			t.Fatalf("merge: %v", err)
 		}
@@ -455,7 +455,7 @@ func TestMergeChartValuesFiles(t *testing.T) {
 
 	t.Run("MissingFileErrorsWhenStrict", func(t *testing.T) {
 		c := chartWith(map[string]string{"a.yaml": "k: v\n"})
-		_, err := mergeChartValuesFiles(c, []string{"missing.yaml"}, false)
+		_, err := mergeChartValuesFilesUncached(c, []string{"missing.yaml"}, false)
 		if err == nil {
 			t.Fatal("expected error for missing file when ignoreMissing=false")
 		}
@@ -466,7 +466,7 @@ func TestMergeChartValuesFiles(t *testing.T) {
 
 	t.Run("InvalidYAMLErrors", func(t *testing.T) {
 		c := chartWith(map[string]string{"bad.yaml": "key: : not-yaml\n"})
-		_, err := mergeChartValuesFiles(c, []string{"bad.yaml"}, false)
+		_, err := mergeChartValuesFilesUncached(c, []string{"bad.yaml"}, false)
 		if err == nil {
 			t.Fatal("expected error for invalid YAML")
 		}
@@ -477,7 +477,7 @@ func TestMergeChartValuesFiles(t *testing.T) {
 
 	t.Run("EmptyNamesReturnsEmpty", func(t *testing.T) {
 		c := chartWith(map[string]string{"a.yaml": "k: v\n"})
-		got, err := mergeChartValuesFiles(c, nil, false)
+		got, err := mergeChartValuesFilesUncached(c, nil, false)
 		if err != nil {
 			t.Fatalf("merge: %v", err)
 		}

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -180,21 +180,6 @@ func (c *diskRenderCache) Put(key string, payload []byte) {
 	}
 }
 
-// SweepBlocking forces a synchronous eviction pass. Test affordance —
-// production callers use the async trigger inside Put. Useful for
-// asserting eviction ordering without flake.
-func (c *diskRenderCache) SweepBlocking() {
-	if c == nil {
-		return
-	}
-	// Wait for any in-flight async sweep to drain before kicking off
-	// our own so the synchronous call sees a stable view.
-	for !c.sweepBusy.CompareAndSwap(0, 1) {
-		time.Sleep(time.Millisecond)
-	}
-	c.sweep()
-}
-
 // sweep walks the cache root, totals byte usage, and (if over the
 // limit) deletes oldest-by-mtime entries until total ≤ limit. Runs
 // on a single goroutine — sweepBusy gates re-trigger so a sustained

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -50,82 +50,12 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	}
 	cfg.Capabilities = caps
 
-	inst := action.NewInstall(cfg)
-	inst.DryRunStrategy = action.DryRunClient
-	inst.ReleaseName = hr.ReleaseName()
-	inst.Namespace = hr.ReleaseNamespace()
-	// Match helm-controller: Devel=true so chart references pinned to a
-	// prerelease semver (e.g. `1.0.0-beta`) resolve. Without this, the
-	// HR renders cleanly in flate (which doesn't consult Devel for local
-	// chart resolution) but fails in cluster, or vice versa.
-	inst.Devel = true
-	inst.IncludeCRDs = !opts.SkipCRDs
-	// HR-scoped policy wins: spec.install.crds / spec.upgrade.crds set
-	// to "Skip" suppresses CRDs even when the CLI requests them.
-	// "Create" / "CreateReplace" force them on. An empty policy lets
-	// the CLI flag decide.
-	switch hr.CRDsPolicy {
-	case "Skip":
-		inst.IncludeCRDs = false
-	case "Create", "CreateReplace":
-		inst.IncludeCRDs = true
-	}
-	// HR-scoped install/upgrade.disableHooks OR'd with the CLI flag,
-	// mirroring helm-controller. Either side forces hooks off — and
-	// the same effective flag drives the post-render hook filter at
-	// the bottom of this function so they don't leak into the output.
-	disableHooks := opts.NoHooks ||
-		(hr.Install != nil && hr.Install.DisableHooks) ||
-		(hr.Upgrade != nil && hr.Upgrade.DisableHooks)
-	inst.DisableHooks = disableHooks
-	inst.IsUpgrade = opts.IsUpgrade
-	inst.EnableDNS = opts.EnableDNS
-	// Honor spec.install.replace per helm-controller's
-	// internal/action/install.go: install.Replace = obj.GetInstall().Replace.
-	// Default false (the chart fields' zero value); set true only when
-	// the HR explicitly asks. Mostly a no-op under DryRunClient but
-	// keeps flate's render path matching upstream so any future
-	// validation behavior change in helm.action lands consistently.
-	if hr.Install != nil {
-		inst.Replace = hr.Install.Replace
-	}
-	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
-	// When flate's wipe-secrets has replaced a substituteFrom / valuesFrom
-	// value with the ..PLACEHOLDER_KEY.. token, chart schemas with DNS /
-	// URL / regex patterns reject it (the placeholder isn't a valid
-	// hostname). Disable schema validation when any placeholder reaches
-	// rendering so the user sees the rendered output rather than a
-	// validation error against a value flate fabricated. Real Flux
-	// resolves the secret to the actual value and validates normally —
-	// flate can't, so this short-circuits the failure mode.
-	inst.SkipSchemaValidation = opts.SkipSchemaValidation || hr.DisableSchemaValidation || manifest.ContainsValuePlaceholder(hrValues)
-	// spec.postRenderers — pipe rendered output through one or more
-	// kustomize patch+image transforms. helm-controller does this via
-	// the same postrenderer.PostRenderer hook.
-	inst.PostRenderer = newPostRenderer(hr.PostRenderers)
-	// action.Install consults its own KubeVersion field for chart
-	// compatibility checks and ignores cfg.Capabilities for that purpose.
-	if opts.KubeVersion != "" {
-		kv, err := common.ParseKubeVersion(opts.KubeVersion)
-		if err != nil {
-			return "", fmt.Errorf("parse kube-version %q: %w", opts.KubeVersion, err)
-		}
-		inst.KubeVersion = kv
-	}
-	// Same for APIVersions — action.Install under DryRunClient
-	// replaces cfg.Capabilities with a fresh default copy and then
-	// only re-applies inst.APIVersions onto that copy. Setting
-	// cfg.Capabilities alone leaves APIVersions empty at render
-	// time, silently dropping the user's --api-versions flag.
-	if len(caps.APIVersions) > 0 {
-		inst.APIVersions = caps.APIVersions
+	inst, disableHooks, err := newInstallAction(cfg, hr, hrValues, opts, caps)
+	if err != nil {
+		return "", err
 	}
 	if hrValues == nil {
 		hrValues = map[string]any{}
-	}
-
-	if hr.Chart.Version != "" {
-		inst.Version = hr.Chart.Version
 	}
 
 	// Apply chart valuesFiles BEFORE HR.Values so HR overrides win.
@@ -175,6 +105,88 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	return out, nil
 }
 
+// newInstallAction builds the DryRunClient action.Install that Template
+// renders through, mirroring helm-controller's install/upgrade field
+// wiring. Returns the configured install, the effective disableHooks
+// flag (reused by Template's post-render hook filter so hooks don't
+// leak into the output when disabled), and any kube-version parse error.
+func newInstallAction(cfg *action.Configuration, hr *manifest.HelmRelease, hrValues map[string]any, opts Options, caps *common.Capabilities) (*action.Install, bool, error) {
+	inst := action.NewInstall(cfg)
+	inst.DryRunStrategy = action.DryRunClient
+	inst.ReleaseName = hr.ReleaseName()
+	inst.Namespace = hr.ReleaseNamespace()
+	// Match helm-controller: Devel=true so chart references pinned to a
+	// prerelease semver (e.g. `1.0.0-beta`) resolve. Without this, the
+	// HR renders cleanly in flate (which doesn't consult Devel for local
+	// chart resolution) but fails in cluster, or vice versa.
+	inst.Devel = true
+	inst.IncludeCRDs = !opts.SkipCRDs
+	// HR-scoped policy wins: spec.install.crds / spec.upgrade.crds set
+	// to "Skip" suppresses CRDs even when the CLI requests them.
+	// "Create" / "CreateReplace" force them on. An empty policy lets
+	// the CLI flag decide.
+	switch hr.CRDsPolicy {
+	case "Skip":
+		inst.IncludeCRDs = false
+	case "Create", "CreateReplace":
+		inst.IncludeCRDs = true
+	}
+	// HR-scoped install/upgrade.disableHooks OR'd with the CLI flag,
+	// mirroring helm-controller. Either side forces hooks off — and
+	// the same effective flag drives the post-render hook filter at
+	// the bottom of Template so they don't leak into the output.
+	disableHooks := opts.NoHooks ||
+		(hr.Install != nil && hr.Install.DisableHooks) ||
+		(hr.Upgrade != nil && hr.Upgrade.DisableHooks)
+	inst.DisableHooks = disableHooks
+	inst.IsUpgrade = opts.IsUpgrade
+	inst.EnableDNS = opts.EnableDNS
+	// Honor spec.install.replace per helm-controller's
+	// internal/action/install.go: install.Replace = obj.GetInstall().Replace.
+	// Default false (the chart fields' zero value); set true only when
+	// the HR explicitly asks. Mostly a no-op under DryRunClient but
+	// keeps flate's render path matching upstream so any future
+	// validation behavior change in helm.action lands consistently.
+	if hr.Install != nil {
+		inst.Replace = hr.Install.Replace
+	}
+	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
+	// When flate's wipe-secrets has replaced a substituteFrom / valuesFrom
+	// value with the ..PLACEHOLDER_KEY.. token, chart schemas with DNS /
+	// URL / regex patterns reject it (the placeholder isn't a valid
+	// hostname). Disable schema validation when any placeholder reaches
+	// rendering so the user sees the rendered output rather than a
+	// validation error against a value flate fabricated. Real Flux
+	// resolves the secret to the actual value and validates normally —
+	// flate can't, so this short-circuits the failure mode.
+	inst.SkipSchemaValidation = opts.SkipSchemaValidation || hr.DisableSchemaValidation || manifest.ContainsValuePlaceholder(hrValues)
+	// spec.postRenderers — pipe rendered output through one or more
+	// kustomize patch+image transforms. helm-controller does this via
+	// the same postrenderer.PostRenderer hook.
+	inst.PostRenderer = newPostRenderer(hr.PostRenderers)
+	// action.Install consults its own KubeVersion field for chart
+	// compatibility checks and ignores cfg.Capabilities for that purpose.
+	if opts.KubeVersion != "" {
+		kv, err := common.ParseKubeVersion(opts.KubeVersion)
+		if err != nil {
+			return nil, false, fmt.Errorf("parse kube-version %q: %w", opts.KubeVersion, err)
+		}
+		inst.KubeVersion = kv
+	}
+	// Same for APIVersions — action.Install under DryRunClient
+	// replaces cfg.Capabilities with a fresh default copy and then
+	// only re-applies inst.APIVersions onto that copy. Setting
+	// cfg.Capabilities alone leaves APIVersions empty at render
+	// time, silently dropping the user's --api-versions flag.
+	if len(caps.APIVersions) > 0 {
+		inst.APIVersions = caps.APIVersions
+	}
+	if hr.Chart.Version != "" {
+		inst.Version = hr.Chart.Version
+	}
+	return inst, disableHooks, nil
+}
+
 // mergeChartValuesFiles is the cache-aware entry point: it consults
 // Client.chartValuesCache before re-parsing and stores the canonical
 // merged map on miss. Callers receive a deep clone (defensive-copy
@@ -197,7 +209,7 @@ func (c *Client) mergeChartValuesFiles(ch *chart.Chart, names []string, ignoreMi
 	if ok {
 		return manifest.DeepCopyMap(cached), nil
 	}
-	merged, err := mergeChartValuesFiles(ch, names, ignoreMissing)
+	merged, err := mergeChartValuesFilesUncached(ch, names, ignoreMissing)
 	if err != nil {
 		return nil, err
 	}
@@ -240,17 +252,17 @@ func chartValuesCacheKey(ch *chart.Chart, names []string, ignoreMissing bool) st
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// mergeChartValuesFiles merges the named values files (relative paths
-// inside the chart archive) in the supplied order. Missing files are
-// skipped when ignoreMissing is true; otherwise the first missing file
-// is an error. Mirrors helm-controller's chartutil layering: each file
-// is merged on top of the previous one.
+// mergeChartValuesFilesUncached merges the named values files (relative
+// paths inside the chart archive) in the supplied order. Missing files
+// are skipped when ignoreMissing is true; otherwise the first missing
+// file is an error. Mirrors helm-controller's chartutil layering: each
+// file is merged on top of the previous one.
 //
 // Pure function — no caching. Client.mergeChartValuesFiles wraps this
 // with the chart-keyed cache layer so production callers never re-parse
 // the same bytes twice. Kept exported-to-package so benchmarks can
 // measure the uncached parse cost in isolation.
-func mergeChartValuesFiles(c *chart.Chart, names []string, ignoreMissing bool) (map[string]any, error) {
+func mergeChartValuesFilesUncached(c *chart.Chart, names []string, ignoreMissing bool) (map[string]any, error) {
 	out := map[string]any{}
 	for _, name := range names {
 		var data []byte

--- a/pkg/helm/template_cache.go
+++ b/pkg/helm/template_cache.go
@@ -23,7 +23,7 @@ import (
 // (template.go's cited ~300 MB on a 200-HR run).
 //
 // The cache is in-memory only; persistence across `flate` invocations
-// is a Phase 3 concern.
+// is handled by the disk-backed layer.
 //
 // Eviction is strict LRU bounded by total `limit` bytes (the sum of
 // every entry's value size). On insert we evict from the back of the
@@ -38,7 +38,7 @@ type templateCache struct {
 	list  *list.List
 	index map[string]*list.Element
 
-	// disk is the persistent cross-process layer (Phase 3.4a). nil
+	// disk is the persistent cross-process layer. nil
 	// when disk caching is disabled (RenderCacheBytes <= 0 or empty
 	// RenderCacheRoot). Get falls through to disk on memory miss and
 	// promotes hits to the in-process LRU; Put writes through to disk
@@ -182,27 +182,6 @@ func (c *templateCache) removeElement(el *list.Element) {
 	c.list.Remove(el)
 	delete(c.index, entry.key)
 	c.size -= entry.cost
-}
-
-// Size reports the running total of cached entry costs (sum of
-// value sizes). Used by tests to verify eviction accounting.
-func (c *templateCache) Size() int64 {
-	if c == nil {
-		return 0
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.size
-}
-
-// Len returns the number of currently-cached entries. Test affordance.
-func (c *templateCache) Len() int {
-	if c == nil {
-		return 0
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.list.Len()
 }
 
 // chartFingerprint returns the hex-encoded sha256 of every input


### PR DESCRIPTION
## Summary
- Extract `newInstallAction(...)` from `Client.Template` (142→~50 lines).
- Move test-only `templateCache.Size()/Len()` and `diskRenderCache.SweepBlocking()` into `export_test.go`.
- Rename package-level `mergeChartValuesFiles`→`mergeChartValuesFilesUncached` (resolves the method/func name collision).
- Strip stale internal phase tags.

Behavior-preserving; part of a code-cleanliness refactor set. Independent (base `main`). **Head of the caching stack** — `refactor/kustomize-cleanup` and `refactor/diskcache-cas` build on this.

## Test plan
- [ ] `go test -race ./pkg/helm/...`
- [ ] `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)