### PR TITLE
fix(configmap): wipe SOPS-encrypted values to placeholders

### DIFF
--- a/pkg/manifest/configmap.go
+++ b/pkg/manifest/configmap.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"encoding/base64"
 	"fmt"
+	"maps"
 )
 
 // ConfigMap is the core/v1 ConfigMap.
@@ -18,8 +19,11 @@ func (c *ConfigMap) Named() NamedResource {
 	return NamedResource{Kind: KindConfigMap, Namespace: c.Namespace, Name: c.Name}
 }
 
-// parseConfigMap decodes a core/v1 ConfigMap.
-func parseConfigMap(doc map[string]any) (*ConfigMap, error) {
+// parseConfigMap decodes a core/v1 ConfigMap. When wipeSecrets is set
+// (the default, matching parseSecret), SOPS-encrypted data values are
+// replaced with placeholders — flate can't decrypt them and the raw
+// ciphertext otherwise poisons downstream rendering.
+func parseConfigMap(doc map[string]any, wipeSecrets bool) (*ConfigMap, error) {
 	if err := checkAPIVersion(doc, "v1"); err != nil {
 		return nil, err
 	}
@@ -29,12 +33,45 @@ func parseConfigMap(doc map[string]any) (*ConfigMap, error) {
 	}
 	cm := &ConfigMap{Name: name, Namespace: ns}
 	if v, ok := doc["data"].(map[string]any); ok {
+		if wipeSecrets {
+			v = wipeSopsCiphertext(v)
+		}
 		cm.Data = v
 	}
 	if v, ok := doc["binaryData"].(map[string]any); ok {
 		cm.BinaryData = v
 	}
 	return cm, nil
+}
+
+// wipeSopsCiphertext replaces SOPS-encrypted ConfigMap values with the
+// same placeholder parseSecret uses for wiped Secret keys. flate runs
+// offline and cannot decrypt, so a SOPS-encrypted ConfigMap (commonly a
+// postBuild.substituteFrom source) would otherwise feed raw ciphertext
+// into envsubst — and the `:` inside `ENC[AES256_GCM,…]` then trips
+// chart validation (Ingress hosts, cert-manager dnsNames). Gated by the
+// caller's wipeSecrets flag so it tracks Secret wiping: callers that opt
+// to keep cleartext Secrets (WipeSecrets=false) keep the ciphertext too.
+// Only encrypted scalars are touched, so a partially-encrypted ConfigMap
+// keeps its cleartext entries. Returns data unchanged when nothing
+// matches to avoid a needless copy on the common cleartext path.
+func wipeSopsCiphertext(data map[string]any) map[string]any {
+	var out map[string]any
+	for k, v := range data {
+		s, ok := v.(string)
+		if !ok || !IsSopsCiphertext(s) {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]any, len(data))
+			maps.Copy(out, data)
+		}
+		out[k] = fmt.Sprintf(ValuePlaceholderTemplate, k)
+	}
+	if out == nil {
+		return data
+	}
+	return out
 }
 
 // Secret is the core/v1 Secret. By default cleartext data is wiped to a

