### PR TITLE
test(source,helm,kustomize): dedup helpers, standardize

### DIFF
--- a/pkg/helm/bench_test.go
+++ b/pkg/helm/bench_test.go
@@ -203,4 +203,3 @@ func benchLocalChartResolver(b *testing.B, name, namespace, dir string) SourceRe
 	})
 	return NewStoreSourceResolver(st)
 }
-

--- a/pkg/helm/loadchart_test.go
+++ b/pkg/helm/loadchart_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // TestLoadChart_CoalescesConcurrentFirstLoad verifies that N parallel
@@ -164,18 +164,15 @@ description: first
 	// changes both size and mtime; the future-mtime stamp guards
 	// against coarse-granularity filesystems where same-second
 	// rewrites can collide.
-	mustWriteFile := func(rel, body string) {
+	writeFuture := func(rel, body string) {
 		t.Helper()
-		path := filepath.Join(dir, rel)
-		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		testutil.WriteFile(t, dir, rel, body)
 		future := time.Now().Add(2 * time.Hour)
-		if err := os.Chtimes(path, future, future); err != nil {
+		if err := os.Chtimes(filepath.Join(dir, rel), future, future); err != nil {
 			t.Fatal(err)
 		}
 	}
-	mustWriteFile("mychart/Chart.yaml", `apiVersion: v2
+	writeFuture("mychart/Chart.yaml", `apiVersion: v2
 name: mychart
 version: 0.1.0
 description: second-version-different-size-and-mtime

--- a/pkg/helm/oci_chart_test.go
+++ b/pkg/helm/oci_chart_test.go
@@ -6,16 +6,16 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // TestLocateOCIChart_PrefersSourceArtifactExtract is the headline of
@@ -60,9 +60,7 @@ func TestLocateOCIChart_PrefersSourceArtifactCopy(t *testing.T) {
 	slot := t.TempDir()
 	chartTGZ := buildChartTarGz(t, "mychart", "0.1.0")
 	tgzPath := filepath.Join(slot, copiedOCILayerFilename)
-	if err := os.WriteFile(tgzPath, chartTGZ, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, tgzPath, string(chartTGZ))
 
 	cli, hr := setupOCIChartTest(t, slot, "copied")
 
@@ -123,9 +121,7 @@ func TestLocateOCIChart_FallsBackWhenNoArtifact(t *testing.T) {
 	// safeName(trimmedRef)+"-"+version+".tgz" — full ref (registry+
 	// path), not just the basename, to avoid cross-registry collisions.
 	cacheTarget := filepath.Join(cli.cacheDir, "ghcr.io-test-chart-0.1.0.tgz")
-	if err := os.WriteFile(cacheTarget, buildChartTarGz(t, "chart", "0.1.0"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, cacheTarget, string(buildChartTarGz(t, "chart", "0.1.0")))
 
 	path, err := cli.locateOCIChart(t.Context(), hr)
 	if err != nil {
@@ -163,13 +159,8 @@ func TestLocateOCIChart_RoutesThroughPullerWhenWired(t *testing.T) {
 
 	slot := t.TempDir()
 	chartDir := filepath.Join(slot, "chart")
-	if err := os.MkdirAll(chartDir, 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"),
-		[]byte("apiVersion: v2\nname: chart\nversion: 0.1.0\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, filepath.Join(chartDir, "Chart.yaml"),
+		"apiVersion: v2\nname: chart\nversion: 0.1.0\n")
 	var pulledFor *manifest.OCIRepository
 	cli.SetOCIPuller(stubPuller{
 		fetch: func(_ context.Context, r *manifest.OCIRepository) (*store.SourceArtifact, error) {
@@ -229,17 +220,12 @@ func TestLocateOCIChart_PrefersSourceArtifactChartnameSubdir(t *testing.T) {
 
 	slot := t.TempDir()
 	chartDir := filepath.Join(slot, "vector") // dir name matches the publisher's chart, not hr.Chart.Name
-	if err := os.MkdirAll(filepath.Join(chartDir, "templates"), 0o750); err != nil {
-		t.Fatal(err)
-	}
 	writeChartFiles(t, chartDir, "vector", "0.52.0")
 	// Real source/oci slots also contain `.flate-digest` (and possibly
 	// `.flate-layer.tar.gz` from a `copy` op). Drop one to verify the
 	// hidden-prefix filter in findChartSubdir doesn't mistake it for
 	// a Chart.yaml-less subdir.
-	if err := os.WriteFile(filepath.Join(slot, ".flate-digest"), []byte("sha256:abcd"), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFileAt(t, filepath.Join(slot, ".flate-digest"), "sha256:abcd")
 
 	cli, hr := setupOCIChartTest(t, slot, "subdir")
 	// hr.Chart.Name purposely differs from the on-disk subdir name to
@@ -269,11 +255,7 @@ func TestLocateOCIChart_AmbiguousSubdirs(t *testing.T) {
 
 	slot := t.TempDir()
 	for _, name := range []string{"chart-a", "chart-b"} {
-		dir := filepath.Join(slot, name)
-		if err := os.MkdirAll(filepath.Join(dir, "templates"), 0o750); err != nil {
-			t.Fatal(err)
-		}
-		writeChartFiles(t, dir, name, "0.1.0")
+		writeChartFiles(t, filepath.Join(slot, name), name, "0.1.0")
 	}
 
 	cli, hr := setupOCIChartTest(t, slot, "ambiguous")
@@ -388,16 +370,9 @@ func setupOCIChartTest(t *testing.T, slot, label string) (*Client, *manifest.Hel
 // files at slot root.
 func writeChartFiles(t *testing.T, root, name, version string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(root, "Chart.yaml"),
-		[]byte("apiVersion: v2\nname: "+name+"\nversion: "+version+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(root, "templates"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "templates", "_helpers.tpl"), nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
+	testutil.WriteFile(t, root, "Chart.yaml",
+		"apiVersion: v2\nname: "+name+"\nversion: "+version+"\n")
+	testutil.WriteFile(t, root, "templates/_helpers.tpl", "")
 }
 
 // buildChartTarGz returns a gzipped tarball of a minimal helm chart
@@ -409,7 +384,7 @@ func buildChartTarGz(t *testing.T, name, version string) []byte {
 	gw := gzip.NewWriter(&buf)
 	tw := tar.NewWriter(gw)
 	files := map[string]string{
-		name + "/Chart.yaml":              "apiVersion: v2\nname: " + name + "\nversion: " + version + "\n",
+		name + "/Chart.yaml":             "apiVersion: v2\nname: " + name + "\nversion: " + version + "\n",
 		name + "/templates/_helpers.tpl": "",
 	}
 	for path, body := range files {

--- a/pkg/helm/resolver_test.go
+++ b/pkg/helm/resolver_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/helm"
-	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/store"
 )
 

--- a/pkg/helm/template_cache_test.go
+++ b/pkg/helm/template_cache_test.go
@@ -176,7 +176,7 @@ func TestTemplateCache_ReplaceDoesNotDuplicate(t *testing.T) {
 // invariant the LRU might be violating. The pass condition is "no
 // race detector / panic"; the cached values themselves are arbitrary.
 func TestTemplateCache_ConcurrentSafety(t *testing.T) {
-	c := newTemplateCache(64 << 10, nil)
+	c := newTemplateCache(64<<10, nil)
 	var wg sync.WaitGroup
 	for i := range 32 {
 		wg.Go(func() {

--- a/pkg/kustomize/bench_test.go
+++ b/pkg/kustomize/bench_test.go
@@ -167,4 +167,3 @@ func BenchmarkStagingCache_MultiKSPerRoot(b *testing.B) {
 		}
 	})
 }
-

--- a/pkg/kustomize/kustomize_test.go
+++ b/pkg/kustomize/kustomize_test.go
@@ -3,12 +3,12 @@ package kustomize
 import (
 	"context"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"sigs.k8s.io/yaml"
+
+	"github.com/home-operations/flate/internal/testutil"
 )
 
 // TestRenderFlux_RespectsCanceledContext asserts the renderer bails
@@ -127,16 +127,9 @@ func TestSubstitute_BashSubstringRemoval(t *testing.T) {
 // itself does not.
 func TestRenderFlux_HonorsCommonMetadata(t *testing.T) {
 	src := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "cm.yaml"), []byte(
-		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\n  labels:\n    app: x\n  annotations:\n    note: y\ndata:\n  k: v\n",
-	), 0o600); err != nil {
-		t.Fatalf("write cm: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(src, "kustomization.yaml"), []byte(
-		"resources:\n- cm.yaml\n",
-	), 0o600); err != nil {
-		t.Fatalf("write kustomization: %v", err)
-	}
+	testutil.WriteFile(t, src, "cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\n  labels:\n    app: x\n  annotations:\n    note: y\ndata:\n  k: v\n")
+	testutil.WriteFile(t, src, "kustomization.yaml", "resources:\n- cm.yaml\n")
 
 	cache, err := NewStagingCache(t.TempDir(), 0)
 	if err != nil {
@@ -199,16 +192,9 @@ func TestRenderFlux_HonorsCommonMetadata(t *testing.T) {
 // caught here.
 func TestRenderFlux_CommonMetadataOverridesOwnerLabels(t *testing.T) {
 	src := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "cm.yaml"), []byte(
-		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\ndata:\n  k: v\n",
-	), 0o600); err != nil {
-		t.Fatalf("write cm: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(src, "kustomization.yaml"), []byte(
-		"resources:\n- cm.yaml\n",
-	), 0o600); err != nil {
-		t.Fatalf("write kustomization: %v", err)
-	}
+	testutil.WriteFile(t, src, "cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\ndata:\n  k: v\n")
+	testutil.WriteFile(t, src, "kustomization.yaml", "resources:\n- cm.yaml\n")
 	cache, err := NewStagingCache(t.TempDir(), 0)
 	if err != nil {
 		t.Fatalf("NewStagingCache: %v", err)
@@ -254,16 +240,9 @@ func TestRenderFlux_CommonMetadataOverridesOwnerLabels(t *testing.T) {
 // resources even without spec.commonMetadata.
 func TestRenderFlux_InjectsOwnerLabels(t *testing.T) {
 	src := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, "cm.yaml"), []byte(
-		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\ndata:\n  k: v\n",
-	), 0o600); err != nil {
-		t.Fatalf("write cm: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(src, "kustomization.yaml"), []byte(
-		"resources:\n- cm.yaml\n",
-	), 0o600); err != nil {
-		t.Fatalf("write kustomization: %v", err)
-	}
+	testutil.WriteFile(t, src, "cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: c\n  namespace: ns\ndata:\n  k: v\n")
+	testutil.WriteFile(t, src, "kustomization.yaml", "resources:\n- cm.yaml\n")
 	cache, err := NewStagingCache(t.TempDir(), 0)
 	if err != nil {
 		t.Fatalf("NewStagingCache: %v", err)

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
 )
 
 // TestPreflightRemoteResources_RewritesSuccessfulFetch confirms the
@@ -25,7 +27,7 @@ func TestPreflightRemoteResources_RewritesSuccessfulFetch(t *testing.T) {
 
 	stage := t.TempDir()
 	ks := filepath.Join(stage, "kustomization.yaml")
-	mustWriteFile(t, ks, "resources:\n  - "+srv.URL+"/foo.yaml\n")
+	testutil.WriteFileAt(t, ks, "resources:\n  - "+srv.URL+"/foo.yaml\n")
 
 	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 		t.Fatalf("preflight: %v", err)
@@ -71,7 +73,7 @@ func TestPreflightRemoteResources_PropagatesFailure(t *testing.T) {
 
 	stage := t.TempDir()
 	ks := filepath.Join(stage, "kustomization.yaml")
-	mustWriteFile(t, ks, "resources:\n  - "+srv.URL+"/missing.yaml\n")
+	testutil.WriteFileAt(t, ks, "resources:\n  - "+srv.URL+"/missing.yaml\n")
 
 	err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage)
 	if err == nil {
@@ -91,7 +93,7 @@ func TestPreflightRemoteResources_IgnoresLocalEntries(t *testing.T) {
 	stage := t.TempDir()
 	ks := filepath.Join(stage, "kustomization.yaml")
 	body := "resources:\n  - ./local.yaml\n  - ../shared/cm.yaml\n"
-	mustWriteFile(t, ks, body)
+	testutil.WriteFileAt(t, ks, body)
 
 	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 		t.Fatalf("preflight: %v", err)
@@ -117,9 +119,9 @@ func TestPreflightRemoteResources_WalksNestedKustomizations(t *testing.T) {
 	if err := os.MkdirAll(nested, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	mustWriteFile(t, filepath.Join(stage, "kustomization.yaml"),
+	testutil.WriteFileAt(t, filepath.Join(stage, "kustomization.yaml"),
 		"resources:\n  - ./components/x\n")
-	mustWriteFile(t, filepath.Join(nested, "kustomization.yaml"),
+	testutil.WriteFileAt(t, filepath.Join(nested, "kustomization.yaml"),
 		"resources:\n  - "+srv.URL+"/nested.yaml\n")
 
 	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
@@ -138,9 +140,9 @@ func TestRenderFlux_RemotePreflightDoesNotMutateSourceNestedKustomization(t *tes
 	t.Cleanup(srv.Close)
 
 	src := t.TempDir()
-	mustWriteFile(t, filepath.Join(src, "kustomization.yaml"), "resources:\n  - ./child\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources:\n  - ./child\n")
 	child := "resources:\n  - " + srv.URL + "/remote.yaml\n"
-	mustWriteFile(t, filepath.Join(src, "child", "kustomization.yaml"), child)
+	testutil.WriteFileAt(t, filepath.Join(src, "child", "kustomization.yaml"), child)
 
 	cache, err := NewStagingCache(t.TempDir(), 0)
 	if err != nil {
@@ -186,7 +188,7 @@ func TestPreflightRemoteResources_HonorsAlternateFilenames(t *testing.T) {
 	for _, name := range []string{"kustomization.yml", "Kustomization"} {
 		t.Run(name, func(t *testing.T) {
 			stage := t.TempDir()
-			mustWriteFile(t, filepath.Join(stage, name),
+			testutil.WriteFileAt(t, filepath.Join(stage, name),
 				"resources:\n  - "+srv.URL+"/x.yaml\n")
 			if err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage); err != nil {
 				t.Fatalf("preflight: %v", err)
@@ -222,7 +224,7 @@ func TestPreflightRemoteResources_FetchesEachURLOnce(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
 			t.Fatal(err)
 		}
-		mustWriteFile(t, filepath.Join(dir, "kustomization.yaml"),
+		testutil.WriteFileAt(t, filepath.Join(dir, "kustomization.yaml"),
 			"resources:\n  - "+srv.URL+"/shared.yaml\n")
 	}
 
@@ -247,23 +249,13 @@ func TestPreflightRemoteResources_FetchesEachURLOnce(t *testing.T) {
 	// is the actual production pattern — one preflight per
 	// RenderFlux invocation.)
 	stage2 := t.TempDir()
-	mustWriteFile(t, filepath.Join(stage2, "kustomization.yaml"),
+	testutil.WriteFileAt(t, filepath.Join(stage2, "kustomization.yaml"),
 		"resources:\n  - "+srv.URL+"/shared.yaml\n")
 	if err := preflightRemoteResources(context.Background(), cache, stage2); err != nil {
 		t.Fatalf("second preflight: %v", err)
 	}
 	if hits != 1 {
 		t.Errorf("expected 1 network call across both runs, got %d", hits)
-	}
-}
-
-func mustWriteFile(t *testing.T, path, body string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
 	}
 }
 
@@ -323,7 +315,7 @@ namespace: my-app
 `
 	dir := t.TempDir()
 	ks := filepath.Join(dir, "kustomization.yaml")
-	mustWriteFile(t, ks, original)
+	testutil.WriteFileAt(t, ks, original)
 
 	if err := rewriteURLResources(context.Background(), newPreflightCache(t), ks); err != nil {
 		t.Fatalf("rewriteURLResources: %v", err)

--- a/pkg/kustomize/stage_test.go
+++ b/pkg/kustomize/stage_test.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/home-operations/flate/internal/testutil"
 )
 
 // TestStagingCache_CopyTree_SkipsBrokenSymlink locks the fix for
@@ -24,7 +26,7 @@ func TestStagingCache_CopyTree_SkipsBrokenSymlink(t *testing.T) {
 	src := t.TempDir()
 
 	// One real file Flux cares about.
-	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
 
 	// One dangling symlink at the root — the exact shape m00nwtchr's
 	// .pre-commit-config.yaml landed as in their local checkout.
@@ -61,7 +63,7 @@ func TestStagingCache_CopyTree_SkipsBrokenSymlink(t *testing.T) {
 func TestStagingCache_CopyTree_FollowsLiveSymlink(t *testing.T) {
 	src := t.TempDir()
 	target := filepath.Join(src, "real.yaml")
-	mustWrite(t, target, "kind: ConfigMap\n")
+	testutil.WriteFileAt(t, target, "kind: ConfigMap\n")
 	if err := os.Symlink(target, filepath.Join(src, "alias.yaml")); err != nil {
 		t.Fatalf("create symlink: %v", err)
 	}
@@ -151,16 +153,6 @@ func TestStagingCache_FetchRemote_CancelDoesNotPoisonCache(t *testing.T) {
 	}
 }
 
-func mustWrite(t *testing.T, path, body string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // TestNewStagingCache_SweepsStaleLeftovers pins the crash-cleanup
 // sweep: any `flate-stage-*` directory under the parent older than
 // staleStageAge is removed when a fresh StagingCache opens. Without
@@ -174,7 +166,7 @@ func TestNewStagingCache_SweepsStaleLeftovers(t *testing.T) {
 	if err := os.MkdirAll(stale, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	mustWrite(t, filepath.Join(stale, "marker"), "leftover")
+	testutil.WriteFileAt(t, filepath.Join(stale, "marker"), "leftover")
 	old := time.Now().Add(-2 * staleStageAge)
 	if err := os.Chtimes(stale, old, old); err != nil {
 		t.Fatal(err)
@@ -185,7 +177,7 @@ func TestNewStagingCache_SweepsStaleLeftovers(t *testing.T) {
 	if err := os.MkdirAll(fresh, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	mustWrite(t, filepath.Join(fresh, "marker"), "fresh")
+	testutil.WriteFileAt(t, filepath.Join(fresh, "marker"), "fresh")
 
 	// And an unrelated dir with the same prefix but not ours.
 	other := filepath.Join(parent, "some-other-tmp")
@@ -224,7 +216,7 @@ func TestStagingCache_HardlinksWhenSameFilesystem(t *testing.T) {
 		t.Fatal(err)
 	}
 	srcFile := filepath.Join(src, "kustomization.yaml")
-	mustWrite(t, srcFile, "resources: []\n")
+	testutil.WriteFileAt(t, srcFile, "resources: []\n")
 
 	cache, err := NewStagingCache(filepath.Join(root, "stage"), 0)
 	if err != nil {
@@ -258,7 +250,7 @@ func TestStagingCache_HardlinksWhenSameFilesystem(t *testing.T) {
 func TestRestoreKustomization_DoesNotMutateSource(t *testing.T) {
 	src := t.TempDir()
 	srcKust := filepath.Join(src, "kustomization.yaml")
-	mustWrite(t, srcKust, "original\n")
+	testutil.WriteFileAt(t, srcKust, "original\n")
 
 	cache, err := NewStagingCache(t.TempDir(), 0)
 	if err != nil {
@@ -327,7 +319,7 @@ func TestIsHTTPClientError(t *testing.T) {
 // sentinel atomically.
 func TestStagingCache_PersistentSentinelWritten(t *testing.T) {
 	src := t.TempDir()
-	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
 
 	root := t.TempDir()
 	cache, err := NewStagingCache(root, 0)
@@ -368,7 +360,7 @@ func TestStagingCache_PersistentSentinelWritten(t *testing.T) {
 // the dir sentinel-free and the next Stage call rebuilds.
 func TestStagingCache_PartialStageRebuildsOnNextRun(t *testing.T) {
 	src := t.TempDir()
-	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
 
 	root := t.TempDir()
 	cache1, err := NewStagingCache(root, 0)
@@ -429,7 +421,7 @@ func TestStagingCache_PartialStageRebuildsOnNextRun(t *testing.T) {
 // recovery test above, this pins the rename-then-sentinel invariant.
 func TestStagingCache_SentinelWrittenAfterRename(t *testing.T) {
 	src := t.TempDir()
-	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
 
 	root := t.TempDir()
 	cache, err := NewStagingCache(root, 0)
@@ -472,7 +464,7 @@ func TestStagingCache_SentinelWrittenAfterRename(t *testing.T) {
 // rename and bump the mtime).
 func TestStagingCache_PersistentSameFingerprintSkipsRebuild(t *testing.T) {
 	src := t.TempDir()
-	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
 
 	root := t.TempDir()
 	cache, err := NewStagingCache(root, 0)
@@ -517,9 +509,9 @@ func TestStagingCache_PersistentSameFingerprintSkipsRebuild(t *testing.T) {
 // fingerprints get independent staged copies.
 func TestStagingCache_PersistentDistinctFingerprintsDistinctDirs(t *testing.T) {
 	srcA := t.TempDir()
-	mustWrite(t, filepath.Join(srcA, "a.yaml"), "kind: A\n")
+	testutil.WriteFileAt(t, filepath.Join(srcA, "a.yaml"), "kind: A\n")
 	srcB := t.TempDir()
-	mustWrite(t, filepath.Join(srcB, "b.yaml"), "kind: B\n")
+	testutil.WriteFileAt(t, filepath.Join(srcB, "b.yaml"), "kind: B\n")
 
 	root := t.TempDir()
 	cache, err := NewStagingCache(root, 0)
@@ -558,7 +550,7 @@ func TestStagingCache_PersistentDistinctFingerprintsDistinctDirs(t *testing.T) {
 // rename a fresh sibling into place and the mtime would change).
 func TestStagingCache_CrossProcessReuse(t *testing.T) {
 	src := t.TempDir()
-	mustWrite(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), "resources: []\n")
 
 	root := t.TempDir()
 	const fp = "cafebabe00000000000000000000000000000000000000000000000000000000"
@@ -621,7 +613,7 @@ func TestStagingCache_CrossProcessReuse(t *testing.T) {
 // removed on Close.
 func TestStagingCache_PerProcessFallbackForEmptyFingerprint(t *testing.T) {
 	src := t.TempDir()
-	mustWrite(t, filepath.Join(src, "k.yaml"), "x: 1\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "k.yaml"), "x: 1\n")
 
 	root := t.TempDir()
 	cache, err := NewStagingCache(root, 0)

--- a/pkg/source/ignore_test.go
+++ b/pkg/source/ignore_test.go
@@ -5,18 +5,15 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/source"
 )
 
+// writeFile drops a one-byte marker file at dir/rel for ignore-walk
+// fixtures — contents are irrelevant, only presence matters.
 func writeFile(t *testing.T, dir, rel string) {
 	t.Helper()
-	p := filepath.Join(dir, rel)
-	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
-	}
-	if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
-		t.Fatalf("write %s: %v", p, err)
-	}
+	testutil.WriteFile(t, dir, rel, "x")
 }
 
 func exists(t *testing.T, p string) bool {


### PR DESCRIPTION
Test-cleanup (behavior- & coverage-preserving). Builds on #507.
- kustomize: local `mustWrite`/`mustWriteFile` → `testutil.WriteFileAt`.
- source: dedup inline file-write scaffolding → `testutil.WriteFile`/`WriteFileAt`; TLS cert helpers already shared.
- helm: `oci_chart`/`loadchart` writes routed through testutil.
Coverage preserved across all 13 packages. −70 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)