### PR TITLE
perf(cold-start): cache helm schema compile + raise GC target

### DIFF
--- a/cmd/flate/main.go
+++ b/cmd/flate/main.go
@@ -14,7 +14,20 @@ import (
 var version = "dev"
 
 func main() {
+	tuneGC()
 	os.Exit(cli.Execute(resolvedVersion()))
+}
+
+// tuneGC raises the GC target for flate's short-lived, allocation-heavy
+// batch runs. A cold reconcile churns hundreds of GC cycles at the
+// default GOGC=100; a higher target trades transient memory (bounded at
+// ~4x the live set) for fewer collections, measurably cutting cold-start
+// CPU. Skipped when the operator set GOGC or GOMEMLIMIT explicitly so
+// their tuning always wins.
+func tuneGC() {
+	if os.Getenv("GOGC") == "" && os.Getenv("GOMEMLIMIT") == "" {
+		debug.SetGCPercent(400)
+	}
 }
 
 func resolvedVersion() string {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/minio/minio-go/v7 v7.2.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
@@ -139,7 +140,6 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/rubenv/sql-migrate v1.8.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -85,6 +85,11 @@ type Client struct {
 	chartCache     map[string]chartCacheEntry
 	chartLoadLocks *keylock.KeyMap[string]
 
+	// schemaCache memoizes compiled values.schema.json validators keyed
+	// by sha256(schema bytes), so a chart's schema is compiled once
+	// rather than per render (helm has no compile cache). See schema.go.
+	schemaCache sync.Map
+
 	// chartValuesCache memoizes mergeChartValuesFiles output keyed by
 	// (chart name + version + joined valuesFiles list). Multiple HRs
 	// sharing a base chart and the same spec.chart.spec.valuesFiles

--- a/pkg/helm/schema.go
+++ b/pkg/helm/schema.go
@@ -1,0 +1,144 @@
+package helm
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"helm.sh/helm/v4/pkg/chart/common/util"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// validateChartSchema reproduces helm's
+// util.ToRenderValuesWithSchemaValidation validation step — coalesce the
+// values, then validate the chart (and each subchart) against its
+// values.schema.json — but compiles each schema exactly once (cached by
+// schema-bytes hash) instead of helm's per-render recompile. The compile
+// (meta-validating a large schema such as bjw-s app-template's) dominates
+// cold-start allocation when one chart backs many HelmReleases; caching it
+// removes that churn while keeping per-release value validation, the
+// coalesce, and the surfaced error byte-identical to helm.
+//
+// A coalesce error returns nil: helm's RunWithContext re-coalesces and
+// surfaces the identical error, so flate defers to it rather than risk a
+// divergent message. The caller wraps a non-nil return like helm does.
+func (c *Client) validateChartSchema(chrt *chart.Chart, chrtVals map[string]any) error {
+	// Coalesce exactly as helm's RunWithContext does (same util.CoalesceValues
+	// on the same values) so flate validates precisely what helm renders.
+	// Coalesce fills missing keys from chart defaults — idempotent, so helm's
+	// subsequent re-coalesce of the same values is a no-op (pinned by the
+	// byte-identical render test).
+	vals, err := util.CoalesceValues(chrt, chrtVals)
+	if err != nil {
+		return nil
+	}
+	if err := c.validateAgainstSchema(chrt, map[string]any(vals)); err != nil {
+		return fmt.Errorf("values don't meet the specifications of the schema(s) in the following chart(s):\n%w", err)
+	}
+	return nil
+}
+
+// validateAgainstSchema mirrors helm util.ValidateAgainstSchema: validate
+// the chart's own schema then recurse into each subchart with its slice of
+// the coalesced values, accumulating per-chart messages.
+func (c *Client) validateAgainstSchema(chrt *chart.Chart, vals map[string]any) error {
+	var sb strings.Builder
+	if len(chrt.Schema) > 0 {
+		if err := c.validateAgainstSingleSchema(vals, chrt.Schema); err != nil {
+			fmt.Fprintf(&sb, "%s:\n", chrt.Name())
+			sb.WriteString(err.Error())
+		}
+	}
+	for _, sub := range chrt.Dependencies() {
+		raw, exists := vals[sub.Name()]
+		if !exists || raw == nil {
+			continue
+		}
+		subVals, ok := raw.(map[string]any)
+		if !ok {
+			fmt.Fprintf(&sb, "%s:\ninvalid type for values: expected object (map), got %T\n", sub.Name(), raw)
+			continue
+		}
+		if err := c.validateAgainstSchema(sub, subVals); err != nil {
+			sb.WriteString(err.Error())
+		}
+	}
+	if sb.Len() > 0 {
+		return errors.New(sb.String())
+	}
+	return nil
+}
+
+// validateAgainstSingleSchema mirrors helm util.ValidateAgainstSingleSchema
+// (including its panic-to-error recover and error formatting) but resolves
+// the compiled schema through the per-Client cache.
+func (c *Client) validateAgainstSingleSchema(vals map[string]any, schemaJSON []byte) (reterr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			reterr = fmt.Errorf("unable to validate schema: %s", r)
+		}
+	}()
+	validator, err := c.compileSchema(schemaJSON)
+	if err != nil {
+		return err
+	}
+	if err := validator.Validate(vals); err != nil {
+		// Match helm util.JSONSchemaValidationError.Error() formatting so
+		// the surfaced message is identical to helm's own validator (its
+		// error type has an unexported field and can't be reused here).
+		msg := strings.TrimPrefix(err.Error(), "jsonschema validation failed with 'file:///values.schema.json#'\n")
+		return errors.New(msg + "\n")
+	}
+	return nil
+}
+
+// schemaEntry memoizes one compiled schema. sync.Once gives single-flight
+// compilation per schema-bytes hash: N parallel HelmReleases sharing a
+// chart compile its schema exactly once.
+type schemaEntry struct {
+	once     sync.Once
+	compiled *jsonschema.Schema
+	err      error
+}
+
+// compileSchema returns the compiled validator for schemaJSON, caching by
+// content hash. The compiler setup mirrors helm's ValidateAgainstSingleSchema
+// (UnmarshalJSON with number precision, the file:///values.schema.json
+// resource). The http/https/urn loaders helm wires are omitted: flate is
+// offline, so a remote $ref is unresolvable either way, and self-contained
+// schemas (the overwhelming majority, including app-template) never touch a
+// loader, so the compiled result is identical.
+func (c *Client) compileSchema(schemaJSON []byte) (*jsonschema.Schema, error) {
+	sum := sha256.Sum256(schemaJSON)
+	v, _ := c.schemaCache.LoadOrStore(string(sum[:]), &schemaEntry{})
+	e := v.(*schemaEntry)
+	e.once.Do(func() {
+		schema, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaJSON))
+		if err != nil {
+			e.err = err
+			return
+		}
+		compiler := jsonschema.NewCompiler()
+		compiler.UseLoader(jsonschema.SchemeURLLoader{"file": jsonschema.FileLoader{}})
+		if err := compiler.AddResource("file:///values.schema.json", schema); err != nil {
+			e.err = err
+			return
+		}
+		e.compiled, e.err = compiler.Compile("file:///values.schema.json")
+	})
+	return e.compiled, e.err
+}
+
+// schemaValidationSkipped reports whether values.schema.json validation is
+// bypassed for this render — the CLI flag, the HR opt-out, or a wipe
+// placeholder in the values (which a DNS/URL/regex schema would reject for a
+// value flate fabricated). Mirrors the original gate at the install site.
+func schemaValidationSkipped(opts Options, hr *manifest.HelmRelease, hrValues map[string]any) bool {
+	return opts.SkipSchemaValidation || hr.DisableSchemaValidation || manifest.ContainsValuePlaceholder(hrValues)
+}

