### PR TITLE
fix(loader): resolve NamespaceTransformer targetNamespace at load time

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -148,6 +148,11 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 }
 
 func (d *discoverer) applyNamespaces(repoRoot string) {
+	// Stamp NamespaceTransformer-injected targetNamespace onto Flux KSes
+	// first so ApplyNamespaceInheritance's projection sees a populated
+	// targetNamespace and the leaf KS renders into the right namespace on
+	// its first pass (issue #528).
+	loader.StampTransformerTargetNamespaces(d.cfg.Store, d.sourceFiles, repoRoot)
 	loader.ApplyNamespaceInheritance(d.cfg.Store, d.sourceFiles, repoRoot)
 	loader.ApplyDefaultNamespaces(d.cfg.Store, d.sourceFiles)
 }

--- a/pkg/loader/transformer_ns.go
+++ b/pkg/loader/transformer_ns.go
@@ -1,0 +1,239 @@
+package loader
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	yaml "go.yaml.in/yaml/v4"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// transformerScanMaxDepth bounds the recursive walk that confirms a
+// `transformers:` reference resolves to a builtin NamespaceTransformer.
+// Real repos nest one or two levels (overlay → transformers/ → shared
+// transformer dir); the cap keeps a pathological resources: cycle from
+// running away even though visited already breaks true cycles.
+const transformerScanMaxDepth = 6
+
+// StampTransformerTargetNamespaces fills empty spec.targetNamespace on
+// file-loaded Flux Kustomizations from a builtin NamespaceTransformer
+// that an enclosing kustomize overlay applies.
+//
+// flatops-style repos keep resources namespace-less "for DRYness" and
+// inject the namespace via a shared NamespaceTransformer that sets
+// spec.targetNamespace on every Kustomization (issue #528). That
+// injection only happens when the overlay is kustomize-built — and when
+// the overlay is rendered by a further-up, itself render-emitted parent,
+// the injection lands *after* flate has already fired the leaf KS's
+// first reconcile. The leaf then renders its children with an empty
+// targetNamespace, producing an empty-namespace copy of each HelmRelease
+// that lingers in the store and later fails to render (no namespace to
+// resolve its chart's HelmRepository against).
+//
+// Resolving the namespace here, at load time, lets the leaf KS render
+// into the right namespace on its first pass — the load-time analog of
+// the same NamespaceTransformer kustomize would apply, mirroring how
+// ApplyNamespaceInheritance front-runs kustomize-controller's
+// apply-time namespace defaulting.
+//
+// Only spec.targetNamespace is set (never metadata.namespace), so the
+// KS's store id stays stable. The value reaches rendered children via
+// ks.Contents (RenderFlux feeds it to kustomize) and reaches
+// store-resident namespace-less resources under spec.path via
+// ApplyNamespaceInheritance's existing projection, which now sees a
+// populated targetNamespace.
+//
+// Runs before ApplyNamespaceInheritance (see discovery.applyNamespaces).
+func StampTransformerTargetNamespaces(s *store.Store, sourceFiles map[manifest.NamedResource]string, repoRoot string) {
+	if len(sourceFiles) == 0 {
+		return
+	}
+	// Per-directory resolution cache: many KSes share the same overlay
+	// ancestry, and resolution re-reads kustomization.yaml files off
+	// disk. Live only for this pass.
+	cache := map[string]nsResolution{}
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		if ks.TargetNamespace != "" {
+			continue
+		}
+		file, ok := sourceFiles[ks.Named()]
+		if !ok {
+			continue
+		}
+		ns := resolveOverlayTransformerNamespace(repoRoot, file, cache)
+		if ns == "" {
+			continue
+		}
+		// Store immutability contract: clone before mutating, then
+		// AddObject the copy. The id is unchanged (targetNamespace isn't
+		// part of NamedResource), so this updates in place.
+		updated := ks.Clone()
+		updated.SetTargetNamespace(ns)
+		s.AddObject(updated)
+	}
+}
+
+// nsResolution memoizes a per-directory transformer-namespace lookup.
+type nsResolution struct {
+	ns string
+	ok bool
+}
+
+// resolveOverlayTransformerNamespace walks up the ancestor directories
+// of a Flux KS's source file and returns the namespace injected by the
+// nearest enclosing overlay's NamespaceTransformer. Deepest enclosing
+// overlay wins (first hit walking up), matching kustomize's "closest
+// overlay" semantics.
+func resolveOverlayTransformerNamespace(repoRoot, file string, cache map[string]nsResolution) string {
+	dir := path.Dir(filepath.ToSlash(file))
+	for dir != "." && dir != "/" && dir != "" {
+		res, ok := cache[dir]
+		if !ok {
+			res = resolveTransformerTargetNamespace(repoRoot, dir)
+			cache[dir] = res
+		}
+		if res.ok {
+			return res.ns
+		}
+		dir = path.Dir(dir)
+	}
+	return ""
+}
+
+// resolveTransformerTargetNamespace inspects the kustomization.yaml at
+// overlayDir. When it applies a `transformers:` entry whose subtree both
+// carries a `namespace:` directive and resolves to a builtin
+// NamespaceTransformer that sets Kustomization spec/targetNamespace, the
+// directive value is the namespace that transformer injects.
+func resolveTransformerTargetNamespace(repoRoot, overlayDir string) nsResolution {
+	d, ok := readKustomizeDirectives(repoRoot, overlayDir)
+	if !ok || len(d.Transformers) == 0 {
+		return nsResolution{}
+	}
+	for _, ref := range d.Transformers {
+		transformerDir, ok := resolveRef(overlayDir, ref)
+		if !ok {
+			continue
+		}
+		td, ok := readKustomizeDirectives(repoRoot, transformerDir)
+		if !ok || td.Namespace == "" {
+			continue
+		}
+		if !subtreeHasNamespaceTransformer(repoRoot, transformerDir, map[string]struct{}{}, 0) {
+			continue
+		}
+		return nsResolution{ns: td.Namespace, ok: true}
+	}
+	return nsResolution{}
+}
+
+// subtreeHasNamespaceTransformer reports whether the kustomize subtree
+// rooted at dir declares (directly or via resources:/transformers:
+// references) a builtin NamespaceTransformer that targets Kustomization
+// spec/targetNamespace. Bounded by transformerScanMaxDepth and a
+// visited set so malformed reference cycles can't loop.
+func subtreeHasNamespaceTransformer(repoRoot, dir string, visited map[string]struct{}, depth int) bool {
+	if depth > transformerScanMaxDepth {
+		return false
+	}
+	if _, seen := visited[dir]; seen {
+		return false
+	}
+	visited[dir] = struct{}{}
+	d, ok := readKustomizeDirectives(repoRoot, dir)
+	if !ok {
+		return false
+	}
+	// A ref is either a file (the transformer manifest itself) or a
+	// directory with its own kustomization.yaml — try both.
+	return slices.ContainsFunc(slices.Concat(d.Resources, d.Transformers), func(ref string) bool {
+		target, ok := resolveRef(dir, ref)
+		if !ok {
+			return false
+		}
+		return fileHasNamespaceTransformer(repoRoot, target) ||
+			subtreeHasNamespaceTransformer(repoRoot, target, visited, depth+1)
+	})
+}
+
+// fileHasNamespaceTransformer reads target as a manifest file and
+// reports whether any document in it is a qualifying NamespaceTransformer.
+// Returns false when target is a directory or unreadable.
+func fileHasNamespaceTransformer(repoRoot, target string) bool {
+	data, err := os.ReadFile(filepath.Join(repoRoot, target)) //nolint:gosec // path composed from known cluster layout
+	if err != nil {
+		return false
+	}
+	docs, err := manifest.SplitDocs(data)
+	if err != nil {
+		return false
+	}
+	return slices.ContainsFunc(docs, docIsNamespaceTransformerForKustomization)
+}
+
+// docIsNamespaceTransformerForKustomization reports whether doc is a
+// builtin NamespaceTransformer with a fieldSpec that writes
+// spec/targetNamespace on Kustomizations — the precise shape that
+// injects a Flux KS's targetNamespace.
+func docIsNamespaceTransformerForKustomization(doc map[string]any) bool {
+	if manifest.DocKind(doc) != "NamespaceTransformer" {
+		return false
+	}
+	specs, _ := doc["fieldSpecs"].([]any)
+	return slices.ContainsFunc(specs, func(raw any) bool {
+		fs, ok := raw.(map[string]any)
+		if !ok {
+			return false
+		}
+		kind, _ := fs["kind"].(string)
+		p, _ := fs["path"].(string)
+		return kind == manifest.KindKustomization && p == "spec/targetNamespace"
+	})
+}
+
+// resolveRef cleans a kustomize resource/transformer reference relative
+// to baseDir, rejecting remote (scheme://) and absolute refs and any
+// path that escapes above the repo (leading ".."). The boolean reports
+// whether the ref is a usable in-repo relative path.
+func resolveRef(baseDir, ref string) (string, bool) {
+	if ref == "" || strings.Contains(ref, "://") || filepath.IsAbs(ref) {
+		return "", false
+	}
+	resolved := path.Clean(path.Join(baseDir, filepath.ToSlash(ref)))
+	if resolved == "." || strings.HasPrefix(resolved, "..") {
+		return "", false
+	}
+	return resolved, true
+}
+
+// kustomizeDirectives is the subset of a kustomization.yaml that
+// transformer-namespace resolution reads.
+type kustomizeDirectives struct {
+	Namespace    string   `yaml:"namespace"`
+	Resources    []string `yaml:"resources"`
+	Transformers []string `yaml:"transformers"`
+}
+
+// readKustomizeDirectives reads the kustomization file in dir (resolved
+// under repoRoot) and returns its namespace/resources/transformers
+// fields. ok is false when no kustomization file is present or it can't
+// be parsed — pure best-effort, same contract as readKustomizeNamespace.
+func readKustomizeDirectives(repoRoot, dir string) (kustomizeDirectives, bool) {
+	for _, name := range manifest.KustomizeBuilderFilenames {
+		data, err := os.ReadFile(filepath.Join(repoRoot, dir, name)) //nolint:gosec // path composed from known cluster layout
+		if err != nil {
+			continue
+		}
+		var d kustomizeDirectives
+		if err := yaml.Unmarshal(data, &d); err != nil {
+			continue
+		}
+		return d, true
+	}
+	return kustomizeDirectives{}, false
+}

