### PR TITLE
test(testutil): add internal/assert + shared test helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gofrs/flock v0.13.0
 	github.com/gonvenience/ytbx v1.5.0
 	github.com/google/cel-go v0.28.1
+	github.com/google/go-cmp v0.7.0
 	github.com/gosimple/slug v1.15.0
 	github.com/homeport/dyff v1.12.0
 	github.com/minio/minio-go/v7 v7.2.0

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,31 @@
+// Package assert holds dependency-free test assertion helpers usable
+// from any package's tests. It deliberately imports no flate packages
+// so that even internal (package X) tests of packages that
+// internal/testutil depends on — manifest, store — can use it without
+// an import cycle.
+package assert
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// Equal fails t (non-fatally) when got != want, reporting both.
+func Equal[T comparable](t testing.TB, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// Diff fails t (non-fatally) with a structural diff when got != want.
+// Uses go-cmp; intended for maps, slices, and structs with exported
+// fields (cmp panics on unexported fields without options) — keep
+// manual comparison for types with unexported state.
+func Diff(t testing.TB, got, want any) {
+	t.Helper()
+	if d := cmp.Diff(want, got); d != "" {
+		t.Errorf("mismatch (-want +got):\n%s", d)
+	}
+}

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -24,3 +24,16 @@ func WriteFile(t testing.TB, root, rel, body string) {
 		t.Fatalf("write %s: %v", p, err)
 	}
 }
+
+// WriteFileAt writes body to path (absolute or cwd-relative), creating
+// any missing parent directories. Companion to WriteFile for callers
+// that already hold a full path rather than a root+rel split.
+func WriteFileAt(t testing.TB, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/testutil/manifest.go
+++ b/internal/testutil/manifest.go
@@ -1,0 +1,31 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// DepRefs wraps NamedResources as bare DependencyRefs (no ReadyExpr),
+// the shape dependency-ordering tests use to express dependsOn edges.
+func DepRefs(ids ...manifest.NamedResource) []manifest.DependencyRef {
+	out := make([]manifest.DependencyRef, len(ids))
+	for i, id := range ids {
+		out[i] = manifest.DependencyRef{NamedResource: id}
+	}
+	return out
+}
+
+// MustYAML decodes a single YAML document literal into a generic map,
+// failing the test on parse error or multi-document input.
+func MustYAML(t testing.TB, doc string) map[string]any {
+	t.Helper()
+	docs, err := manifest.SplitDocs([]byte(doc))
+	if err != nil {
+		t.Fatalf("SplitDocs: %v\n%s", err, doc)
+	}
+	if len(docs) != 1 {
+		t.Fatalf("expected single doc, got %d", len(docs))
+	}
+	return docs[0]
+}

--- a/internal/testutil/maplister.go
+++ b/internal/testutil/maplister.go
@@ -20,3 +20,7 @@ func (m MapLister) ListObjects(kind string) []manifest.BaseManifest {
 	}
 	return out
 }
+
+// EmptyLister returns a MapLister with no entries — a minimal non-nil
+// ObjectLister for tests that only need to construct a change.Filter.
+func EmptyLister() MapLister { return MapLister{} }

--- a/internal/testutil/status.go
+++ b/internal/testutil/status.go
@@ -8,6 +8,18 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
+// NewStoreWithStatuses returns a fresh Store with each id pre-set to
+// the given status (empty message), collapsing the store.New() +
+// per-id UpdateStatus boilerplate common to dependency and render
+// tests that need a pre-populated store.
+func NewStoreWithStatuses(statuses map[manifest.NamedResource]store.Status) *store.Store {
+	s := store.New()
+	for id, st := range statuses {
+		s.UpdateStatus(id, st, "")
+	}
+	return s
+}
+
 // WaitForStatus polls st until id reaches want status or a 2-second
 // deadline expires. It is the shared polling helper used by controller
 // tests (helmrelease, kustomization, source) to avoid identical inline


### PR DESCRIPTION
## Summary
Foundation for the test-suite cleanup. Purely additive — no existing test touched.
- New `internal/assert` (dependency-free `Equal`/`Diff` via go-cmp) — usable even by `package manifest`/`package store` internal tests that can't import `internal/testutil` (import cycle).
- `internal/testutil`: add `WriteFileAt`, `DepRefs`, `MustYAML`, `NewStoreWithStatuses`, `EmptyLister`.
- Promote `github.com/google/go-cmp` to a direct dependency.

First of a set of test-cleanup PRs; the per-package PRs build on these helpers.

## Test plan
- [ ] `go build ./... && go vet ./...`
- [ ] `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)