### PR TITLE
fix(oci): skip provenance layer when selecting the chart layer

### DIFF
--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -152,21 +152,35 @@ func readSlotManifest(slot, digestStr string) (*ocispec.Manifest, error) {
 	return &m, nil
 }
 
-// pickLayer returns the first layer matching selector.MediaType,
-// or the first layer overall when selector is nil or MediaType is empty.
+// pickLayer returns the layer matching selector.MediaType, or — with no
+// selector — the first non-provenance layer (falling back to layers[0]).
+//
+// The provenance skip is load-bearing. `helm push` lists a signed
+// chart's detached-signature layer (helmChartProvenanceMediaType) AHEAD
+// of the gzipped content layer, so the old "return layers[0]" handed the
+// signature blob (PGP text, not a tarball) to gzip extraction — "gzip:
+// invalid header" on every signed chart (cert-manager, truecharts,
+// grafana/prometheus community, ...). Skipping only the provenance type
+// keeps the documented default-to-first-layer behavior intact for every
+// other shape, including generic single-layer Flux artifacts.
 func pickLayer(layers []ocispec.Descriptor, selector *manifest.OCILayerSelector) (ocispec.Descriptor, bool) {
 	if len(layers) == 0 {
 		return ocispec.Descriptor{}, false
 	}
-	if selector == nil || selector.MediaType == "" {
-		return layers[0], true
+	if selector != nil && selector.MediaType != "" {
+		for _, l := range layers {
+			if l.MediaType == selector.MediaType {
+				return l, true
+			}
+		}
+		return ocispec.Descriptor{}, false
 	}
 	for _, l := range layers {
-		if l.MediaType == selector.MediaType {
+		if l.MediaType != helmChartProvenanceMediaType {
 			return l, true
 		}
 	}
-	return ocispec.Descriptor{}, false
+	return layers[0], true
 }
 
 // digestPath resolves a digest to its on-disk path inside slot,

--- a/pkg/source/oci/layer_test.go
+++ b/pkg/source/oci/layer_test.go
@@ -57,6 +57,27 @@ func TestPickLayer(t *testing.T) {
 	}
 }
 
+// TestPickLayer_ProvenanceFirstSkipped pins the signed-chart fix: when
+// no selector is set and the manifest lists the provenance (.prov)
+// signature layer ahead of the gzipped content layer — the shape
+// `helm push` produces for every signed chart — pickLayer must skip the
+// provenance layer and return the content layer, not blindly grab
+// layers[0]. The old layers[0] default fed the signature blob to gzip
+// extraction → "gzip: invalid header".
+func TestPickLayer_ProvenanceFirstSkipped(t *testing.T) {
+	layers := []ocispec.Descriptor{
+		{MediaType: "application/vnd.cncf.helm.chart.provenance.v1.prov"},
+		{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip"},
+	}
+	got, ok := pickLayer(layers, nil)
+	if !ok {
+		t.Fatal("pickLayer returned ok=false")
+	}
+	if got.MediaType != "application/vnd.cncf.helm.chart.content.v1.tar+gzip" {
+		t.Errorf("mediaType = %q, want the content layer (provenance must be skipped)", got.MediaType)
+	}
+}
+
 func TestApplyLayerSelector_Extract(t *testing.T) {
 	slot := t.TempDir()
 
@@ -178,6 +199,30 @@ func TestApplyLayerSelector_DefaultsToFirstLayer(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(slot, "Chart.yaml")); !os.IsNotExist(err) {
 		t.Errorf("default selection should not extract second layer, stat err=%v", err)
+	}
+}
+
+// TestApplyLayerSelector_ProvenanceFirstDefault is the end-to-end
+// counterpart to TestPickLayer_ProvenanceFirstSkipped: a nil selector
+// against a `[provenance, content]` manifest (the signed-chart shape)
+// must extract the chart from the content layer rather than try to
+// gunzip the provenance signature.
+func TestApplyLayerSelector_ProvenanceFirstDefault(t *testing.T) {
+	slot := t.TempDir()
+	prov := []byte("-----BEGIN PGP SIGNED MESSAGE-----\nnot a tarball\n")
+	chart := mustTarGz(t, map[string]string{"Chart.yaml": "apiVersion: v2\nname: x\nversion: 0.1.0\n"})
+	digProv := writeBlob(t, slot, prov)
+	digChart := writeBlob(t, slot, chart)
+	_, manifestDigest := writeManifest(t, slot, []ocispec.Descriptor{
+		{MediaType: "application/vnd.cncf.helm.chart.provenance.v1.prov", Digest: digProv, Size: int64(len(prov))},
+		{MediaType: "application/vnd.cncf.helm.chart.content.v1.tar+gzip", Digest: digChart, Size: int64(len(chart))},
+	})
+
+	if err := applyLayerSelector(t.Context(), slot, manifestDigest.String(), nil); err != nil {
+		t.Fatalf("applyLayerSelector: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(slot, "Chart.yaml")); err != nil {
+		t.Errorf("expected Chart.yaml extracted from the content layer: %v", err)
 	}
 }
 

--- a/pkg/source/oci/resolve.go
+++ b/pkg/source/oci/resolve.go
@@ -140,6 +140,15 @@ func pickSemverTag(tags []string, expr, filterPattern, mediaType string) (string
 
 const helmChartLayerMediaType = "application/vnd.cncf.helm.chart.content.v1.tar+gzip"
 
+// helmChartProvenanceMediaType is the media type helm assigns to the
+// detached PGP signature (`<chart>.prov`) it pushes alongside a signed
+// chart. `helm push` lists this layer AHEAD of the chart content layer
+// in the OCI manifest, and the blob is signature text — not a gzipped
+// tarball. pickLayer must skip it so the default (no-selector) path
+// doesn't hand it to gzip extraction; every signed chart (cert-manager,
+// truecharts, grafana/prometheus community, ...) carries one.
+const helmChartProvenanceMediaType = "application/vnd.cncf.helm.chart.provenance.v1.prov"
+
 func layerMediaType(selector *manifest.OCILayerSelector) string {
 	if selector == nil {
 		return ""


### PR DESCRIPTION
## Summary

Signed OCI Helm charts ship a detached-signature layer
(`application/vnd.cncf.helm.chart.provenance.v1.prov`) that `helm push`
lists **ahead** of the gzipped content layer. `pickLayer` blindly
returned `layers[0]`, so the `.prov` signature blob — PGP text, not a
tarball — was handed to gzip extraction, producing
`layer select: extract layer: gzip: gzip: invalid header` on **every**
signed chart (cert-manager, all TrueCharts, grafana-community,
prometheus-community, ...).

With no explicit `spec.layerSelector`, `pickLayer` now returns the first
**non-provenance** layer (falling back to `layers[0]`). The documented
default-to-first-layer behavior is otherwise untouched, including
generic single-layer Flux artifacts.

Verified against a real-world cluster repo (`Boemeltrein/TalosCluster`):
31 OCIRepository charts that failed with `gzip: invalid header` now pull
and render (e.g. cert-manager renders its real `v1.20.2` templates).

## Test plan

- [x] `go test ./pkg/source/oci/...` — added `TestPickLayer_ProvenanceFirstSkipped` and `TestApplyLayerSelector_ProvenanceFirstDefault` (nil-selector `[provenance, content]` extracts the chart)
- [x] Existing `TestPickLayer` / `TestApplyLayerSelector_DefaultsToFirstLayer` still pass (default-to-first-layer preserved)
- [x] `golangci-lint run` clean
- [x] `flate test all` against TalosCluster: cold cache, signed charts extract & render

🤖 Generated with [Claude Code](https://claude.com/claude-code)