--- a/pkg/helm/schema_test.go
+++ b/pkg/helm/schema_test.go
@@ -1,0 +1,76 @@
+package helm
+
+import (
+	"testing"
+
+	"helm.sh/helm/v4/pkg/chart/common"
+	"helm.sh/helm/v4/pkg/chart/common/util"
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+)
+
+// TestValidateChartSchema_MatchesHelm pins that flate's cached schema
+// validation (schema.go) is byte-for-byte equivalent to helm's own
+// per-render path: same pass/fail, same surfaced error message. This is
+// the behavior-preservation contract behind compiling each chart's schema
+// once instead of per render.
+func TestValidateChartSchema_MatchesHelm(t *testing.T) {
+	schema := []byte(`{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"properties": {"replicas": {"type": "integer", "minimum": 1}},
+		"required": ["replicas"]
+	}`)
+	mkChart := func() *chart.Chart {
+		return &chart.Chart{
+			Metadata: &chart.Metadata{Name: "demo", Version: "0.1.0"},
+			Schema:   schema,
+		}
+	}
+
+	cases := []struct {
+		name string
+		vals map[string]any
+	}{
+		{"valid", map[string]any{"replicas": int64(2)}},
+		{"missing_required", map[string]any{}},
+		{"wrong_type", map[string]any{"replicas": "two"}},
+		{"below_minimum", map[string]any{"replicas": int64(0)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Client{}
+			flateErr := c.validateChartSchema(mkChart(), tc.vals)
+			_, helmErr := util.ToRenderValuesWithSchemaValidation(
+				mkChart(), tc.vals,
+				common.ReleaseOptions{Name: "r", Namespace: "d", IsInstall: true},
+				nil, false,
+			)
+
+			if (flateErr == nil) != (helmErr == nil) {
+				t.Fatalf("nil-ness mismatch: flate=%v helm=%v", flateErr, helmErr)
+			}
+			if flateErr != nil && flateErr.Error() != helmErr.Error() {
+				t.Errorf("error message mismatch:\n flate: %q\n helm:  %q", flateErr.Error(), helmErr.Error())
+			}
+		})
+	}
+}
+
+// TestCompileSchema_CachesSingleFlight pins that a schema compiles once and
+// is reused: the same bytes return the same *jsonschema.Schema pointer.
+func TestCompileSchema_CachesSingleFlight(t *testing.T) {
+	c := &Client{}
+	schema := []byte(`{"type":"object"}`)
+	a, err := c.compileSchema(schema)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	b, err := c.compileSchema([]byte(`{"type":"object"}`))
+	if err != nil {
+		t.Fatalf("compile (2): %v", err)
+	}
+	if a != b {
+		t.Errorf("expected cached compile to return the same *jsonschema.Schema, got distinct pointers")
+	}
+}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -50,7 +50,7 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 	}
 	cfg.Capabilities = caps
 
