### PR TITLE
refactor: unify disk-cache sweep + atomic CAS staging (internal/diskcache, internal/cas)

### DIFF
--- a/internal/cas/stage.go
+++ b/internal/cas/stage.go
@@ -1,0 +1,61 @@
+// Package cas holds the atomic content-addressed staging dance shared
+// by baseline materialization and the kustomize stage cache: build into
+// a sibling temp dir, atomically rename it into the final slot, and —
+// when the rename loses a cross-process race — discard the temp and
+// adopt the winner's already-finalized directory.
+//
+// What "build" does and how a race is detected differ between callers
+// (baseline writes a git tree + .git marker and adopts on a finalized
+// directory; the stage cache copies a file tree and adopts on a sentinel
+// file), so both are callbacks. The temp-dir lifecycle, the rename, and
+// the discard-on-failure cleanup are identical and live here.
+package cas
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Stage builds final atomically. It creates a sibling temp dir
+// (filepath.Base(final)+".tmp.*") under parent, runs build against that
+// temp dir, then renames it onto final. parent must already exist.
+//
+//   - The MkdirTemp error is wrapped with tmpPrefix ("<tmpPrefix>: %w").
+//   - On a build error the temp dir is removed and the error is returned
+//     unwrapped — the build callback owns its own error context.
+//   - On rename success final is the built tree.
+//   - On rename failure the temp dir is removed and adopt is consulted:
+//     when adopt reports true a peer already finalized final and we
+//     adopt it (no error); otherwise the rename error is wrapped with
+//     finalizePrefix ("<finalizePrefix>: %w").
+//
+// The two prefixes keep each call site's existing error strings intact
+// ("baseline staging"/"baseline finalize", "stage tmp"/"stage finalize").
+//
+// adopted reports whether the returned slot came from adopting a peer's
+// finalized directory (false on the normal rename-wins path); callers
+// that distinguish "we built it" from "we adopted it" use it, others
+// ignore it.
+func Stage(parent, final, tmpPrefix, finalizePrefix string, build func(staging string) error, adopt func() bool) (adopted bool, err error) {
+	staging, err := os.MkdirTemp(parent, filepath.Base(final)+".tmp.*")
+	if err != nil {
+		return false, fmt.Errorf("%s: %w", tmpPrefix, err)
+	}
+	if err := build(staging); err != nil {
+		_ = os.RemoveAll(staging)
+		return false, err
+	}
+	if err := os.Rename(staging, final); err != nil {
+		_ = os.RemoveAll(staging)
+		// A racing peer process beat us to the rename. Content
+		// addressing guarantees the trees are equivalent, so when the
+		// caller confirms the winner finalized, adopt it instead of
+		// re-materializing or surfacing the lost-race error.
+		if adopt() {
+			return true, nil
+		}
+		return false, fmt.Errorf("%s: %w", finalizePrefix, err)
+	}
+	return false, nil
+}

