### PR TITLE
fix(helmrelease): prune unchanged dependsOn targets in changed-only mode

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -522,7 +523,22 @@ func (c *Controller) collectHRDeps(hr *manifest.HelmRelease) []manifest.Dependen
 	if len(hr.DependsOn) == 0 {
 		return nil
 	}
-	return append([]manifest.DependencyRef(nil), hr.DependsOn...)
+	deps := append([]manifest.DependencyRef(nil), hr.DependsOn...)
+	// Changed-only mode: a dependsOn target outside the keep-set is
+	// unchanged, so its producing Kustomization is skipped and the target
+	// HR is never render-emitted into the Store — depwait would report
+	// "dependency not found" for a dep that's simply unchanged. Drop it:
+	// an unchanged dep is satisfied for a delta check, mirroring how a
+	// skipped in-Store resource resolves Ready via base.PreGate. dependsOn
+	// is pure reconcile ordering and never affects offline render content
+	// (see change.transitiveDeps). Unlike KS deps, HRs have no file-loaded
+	// Store object to carry that Ready, hence the prune here. See #517.
+	if f := c.Filter(); f != nil && f.Enabled() {
+		deps = slices.DeleteFunc(deps, func(d manifest.DependencyRef) bool {
+			return !f.ShouldReconcile(d.NamedResource)
+		})
+	}
+	return deps
 }
 
 // preparePrereqs collects refs that helm.Prepare reads from the live

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -562,3 +562,35 @@ func TestController_CollectHRDepsClone(t *testing.T) {
 		t.Errorf("collectHRDeps did not return a defensive copy")
 	}
 }
+
+func TestController_CollectHRDepsPrunesUnchangedDeps(t *testing.T) {
+	// #517: in changed-only mode a changed HR's dependsOn on an UNCHANGED
+	// dep must be pruned. The unchanged dep's producing Kustomization is
+	// skipped, so the dep HR is never render-emitted into the Store and
+	// depwait would spuriously fail "dependency not found". Build a filter
+	// whose keep-set contains qbittorrent (its file changed) but not
+	// prowlarr (unchanged): only the in-keep dep survives.
+	qbit := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "downloads", Name: "qbittorrent"}
+	prowlarr := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "downloads", Name: "prowlarr"}
+	filter := change.NewFilter(
+		change.NewSet([]string{"qbittorrent.yaml"}),
+		map[manifest.NamedResource]string{qbit: "qbittorrent.yaml", prowlarr: "prowlarr.yaml"},
+		"",
+		testutil.MapLister{},
+	)
+	c, _ := newTestController(t, filter)
+	hr := &manifest.HelmRelease{
+		Name: "lidarr", Namespace: "downloads",
+		DependsOn: []manifest.DependencyRef{{NamedResource: qbit}, {NamedResource: prowlarr}},
+	}
+	got := c.collectHRDeps(hr)
+	if len(got) != 1 || got[0].NamedResource != qbit {
+		t.Fatalf("collectHRDeps = %+v; want only the in-keep qbittorrent dep", got)
+	}
+
+	// Sanity: a disabled filter (full mode) prunes nothing.
+	cFull, _ := newTestController(t, nil)
+	if got := cFull.collectHRDeps(hr); len(got) != 2 {
+		t.Errorf("disabled filter must not prune; collectHRDeps = %+v", got)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -554,6 +554,50 @@ func TestE2E_SubstituteDisabledAnnotation(t *testing.T) {
 	}
 }
 
