### PR TITLE
test(orchestrator,change,loader,discovery): dedup helpers, table-ize

### DIFF
--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -8,29 +8,9 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 )
-
-// emptyLister is enough for filter resolution tests where transitiveDeps
-// would otherwise fail to find the parent KS in a real store.
-type emptyLister struct{}
-
-func (emptyLister) GetObject(manifest.NamedResource) manifest.BaseManifest { return nil }
-func (emptyLister) ListObjects(string) []manifest.BaseManifest             { return nil }
-
-// mapLister returns canned objects from a map for transitive-deps testing.
-type mapLister map[manifest.NamedResource]manifest.BaseManifest
-
-func (m mapLister) GetObject(id manifest.NamedResource) manifest.BaseManifest { return m[id] }
-func (m mapLister) ListObjects(kind string) []manifest.BaseManifest {
-	out := make([]manifest.BaseManifest, 0, len(m))
-	for id, obj := range m {
-		if id.Kind == kind {
-			out = append(out, obj)
-		}
-	}
-	return out
-}
 
 func TestFilter_DisabledKeepsEverything(t *testing.T) {
 	var f Filter
@@ -46,7 +26,7 @@ func TestFilter_ResolveDirectMatch(t *testing.T) {
 		NewSet([]string{"apps/x/helmrelease.yaml"}),
 		map[manifest.NamedResource]string{hr: "apps/x/helmrelease.yaml"},
 		"",
-		emptyLister{},
+		testutil.EmptyLister(),
 	)
 	if !f.ShouldReconcile(hr) {
 		t.Fatalf("expected direct-match keep; keep=%v", f.KeepNames())
@@ -81,7 +61,7 @@ func TestFilter_SharedComponentPropagatesToAllConsumers(t *testing.T) {
 			hrAtuin: "apps/default/atuin/app/helmrelease.yaml",
 		},
 		"",
-		mapLister{ksPlex: plex, ksAtuin: atuin},
+		testutil.MapLister{ksPlex: plex, ksAtuin: atuin},
 	)
 
 	for _, id := range []manifest.NamedResource{ksPlex, ksAtuin, hrPlex, hrAtuin} {
@@ -117,7 +97,7 @@ func TestFilter_AncestorKSAlsoKept(t *testing.T) {
 			hrPlex: "apps/media/plex/app/helmrelease.yaml",
 		},
 		"",
-		mapLister{metaID: meta, plexID: plex},
+		testutil.MapLister{metaID: meta, plexID: plex},
 	)
 
 	for _, id := range []manifest.NamedResource{plexID, hrPlex, metaID} {
@@ -157,7 +137,7 @@ func TestFilter_StructuralParentOfOwnerKSAlsoKept(t *testing.T) {
 			hrActual: "apps/base/self-hosted/actual/helmrelease.yaml",
 		},
 		"",
-		mapLister{parentID: parent, leafID: leaf},
+		testutil.MapLister{parentID: parent, leafID: leaf},
 	)
 
 	for _, id := range []manifest.NamedResource{hrActual, leafID, parentID} {
@@ -196,7 +176,7 @@ func TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings(t *testing.T) {
 			hrAtuin: "apps/default/atuin/app/helmrelease.yaml",
 		},
 		"",
-		mapLister{metaID: meta, plexID: plex, atuinID: atuin},
+		testutil.MapLister{metaID: meta, plexID: plex, atuinID: atuin},
 	)
 
 	if !f.ShouldReconcile(metaID) {
@@ -223,7 +203,7 @@ func TestFilter_KeepNamespaces(t *testing.T) {
 		NewSet([]string{"a.yaml", "b.yaml", "c.yaml"}),
 		map[manifest.NamedResource]string{a: "a.yaml", b: "b.yaml", c: "c.yaml"},
 		"",
-		mapLister{a: ksA, b: ksB, c: ksCluster},
+		testutil.MapLister{a: ksA, b: ksB, c: ksCluster},
 	)
 	ns := f.KeepNamespaces()
 	got := make([]string, 0, len(ns))
@@ -257,7 +237,7 @@ func TestFilter_TransitiveDepsHelmRelease(t *testing.T) {
 		NewSet([]string{"hr.yaml"}),
 		map[manifest.NamedResource]string{hrID: "hr.yaml"},
 		"",
-		mapLister{hrID: hr},
+		testutil.MapLister{hrID: hr},
 	)
 
 	if !f.ShouldReconcile(repoID) {
@@ -284,7 +264,7 @@ func TestFilter_TransitiveDepsKustomization(t *testing.T) {
 		NewSet([]string{"ks.yaml"}),
 		map[manifest.NamedResource]string{ksID: "ks.yaml"},
 		"",
-		mapLister{ksID: ks},
+		testutil.MapLister{ksID: ks},
 	)
 
 	if !f.ShouldReconcile(gitID) {
@@ -315,7 +295,7 @@ func TestFilter_DependsOnNotFollowed(t *testing.T) {
 		NewSet([]string{"a.yaml"}),
 		map[manifest.NamedResource]string{aID: "a.yaml"},
 		"",
-		mapLister{aID: a, bID: b},
+		testutil.MapLister{aID: a, bID: b},
 	)
 
 	if !f.ShouldReconcile(aID) {
@@ -351,7 +331,7 @@ func TestFilter_AddExtendsKeepSetAtRuntime(t *testing.T) {
 		NewSet([]string{"apps/database/parent.yaml"}),
 		map[manifest.NamedResource]string{parent: "apps/database/parent.yaml"},
 		"",
-		emptyLister{},
+		testutil.EmptyLister(),
 	)
 	if !f.ShouldReconcile(parent) {
 		t.Fatalf("parent must be in keep set from file change; keep=%v", f.KeepNames())
@@ -387,7 +367,7 @@ func TestFilter_ShouldReconcileEmptyNamespaceFallback(t *testing.T) {
 		NewSet([]string{"f"}),
 		map[manifest.NamedResource]string{hrLoaded: "f"},
 		"",
-		emptyLister{},
+		testutil.EmptyLister(),
 	)
 	// keep contains hrLoaded (namespace=""); a lookup with namespace=media
 	// must still hit via the (Kind, Name) fallback index.
@@ -435,7 +415,7 @@ func TestFilter_AddEmittedRejectsAncestorOnlyEmitter(t *testing.T) {
 			siblingApp:  "kubernetes/apps/media/plex/ks.yaml",
 		},
 		"",
-		mapLister{leafKS: leafKSObj, clusterApps: clusterAppsObj, siblingApp: siblingObj},
+		testutil.MapLister{leafKS: leafKSObj, clusterApps: clusterAppsObj, siblingApp: siblingObj},
 	)
 
 	if !f.ShouldReconcile(leafKS) {
@@ -489,7 +469,7 @@ func TestFilter_AddEmittedNoCascadeAcrossDeepAncestorChain(t *testing.T) {
 	spegelSibling := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "spegel"}
 	reloaderSibling := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kube-system", Name: "descheduler-app"}
 
-	objs := mapLister{
+	objs := testutil.MapLister{
 		clusterApps: &manifest.Kustomization{Name: clusterApps.Name, Namespace: clusterApps.Namespace,
 			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"}},
 		kubeSystem: &manifest.Kustomization{Name: kubeSystem.Name, Namespace: kubeSystem.Namespace,
@@ -571,7 +551,7 @@ func TestFilter_AddEmittedFromPrimaryParent(t *testing.T) {
 		NewSet([]string{"apps/database/parent.yaml"}),
 		map[manifest.NamedResource]string{parent: "apps/database/parent.yaml"},
 		"",
-		emptyLister{},
+		testutil.EmptyLister(),
 	)
 	if !f.ShouldReconcile(parent) {
 		t.Fatalf("parent must be primary from direct file change; keep=%v", f.KeepNames())
@@ -600,7 +580,7 @@ func TestFilter_KeepByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
 		NewSet([]string{"apps/cluster-infra/external-secrets/ks.yaml"}),
 		map[manifest.NamedResource]string{kept: "apps/cluster-infra/external-secrets/ks.yaml"},
 		"",
-		emptyLister{},
+		testutil.EmptyLister(),
 	)
 	if !f.ShouldReconcile(kept) {
 		t.Fatalf("precondition: cluster-infra/external-secrets must be in keep; keep=%v", f.KeepNames())
@@ -645,7 +625,7 @@ func TestFilter_TransitiveDepsHelmReleaseViaHelmChartCRD(t *testing.T) {
 		NewSet([]string{"hr.yaml"}),
 		map[manifest.NamedResource]string{hrID: "hr.yaml"},
 		"",
-		mapLister{hrID: hr, hcID: hc},
+		testutil.MapLister{hrID: hr, hcID: hc},
 	)
 
 	if !f.ShouldReconcile(hcID) {
@@ -719,7 +699,7 @@ func TestFilter_SubstituteFromConfigMapKeepsProducerKustomization(t *testing.T) 
 			rawSettingsID: "kubernetes/components/cluster-settings/cluster-settings.yaml",
 		},
 		"",
-		mapLister{
+		testutil.MapLister{
 			clusterApps:   clusterAppsObj,
 			clusterVars:   clusterVarsObj,
 			ntfy:          ntfyObj,
@@ -784,7 +764,7 @@ func TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly(t *testing.T
 			cmID:     "kubernetes/apps/settings/cm.yaml",
 		},
 		"",
-		mapLister{producer: producerObj, child: childObj, cmID: cmObj},
+		testutil.MapLister{producer: producerObj, child: childObj, cmID: cmObj},
 	)
 
 	if !f.ShouldReconcile(parent) {
@@ -845,7 +825,7 @@ func TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer(t *testing.T) {
 			cmID:     "kubernetes/apps/settings/cm.yaml",
 		},
 		"",
-		mapLister{producer: producerObj, child: childObj, cmID: cmObj},
+		testutil.MapLister{producer: producerObj, child: childObj, cmID: cmObj},
 	)
 
 	var added []manifest.NamedResource
@@ -901,7 +881,7 @@ func TestFilter_ChainedSubstituteFromProducers(t *testing.T) {
 			cmBID: "kubernetes/c/cm-b.yaml",
 		},
 		"",
-		mapLister{a: aObj, b: bObj, c: cObj, cmAID: cmA, cmBID: cmB},
+		testutil.MapLister{a: aObj, b: bObj, c: cObj, cmAID: cmA, cmBID: cmB},
 	)
 
 	if !f.ShouldReconcile(a) {
@@ -939,7 +919,7 @@ func TestFilter_SelfProducerSkippedInResolve(t *testing.T) {
 			cmID: "kubernetes/self/cm.yaml",
 		},
 		"",
-		mapLister{self: selfObj, cmID: cmObj},
+		testutil.MapLister{self: selfObj, cmID: cmObj},
 	)
 
 	if !f.ShouldReconcile(self) {
@@ -992,7 +972,7 @@ func TestFilter_ProducerByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
 			cmNS2ID: "p2/cm.yaml",
 		},
 		"",
-		mapLister{a: aObj, b: bObj, cmNS1ID: cmNS1, cmNS2ID: cmNS2},
+		testutil.MapLister{a: aObj, b: bObj, cmNS1ID: cmNS1, cmNS2ID: cmNS2},
 	)
 
 	gotNS1 := f.ProducersFor(cmNS1ID)

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/discovery"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -22,7 +23,7 @@ func TestRun_SmallTree(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	mustWrite(t, filepath.Join(dir, "flux", "parent.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "flux", "parent.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -35,7 +36,7 @@ spec:
     name: flux-system
   interval: 10m
 `)
-	mustWrite(t, filepath.Join(dir, "apps", "child.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "child.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -48,7 +49,7 @@ spec:
     name: flux-system
   interval: 10m
 `)
-	mustWrite(t, filepath.Join(dir, "apps", "leaf", "kustomization.yaml"), `resources: []
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "leaf", "kustomization.yaml"), `resources: []
 `)
 
 	st := store.New()
@@ -98,7 +99,7 @@ func TestRun_AliasesNonDefaultNamespaceBootstrap(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	mustWrite(t, filepath.Join(dir, "flux", "cluster.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "flux", "cluster.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -112,7 +113,7 @@ spec:
     namespace: gitops-system
   interval: 1h
 `)
-	mustWrite(t, filepath.Join(dir, "apps", "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "kustomization.yaml"), "resources: []\n")
 
 	st := store.New()
 	if _, err := discovery.Run(context.Background(), discovery.Config{
@@ -147,7 +148,7 @@ func TestRun_AliasesBootstrapOCIRepository(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	mustWrite(t, filepath.Join(dir, "flux", "cluster.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "flux", "cluster.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -161,7 +162,7 @@ spec:
     namespace: flux-system
   interval: 1h
 `)
-	mustWrite(t, filepath.Join(dir, "apps", "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "kustomization.yaml"), "resources: []\n")
 
 	st := store.New()
 	if _, err := discovery.Run(context.Background(), discovery.Config{
@@ -199,7 +200,7 @@ func TestRun_ResourceSetReExpandsForLateRSIPs(t *testing.T) {
 
 	// Root: a parent KS that points at apps/, plus an RS at the same
 	// level. The RS selects RSIPs by label in its own namespace.
-	mustWrite(t, filepath.Join(dir, "flux", "parent.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "flux", "parent.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata: {name: parent, namespace: flux-system}
@@ -208,7 +209,7 @@ spec:
   sourceRef: {kind: GitRepository, name: flux-system}
   interval: 10m
 `)
-	mustWrite(t, filepath.Join(dir, "flux", "rs.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "flux", "rs.yaml"), `---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
 metadata: {name: late-rs, namespace: flux-system}
@@ -231,7 +232,7 @@ spec:
 	// that path before the RSIP is in the store. Re-rendering the RS
 	// on a later iter is what makes the child-rsip Kustomization show
 	// up at all.
-	mustWrite(t, filepath.Join(dir, "apps", "rsip.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "rsip.yaml"), `---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSetInputProvider
 metadata:
@@ -299,16 +300,6 @@ func TestFindRepoRoot_NoGitFallsBack(t *testing.T) {
 	}
 }
 
-func mustWrite(t *testing.T, path, content string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestRun_AliasesURLMatchedInTreeGitRepository pins the Zariel/
 // home-ops pattern: a GitRepository CR defined IN the tree
 // whose spec.url points at the same remote the working tree
@@ -327,14 +318,14 @@ func TestRun_AliasesURLMatchedInTreeGitRepository(t *testing.T) {
 
 	// Stand up a minimal .git/config so PlainOpen sees a repo and
 	// readWorkingTreeRemotes returns one remote.
-	mustWrite(t, filepath.Join(dir, ".git", "config"), `[core]
+	testutil.WriteFileAt(t, filepath.Join(dir, ".git", "config"), `[core]
 	repositoryformatversion = 0
 [remote "origin"]
 	url = git@github.com:Example/home-ops.git
 `)
-	mustWrite(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
 
-	mustWrite(t, filepath.Join(dir, "k8s", "flux", "cluster.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "flux", "cluster.yaml"), `---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -359,7 +350,7 @@ spec:
     name: home-kubernetes
   interval: 1h
 `)
-	mustWrite(t, filepath.Join(dir, "k8s", "apps", "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "apps", "kustomization.yaml"), "resources: []\n")
 
 	st := store.New()
 	if _, err := discovery.Run(context.Background(), discovery.Config{
@@ -398,14 +389,14 @@ spec:
 func TestRun_LeavesUnmatchedInTreeGitRepository(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	mustWrite(t, filepath.Join(dir, ".git", "config"), `[core]
+	testutil.WriteFileAt(t, filepath.Join(dir, ".git", "config"), `[core]
 	repositoryformatversion = 0
 [remote "origin"]
 	url = git@github.com:Example/home-ops.git
 `)
-	mustWrite(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, ".git", "HEAD"), "ref: refs/heads/main\n")
 
-	mustWrite(t, filepath.Join(dir, "k8s", "flux", "shared-infra.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "flux", "shared-infra.yaml"), `---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -428,7 +419,7 @@ spec:
     name: shared-infra
   interval: 1h
 `)
-	mustWrite(t, filepath.Join(dir, "k8s", "apps", "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "apps", "kustomization.yaml"), "resources: []\n")
 
 	st := store.New()
 	if _, err := discovery.Run(context.Background(), discovery.Config{
@@ -457,7 +448,7 @@ func TestRun_ComponentGeneratorMaterializesCM(t *testing.T) {
 	dir := t.TempDir()
 
 	// Flux Kustomization in flux-system pointing at ./cluster
-	mustWrite(t, filepath.Join(dir, "flux", "ks.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(dir, "flux", "ks.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -469,13 +460,13 @@ spec:
   interval: 10m
 `)
 	// cluster/kustomization.yaml references the Component
-	mustWrite(t, filepath.Join(dir, "cluster", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1
+	testutil.WriteFileAt(t, filepath.Join(dir, "cluster", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 components:
   - ../components/cluster-settings
 `)
 	// Component declares the configMapGenerator
-	mustWrite(t, filepath.Join(dir, "components", "cluster-settings", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1alpha1
+	testutil.WriteFileAt(t, filepath.Join(dir, "components", "cluster-settings", "kustomization.yaml"), `apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 configMapGenerator:
   - name: cluster-settings

--- a/pkg/loader/existence_test.go
+++ b/pkg/loader/existence_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -16,7 +17,7 @@ import (
 // the Store and land in Existence instead.
 func TestDiscoveryOnly_SkipsNonDiscoveryKinds(t *testing.T) {
 	dir := t.TempDir()
-	writeExistenceFile(t, dir, "ks.yaml", `
+	testutil.WriteFile(t, dir, "ks.yaml", `
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -88,7 +89,7 @@ data:
 // AddObjects it into the Store so the wait can clear.
 func TestDiscoveryOnly_PromoteMaterializesFromIndex(t *testing.T) {
 	dir := t.TempDir()
-	writeExistenceFile(t, dir, "cm.yaml", `
+	testutil.WriteFile(t, dir, "cm.yaml", `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -152,7 +153,7 @@ func TestExistenceIndex_PromoteUnknownIDReturnsFalse(t *testing.T) {
 // orchestrator.
 func TestExistenceIndex_PromoteFileRemovedBetweenRecordAndPromote(t *testing.T) {
 	dir := t.TempDir()
-	writeExistenceFile(t, dir, "cm.yaml", `
+	testutil.WriteFile(t, dir, "cm.yaml", `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -188,7 +189,7 @@ data:
 // same file once per dep in the common multi-doc fixture pattern.
 func TestExistenceIndex_PromoteMultiDocLoadsSiblings(t *testing.T) {
 	dir := t.TempDir()
-	writeExistenceFile(t, dir, "bundle.yaml", `
+	testutil.WriteFile(t, dir, "bundle.yaml", `
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -234,7 +235,7 @@ data:
 // redirecting every KS render to the wrong source root).
 func TestDiscoveryOnly_SourcesStayFileLoaded(t *testing.T) {
 	dir := t.TempDir()
-	writeExistenceFile(t, dir, "src.yaml", `
+	testutil.WriteFile(t, dir, "src.yaml", `
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
@@ -276,13 +277,5 @@ spec:
 		if st.GetObject(want) == nil {
 			t.Errorf("source %s must stay in Store under DiscoveryOnly; got nil", want.String())
 		}
-	}
-}
-
-func writeExistenceFile(t *testing.T, dir, name, content string) {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/pkg/loader/kustomization_test.go
+++ b/pkg/loader/kustomization_test.go
@@ -2,59 +2,38 @@ package loader
 
 import "testing"
 
-// TestResolveDataPath_RelativeUnderBase covers the happy path: a
-// generator file path that stays under the kustomization directory
-// resolves to its absolute equivalent.
-func TestResolveDataPath_RelativeUnderBase(t *testing.T) {
-	abs, ok := resolveDataPath("/tmp/cluster/apps/foo", "data/values.yaml")
-	if !ok {
-		t.Fatalf("expected resolve to succeed for in-tree relative path")
+// TestResolveDataPath covers generator-file path resolution. Rows:
+//   - in-tree relative path resolves to its absolute equivalent;
+//   - traversal-escaping rels are rejected — defense-in-depth from the
+//     round-4 audit: a kustomization.yaml declaring `files:
+//     ["../../../etc/passwd"]` must NOT escape the kustomization dir;
+//   - absolute paths pass through verbatim (after Clean) — kustomize
+//     accepts them and downstream "under --path?" checks still apply;
+//   - empty rel is rejected, matching kustomize.
+func TestResolveDataPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    string
+		rel     string
+		wantAbs string
+		wantOK  bool
+	}{
+		{"relative under base", "/tmp/cluster/apps/foo", "data/values.yaml", "/tmp/cluster/apps/foo/data/values.yaml", true},
+		{"traversal parent", "/tmp/cluster/apps/foo", "../escape.yaml", "", false},
+		{"traversal deep", "/tmp/cluster/apps/foo", "../../etc/passwd", "", false},
+		{"traversal mixed", "/tmp/cluster/apps/foo", "sub/../../escape", "", false},
+		{"absolute passes through", "/tmp/cluster/apps", "/etc/values.yaml", "/etc/values.yaml", true},
+		{"empty rejected", "/tmp/cluster/apps", "", "", false},
 	}
-	if abs != "/tmp/cluster/apps/foo/data/values.yaml" {
-		t.Errorf("unexpected resolution: %s", abs)
-	}
-}
-
-// TestResolveDataPath_RejectsTraversal locks the defense-in-depth
-// guard added after the round-4 audit: a kustomization.yaml that
-// declares `files: ["../../../etc/passwd"]` must NOT escape the
-// kustomization directory. The resolved key is consulted against
-// tree-walk paths today (no escape can match a walked path rooted
-// at --path), but a future caller that opens the path would hit a
-// path-traversal surface for free without this guard.
-func TestResolveDataPath_RejectsTraversal(t *testing.T) {
-	cases := []string{
-		"../escape.yaml",
-		"../../etc/passwd",
-		"sub/../../escape",
-	}
-	for _, rel := range cases {
-		if _, ok := resolveDataPath("/tmp/cluster/apps/foo", rel); ok {
-			t.Errorf("rel %q should have been rejected as escaping base", rel)
-		}
-	}
-}
-
-// TestResolveDataPath_AbsolutePathPassesThrough confirms the
-// documented exception: kustomize accepts absolute paths for
-// generator files, so we pass them verbatim (after Clean). The
-// loader's downstream "is this under --path?" check still applies
-// at walk time; resolveDataPath isn't responsible for absolute-path
-// containment.
-func TestResolveDataPath_AbsolutePathPassesThrough(t *testing.T) {
-	abs, ok := resolveDataPath("/tmp/cluster/apps", "/etc/values.yaml")
-	if !ok {
-		t.Fatalf("expected absolute path to resolve")
-	}
-	if abs != "/etc/values.yaml" {
-		t.Errorf("absolute path should pass through verbatim; got %s", abs)
-	}
-}
-
-// TestResolveDataPath_EmptyRejected guards the explicit empty-rel
-// check — kustomize would reject an empty entry too.
-func TestResolveDataPath_EmptyRejected(t *testing.T) {
-	if _, ok := resolveDataPath("/tmp/cluster/apps", ""); ok {
-		t.Errorf("empty rel should be rejected")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			abs, ok := resolveDataPath(tc.base, tc.rel)
+			if ok != tc.wantOK {
+				t.Fatalf("resolveDataPath(%q, %q) ok = %v, want %v", tc.base, tc.rel, ok, tc.wantOK)
+			}
+			if ok && abs != tc.wantAbs {
+				t.Errorf("resolveDataPath(%q, %q) = %q, want %q", tc.base, tc.rel, abs, tc.wantAbs)
+			}
+		})
 	}
 }

--- a/pkg/orchestrator/cycles_test.go
+++ b/pkg/orchestrator/cycles_test.go
@@ -7,19 +7,16 @@ import (
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
 
 func makeKS(name, ns string, deps ...manifest.NamedResource) *manifest.Kustomization {
-	refs := make([]manifest.DependencyRef, len(deps))
-	for i, d := range deps {
-		refs[i] = manifest.DependencyRef{NamedResource: d}
-	}
 	return &manifest.Kustomization{
 		Name: name, Namespace: ns,
 		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./" + name},
-		DependsOn:         refs,
+		DependsOn:         testutil.DepRefs(deps...),
 	}
 }
 
@@ -233,12 +230,12 @@ func TestUpdateDependencyGraphFor_HelmRelease(t *testing.T) {
 	o := &Orchestrator{store: store.New()}
 	o.store.AddObject(&manifest.HelmRelease{
 		Name: "x", Namespace: "ns",
-		DependsOn: []manifest.DependencyRef{{NamedResource: idY}},
+		DependsOn: testutil.DepRefs(idY),
 	})
 	o.updateDependencyGraphFor(idX)
 	o.store.AddObject(&manifest.HelmRelease{
 		Name: "y", Namespace: "ns",
-		DependsOn: []manifest.DependencyRef{{NamedResource: idX}},
+		DependsOn: testutil.DepRefs(idX),
 	})
 	o.updateDependencyGraphFor(idY)
 


### PR DESCRIPTION
Test-cleanup (behavior- & coverage-preserving). Builds on #507.
- orchestrator: `makeKS` deps via `testutil.DepRefs`.
- change: local `emptyLister`/`mapLister` → `testutil.EmptyLister()`/`MapLister` (23 sites).
- loader: `TestResolveDataPath_*` → one table; local writer → `testutil.WriteFile`.
- discovery: local `mustWrite` → `testutil.WriteFileAt` (21 sites).
Coverage preserved across all four. −60 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)