--- a/internal/diskcache/sweep.go
+++ b/internal/diskcache/sweep.go
@@ -1,0 +1,64 @@
+// Package diskcache holds the pieces of the single-flight, mtime-LRU
+// disk-cache sweep shared by the helm render cache and the kustomize
+// stage cache. The two consumers collect their entries very
+// differently (a recursive file walk vs. a two-level, sentinel-filtered
+// directory scan), so collection stays in each package; what's shared
+// here is the single-flight gate that keeps a burst of writes from
+// forking one sweep per write, and the oldest-first eviction loop that
+// deletes entries until total bytes fall under a cap.
+package diskcache
+
+import (
+	"slices"
+	"sync/atomic"
+)
+
+// Gate is a single-flight gate for an asynchronous sweep: at most one
+// sweep runs at a time, so a write storm past the cap schedules exactly
+// one eviction pass instead of N. The zero value is ready to use.
+type Gate struct {
+	busy atomic.Bool
+}
+
+// TryAcquire returns true and marks the gate busy when no sweep is in
+// flight, false when one already is. The acquirer owns the gate until
+// it calls Release.
+func (g *Gate) TryAcquire() bool { return g.busy.CompareAndSwap(false, true) }
+
+// Release clears the busy flag so the next over-cap write can
+// re-trigger. Pair every successful TryAcquire with a Release (defer it
+// in the sweep goroutine).
+func (g *Gate) Release() { g.busy.Store(false) }
+
+// Entry is one candidate for eviction: an absolute path, its byte size,
+// and the mtime the LRU order is computed from (unix nanos for a stable
+// total order across the two callers' clock representations).
+type Entry struct {
+	Path  string
+	Size  int64
+	MTime int64
+}
+
+// EvictOldest removes entries oldest-first until the running total is at
+// or below limit. total is the caller's pre-summed byte usage of
+// entries; when it's already within limit nothing is removed. less
+// defines the eviction order (callers pin their own tie-break — helm
+// sorts by mtime then path, the stage cache by mtime alone). remove
+// deletes one entry's path and returns an error on failure; a failed
+// remove is skipped (its bytes stay counted) and the sweep continues,
+// matching both call sites' best-effort semantics.
+func EvictOldest(entries []Entry, total, limit int64, less func(a, b Entry) int, remove func(e Entry) error) {
+	if total <= limit {
+		return
+	}
+	slices.SortFunc(entries, less)
+	for _, e := range entries {
+		if total <= limit {
+			break
+		}
+		if err := remove(e); err != nil {
+			continue
+		}
+		total -= e.Size
+	}
+}

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
+	"github.com/home-operations/flate/internal/cas"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/source/gittree"
 )
@@ -119,23 +120,12 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		// finalize is an atomic rename — concurrent diffs against the
 		// same commit will either share the finished slot or fall
 		// through to their own stage (one wins the rename, the rest
-		// see ErrExist and clean up).
-		staging, err := os.MkdirTemp(filepath.Dir(slot), filepath.Base(slot)+".tmp.*")
-		if err != nil {
-			return "", false, fmt.Errorf("baseline staging: %w", err)
-		}
-		if err := materializeAndMark(repo, hash, staging); err != nil {
-			_ = os.RemoveAll(staging)
+		// see ErrExist, discard the temp, and adopt the winner's slot).
+		if _, err := cas.Stage(filepath.Dir(slot), slot, "baseline staging", "baseline finalize",
+			func(staging string) error { return materializeAndMark(repo, hash, staging) },
+			func() bool { info, statErr := os.Stat(slot); return statErr == nil && info.IsDir() },
+		); err != nil {
 			return "", false, err
-		}
-		if err := os.Rename(staging, slot); err != nil {
-			_ = os.RemoveAll(staging)
-			// A racing diff may have finalized first; if the slot now
-			// exists we can adopt it without re-materializing.
-			if info, statErr := os.Stat(slot); statErr == nil && info.IsDir() {
-				return slot, true, nil
-			}
-			return "", false, fmt.Errorf("baseline finalize: %w", err)
 		}
 		return slot, true, nil
 	}

--- a/pkg/helm/export_test.go
+++ b/pkg/helm/export_test.go
@@ -32,7 +32,7 @@ func (c *diskRenderCache) SweepBlocking() {
 	}
 	// Wait for any in-flight async sweep to drain before kicking off
 	// our own so the synchronous call sees a stable view.
-	for !c.sweepBusy.CompareAndSwap(0, 1) {
+	for !c.sweepGate.TryAcquire() {
 		time.Sleep(time.Millisecond)
 	}
 	c.sweep()

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -10,11 +10,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"sync"
-	atomicflag "sync/atomic"
 	"time"
 
+	"github.com/home-operations/flate/internal/diskcache"
 	"github.com/home-operations/flate/pkg/source/atomic"
 )
 
