### PR TITLE
ci: restore goreleaser job, run release-only

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,6 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
   release:
     types:
       - published
@@ -22,8 +19,7 @@ jobs:
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=semver,pattern={{version}}
-        type=raw,value=rolling,enable=${{ github.event_name == 'release' }}
-        type=ref,event=branch
+        type=raw,value=rolling
       output: image
       platforms: linux/amd64,linux/arm64
       push: true
@@ -34,3 +30,53 @@ jobs:
         - registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+  goreleaser:
+    name: Run GoReleaser
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Install UPX
+        uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
+        with:
+          install-only: true
+
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Generate Homebrew Tap Token
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+          permission-contents: write
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}


### PR DESCRIPTION
Fixes a regression from [#525](https://github.com/home-operations/flate/pull/525): adopting the `docker/github-builder` reusable workflow **dropped the goreleaser job** (Go binaries → GitHub release assets + homebrew-tap) and made the container build run on `main` pushes too.

This restores `release.yaml` to **release-only** (its original trigger) with two jobs, both on `release: published`:
- `release` — the container image via `docker/github-builder` (multi-arch, SBOM, cosign), tags `:<version>` + `:rolling`.
- `goreleaser` — the original GoReleaser job, unchanged (binaries, GitHub release, homebrew-tap).

No `main`-push build for flate (per your "only run on release"). actionlint + zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)