-	inst, disableHooks, err := newInstallAction(cfg, hr, hrValues, opts, caps)
+	inst, disableHooks, err := newInstallAction(cfg, hr, opts, caps)
 	if err != nil {
 		return "", err
 	}
@@ -85,6 +85,16 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 		}
 	}
 
+	// Validate against the chart's values.schema.json with a cached compile
+	// instead of helm's per-render recompile (inst.SkipSchemaValidation is
+	// true so helm won't redo it). Runs only on a cache miss — matching when
+	// helm previously validated; the cache-hit return above never validated.
+	if !schemaValidationSkipped(opts, hr, hrValues) {
+		if err := c.validateChartSchema(loaded.Chart, finalValues); err != nil {
+			return "", fmt.Errorf("helm template %s/%s: %w", hr.Namespace, hr.Name, err)
+		}
+	}
+
 	rel, err := inst.RunWithContext(ctx, loaded.Chart, finalValues)
 	if err != nil {
 		return "", fmt.Errorf("helm template %s/%s: %w", hr.Namespace, hr.Name, err)
@@ -110,7 +120,7 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 // wiring. Returns the configured install, the effective disableHooks
 // flag (reused by Template's post-render hook filter so hooks don't
 // leak into the output when disabled), and any kube-version parse error.
-func newInstallAction(cfg *action.Configuration, hr *manifest.HelmRelease, hrValues map[string]any, opts Options, caps *common.Capabilities) (*action.Install, bool, error) {
+func newInstallAction(cfg *action.Configuration, hr *manifest.HelmRelease, opts Options, caps *common.Capabilities) (*action.Install, bool, error) {
 	inst := action.NewInstall(cfg)
 	inst.DryRunStrategy = action.DryRunClient
 	inst.ReleaseName = hr.ReleaseName()
@@ -151,15 +161,13 @@ func newInstallAction(cfg *action.Configuration, hr *manifest.HelmRelease, hrVal
 		inst.Replace = hr.Install.Replace
 	}
 	inst.DisableOpenAPIValidation = hr.DisableOpenAPIValidation
-	// When flate's wipe-secrets has replaced a substituteFrom / valuesFrom
-	// value with the ..PLACEHOLDER_KEY.. token, chart schemas with DNS /
-	// URL / regex patterns reject it (the placeholder isn't a valid
-	// hostname). Disable schema validation when any placeholder reaches
-	// rendering so the user sees the rendered output rather than a
-	// validation error against a value flate fabricated. Real Flux
-	// resolves the secret to the actual value and validates normally —
-	// flate can't, so this short-circuits the failure mode.
-	inst.SkipSchemaValidation = opts.SkipSchemaValidation || hr.DisableSchemaValidation || manifest.ContainsValuePlaceholder(hrValues)
+	// flate validates values against the chart's values.schema.json itself
+	// (cached compile, see schema.go) and always tells helm to skip its own
+	// per-render recompile. The skip conditions — CLI flag, HR opt-out, or a
+	// wipe placeholder (a DNS/URL/regex schema would reject the fabricated
+	// ..PLACEHOLDER_KEY.. token) — are applied at the validation call site
+	// via schemaValidationSkipped.
+	inst.SkipSchemaValidation = true
 	// spec.postRenderers — pipe rendered output through one or more
 	// kustomize patch+image transforms. helm-controller does this via
 	// the same postrenderer.PostRenderer hook.


### PR DESCRIPTION
## Summary
Cold reconcile (empty caches) is **CPU-bound, not network-bound**. Two behavior-preserving wins, profiled against a real home-ops repo (`buroa/k8s-gitops`, ~168 resources):

1. **Per-chart schema-compile cache** (`pkg/helm/schema.go`). helm recompiles each chart's `values.schema.json` on *every* render (no compile cache). With one chart (`bjw-s/app-template`, a large schema) backing ~100 HelmReleases, that per-release schema meta-validation was **~30% of all allocations (1.16 GB)**. flate now validates against a per-`Client` compiled-schema cache (keyed by schema-bytes hash) and sets helm's `SkipSchemaValidation` so it doesn't recompile — same `CoalesceValues`, same `jsonschema` compile, same surfaced error. A helm-parity test pins identical pass/fail **and** identical error text.
2. **`GOGC=400` default** for the short-lived CLI (`cmd/flate/main.go`), overridable via `GOGC`/`GOMEMLIMIT`. Concurrent GC competes for scarce cores on small runners; fewer cycles helps there.

## Measured (cold `build all`, best-of-3)
| | 16 cores | 2 cores (CI-like) |
|---|---|---|
| stock | 2.09s | **3.31s** |
| this PR | 2.01s | **2.25s (~32% faster)** |

No-op on many-core boxes; the win lands on core-constrained CI runners (2 vCPU), the real cold-start target.

## Safety
- Rendered output **byte-identical** (69,223 lines, before/after on the real repo).
- New `TestValidateChartSchema_MatchesHelm` proves the cached path matches helm's validator exactly (valid / missing-required / wrong-type / below-minimum).
- helm `go test -race` green; `golangci-lint` 0 issues.

## Test plan
- [ ] `go test -race ./pkg/helm/...`
- [ ] `golangci-lint run`
- [ ] cold `flate build all` output unchanged vs `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)