@@ -43,7 +42,7 @@ type diskRenderCache struct {
 	root  string
 	limit int64 // total disk bytes; <=0 disables disk caching
 
-	sweepBusy atomicflag.Int32 // 1 = a sweep is in flight; gates re-trigger
+	sweepGate diskcache.Gate // single-flight gate so a burst of Puts triggers one sweep
 
 	// rootOnce ensures the root directory is mkdir'd exactly once
 	// per process. The first Put creates the directory tree lazily;
@@ -170,12 +169,12 @@ func (c *diskRenderCache) Put(key string, payload []byte) {
 		return
 	}
 
-	// Kick a sweep if one isn't already running. CompareAndSwap keeps
-	// the trigger single-flight: a burst of Puts past the limit will
+	// Kick a sweep if one isn't already running. The gate keeps the
+	// trigger single-flight: a burst of Puts past the limit will
 	// schedule exactly one sweep, which sees every entry written
 	// before it starts walking and prunes the oldest until total ≤
 	// limit.
-	if c.sweepBusy.CompareAndSwap(0, 1) {
+	if c.sweepGate.TryAcquire() {
 		go c.sweep()
 	}
 }
@@ -190,15 +189,10 @@ func (c *diskRenderCache) Put(key string, payload []byte) {
 // and a stat / unlink failure on one entry shouldn't stop the rest of
 // the sweep.
 func (c *diskRenderCache) sweep() {
-	defer c.sweepBusy.Store(0)
+	defer c.sweepGate.Release()
 
-	type entry struct {
-		path  string
-		size  int64
-		mtime int64 // unix nanos for stable sort
-	}
 	var (
-		entries []entry
+		entries []diskcache.Entry
 		total   int64
 	)
 	walkErr := filepath.WalkDir(c.root, func(path string, d fs.DirEntry, err error) error {
@@ -215,10 +209,10 @@ func (c *diskRenderCache) sweep() {
 		if ierr != nil {
 			return nil
 		}
-		entries = append(entries, entry{
-			path:  path,
-			size:  info.Size(),
-			mtime: info.ModTime().UnixNano(),
+		entries = append(entries, diskcache.Entry{
+			Path:  path,
+			Size:  info.Size(),
+			MTime: info.ModTime().UnixNano(), // unix nanos for stable sort
 		})
 		total += info.Size()
 		return nil
@@ -226,31 +220,26 @@ func (c *diskRenderCache) sweep() {
 	if walkErr != nil {
 		slog.Debug("helm render cache: sweep walk", "root", c.root, "err", walkErr)
 	}
-	if total <= c.limit {
-		return
-	}
 
 	// Oldest first — those evict before the most recently used. Stable
 	// against ties (sort by mtime then path) so two test entries
 	// written within the same nanosecond don't evict in
 	// platform-dependent order.
-	slices.SortFunc(entries, func(a, b entry) int {
-		if c := cmp.Compare(a.mtime, b.mtime); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.path, b.path)
-	})
-
-	for _, e := range entries {
-		if total <= c.limit {
-			break
-		}
-		if err := os.Remove(e.path); err != nil {
-			slog.Debug("helm render cache: sweep remove", "path", e.path, "err", err)
-			continue
-		}
-		total -= e.size
-	}
+	diskcache.EvictOldest(entries, total, c.limit,
+		func(a, b diskcache.Entry) int {
+			if c := cmp.Compare(a.MTime, b.MTime); c != 0 {
+				return c
+			}
+			return cmp.Compare(a.Path, b.Path)
+		},
+		func(e diskcache.Entry) error {
+			if err := os.Remove(e.Path); err != nil {
+				slog.Debug("helm render cache: sweep remove", "path", e.Path, "err", err)
+				return err
+			}
+			return nil
+		},
+	)
 }
 
 // nowFn is the wall-clock used by Get's mtime bump. Pulled out so

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -1,6 +1,7 @@
 package kustomize
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -8,12 +9,12 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/home-operations/flate/internal/cas"
+	"github.com/home-operations/flate/internal/diskcache"
 	"github.com/home-operations/flate/internal/keylock"
 	atomicfile "github.com/home-operations/flate/pkg/source/atomic"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
@@ -68,11 +69,11 @@ type StagingCache struct {
 	// the winner's sentinel via the cross-process retry below.
 	fpLocks *keylock.KeyMap[string]
 
-	// sweepInflight is a single-flight gate: when the persistent cache
+	// sweepGate is a single-flight gate: when the persistent cache
 	// trips its size cap, exactly one Stage call kicks the sweep on a
 	// background goroutine and every other concurrent caller observes
 	// the in-flight bit and skips.
-	sweepInflight atomic.Bool
+	sweepGate diskcache.Gate
 
 	// remoteFetches dedupes URL fetches across every preflight pass in
 	// one orchestrator run. A single kustomization.yaml URL may be
@@ -293,34 +294,31 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 	}
 
 	// Stage into a sibling tempdir + atomic rename so concurrent
-	// readers never observe a partial tree.
-	staging, err := os.MkdirTemp(filepath.Dir(dir), filepath.Base(dir)+".tmp.*")
+	// readers never observe a partial tree. On a lost rename race we
+	// adopt the winner only when its sentinel is present — content
+	// addressing guarantees the trees are equivalent.
+	adopted, err := cas.Stage(filepath.Dir(dir), dir, "stage tmp", "stage finalize",
+		func(staging string) error { return c.copyTreeInto(source, staging) },
+		func() bool { _, statErr := os.Stat(sentinel); return statErr == nil },
+	)
 	if err != nil {
-		return "", fmt.Errorf("stage tmp: %w", err)
-	}
-	if err := c.copyTreeInto(source, staging); err != nil {
-		_ = os.RemoveAll(staging)
 		return "", err
 	}
-	// Rename FIRST, sentinel AFTER. If we wrote the sentinel into the
-	// tmp dir and then crashed (or the rename failed mid-flight on a
-	// filesystem that doesn't truly fulfill POSIX atomicity), a
-	// subsequent reader could observe an incomplete tree with a
-	// sentinel inside it and skip the rebuild. By renaming the
-	// sentinel-free tree first and writing the sentinel into the
-	// renamed dir, any crash window leaves the dir without a sentinel,
-	// which the read path correctly treats as "not complete, rebuild."
-	if err := os.Rename(staging, dir); err != nil {
-		_ = os.RemoveAll(staging)
-		// A racing peer process beat us to it. Adopt the winner —
-		// content addressing guarantees the trees are equivalent.
-		if _, statErr := os.Stat(sentinel); statErr == nil {
-			c.cacheStagePromise(fingerprint, dir)
-			c.maybeKickSweep()
-			return dir, nil
-		}
-		return "", fmt.Errorf("stage finalize: %w", err)
+	if adopted {
+		c.cacheStagePromise(fingerprint, dir)
+		c.maybeKickSweep()
+		return dir, nil
 	}
+	// Rename FIRST (inside cas.Stage above), sentinel AFTER. If we
+	// wrote the sentinel into the tmp dir and then crashed (or the
+	// rename failed mid-flight on a filesystem that doesn't truly
+	// fulfill POSIX atomicity), a subsequent reader could observe an
+	// incomplete tree with a sentinel inside it and skip the rebuild.
+	// By renaming the sentinel-free tree first and writing the sentinel
+	// into the renamed dir, any crash window leaves the dir without a
+	// sentinel, which the read path correctly treats as "not complete,
+	// rebuild."
+	//
 	// Sentinel is empty; its presence alone is the signal. Use
 	// atomic.WriteFile so a crash during this write doesn't leave a
 	// partially-named or zero-length sentinel that confuses a later
@@ -385,23 +383,15 @@ func (c *StagingCache) maybeKickSweep() {
 	if c.maxBytes <= 0 || c.root == "" {
 		return
 	}
-	if !c.sweepInflight.CompareAndSwap(false, true) {
+	if !c.sweepGate.TryAcquire() {
 		return
 	}
 	go func() {
-		defer c.sweepInflight.Store(false)
+		defer c.sweepGate.Release()
 		if err := sweepStageBySize(c.root, c.maxBytes); err != nil {
 			slog.Debug("stage cache sweep", "err", err)
 		}
 	}()
-}
-
-// stageEntry summarizes one persistent stage directory under the
-// cache root for the LRU sweep.
-type stageEntry struct {
-	path  string
-	mtime time.Time
-	size  int64
 }
 
 // sweepStageBySize walks root and, when total size exceeds maxBytes,
@@ -418,7 +408,7 @@ func sweepStageBySize(root string, maxBytes int64) error {
 	if err != nil {
 		return err
 	}
-	var entries []stageEntry
+	var entries []diskcache.Entry
 	var total int64
 	for _, p := range prefixes {
 		if !p.IsDir() {
@@ -455,33 +445,27 @@ func sweepStageBySize(root string, maxBytes int64) error {
 				continue
 			}
 			size := dirSize(full)
-			entries = append(entries, stageEntry{path: full, mtime: info.ModTime(), size: size})
+			entries = append(entries, diskcache.Entry{Path: full, MTime: info.ModTime().UnixNano(), Size: size})
 			total += size
 		}
 	}
-	if total <= maxBytes {
-		return nil
-	}
 	// Oldest first; evict until under cap.
-	slices.SortFunc(entries, func(a, b stageEntry) int {
-		return a.mtime.Compare(b.mtime)
-	})
-	for _, e := range entries {
-		if total <= maxBytes {
-			break
-		}
-		if err := os.RemoveAll(e.path); err != nil {
-			slog.Debug("stage cache evict", "path", e.path, "err", err)
-			continue
-		}
-		total -= e.size
-		// Best-effort: drop the prefix dir if it's now empty so
-		// repeated sweeps don't accumulate dead 2-char shells.
-		prefixDir := filepath.Dir(e.path)
-		if rem, err := os.ReadDir(prefixDir); err == nil && len(rem) == 0 {
-			_ = os.Remove(prefixDir)
-		}
-	}
+	diskcache.EvictOldest(entries, total, maxBytes,
+		func(a, b diskcache.Entry) int { return cmp.Compare(a.MTime, b.MTime) },
+		func(e diskcache.Entry) error {
+			if err := os.RemoveAll(e.Path); err != nil {
+				slog.Debug("stage cache evict", "path", e.Path, "err", err)
+				return err
+			}
+			// Best-effort: drop the prefix dir if it's now empty so
+			// repeated sweeps don't accumulate dead 2-char shells.
+			prefixDir := filepath.Dir(e.Path)
+			if rem, err := os.ReadDir(prefixDir); err == nil && len(rem) == 0 {
+				_ = os.Remove(prefixDir)
+			}
+			return nil
+		},
+	)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- New `internal/diskcache`: shared single-flight `Gate` + oldest-first `EvictOldest` (the LRU sweep duplicated across helm + kustomize).
- New `internal/cas`: shared atomic stage-into-sibling → rename → adopt-on-race `Stage` (duplicated across baseline + kustomize).
- Migrate `helm/render_cache_disk.go`, `kustomize/stage.go`, `baseline/baseline.go` onto them.

Behavior-preserving (eviction thresholds, key derivation, error strings, and concurrency semantics unchanged); part of a code-cleanliness refactor set.

> **Stacked PR (merge last).** Base is `refactor/kustomize-cleanup`. Depends on the helm + kustomize PRs; merge **after** both.

## Test plan
- [ ] `go test -race ./...` (helm/kustomize/baseline concurrency tests)
- [ ] `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)