+// TestE2E_ChangedOnlyHRDependsOnUnchangedDep is the regression test for
+// issue #517: in changed-only mode a changed HelmRelease whose
+// spec.dependsOn references an UNCHANGED HelmRelease must not fail
+// "dependency not found". The dependency's producing Kustomization is
+// SKIPPED (unchanged), so its HR is never render-emitted into the store
+// — but an unchanged dependency is satisfied by definition for a delta
+// check. The dependson/ fixture mirrors the bjw-s layout that surfaced
+// the bug: per-app Flux Kustomizations with targetNamespace, bare HRs,
+// lidarr dependsOn qbittorrent.
+func TestE2E_ChangedOnlyHRDependsOnUnchangedDep(t *testing.T) {
+	clusterPath, repoRoot := initGitFixtureFrom(t, testdataPath(t, "dependson"))
+
+	// Edit a value in lidarr's HelmRelease so only lidarr is in changed
+	// scope; qbittorrent (its dependsOn target) stays unchanged, so its
+	// Kustomization is skipped and the qbittorrent HR is never emitted.
+	hr := filepath.Join(repoRoot, "apps", "downloads", "lidarr", "app", "helmrelease.yaml")
+	body, err := os.ReadFile(hr) //nolint:gosec // repoRoot is t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := strings.Replace(string(body), "hello-from-lidarr", "hello-from-lidarr-edited", 1)
+	if mutated == string(body) {
+		t.Fatal("sentinel 'hello-from-lidarr' not found in lidarr helmrelease.yaml")
+	}
+	if err := os.WriteFile(hr, []byte(mutated), 0o600); err != nil { //nolint:gosec // repoRoot is t.TempDir()
+		t.Fatal(err)
+	}
+
+	out := runCLIOutputOnly(t, "test", "all", "--path", clusterPath, "--base", "HEAD")
+
+	if strings.Contains(out, "dependency not found") {
+		t.Errorf("changed-only HR dependsOn on an unchanged dep must not fail:\n%s", out)
+	}
+	if lidarr := mustExtractLine(t, out, "HelmRelease/downloads/lidarr"); !strings.Contains(lidarr, "PASSED") {
+		t.Errorf("lidarr HR should PASS once the unchanged dep is pruned; got: %s", lidarr)
+	}
+	// Confirm the test actually exercises the bug: qbittorrent's KS (the
+	// dep's producer) must be skipped, otherwise the dep would render and
+	// the assertion above would pass trivially.
+	if line := mustExtractSkipLine(t, out, "Kustomization/downloads/qbittorrent"); !strings.Contains(line, "SKIPPED") {
+		t.Errorf("expected qbittorrent KS SKIPPED (unchanged); got: %s", line)
+	}
+}
+
 func mustExtractLine(t *testing.T, haystack, needle string) string {
 	t.Helper()
 	for line := range strings.SplitSeq(haystack, "\n") {
@@ -563,6 +607,67 @@ func mustExtractLine(t *testing.T, haystack, needle string) string {
 	}
 	t.Fatalf("status line for %q not found in:\n%s", needle, haystack)
 	return ""
+}
+
+// mustExtractSkipLine returns the SKIPPED status line containing needle,
+// failing the test if no such line exists. Companion to mustExtractLine
+// for the changed-only path where mustExtractLine's PASSED/FAILED filter
+// wouldn't match a skipped resource.
+func mustExtractSkipLine(t *testing.T, haystack, needle string) string {
+	t.Helper()
+	for line := range strings.SplitSeq(haystack, "\n") {
+		if strings.Contains(line, needle) && strings.Contains(line, "SKIPPED") {
+			return line
+		}
+	}
+	t.Fatalf("SKIPPED line for %q not found in:\n%s", needle, haystack)
+	return ""
+}
+
+// initGitFixtureFrom copies the fixture tree at src into a fresh tempdir,
+// inits a git repo, and commits the whole tree as the baseline. Returns
+// (clusterPath, repoRoot): clusterPath is the repoRoot/flux entrypoint
+// callers pass as --path; repoRoot is the .git ancestor so the test can
+// mutate fixture files after committing. Mirrors initGitFixture but seeds
+// from a testdata fixture rather than inline bytes.
+func initGitFixtureFrom(t *testing.T, src string) (clusterPath, repoRoot string) {
+	t.Helper()
+	dir := t.TempDir()
+	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, p)
+		out := filepath.Join(dir, rel)
+		if info.IsDir() {
+			return os.MkdirAll(out, 0o750)
+		}
+		data, err := os.ReadFile(p) //nolint:gosec // p is supplied by filepath.Walk over a known root
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(out, data, 0o600) //nolint:gosec // dir is t.TempDir()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "flux"), dir
 }
 
 // initGitFixture creates a tempdir with a real git repo, commits a

--- a/testdata/dependson/apps/downloads/kustomization.yaml
+++ b/testdata/dependson/apps/downloads/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: downloads
+resources:
+  - ./qbittorrent/ks.yaml
+  - ./lidarr/ks.yaml