--- a/pkg/loader/transformer_ns_test.go
+++ b/pkg/loader/transformer_ns_test.go
@@ -1,0 +1,215 @@
+package loader
+
+import (
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// namespaceTransformer is the shared builtin NamespaceTransformer
+// flatops uses (kubernetes/transformers/transformer.yaml): it writes
+// spec/targetNamespace onto every Kustomization.
+const namespaceTransformer = `apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: apply-ns
+  namespace: .invalid
+fieldSpecs:
+  - path: metadata/name
+    kind: Namespace
+    create: true
+  - path: spec/targetNamespace
+    group: kustomize.toolkit.fluxcd.io
+    kind: Kustomization
+    create: true
+`
+
+// writeFlatopsOverlay lays down the flatops namespace-overlay shape: an
+// overlay kustomization.yaml that pulls in a transformers/ subtree whose
+// `namespace:` directive feeds the shared NamespaceTransformer.
+func writeFlatopsOverlay(t *testing.T, root, ns string) {
+	t.Helper()
+	writeFile(t, root, "apps/"+ns+"/kustomization.yaml", `resources:
+  - ./namespace.yaml
+  - ./`+ns+`/ks.yaml
+transformers:
+  - ./transformers
+`)
+	writeFile(t, root, "apps/"+ns+"/transformers/kustomization.yaml", `namespace: `+ns+`
+resources:
+  - ../../../transformers
+`)
+	writeFile(t, root, "transformers/kustomization.yaml", "resources:\n  - ./transformer.yaml\n")
+	writeFile(t, root, "transformers/transformer.yaml", namespaceTransformer)
+}
+
+func leafKS(name, path string) *manifest.Kustomization {
+	return &manifest.Kustomization{
+		Name:              name,
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: path},
+		Contents: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata":   map[string]any{"name": name},
+			"spec":       map[string]any{"path": path},
+		},
+	}
+}
+
+func TestStampTransformerTargetNamespaces_NamespaceTransformer(t *testing.T) {
+	root := t.TempDir()
+	writeFlatopsOverlay(t, root, "gpu-operator")
+
+	s := store.New()
+	ks := leafKS("gpu-operator", "./apps/gpu-operator/gpu-operator/app")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/gpu-operator/gpu-operator/ks.yaml",
+	}
+
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+
+	got, ok := store.Get[*manifest.Kustomization](s, ks.Named())
+	if !ok {
+		t.Fatal("KS missing after stamp")
+	}
+	if got.TargetNamespace != "gpu-operator" {
+		t.Errorf("TargetNamespace=%q want gpu-operator", got.TargetNamespace)
+	}
+	// RenderFlux feeds Contents to kustomize, so the raw doc must carry
+	// targetNamespace too — not just the typed field.
+	spec, _ := got.Contents["spec"].(map[string]any)
+	if spec["targetNamespace"] != "gpu-operator" {
+		t.Errorf("Contents spec.targetNamespace=%v want gpu-operator", spec["targetNamespace"])
+	}
+}
+
+func TestStampTransformerTargetNamespaces_PlainNamespaceUntouched(t *testing.T) {
+	root := t.TempDir()
+	// A plain `namespace:` directive with NO NamespaceTransformer — the
+	// existing metadata.namespace inheritance owns this; we must not
+	// stamp targetNamespace.
+	writeFile(t, root, "apps/plain/kustomization.yaml", `namespace: media
+resources:
+  - ./app/ks.yaml
+`)
+
+	s := store.New()
+	ks := leafKS("plain", "./apps/plain/app/workload")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/plain/app/ks.yaml",
+	}
+
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (no NamespaceTransformer)", got.TargetNamespace)
+	}
+}
+
+func TestStampTransformerTargetNamespaces_TransformersWithoutNamespaceTransformerIgnored(t *testing.T) {
+	root := t.TempDir()
+	// Overlay references a transformers subtree carrying a `namespace:`
+	// directive, but the transformer is some OTHER builtin (here a
+	// LabelTransformer) — not a NamespaceTransformer targeting
+	// Kustomization spec/targetNamespace. Must not stamp.
+	writeFile(t, root, "apps/other/kustomization.yaml", `resources:
+  - ./other/ks.yaml
+transformers:
+  - ./transformers
+`)
+	writeFile(t, root, "apps/other/transformers/kustomization.yaml", `namespace: other
+resources:
+  - ./labels.yaml
+`)
+	writeFile(t, root, "apps/other/transformers/labels.yaml", `apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: add-labels
+labels:
+  team: platform
+fieldSpecs:
+  - path: metadata/labels
+    create: true
+`)
+
+	s := store.New()
+	ks := leafKS("other", "./apps/other/other/app")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/other/other/ks.yaml",
+	}
+
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (no NamespaceTransformer)", got.TargetNamespace)
+	}
+}
+
+func TestStampTransformerTargetNamespaces_ExplicitTargetNamespacePreserved(t *testing.T) {
+	root := t.TempDir()
+	writeFlatopsOverlay(t, root, "gpu-operator")
+
+	s := store.New()
+	ks := leafKS("gpu-operator", "./apps/gpu-operator/gpu-operator/app")
+	ks.TargetNamespace = "explicit" // already set in the source YAML
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/gpu-operator/gpu-operator/ks.yaml",
+	}
+
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	if got.TargetNamespace != "explicit" {
+		t.Errorf("TargetNamespace=%q want explicit (must not override)", got.TargetNamespace)
+	}
+}
+
+func TestStampTransformerTargetNamespaces_DeepestOverlayWins(t *testing.T) {
+	root := t.TempDir()
+	// Outer overlay injects "outer"; an inner overlay nested under it
+	// injects "inner". The KS lives under the inner overlay, so inner
+	// (the deepest enclosing overlay) wins.
+	writeFile(t, root, "apps/outer/kustomization.yaml", `resources:
+  - ./inner
+transformers:
+  - ./transformers
+`)
+	writeFile(t, root, "apps/outer/transformers/kustomization.yaml", `namespace: outer
+resources:
+  - ../../../transformers
+`)
+	writeFile(t, root, "apps/outer/inner/kustomization.yaml", `resources:
+  - ./app/ks.yaml
+transformers:
+  - ./transformers
+`)
+	writeFile(t, root, "apps/outer/inner/transformers/kustomization.yaml", `namespace: inner
+resources:
+  - ../../../../transformers
+`)
+	writeFile(t, root, "transformers/kustomization.yaml", "resources:\n  - ./transformer.yaml\n")
+	writeFile(t, root, "transformers/transformer.yaml", namespaceTransformer)
+
+	s := store.New()
+	ks := leafKS("app", "./apps/outer/inner/app/workload")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/outer/inner/app/ks.yaml",
+	}
+
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	if got.TargetNamespace != "inner" {
+		t.Errorf("TargetNamespace=%q want inner (deepest overlay)", got.TargetNamespace)
+	}
+}

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -157,6 +157,23 @@ func (k *Kustomization) UpdatePostBuildSubstitutions(subs map[string]any) {
 	maps.Copy(sub, subs)
 }
 
