### PR TITLE
fix(diff): resolve self-referential GitRepository on the baseline side

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -141,20 +141,47 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 	return tmp, false, nil
 }
 
-// materializeAndMark extracts the commit tree into root and drops a
-// .git marker directory.
+// materializeAndMark extracts the commit tree into root and writes a
+// minimal, openable .git into it. The .git serves two ends:
 //
-// The .git marker is required so discovery.FindRepoRoot (used by
-// orchestrator.buildChangeFilter's repo-root widening, PR #348) lifts
-// the synthetic --path-orig to root, lining up with the current side's
-// repoRoot. Without it, the per-side .git roots match (both fall back
-// to the passed path) and the widening short-circuits.
+//   - discovery.FindRepoRoot (used by orchestrator.buildChangeFilter's
+//     repo-root widening, PR #348) lifts the synthetic --path-orig to root,
+//     lining up with the current side's repoRoot. Without a .git the
+//     per-side roots match (both fall back to the passed path) and the
+//     widening short-circuits.
+//   - it carries the source repo's git remotes, so the baseline is
+//     self-describing: discovery's self-referential GitRepository alias —
+//     which URL-matches a GitRepository's spec.url against the working
+//     tree's remotes — fires on the baseline side too. A remotes-less
+//     marker leaves a private self-source unresolved, rendering the whole
+//     baseline empty (so every resource shows as a wholesale addition).
+//
+// It's a config + HEAD only — enough for go-git's PlainOpen and
+// repo.Config(); the dangling HEAD ref is never dereferenced.
 func materializeAndMark(repo *git.Repository, hash plumbing.Hash, root string) error {
 	if err := materialize(repo, hash, root); err != nil {
 		return err
 	}
-	if err := os.Mkdir(filepath.Join(root, ".git"), 0o700); err != nil {
+	dir := filepath.Join(root, ".git")
+	if err := os.Mkdir(dir, 0o700); err != nil {
 		return fmt.Errorf("baseline .git marker: %w", err)
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		return fmt.Errorf("baseline git config: %w", err)
+	}
+	var b strings.Builder
+	b.WriteString("[core]\n\trepositoryformatversion = 0\n")
+	for _, remote := range cfg.Remotes {
+		for _, url := range remote.URLs {
+			fmt.Fprintf(&b, "[remote %q]\n\turl = %s\n", remote.Name, url)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(b.String()), 0o600); err != nil {
+		return fmt.Errorf("baseline .git/config: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o600); err != nil {
+		return fmt.Errorf("baseline .git/HEAD: %w", err)
 	}
 	return nil
 }

--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -42,6 +42,43 @@ func TestAutoResolve_ExplicitBase(t *testing.T) {
 	_ = commitB
 }
 
+// TestMaterializeAndMark_CarriesRemotes pins that the materialized baseline
+// tree's .git is openable and exposes the source repo's remotes — the
+// property discovery's self-referential GitRepository alias relies on.
+// Without it the baseline's private self-source goes unresolved and the
+// whole tree renders empty (every resource shown as a wholesale addition).
+func TestMaterializeAndMark_CarriesRemotes(t *testing.T) {
+	dir := t.TempDir()
+	commit := initRepoWithFile(t, dir, "a.yaml", "x")
+	repo, err := git.PlainOpen(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const url = "ssh://git@github.com/example/cluster.git"
+	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{url}}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := AutoResolve(dir, commit.String(), cacheroot.Layout{})
+	if err != nil {
+		t.Fatalf("AutoResolve: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(res.TempDir) }()
+
+	// The same open + Config() that discovery.readWorkingTreeRemotes performs.
+	got, err := git.PlainOpenWithOptions(res.TempDir, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		t.Fatalf("materialized baseline .git not openable: %v", err)
+	}
+	cfg, err := got.Config()
+	if err != nil {
+		t.Fatalf("materialized baseline config: %v", err)
+	}
+	if origin, ok := cfg.Remotes["origin"]; !ok || len(origin.URLs) == 0 || origin.URLs[0] != url {
+		t.Errorf("materialized .git missing origin remote %q; got %+v", url, cfg.Remotes)
+	}
+}
+
 // TestAutoResolve_UpstreamMergeBase exercises the @{u} rung: HEAD is on
 // a branch whose config points at a remote-tracking ref, and the
 // merge-base resolves correctly.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
 	"github.com/home-operations/flate/internal/cli"
@@ -250,6 +251,84 @@ func TestE2E_DiffAutoBaseline_Base(t *testing.T) {
 	if !strings.Contains(out, "original") {
 		t.Errorf("expected baseline 'original' to surface in diff body:\n%s", out)
 	}
+}
+
+// TestE2E_DiffSelfRefBaselineRenders is the regression guard for the
+// changed-only baseline self-alias bug (TalosCluster PR #5386). The flux
+// source is a GitRepository named "cluster" — not the bootstrap "flux-
+// system" anchor — that is self-referential (its URL matches the repo's own
+// remote) and gated behind a missing deploy-key secret, so it resolves only
+// through the URL-match self-alias. The baseline render must alias it (using
+// the working tree's remotes, even though the materialized baseline tree has
+// none), or the whole tree renders empty and every resource shows as a
+// wholesale addition instead of the one-line changeset.
+func TestE2E_DiffSelfRefBaselineRenders(t *testing.T) {
+	repoRoot := initSelfRefGitFixture(t)
+	testutil.WriteFileAt(t, filepath.Join(repoRoot, "k8s", "apps", "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: apps}
+data:
+  value: changed
+`)
+	// Isolated cache so the baseline is freshly materialized (the fixture's
+	// deterministic commit SHA would otherwise reuse a cached baseline tree).
+	out := runCLI(t, "diff", "ks", "--path", repoRoot, "--base", "HEAD",
+		"--allow-missing-secrets", "--cache-dir", t.TempDir())
+	// The baseline must have rendered the old value, so the diff is a value
+	// change. With the bug the baseline is empty and `original` never
+	// appears — the whole ConfigMap shows as a wholesale addition.
+	if !strings.Contains(out, "original") {
+		t.Errorf("baseline rendered empty (whole tree shown as additions, not the changeset):\n%s", out)
+	}
+	if !strings.Contains(out, "changed") {
+		t.Errorf("expected the changed value to surface:\n%s", out)
+	}
+}
+
+// initSelfRefGitFixture builds a git repo with an origin remote and a flux
+// entrypoint sourced from a self-referential GitRepository named "cluster"
+// (gated behind a missing secret). Returns the repo root to use as --path.
+func initSelfRefGitFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin", URLs: []string{"https://github.com/example/cluster.git"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	writeFile := func(rel, body string) { testutil.WriteFile(t, dir, rel, body) }
+	writeFile("k8s/flux/entry.yaml", `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: cluster, namespace: flux-system}
+spec:
+  url: ssh://git@github.com/example/cluster.git
+  ref: {branch: main}
+  secretRef: {name: deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  interval: 10m
+  path: ./k8s/apps
+  sourceRef: {kind: GitRepository, name: cluster, namespace: flux-system}
+`)
+	writeFile("k8s/apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	writeFile("k8s/apps/cm.yaml", `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: apps}
+data:
+  value: original
+`)
+	gitCommitAll(t, repo)
+	return dir
 }
 
 // TestE2E_DiffImagesRequiresBaselineWhenNoGit pins the error UX when
@@ -626,6 +705,24 @@ func mustExtractSkipLine(t *testing.T, haystack, needle string) string {
 	return ""
 }
 
+// gitCommitAll stages and commits the whole worktree with a fixed author,
+// so every fixture lands one deterministic "init" commit.
+func gitCommitAll(t *testing.T, repo *gogit.Repository) {
+	t.Helper()
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Commit("init", &gogit.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // initGitFixtureFrom copies the fixture tree at src into a fresh tempdir,
 // inits a git repo, and commits the whole tree as the baseline. Returns
 // (clusterPath, repoRoot): clusterPath is the repoRoot/flux entrypoint
@@ -657,18 +754,7 @@ func initGitFixtureFrom(t *testing.T, src string) (clusterPath, repoRoot string)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wt, err := repo.Worktree()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := wt.Add("."); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := wt.Commit("init", &gogit.CommitOptions{
-		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	gitCommitAll(t, repo)
 	return filepath.Join(dir, "flux"), dir
 }
 
@@ -707,18 +793,7 @@ metadata: {name: hello, namespace: apps}
 data:
   value: original
 `)
-	wt, err := repo.Worktree()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := wt.Add("."); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := wt.Commit("init", &gogit.CommitOptions{
-		Author: &object.Signature{Name: "t", Email: "t@example", When: time.Unix(0, 0)},
-	}); err != nil {
-		t.Fatal(err)
-	}
+	gitCommitAll(t, repo)
 	return filepath.Join(dir, "kubernetes", "flux"), dir
 }
 


### PR DESCRIPTION
## Summary

In changed-only mode (`--base` / `--path-orig`), `flate diff` could render a one-line change as a **whole-tree diff** — every resource shown as a wholesale addition — when the cluster's flux source is a **self-referential GitRepository gated behind a private (missing) secret**.

## Root cause

The baseline tree is materialized from git with only a **bare `.git` marker** directory (no remotes — it exists so `discovery.FindRepoRoot` widening works). Discovery aliases a self-referential GitRepository (whose `spec.url` is the cluster's own repo) by **URL-matching against the working tree's remotes**. The materialized baseline has none, so:

- current side: GitRepository URL matches the working-tree remote → aliased → renders ✅
- baseline side: no remotes → alias never fires → private self-source `skipped (missing secret)` → **baseline renders empty** → current render shows entirely as `+ added`

This only bites sources named other than the `flux-system` bootstrap anchor (e.g. `cluster`), since those rely solely on the URL-match self-alias.

## Fix

`baseline.materializeAndMark` now writes a **minimal, openable `.git`** (`config` + `HEAD`) carrying the source repo's remotes into the materialized tree, instead of a bare marker. The baseline becomes self-describing and the existing self-alias resolves there too — no changes to discovery/orchestrator/CLI. `config` + `HEAD` is enough for go-git's `PlainOpen` + `repo.Config()`; the dangling `HEAD` ref is never dereferenced.

## Reproduction (real consumer: `Boemeltrein/TalosCluster` PR #5386)

Same one-line chart revert (`zwavejs2mqtt 25.8.0 → 25.7.0`), `--base HEAD --allow-missing-secrets`:

| `flate diff` | before | after |
| --- | --- | --- |
| kustomization | 2728 lines — **98 docs added** | 7 lines — **1 value change** |
| helmrelease | 426 lines — **7 docs added** | 61 lines — **10 value changes** |

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt` clean
- [x] `golangci-lint run` → 0 issues
- [x] `go test ./... -race` green
- [x] **Unit** (`pkg/baseline`): `TestMaterializeAndMark_CarriesRemotes` — the materialized `.git` opens via go-git and exposes the origin remote
- [x] **E2E** (`test/e2e`): `TestE2E_DiffSelfRefBaselineRenders` — a `cluster`-named self-referential fixture renders the changeset, not the whole tree (uses an isolated `--cache-dir` since baselines are cached by commit SHA)
- [x] Verified against the real cluster (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)