--- a/pkg/manifest/configmap.go
+++ b/pkg/manifest/configmap.go
@@ -55,6 +55,10 @@ func parseConfigMap(doc map[string]any, wipeSecrets bool) (*ConfigMap, error) {
 // Only encrypted scalars are touched, so a partially-encrypted ConfigMap
 // keeps its cleartext entries. Returns data unchanged when nothing
 // matches to avoid a needless copy on the common cleartext path.
+//
+// Scope: this covers ConfigMap data (and Secret data, via parseSecret).
+// SOPS-encrypted inline HelmRelease spec.values — a partially-encrypted
+// HR file via encrypted_regex — bypass this path and are left as-is.
 func wipeSopsCiphertext(data map[string]any) map[string]any {
 	var out map[string]any
 	for k, v := range data {

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -993,11 +993,52 @@ metadata:
 data:
   DOMAIN: example.com
 `)
-	cm, err := parseConfigMap(doc)
+	cm, err := parseConfigMap(doc, true)
 	if err != nil {
 		t.Fatalf("parseConfigMap: %v", err)
 	}
 	assert.Diff(t, cm.Data, map[string]any{"DOMAIN": "example.com"})
+}
+
+// TestParseConfigMap_WipesSopsCiphertext pins the offline-SOPS fix: a
+// SOPS-encrypted ConfigMap (commonly a postBuild.substituteFrom source)
+// must surface placeholders, not raw ciphertext, when wipeSecrets is set
+// (the default). flate can't decrypt, and the `:` inside ENC[...]
+// otherwise leaks into envsubst and trips chart validation (Ingress
+// hosts, cert-manager dnsNames). Cleartext entries are left untouched,
+// and wipeSecrets=false preserves the ciphertext to track Secret wiping.
+func TestParseConfigMap_WipesSopsCiphertext(t *testing.T) {
+	const ciphertext = "ENC[AES256_GCM,data:NWahjtvi/hiAX9sVkctDGcmWOn0=,iv:2fxQddhm7pwpnO23VkFFgPPEXudfa7TgI0oxUkAjZtA=,tag:rS3MK2jGptzB3RyWOj+Amg==,type:str]"
+	src := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-config
+  namespace: flux-system
+data:
+  BASE_DOMAIN: ` + ciphertext + `
+  PLAINTEXT: keep-me
+`
+	t.Run("wiped", func(t *testing.T) {
+		cm, err := parseConfigMap(mustYAML(t, src), true)
+		if err != nil {
+			t.Fatalf("parseConfigMap: %v", err)
+		}
+		assert.Diff(t, cm.Data, map[string]any{
+			"BASE_DOMAIN": fmt.Sprintf(ValuePlaceholderTemplate, "BASE_DOMAIN"),
+			"PLAINTEXT":   "keep-me",
+		})
+	})
+	t.Run("preserved when wipeSecrets=false", func(t *testing.T) {
+		cm, err := parseConfigMap(mustYAML(t, src), false)
+		if err != nil {
+			t.Fatalf("parseConfigMap: %v", err)
+		}
+		assert.Diff(t, cm.Data, map[string]any{
+			"BASE_DOMAIN": ciphertext,
+			"PLAINTEXT":   "keep-me",
+		})
+	})
 }
 
 func TestParseSecret(t *testing.T) {

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -135,7 +135,7 @@ func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
 	case kind == KindResourceSetInputProvider && strings.HasPrefix(apiVersion, FluxOperatorDomain):
 		return parseResourceSetInputProvider(doc)
 	case kind == KindConfigMap:
-		return parseConfigMap(doc)
+		return parseConfigMap(doc, opts.WipeSecrets)
 	case kind == KindSecret:
 		return parseSecret(doc, opts.WipeSecrets)
 	}

--- a/pkg/manifest/sops.go
+++ b/pkg/manifest/sops.go
@@ -1,5 +1,23 @@
 package manifest
 
+import "strings"
+
+// sopsCiphertextPrefix opens every SOPS-encrypted scalar. SOPS rewrites
+// an encrypted value as `ENC[AES256_GCM,data:…,iv:…,tag:…,type:…]`; the
+// algorithm-qualified prefix plus trailing `]` is specific enough that a
+// real cleartext value never matches it by accident.
+const sopsCiphertextPrefix = "ENC[AES256_GCM,"
+
+// IsSopsCiphertext reports whether s is a SOPS-encrypted scalar that
+// flate (running offline, with no decryption key) cannot decrypt. Used
+// to wipe leftover ciphertext to a placeholder so it doesn't poison
+// downstream rendering — e.g. an encrypted ConfigMap value flowing into
+// postBuild substitution, where the `:` inside the ciphertext breaks
+// chart validation (Ingress hosts, cert-manager dnsNames, ...).
+func IsSopsCiphertext(s string) bool {
+	return strings.HasPrefix(s, sopsCiphertextPrefix) && strings.HasSuffix(s, "]")
+}
+
 // IsEncryptedSecret reports whether doc looks like a SOPS-encrypted
 // Kubernetes resource. SOPS appends a top-level `sops` map containing
 // its metadata (mac, kms/age/pgp blocks, version) after encrypting the

--- a/pkg/manifest/sops_test.go
+++ b/pkg/manifest/sops_test.go
@@ -63,6 +63,29 @@ func TestIsEncryptedSecret(t *testing.T) {
 	}
 }
 
+func TestIsSopsCiphertext(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"encrypted str scalar", "ENC[AES256_GCM,data:abc=,iv:def=,tag:ghi=,type:str]", true},
+		{"encrypted comment scalar", "ENC[AES256_GCM,data:abc=,iv:def=,tag:ghi=,type:comment]", true},
+		{"cleartext value", "example.com", false},
+		{"empty", "", false},
+		{"prefix only, no close bracket", "ENC[AES256_GCM,data:abc", false},
+		{"different algorithm", "ENC[CHACHA20_POLY1305,data:abc]", false},
+		{"substring not at start", "host=ENC[AES256_GCM,data:abc]", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSopsCiphertext(tc.in); got != tc.want {
+				t.Errorf("IsSopsCiphertext(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHasSubstituteDisabled(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

flate runs offline and cannot decrypt SOPS. A SOPS-encrypted **ConfigMap**
(commonly a `postBuild.substituteFrom` source) fed its raw
`ENC[AES256_GCM,...]` ciphertext straight into envsubst, and the `:`
inside the ciphertext then tripped chart validation — e.g.
`Expected [hosts.host] to not contain [:]` on Ingress hosts and
cert-manager dnsNames. Encrypted **Secrets** were already wiped to
placeholders; ConfigMaps were the asymmetric gap.

`parseConfigMap` now replaces SOPS-encrypted scalar values with the same
`..PLACEHOLDER_<key>..` token `parseSecret` uses, **gated by the caller's
`WipeSecrets` flag** so it tracks Secret wiping: embedders that keep
cleartext Secrets (`WipeSecrets=false`) keep the ciphertext too. Only
encrypted scalars are touched, so a partially-encrypted ConfigMap keeps
its cleartext entries. The CLI hardcodes `WipeSecrets=true`, so this is
the default behavior there.

Verified against a real-world cluster repo (`Boemeltrein/TalosCluster`):
11 HelmReleases whose `${BASE_DOMAIN}` etc. resolved from an encrypted
ConfigMap and rendered `host: app.ENC[...]` now render
`host: app...PLACEHOLDER_BASE_DOMAIN..` and pass validation.

## Test plan

- [x] `go test ./pkg/manifest/...` — `TestParseConfigMap_WipesSopsCiphertext` covers both `WipeSecrets=true` (placeholder) and `false` (ciphertext preserved); `TestIsSopsCiphertext` covers the detector
- [x] Cleartext ConfigMaps unchanged (`TestParseConfigMap`)
- [x] `golangci-lint run` clean
- [x] `flate test all` against TalosCluster: encrypted-substitution HelmReleases render & pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)