+// SetTargetNamespace sets spec.targetNamespace on both the typed field
+// and the raw Contents doc so RenderFlux (which feeds Contents to
+// kustomize) and the typed readers stay consistent. Mirrors
+// UpdatePostBuildSubstitutions' dual-write contract.
+func (k *Kustomization) SetTargetNamespace(ns string) {
+	k.TargetNamespace = ns
+	if k.Contents == nil {
+		return
+	}
+	spec, _ := k.Contents["spec"].(map[string]any)
+	if spec == nil {
+		spec = make(map[string]any)
+		k.Contents["spec"] = spec
+	}
+	spec["targetNamespace"] = ns
+}
+
 // parseKustomization decodes a Flux Kustomization CR via the
 // kustomize-controller typed schema. The raw doc is retained in
 // Contents because RenderFlux still feeds it to fluxcd/pkg/kustomize

--- a/pkg/orchestrator/transformer_ns_test.go
+++ b/pkg/orchestrator/transformer_ns_test.go
@@ -1,0 +1,124 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestOrchestrator_TransformerTargetNamespace reproduces issue #528: a
+// namespace-less HelmRelease under a leaf Flux Kustomization whose
+// namespace is supplied by a builtin NamespaceTransformer (flatops
+// pattern). The leaf KS has no file-loaded structural parent, so its
+// first reconcile fires before any render could inject targetNamespace.
+//
+// Pre-fix: the leaf renders with targetNamespace="" and emits an
+// empty-namespace HelmRelease that lingers in the store. Post-fix:
+// StampTransformerTargetNamespaces resolves the NamespaceTransformer's
+// namespace at load time and stamps it onto the leaf KS, so the render
+// produces exactly one correctly-namespaced HelmRelease.
+func TestOrchestrator_TransformerTargetNamespace(t *testing.T) {
+	dir := t.TempDir()
+
+	// Shared builtin NamespaceTransformer (kubernetes/transformers/).
+	testutil.WriteFile(t, dir, "transformers/kustomization.yaml", "resources:\n  - ./transformer.yaml\n")
+	testutil.WriteFile(t, dir, "transformers/transformer.yaml", `apiVersion: builtin
+kind: NamespaceTransformer
+metadata:
+  name: apply-ns
+  namespace: .invalid
+fieldSpecs:
+  - path: metadata/name
+    kind: Namespace
+    create: true
+  - path: spec/targetNamespace
+    group: kustomize.toolkit.fluxcd.io
+    kind: Kustomization
+    create: true
+`)
+
+	// Namespace overlay: pulls in the transformer subtree whose
+	// `namespace:` directive feeds the NamespaceTransformer.
+	testutil.WriteFile(t, dir, "apps/myapp/kustomization.yaml", `resources:
+  - ./namespace.yaml
+  - ./myapp/ks.yaml
+transformers:
+  - ./transformers
+`)
+	testutil.WriteFile(t, dir, "apps/myapp/namespace.yaml", `apiVersion: v1
+kind: Namespace
+metadata:
+  name: .invalid
+`)
+	testutil.WriteFile(t, dir, "apps/myapp/transformers/kustomization.yaml", `namespace: myns
+resources:
+  - ../../../transformers
+`)
+
+	// Leaf Flux KS — no targetNamespace in the file; it is supplied by
+	// the overlay's transformer. No other KS covers its path, so flate
+	// has no structural parent to gate its first render on.
+	testutil.WriteFile(t, dir, "apps/myapp/myapp/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: myapp
+  namespace: flux-system
+spec:
+  path: ./apps/myapp/myapp/app
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/myapp/myapp/app/kustomization.yaml", "resources:\n  - ./helmrelease.yaml\n")
+	// Namespace-less, suspended HR — suspend keeps the controller from
+	// reaching for a chart, so the test asserts the rendered namespace
+	// without needing a live Helm source.
+	testutil.WriteFile(t, dir, "apps/myapp/myapp/app/helmrelease.yaml", `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: myapp
+spec:
+  suspend: true
+  chartRef:
+    kind: OCIRepository
+    name: myapp
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	namespaced := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "myns", Name: "myapp"}
+	if o.store.GetObject(namespaced) == nil {
+		t.Errorf("expected HelmRelease at myns/myapp; HR objects in store: %v",
+			hrIDs(o))
+	}
+
+	// The empty-namespace phantom must never reach the store.
+	phantom := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "", Name: "myapp"}
+	if obj := o.store.GetObject(phantom); obj != nil {
+		t.Errorf("empty-namespace HelmRelease phantom present in store: %v", phantom)
+	}
+
+	for id := range res.Failed {
+		if id.Kind == manifest.KindHelmRelease {
+			t.Errorf("unexpected HelmRelease failure: %s = %v", id, res.Failed[id])
+		}
+	}
+}
+
+func hrIDs(o *Orchestrator) []string {
+	var out []string
+	for _, obj := range o.store.ListObjects(manifest.KindHelmRelease) {
+		out = append(out, obj.Named().String())
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Fixes #528 — namespace-less HelmReleases linger in the object store as empty-namespace phantoms and later fail to render.

In repos like [jfroy/flatops](https://github.com/jfroy/flatops), resources are written without `metadata.namespace` "for DRYness" and the namespace is applied by a shared builtin `NamespaceTransformer` that injects `spec.targetNamespace` into each Flux `Kustomization`. That injection only happens at the overlay's kustomize-build time. When the overlay is rendered by a further-up, **itself render-emitted** parent, flate's Bootstrap parent gate doesn't know about that parent, so the leaf KS's first reconcile fires before `targetNamespace` is injected — it renders with an empty `targetNamespace` and emits `{HelmRelease, "", name}`. That phantom fails (no namespace to resolve its chart's `HelmRepository`/chart against) and, because it was "rendered," `detectOrphans` won't demote it, so the whole run errors out. The parent later injects the namespace and the leaf re-renders the correct copy — leaving two.

flate already front-runs kustomize-controller's apply-time namespace defaulting at load time (`pkg/loader/inherit.go`), but it only understood kustomize `namespace:` directives and cross-tree `replacements:` — never a `NamespaceTransformer` reached via `transformers:`.

## Approach (load-time)

- New `pkg/loader/transformer_ns.go`: `StampTransformerTargetNamespaces` resolves the namespace a `NamespaceTransformer` will inject — by following the overlay's `transformers:` reference to its `namespace:` directive, guarded by confirming a real `NamespaceTransformer` whose `fieldSpecs` target Kustomization `spec/targetNamespace` — and stamps it onto the leaf KS's `spec.targetNamespace` **before any render**. The first render then produces exactly one correctly-namespaced HelmRelease; no phantom is ever created.
- `pkg/manifest/kustomization.go`: `SetTargetNamespace` dual-writes the typed field and the raw `Contents` doc (RenderFlux feeds `Contents` to kustomize), mirroring `UpdatePostBuildSubstitutions`.
- `pkg/discovery/discovery.go`: runs the pass before `ApplyNamespaceInheritance`, so the existing projection sees a populated `targetNamespace`.

### Scope guards
- Only stamps when `spec.targetNamespace` is empty (never overrides an explicit value).
- Only fires when a qualifying `NamespaceTransformer` is actually present.
- Only sets `targetNamespace` (a spec field) — never `metadata.namespace` — so the KS's store id stays stable and plain `namespace:`-directive behavior is untouched.

Lets jfroy drop the `spec.targetNamespace` workaround added to the HR.

## Test plan

- [x] `pkg/loader` unit tests: NamespaceTransformer resolution, deepest-overlay-wins, explicit-value preserved, and negatives (plain `namespace:` only / `transformers:` without a NamespaceTransformer → untouched).
- [x] `pkg/orchestrator` integration test + fixture reproducing the end-to-end pattern; asserts exactly one `HelmRelease` (namespaced), no empty-namespace copy, no failures. **Confirmed it fails without the fix** (phantom present) and passes with it.
- [x] CLI smoke test: `flate get hr` against the fixture shows one HR in the injected namespace, no phantom.
- [x] Full `go test ./...` and `golangci-lint run ./...` (0 issues) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)