### PR TITLE
test(store,depwait,diff,baseline,task): dedup helpers, assert migration

### DIFF
--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
@@ -202,9 +203,7 @@ func TestAutoResolve_DetachedHEAD(t *testing.T) {
 // error with a message naming the alternative flags.
 func TestAutoResolve_NoGit(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "f.yaml"), []byte("x"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, filepath.Join(dir, "f.yaml"), "x")
 	_, err := AutoResolve(dir, "", cacheroot.Layout{})
 	if err == nil {
 		t.Fatal("expected error for non-git path")
@@ -435,13 +434,7 @@ func initRepoWithFile(t *testing.T, dir, path, content string) plumbing.Hash {
 	if err != nil {
 		t.Fatal(err)
 	}
-	full := filepath.Join(dir, path)
-	if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, filepath.Join(dir, path), content)
 	wt, err := r.Worktree()
 	if err != nil {
 		t.Fatal(err)
@@ -460,10 +453,7 @@ func initRepoWithFile(t *testing.T, dir, path, content string) plumbing.Hash {
 
 func writeAndCommit(t *testing.T, dir, path, content string) plumbing.Hash {
 	t.Helper()
-	full := filepath.Join(dir, path)
-	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, filepath.Join(dir, path), content)
 	r := openHelper(t, dir)
 	wt, err := r.Worktree()
 	if err != nil {

--- a/pkg/depwait/bench_test.go
+++ b/pkg/depwait/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -16,7 +17,7 @@ import (
 // children whose deps already landed; the wait should never block.
 func BenchmarkWatchReady_ManyDeps(b *testing.B) {
 	s := store.New()
-	deps := make([]manifest.DependencyRef, 0, 50)
+	ids := make([]manifest.NamedResource, 0, 50)
 	for i := range 50 {
 		id := manifest.NamedResource{
 			Kind: manifest.KindGitRepository, Namespace: "ns",
@@ -24,8 +25,9 @@ func BenchmarkWatchReady_ManyDeps(b *testing.B) {
 		}
 		s.AddObject(&manifest.GitRepository{Name: id.Name, Namespace: id.Namespace})
 		s.UpdateStatus(id, store.StatusReady, "")
-		deps = append(deps, manifest.DependencyRef{NamedResource: id})
+		ids = append(ids, id)
 	}
+	deps := testutil.DepRefs(ids...)
 	w := &Waiter{Store: s, Timeout: 5 * time.Second}
 	ctx := context.Background()
 

--- a/pkg/depwait/depwait_test.go
+++ b/pkg/depwait/depwait_test.go
@@ -8,19 +8,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
-
-// refs wraps NamedResources as bare DependencyRefs (no ReadyExpr)
-// so test cases keep their original shape.
-func refs(ids ...manifest.NamedResource) []manifest.DependencyRef {
-	out := make([]manifest.DependencyRef, len(ids))
-	for i, id := range ids {
-		out[i] = manifest.DependencyRef{NamedResource: id}
-	}
-	return out
-}
 
 // lookupStub satisfies ExistenceLookup from inline closures so
 // individual tests can express both halves of the contract without
@@ -68,14 +59,15 @@ func (r rendersStub) QuiescenceCh() <-chan struct{} {
 }
 
 func TestWaiter_AllReady(t *testing.T) {
-	s := store.New()
 	dep1 := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "a"}
 	dep2 := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "b"}
-	s.UpdateStatus(dep1, store.StatusReady, "")
-	s.UpdateStatus(dep2, store.StatusReady, "")
+	s := testutil.NewStoreWithStatuses(map[manifest.NamedResource]store.Status{
+		dep1: store.StatusReady,
+		dep2: store.StatusReady,
+	})
 
 	w := &Waiter{Store: s, Timeout: time.Second}
-	sum := WaitAll(w.Watch(context.Background(), refs(dep1, dep2)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep1, dep2)))
 	if sum.AnyFailed() {
 		t.Errorf("expected all ready: %+v", sum)
 	}
@@ -89,7 +81,7 @@ func TestWaiter_OneFails(t *testing.T) {
 	s.UpdateStatus(dep2, store.StatusFailed, "denied")
 
 	w := &Waiter{Store: s, Timeout: time.Second}
-	sum := WaitAll(w.Watch(context.Background(), refs(dep1, dep2)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep1, dep2)))
 	if !sum.AnyFailed() {
 		t.Errorf("expected failure: %+v", sum)
 	}
@@ -104,7 +96,7 @@ func TestWaiter_Exists_NonStatusKind(t *testing.T) {
 	go s.AddObject(&manifest.ConfigMap{Name: "cm", Namespace: "ns"})
 
 	w := &Waiter{Store: s, Timeout: time.Second}
-	sum := WaitAll(w.Watch(context.Background(), refs(id)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(id)))
 	if sum.AnyFailed() {
 		t.Errorf("expected ConfigMap to become ready: %+v", sum)
 	}
@@ -114,7 +106,7 @@ func TestWaiter_Timeout(t *testing.T) {
 	s := store.New()
 	dep := manifest.NamedResource{Kind: manifest.KindGitRepository, Name: "absent"}
 	w := &Waiter{Store: s, Timeout: 20 * time.Millisecond}
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	if !sum.AnyFailed() {
 		t.Errorf("expected timeout failure: %+v", sum)
 	}
@@ -129,7 +121,7 @@ func TestWaiter_MissingDepFailsFast(t *testing.T) {
 	w := &Waiter{Store: s, Timeout: 30 * time.Second}
 
 	start := time.Now()
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	elapsed := time.Since(start)
 
 	if !sum.AnyFailed() {
@@ -168,7 +160,7 @@ func TestWaiter_ResolveMissingLazyPromotes(t *testing.T) {
 	}
 
 	w := &Waiter{Store: s, Timeout: 5 * time.Second, Existence: lookupStub{promote: resolve}}
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 
 	if !resolveCalled {
 		t.Errorf("Existence.Promote was never invoked")
@@ -189,7 +181,7 @@ func TestWaiter_ResolveMissingFalseStillFails(t *testing.T) {
 	resolve := func(manifest.NamedResource) bool { return false }
 	w := &Waiter{Store: s, Timeout: 5 * time.Second, Existence: lookupStub{promote: resolve}}
 
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	if !sum.AnyFailed() {
 		t.Errorf("Existence.Promote=false should still fail: %+v", sum)
 	}
@@ -227,7 +219,7 @@ func TestWaiter_RenderOnlyDepWaitsBeyondGrace(t *testing.T) {
 		Timeout:   MissingGrace + 5*time.Second,
 		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	if sum.AnyFailed() {
 		t.Errorf("render-only dep that arrived after grace should clear, not fail: %+v", sum)
 	}
@@ -255,7 +247,7 @@ func TestWaiter_RenderOnlyDepStillFailsAfterFullTimeout(t *testing.T) {
 		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	start := time.Now()
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	elapsed := time.Since(start)
 
 	if !sum.AnyFailed() {
@@ -295,7 +287,7 @@ func TestWaiter_FileIndexedPromoteFailsFastAtGrace(t *testing.T) {
 		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	start := time.Now()
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	elapsed := time.Since(start)
 
 	if !sum.AnyFailed() {
@@ -340,7 +332,7 @@ func TestWaiter_RenderOnlyCappedAtRenderProducingTimeout(t *testing.T) {
 		Existence: lookupStub{promote: resolve, fileIndexed: isFileIndexed},
 	}
 	start := time.Now()
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	elapsed := time.Since(start)
 
 	if !sum.AnyFailed() {
@@ -399,7 +391,7 @@ func TestWaiter_RenderInflightDrainShortCircuits(t *testing.T) {
 	}
 
 	start := time.Now()
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	elapsed := time.Since(start)
 
 	if !sum.AnyFailed() {
@@ -446,7 +438,7 @@ func TestWaiter_RenderInflightActiveHoldsTheWait(t *testing.T) {
 		s.UpdateStatus(dep, store.StatusReady, "")
 	}()
 
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	if sum.AnyFailed() {
 		t.Errorf("dep arrived after grace with Renders active; expected Ready: %+v", sum)
 	}
@@ -479,7 +471,7 @@ func TestWaiter_RenderOnlyCancelDuringLongWaitSurfacesCancelled(t *testing.T) {
 		cancel()
 	}()
 
-	sum := WaitAll(w.Watch(ctx, refs(dep)))
+	sum := WaitAll(w.Watch(ctx, testutil.DepRefs(dep)))
 	// classify() maps context.Canceled to DepCancelled / "cancelled".
 	if got := sum.Messages[dep]; got != "cancelled" {
 		t.Errorf("expected 'cancelled' after step-2 ctx cancel, got %q", got)
@@ -519,7 +511,7 @@ func TestWaiter_NoDeps(t *testing.T) {
 func TestWaiter_PanicReportedAsFailed(t *testing.T) {
 	w := &Waiter{} // Store nil — depExists will nil-deref
 	dep := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "x"}
-	sum := WaitAll(w.Watch(context.Background(), refs(dep)))
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
 	if !sum.AnyFailed() {
 		t.Fatalf("expected fail on panic: %+v", sum)
 	}

--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -3,6 +3,8 @@ package diff
 import (
 	"strings"
 	"testing"
+
+	"github.com/home-operations/flate/internal/assert"
 )
 
 func cm(name, ns, key, value string) Doc {
@@ -46,9 +48,7 @@ func TestRun_NoChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(diffs) != 0 {
-		t.Errorf("expected zero diffs, got %d", len(diffs))
-	}
+	assert.Equal(t, len(diffs), 0)
 }
 
 // TestRun_AddedAndRemoved covers the case where the only change is
@@ -61,9 +61,7 @@ func TestRun_AddedAndRemoved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(diffs) != 2 {
-		t.Errorf("expected 2 diffs for add+remove, got %d", len(diffs))
-	}
+	assert.Equal(t, len(diffs), 2) // one add + one remove
 }
 
 // TestRun_Deletion verifies a wholly-removed resource produces a
@@ -336,10 +334,7 @@ func TestResourceDiff_Header(t *testing.T) {
 		Parent: Parent{Kind: "HelmRelease", Namespace: "media", Name: "qui"},
 		Kind:   "Deployment", Namespace: "media", Name: "qui",
 	}
-	want := "HelmRelease: media/qui Deployment: media/qui"
-	if got := hrDiff.Header(); got != want {
-		t.Errorf("HR header:\n got %q\nwant %q", got, want)
-	}
+	assert.Equal(t, hrDiff.Header(), "HelmRelease: media/qui Deployment: media/qui")
 
 	ksDiff := ResourceDiff{
 		Parent: Parent{
@@ -351,10 +346,7 @@ func TestResourceDiff_Header(t *testing.T) {
 	// Parent.Path is preserved on the struct (for JSON/YAML
 	// consumers) but deliberately omitted from the human header so
 	// KS-owned and HR-owned entries render symmetrically.
-	want = "Kustomization: media/qui HelmRelease: media/qui"
-	if got := ksDiff.Header(); got != want {
-		t.Errorf("KS header:\n got %q\nwant %q", got, want)
-	}
+	assert.Equal(t, ksDiff.Header(), "Kustomization: media/qui HelmRelease: media/qui")
 }
 
 // TestRun_StripAttrsRemovesNoise pins that Options.StripAttrs is
@@ -383,9 +375,7 @@ func TestRun_StripAttrsRemovesNoise(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(diffs) != 0 {
-		t.Errorf("stripped annotation should produce no diff entries; got %d:\n%+v", len(diffs), diffs)
-	}
+	assert.Equal(t, len(diffs), 0) // stripped annotation produces no entries
 
 	// Sanity: without --strip-attr, the same change DOES surface as
 	// a diff — proves the strip is what's suppressing the entry.
@@ -393,9 +383,7 @@ func TestRun_StripAttrsRemovesNoise(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(diffs) != 1 {
-		t.Errorf("control: unstripped annotation change should surface; got %d diffs", len(diffs))
-	}
+	assert.Equal(t, len(diffs), 1) // control: unstripped change surfaces
 }
 
 // TestRun_RedactsConfigMapBinaryData locks the ConfigMap.binaryData

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -12,6 +12,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/home-operations/flate/internal/assert"
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -31,9 +32,7 @@ func TestStore_AddObjectIdempotent(t *testing.T) {
 
 	s.AddObject(cm)
 	s.AddObject(cm)
-	if count != 1 {
-		t.Errorf("expected exactly 1 event for two identical adds, got %d", count)
-	}
+	assert.Equal(t, count, 1) // exactly 1 event for two identical adds
 	if got := s.GetObject(id); got == nil {
 		t.Errorf("GetObject after AddObject returned nil")
 	}
@@ -60,9 +59,8 @@ func TestStore_AddObject_CloneTriggersUpdate(t *testing.T) {
 	clone.Data = map[string]any{"k": "v"}
 	s.AddObject(&clone)
 
-	if seen != 2 {
-		t.Errorf("expected two AddObject events (initial + clone), got %d", seen)
-	}
+	assert.Equal(t, seen, 2) // initial + clone
+
 	got, ok := s.GetObject(id).(*manifest.ConfigMap)
 	if !ok {
 		t.Fatalf("expected *manifest.ConfigMap, got %T", s.GetObject(id))
@@ -101,9 +99,7 @@ func TestStore_AddListener_Flush(t *testing.T) {
 	s.AddListener(EventObjectAdded, func(id manifest.NamedResource, _ any) {
 		got = append(got, id.Name)
 	}, true)
-	if len(got) != 2 {
-		t.Errorf("expected 2 replayed, got %d", len(got))
-	}
+	assert.Equal(t, len(got), 2) // both seeds replayed
 }
 
 // TestStore_Refire_ResetsStatusBeforeDispatch pins the contract that
@@ -145,9 +141,7 @@ func TestStore_Refire_NoopMissingID(t *testing.T) {
 	fired := 0
 	s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) { fired++ }, false)
 	s.Refire(id) // must not panic, must not dispatch
-	if fired != 0 {
-		t.Errorf("Refire on missing id fired %d events; want 0", fired)
-	}
+	assert.Equal(t, fired, 0)
 	if _, ok := s.GetStatus(id); ok {
 		t.Errorf("Refire on missing id left status behind")
 	}
@@ -164,9 +158,7 @@ func TestStore_UpdateStatus_Idempotent(t *testing.T) {
 	s.UpdateStatus(id, StatusPending, "starting")
 	s.UpdateStatus(id, StatusPending, "starting")
 	s.UpdateStatus(id, StatusReady, "done")
-	if count != 2 {
-		t.Errorf("expected 2 status events, got %d", count)
-	}
+	assert.Equal(t, count, 2)
 	info, ok := s.GetStatus(id)
 	if !ok || info.Status != StatusReady {
 		t.Errorf("status: %+v ok=%v", info, ok)
@@ -187,12 +179,9 @@ func TestStore_SetCondition_NonReadyFiresStatusEvent(t *testing.T) {
 		statusEvents++
 	}, false)
 	s.SetCondition(id, Condition{Type: ConditionHealthy, Status: metav1.ConditionTrue, Reason: "Healthy"})
-	if statusEvents != 1 {
-		t.Errorf("non-Ready SetCondition fired %d events; want 1", statusEvents)
-	}
-	got := s.GetConditions(id)
-	if len(got) != 2 {
-		t.Fatalf("expected 2 conditions, got %d", len(got))
+	assert.Equal(t, statusEvents, 1) // non-Ready SetCondition still fires
+	if got := len(s.GetConditions(id)); got != 2 {
+		t.Fatalf("expected 2 conditions, got %d", got)
 	}
 }
 
@@ -211,9 +200,7 @@ func TestStore_SetCondition_ReadyFiresStatusEvent(t *testing.T) {
 		Type: ConditionReady, Status: metav1.ConditionTrue,
 		Reason: ReasonSucceeded, Message: "ok",
 	})
-	if statusEvents != 1 {
-		t.Errorf("Ready SetCondition fired %d events; want 1", statusEvents)
-	}
+	assert.Equal(t, statusEvents, 1)
 }
 
 func TestStore_SetCondition_IdenticalIsNoOp(t *testing.T) {
@@ -225,9 +212,7 @@ func TestStore_SetCondition_IdenticalIsNoOp(t *testing.T) {
 	cond := Condition{Type: ConditionReady, Status: metav1.ConditionTrue, Reason: ReasonSucceeded}
 	s.SetCondition(id, cond)
 	s.SetCondition(id, cond)
-	if statusEvents != 1 {
-		t.Errorf("identical SetCondition fired %d events; want 1", statusEvents)
-	}
+	assert.Equal(t, statusEvents, 1) // identical SetCondition is a no-op
 }
 
 // Mutate encodes the clone-then-AddObject pattern. Verify it clones
@@ -252,9 +237,7 @@ func TestStore_Mutate(t *testing.T) {
 	if !ok {
 		t.Fatalf("Mutate returned false on a present id")
 	}
-	if fired != 1 {
-		t.Errorf("expected EventObjectAdded to fire once on Mutate; got %d", fired)
-	}
+	assert.Equal(t, fired, 1) // EventObjectAdded fires once on Mutate
 	// Original pointer unchanged (clone semantics).
 	if len(orig.DependsOn) != 1 {
 		t.Errorf("original pointer was mutated; clone failed: %v", orig.DependsOn)
@@ -274,24 +257,19 @@ func TestStore_Mutate(t *testing.T) {
 
 func TestStore_FailedResources(t *testing.T) {
 	s := New()
-	if len(s.FailedResources()) != 0 {
-		t.Errorf("empty store should not have failures")
-	}
+	assert.Equal(t, len(s.FailedResources()), 0) // empty store
+
 	ks := &manifest.Kustomization{Name: "x", Namespace: ""}
 	id := ks.Named()
 	s.AddObject(ks)
 	s.UpdateStatus(id, StatusFailed, "boom")
-	if got := len(s.FailedResources()); got != 1 {
-		t.Errorf("FailedResources count: %d, want 1", got)
-	}
+	assert.Equal(t, len(s.FailedResources()), 1)
 
 	// Phantom guard: a SetCondition that races after DeleteObject must
 	// not resurrect a failure entry for an id that no longer exists.
 	s.DeleteObject(id)
-	s.UpdateStatus(id, StatusFailed, "phantom") // simulates the race
-	if got := len(s.FailedResources()); got != 0 {
-		t.Errorf("FailedResources after DeleteObject: %d, want 0 (phantom entry leaked)", got)
-	}
+	s.UpdateStatus(id, StatusFailed, "phantom")  // simulates the race
+	assert.Equal(t, len(s.FailedResources()), 0) // phantom entry must not leak
 }
 
 // PR125 switched ListObjects(kind) to a byName-index walk when kind is
@@ -304,19 +282,11 @@ func TestStore_ListObjects_ByKindIndex(t *testing.T) {
 	s.AddObject(newCM("b", "ns2"))
 	s.AddObject(&manifest.Secret{Name: "s", Namespace: "ns1"})
 
-	if got := len(s.ListObjects(manifest.KindConfigMap)); got != 2 {
-		t.Errorf("ListObjects(KindConfigMap) = %d, want 2", got)
-	}
-	if got := len(s.ListObjects(manifest.KindSecret)); got != 1 {
-		t.Errorf("ListObjects(KindSecret) = %d, want 1", got)
-	}
-	if got := len(s.ListObjects("")); got != 3 {
-		t.Errorf("ListObjects(\"\") = %d, want 3", got)
-	}
+	assert.Equal(t, len(s.ListObjects(manifest.KindConfigMap)), 2)
+	assert.Equal(t, len(s.ListObjects(manifest.KindSecret)), 1)
+	assert.Equal(t, len(s.ListObjects("")), 3) // empty kind walks all
 	s.DeleteObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "ns1", Name: "a"})
-	if got := len(s.ListObjects(manifest.KindConfigMap)); got != 1 {
-		t.Errorf("after Delete: ListObjects(KindConfigMap) = %d, want 1", got)
-	}
+	assert.Equal(t, len(s.ListObjects(manifest.KindConfigMap)), 1) // index stays consistent
 }
 
 // TestStore_ListObjects_DeterministicOrder pins the sort contract:
@@ -547,9 +517,7 @@ func TestStore_AddListener_Unsubscribe(t *testing.T) {
 	s.AddObject(newCM("a", "ns"))
 	unsub()
 	s.AddObject(newCM("b", "ns"))
-	if count != 1 {
-		t.Errorf("expected 1 event after unsubscribe, got %d", count)
-	}
+	assert.Equal(t, count, 1) // post-unsubscribe add is silent
 }
 
 func TestStore_SetArtifact(t *testing.T) {
@@ -563,9 +531,7 @@ func TestStore_SetArtifact(t *testing.T) {
 	}, false)
 	s.SetArtifact(id, art)
 	s.SetArtifact(id, art) // idempotent
-	if count != 1 {
-		t.Errorf("expected 1 artifact event, got %d", count)
-	}
+	assert.Equal(t, count, 1)
 	got := s.GetArtifact(id)
 	if got == nil {
 		t.Errorf("GetArtifact: nil")
@@ -601,9 +567,7 @@ func TestStore_SetArtifact_DistinctPointerDedup(t *testing.T) {
 	s.SetArtifact(id, makeArt()) // fresh pointer, identical content
 	s.SetArtifact(id, makeArt()) // fresh pointer, identical content
 
-	if events != 1 {
-		t.Errorf("expected 1 event despite 3 sets with identical content, got %d", events)
-	}
+	assert.Equal(t, events, 1) // content-equal re-sets dedup
 }
 
 // TestStore_SetArtifact_PointerIdentityShortCircuit pins Item 7's
@@ -624,9 +588,7 @@ func TestStore_SetArtifact_PointerIdentityShortCircuit(t *testing.T) {
 	s.SetArtifact(id, art) // same pointer
 	s.SetArtifact(id, art) // same pointer
 
-	if events != 1 {
-		t.Errorf("expected 1 event for same-pointer re-set, got %d", events)
-	}
+	assert.Equal(t, events, 1) // same-pointer re-set short-circuits
 }
 
 // TestStore_SetArtifact_DifferentContent pins the inverse: a
@@ -645,9 +607,7 @@ func TestStore_SetArtifact_DifferentContent(t *testing.T) {
 		{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "cm-2"}},
 	}})
 
-	if events != 2 {
-		t.Errorf("expected 2 events for distinct content, got %d", events)
-	}
+	assert.Equal(t, events, 2) // distinct content fires each time
 }
 
 func TestStore_ListenerPanicIsolated(t *testing.T) {
@@ -660,9 +620,7 @@ func TestStore_ListenerPanicIsolated(t *testing.T) {
 		other++
 	}, false)
 	s.AddObject(newCM("a", "ns")) // should not crash
-	if other != 1 {
-		t.Errorf("other listener should still have run, got %d", other)
-	}
+	assert.Equal(t, other, 1)     // sibling listener still ran
 }
 
 // AddListener with flush=true replays existing store contents into the
@@ -686,9 +644,7 @@ func TestStore_ListenerPanicRecoveredDuringReplay(t *testing.T) {
 	s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) {
 		other++
 	}, true)
-	if other != 2 {
-		t.Errorf("post-panic listener should replay 2 objects, got %d", other)
-	}
+	assert.Equal(t, other, 2) // store healthy after recovered replay panic
 }
 
 func TestStore_Concurrency(_ *testing.T) {
@@ -821,9 +777,7 @@ func TestStore_AddRendered_DispatchesListeners(t *testing.T) {
 		seen.Add(1)
 	}, false)
 	s.AddRendered(newCM("a", "ns"))
-	if got := seen.Load(); got != 1 {
-		t.Errorf("AddRendered fired %d events; want 1 (listener contract violated)", got)
-	}
+	assert.Equal(t, seen.Load(), int64(1)) // AddRendered must dispatch
 }
 
 // TestStore_AddListenerNoFlush_NoMissedConcurrentWrites pins that a
@@ -950,10 +904,7 @@ func TestStore_SetConditionLocked_StableSliceLength(t *testing.T) {
 		s.UpdateStatus(id, status, fmt.Sprintf("iter-%d", i))
 	}
 
-	conds := s.GetConditions(id)
-	if got := len(conds); got != 1 {
-		t.Errorf("conditions slice length = %d after 100 same-type mutations, want 1", got)
-	}
+	assert.Equal(t, len(s.GetConditions(id)), 1) // in-place overwrite, no growth
 }
 
 // TestStore_SetConditionLocked_AppendsDistinctTypes pins the

--- a/pkg/task/task_test.go
+++ b/pkg/task/task_test.go
@@ -5,6 +5,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/home-operations/flate/internal/assert"
 )
 
 func TestNewBounded_LimitsConcurrentBodies(t *testing.T) {
@@ -65,9 +67,7 @@ func TestNew_DefaultsToBounded(t *testing.T) {
 	if s.sem == nil {
 		t.Fatal("New() returned a Service with no worker cap; expected bounded default")
 	}
-	if got, want := cap(s.sem), defaultWorkers; got != want {
-		t.Errorf("New() worker cap = %d, want %d", got, want)
-	}
+	assert.Equal(t, cap(s.sem), defaultWorkers)
 }
 
 // TestNewUnbounded_HasNoCap pins the explicit opt-in path: callers
@@ -89,9 +89,7 @@ func TestService_BlockTillDone(t *testing.T) {
 		})
 	}
 	s.BlockTillDone()
-	if n.Load() != 50 {
-		t.Errorf("expected 50, got %d", n.Load())
-	}
+	assert.Equal(t, n.Load(), int64(50))
 }
 
 func TestService_PanicCountedAndRecovered(t *testing.T) {
@@ -100,9 +98,7 @@ func TestService_PanicCountedAndRecovered(t *testing.T) {
 		panic("oops")
 	})
 	s.BlockTillDone()
-	if s.Failures() != 1 {
-		t.Errorf("expected 1 failure, got %d", s.Failures())
-	}
+	assert.Equal(t, s.Failures(), int64(1))
 }
 
 // TestCoalescer_RecoversSlotAfterPanic guards a stuck-slot bug: if
@@ -124,24 +120,18 @@ func TestCoalescer_RecoversSlotAfterPanic(t *testing.T) {
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("panicking call: expected 1 run, got %d", got)
 	}
-	if got := s.Failures(); got != 1 {
-		t.Errorf("Service.Failures: expected 1, got %d", got)
-	}
+	assert.Equal(t, s.Failures(), int64(1))
 	c.mu.Lock()
 	slots := len(c.slot)
 	c.mu.Unlock()
-	if slots != 0 {
-		t.Errorf("panicked slot was retained: len(slot) = %d, want 0", slots)
-	}
+	assert.Equal(t, slots, 0) // panicked slot must not be retained
 
 	// Slot must be unlocked: a fresh Submit on the same key runs.
 	c.Submit(context.Background(), "recovery", "k", func(_ context.Context) {
 		calls.Add(1)
 	})
 	s.BlockTillDone()
-	if got := calls.Load(); got != 2 {
-		t.Errorf("post-panic Submit blocked: expected 2 runs total, got %d", got)
-	}
+	assert.Equal(t, calls.Load(), int64(2)) // post-panic Submit re-runs
 }
 
 func TestCoalescer_DropsIdleSlots(t *testing.T) {
@@ -154,9 +144,7 @@ func TestCoalescer_DropsIdleSlots(t *testing.T) {
 	c.mu.Lock()
 	got := len(c.slot)
 	c.mu.Unlock()
-	if got != 0 {
-		t.Errorf("idle coalescer slots = %d, want 0", got)
-	}
+	assert.Equal(t, got, 0) // idle slots dropped
 }
 
 func TestCoalescer_SerializesPerKey(t *testing.T) {
@@ -195,9 +183,7 @@ func TestCoalescer_SerializesPerKey(t *testing.T) {
 	close(gate)
 	s.BlockTillDone()
 
-	if got := runs.Load(); got != 2 {
-		t.Errorf("expected exactly 2 runs (initial + 1 coalesced re-run), got %d", got)
-	}
+	assert.Equal(t, runs.Load(), int64(2)) // initial + 1 coalesced re-run
 	if peak := maxConcurrent.Load(); peak > 1 {
 		t.Errorf("Coalescer permitted %d concurrent runs for same key; must be 1", peak)
 	}


### PR DESCRIPTION
Test-cleanup (behavior- & coverage-preserving). Builds on #507.
- depwait: local `refs` → `testutil.DepRefs` (15 sites); `NewStoreWithStatuses` for ready-deps setup.
- store (`package store`, internal): `internal/assert` only (import-cycle rule) — ~20 checks → `assert.Equal`.
- diff/task: `assert.Equal` migration; baseline: file writes → `testutil.WriteFileAt`.
Coverage preserved across all five. −91 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)