### PR TITLE
feat: stamp build version into the container image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,9 @@ jobs:
       packages: write
     uses: docker/github-builder/.github/workflows/build.yml@17bd7d64200cae4ba58ffc099934e8012ae320f2 # v1.10.0
     with:
+      build-args: |
+        VERSION=${{ github.ref_name }}
+        REVISION=${{ github.sha }}
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=semver,pattern={{version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM golang:1.26-alpine AS build
+ARG VERSION=dev
+ARG REVISION=dev
 WORKDIR /src
 # ca-certificates so the scratch stage can verify TLS to ghcr.io,
 # helm-chart repos, OCI registries, etc.
@@ -6,7 +8,7 @@ RUN apk add --no-cache ca-certificates upx
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/flate ./cmd/flate
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${REVISION}" -o /out/flate ./cmd/flate
 RUN upx --best --lzma /out/flate
 
 FROM scratch

--- a/cmd/flate/main.go
+++ b/cmd/flate/main.go
@@ -8,14 +8,32 @@ import (
 	"github.com/home-operations/flate/internal/cli"
 )
 
-// version is set at build time via -ldflags by goreleaser. When the
-// binary is built with plain `go build` / `go install`, version stays
-// "dev" and we fall back to the module BuildInfo for a useful display.
-var version = "dev"
+// version and commit are stamped at build time via -ldflags: goreleaser
+// sets version for release binaries, and the container Dockerfile sets both.
+// With a plain `go build` / `go install` they keep their defaults and we
+// fall back to the module BuildInfo for a useful version display.
+var (
+	version = "dev"
+	commit  = "unknown"
+)
 
 func main() {
 	tuneGC()
-	os.Exit(cli.Execute(resolvedVersion()))
+	os.Exit(cli.Execute(versionString()))
+}
+
+// versionString renders the value behind `flate --version`, appending a
+// short commit when one was stamped in (the container build sets it).
+func versionString() string {
+	v := resolvedVersion()
+	if commit == "unknown" {
+		return v
+	}
+	short := commit
+	if len(short) > 7 {
+		short = short[:7]
+	}
+	return v + " (" + short + ")"
 }
 
 // tuneGC raises the GC target for flate's short-lived, allocation-heavy


### PR DESCRIPTION
Part of standardizing build-version stamping across the org's Go services — all five now pass **VERSION + REVISION** into the container's Go binary.

flate's release binaries are stamped by goreleaser (version only), but the container image built by `docker/github-builder` wasn't stamped at all, and flate had no commit var. This adds both:

- **cmd/flate/main.go**: add `commit` alongside `version`; `flate --version` now renders `version (shortcommit)` when stamped, falling back to the existing `debug.ReadBuildInfo()` behavior otherwise.
- **Dockerfile**: add `ARG VERSION`/`ARG REVISION`, inject via `-ldflags "… -X main.version=${VERSION} -X main.commit=${REVISION}"`.
- **release.yaml**: pass `VERSION=${{ github.ref_name }}` and `REVISION=${{ github.sha }}`.

Verified the stamped binary reports e.g. `flate version v1.2.3 (abc1234)`; unstamped builds are unchanged. goreleaser release binaries are unaffected (still version-only).

> The `Release` workflow calls a reusable workflow, so it can't run on this PR — first exercised on the next push to `main` / release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
