### PR TITLE
test(cli,controllers,misc): dedup helpers

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
 )
 
 // runCLI drives cli.Run inside the test binary and returns
@@ -32,7 +34,7 @@ func writeFixture(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	k8s := filepath.Join(root, "kubernetes")
-	mustWrite(t, filepath.Join(k8s, "flux", "cluster.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(k8s, "flux", "cluster.yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -44,9 +46,9 @@ spec:
   path: ./apps
   sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
 `)
-	mustWrite(t, filepath.Join(k8s, "apps", "kustomization.yaml"),
+	testutil.WriteFileAt(t, filepath.Join(k8s, "apps", "kustomization.yaml"),
 		"resources:\n- cm.yaml\n")
-	mustWrite(t, filepath.Join(k8s, "apps", "cm.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(k8s, "apps", "cm.yaml"), `---
 apiVersion: v1
 kind: ConfigMap
 metadata: {name: hello, namespace: apps}
@@ -68,7 +70,7 @@ func writeMultiNamespaceFixture(t *testing.T) string {
 		{name: "apps-a", namespace: "alpha", path: "apps-a"},
 		{name: "apps-b", namespace: "beta", path: "apps-b"},
 	} {
-		mustWrite(t, filepath.Join(k8s, "flux", tc.name+".yaml"), `---
+		testutil.WriteFileAt(t, filepath.Join(k8s, "flux", tc.name+".yaml"), `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
@@ -79,8 +81,8 @@ spec:
   path: ./`+tc.path+`
   sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
 `)
-		mustWrite(t, filepath.Join(k8s, tc.path, "kustomization.yaml"), "resources:\n- cm.yaml\n")
-		mustWrite(t, filepath.Join(k8s, tc.path, "cm.yaml"), `---
+		testutil.WriteFileAt(t, filepath.Join(k8s, tc.path, "kustomization.yaml"), "resources:\n- cm.yaml\n")
+		testutil.WriteFileAt(t, filepath.Join(k8s, tc.path, "cm.yaml"), `---
 apiVersion: v1
 kind: ConfigMap
 metadata: {name: `+tc.name+`, namespace: `+tc.namespace+`}
@@ -89,16 +91,6 @@ data:
 `)
 	}
 	return k8s
-}
-
-func mustWrite(t *testing.T, p, body string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // TestRun_VersionFlag covers the --version path that cobra wires onto
@@ -643,7 +635,7 @@ func TestDiff_OutputMarkdown(t *testing.T) {
 	// Mutate the baseline ConfigMap so the diff renders a non-empty
 	// hunk. Without the delta `diff.Render` returns the empty-set
 	// "_No changes._" body and the ```diff fence assertion misses.
-	mustWrite(t, filepath.Join(orig, "kubernetes", "apps", "cm.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(orig, "kubernetes", "apps", "cm.yaml"), `---
 apiVersion: v1
 kind: ConfigMap
 metadata: {name: hello, namespace: apps}

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/home-operations/flate/internal/format"
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
@@ -93,7 +94,7 @@ func TestScopedNamespaces_PathOrigAutoScopesToKeepSet(t *testing.T) {
 			netHR.Named():   "networking.yaml",
 		},
 		"",
-		emptyLister{},
+		testutil.EmptyLister(),
 	)
 	got := c.scopedNamespaces(f)
 	for _, want := range []string{"media", "networking"} {
@@ -102,13 +103,6 @@ func TestScopedNamespaces_PathOrigAutoScopesToKeepSet(t *testing.T) {
 		}
 	}
 }
-
-// emptyLister satisfies change.ObjectLister with empty results — used
-// for filter resolution tests where transitive deps aren't exercised.
-type emptyLister struct{}
-
-func (emptyLister) GetObject(manifest.NamedResource) manifest.BaseManifest { return nil }
-func (emptyLister) ListObjects(string) []manifest.BaseManifest             { return nil }
 
 func TestScopedNamespaces_NoFilterMeansAll(t *testing.T) {
 	c := &commonFlags{namespace: ""}

--- a/pkg/controllers/kustomization/reconcile_test.go
+++ b/pkg/controllers/kustomization/reconcile_test.go
@@ -2,7 +2,6 @@ package kustomization
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -25,9 +24,9 @@ import (
 func newControllerWithFixture(t *testing.T) (*Controller, *store.Store, string) {
 	t.Helper()
 	root := t.TempDir()
-	mustWriteFile(t, filepath.Join(root, "apps", "kustomization.yaml"),
+	testutil.WriteFileAt(t, filepath.Join(root, "apps", "kustomization.yaml"),
 		"resources:\n- cm.yaml\n")
-	mustWriteFile(t, filepath.Join(root, "apps", "cm.yaml"), `---
+	testutil.WriteFileAt(t, filepath.Join(root, "apps", "cm.yaml"), `---
 apiVersion: v1
 kind: ConfigMap
 metadata: {name: hello, namespace: default}
@@ -60,16 +59,6 @@ data: {greeting: hi}
 		tasks.BlockTillDone()
 	})
 	return c, s, root
-}
-
-func mustWriteFile(t *testing.T, p, body string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
 }
 
 // TestReconcile_HappyPath drives the full reconcile flow: AddObject

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/home-operations/flate/internal/cli"
+	"github.com/home-operations/flate/internal/testutil"
 )
 
 func runCLI(t *testing.T, args ...string) string {
@@ -576,15 +577,7 @@ func initGitFixture(t *testing.T) (clusterPath, repoRoot string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	writeFile := func(rel, body string) {
-		full := filepath.Join(dir, rel)
-		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(full, []byte(body), 0o600); err != nil { //nolint:gosec // dir is t.TempDir()
-			t.Fatal(err)
-		}
-	}
+	writeFile := func(rel, body string) { testutil.WriteFile(t, dir, rel, body) }
 	writeFile("kubernetes/flux/cluster.yaml", `---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository


### PR DESCRIPTION
Test-cleanup (behavior- & coverage-preserving). Builds on #507.
- cli: local `mustWrite` → `testutil.WriteFileAt`; local `emptyLister` → `testutil.EmptyLister()`.
- controllers: `mustWriteFile` → `testutil.WriteFileAt`.
- e2e: `initGitFixture` writer → `testutil.WriteFile`.
Coverage preserved across all owned packages. −32 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)