### PR TITLE
chore(discovery): demote self-referential alias log to Debug

### DIFF
--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -140,7 +140,7 @@ func (d *discoverer) overrideSelfReferentialGitRepositories(repoRoot string) []m
 			URL:  "file://" + repoRoot, LocalPath: repoRoot,
 		})
 		d.cfg.Store.UpdateStatus(id, store.StatusReady, "bootstrap alias (URL matches working tree)")
-		slog.Info("discovery: aliased in-tree GitRepository to working tree (URL matches working-tree remote)",
+		slog.Debug("discovery: aliased in-tree GitRepository to working tree (URL matches working-tree remote)",
 			"id", id.String(), "url", repo.URL, "normalizedKey", normalized, "localPath", repoRoot)
 		overridden = append(overridden, id)
 	}


### PR DESCRIPTION
## Summary
- `overrideSelfReferentialGitRepositories` was emitting `slog.Info` for every aliased `GitRepository`, which clutters default-level output during normal `flate diff` runs.
- Demote to `slog.Debug` to match the sibling alias path in `publishBootstrapAlias` (`pkg/discovery/bootstrap.go:163`).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [ ] Run `flate diff` against a repo whose Flux `GitRepository.spec.url` matches a working-tree remote; confirm the line no longer appears at default level but does appear with `--log-level=debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)