--- a/testdata/dependson/apps/downloads/lidarr/app/helmrelease.yaml
+++ b/testdata/dependson/apps/downloads/lidarr/app/helmrelease.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: lidarr
+spec:
+  interval: 10m
+  dependsOn:
+    - name: qbittorrent
+  chart:
+    spec:
+      chart: charts/mychart
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  values:
+    greeting: hello-from-lidarr

--- a/testdata/dependson/apps/downloads/lidarr/app/kustomization.yaml
+++ b/testdata/dependson/apps/downloads/lidarr/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/testdata/dependson/apps/downloads/lidarr/ks.yaml
+++ b/testdata/dependson/apps/downloads/lidarr/ks.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: lidarr
+  namespace: downloads
+spec:
+  interval: 10m
+  path: ./apps/downloads/lidarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: downloads

--- a/testdata/dependson/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/testdata/dependson/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: qbittorrent
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: charts/mychart
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  values:
+    greeting: hello-from-qbittorrent

--- a/testdata/dependson/apps/downloads/qbittorrent/app/kustomization.yaml
+++ b/testdata/dependson/apps/downloads/qbittorrent/app/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/testdata/dependson/apps/downloads/qbittorrent/ks.yaml
+++ b/testdata/dependson/apps/downloads/qbittorrent/ks.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: qbittorrent
+  namespace: downloads
+spec:
+  interval: 10m
+  path: ./apps/downloads/qbittorrent/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: downloads

--- a/testdata/dependson/charts/mychart/Chart.yaml
+++ b/testdata/dependson/charts/mychart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: mychart
+description: minimal local chart used for flate E2E tests
+version: 0.1.0
+appVersion: "1.0"

--- a/testdata/dependson/charts/mychart/templates/configmap.yaml
+++ b/testdata/dependson/charts/mychart/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+  namespace: {{ .Release.Namespace }}
+data:
+  greeting: {{ .Values.greeting | quote }}
+  replicas: "{{ .Values.replicas }}"

--- a/testdata/dependson/charts/mychart/values.yaml
+++ b/testdata/dependson/charts/mychart/values.yaml
@@ -1,0 +1,2 @@
+greeting: hi
+replicas: 1

--- a/testdata/dependson/flux/apps.yaml
+++ b/testdata/dependson/flux/apps.yaml
@@ -1,0 +1,22 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/downloads
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system


### PR DESCRIPTION
## Summary

Fixes #517 — in changed-only mode (`flate diff/test ... --base <rev>` or `--path-orig`), a changed HelmRelease whose `spec.dependsOn` references an **unchanged** HelmRelease fails with a spurious `dependencies failed: HelmRelease/<ns>/<dep>: dependency not found`.

**Root cause:** HelmReleases are render-emitted by their Flux Kustomization (DiscoveryOnly keeps them in the Existence index, not the Store; the KS render emits them with `targetNamespace` applied). In changed-only mode the change filter SKIPS unchanged Kustomizations, so a skipped KS never renders and its HR is never added to the Store. `collectHRDeps` fed `dependsOn` straight into depwait, which then can't find the dep. Kustomization-level deps avoid this because KS objects are file-loaded into the Store and a skipped KS still resolves `Ready/unchanged` via `base.PreGate` — render-emitted HRs have no such in-store object.

**Fix:** prune an HR's `dependsOn` to drop targets outside the changed-only keep-set. An unchanged dependency is satisfied by definition for a delta check, and `dependsOn` is pure reconcile ordering with no effect on offline render content (per `change.transitiveDeps`). A changed dep still resolves true via the keep-set's empty-namespace name bridge, so a genuinely-failing changed dependency still cascades. Mirrors the existing `kustomization.collectDeps` Filter-consultation pattern; full mode (filter disabled) is unaffected.

## Test plan

- [x] New e2e regression test `TestE2E_ChangedOnlyHRDependsOnUnchangedDep` — nested bjw-s fixture (`testdata/dependson/`: per-app Flux KS + `targetNamespace`, bare HRs, lidarr→qbittorrent), edits lidarr under `--base HEAD`, asserts no `dependency not found`, lidarr PASSED, qbittorrent KS SKIPPED. Confirmed to FAIL without the fix and PASS with it.
- [x] Unit test `TestController_CollectHRDepsPrunesUnchangedDeps` — in-keep dep survives, out-of-keep dep pruned, disabled filter prunes nothing.
- [x] `mise lint` 0 issues; `mise test` full suite green.
- [x] Full-mode `test all` (no `--base`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)