### PR TITLE
feat(cli): add -p/-P shorthands for --path/--path-orig

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -73,8 +73,8 @@ type commonFlags struct {
 // claim `name`, and diff doesn't claim `table`. Passing no formats (test,
 // which emits one fixed report) registers no -o flag at all.
 func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
-	fs.StringVar(&f.path, "path", ".", "path to the Flux cluster directory")
-	fs.StringVar(&f.pathOrig, "path-orig", "",
+	fs.StringVarP(&f.path, "path", "p", ".", "path to the Flux cluster directory")
+	fs.StringVarP(&f.pathOrig, "path-orig", "P", "",
 		"baseline path; when set, every command runs in changed-only mode")
 	bindBase(fs, f)
 	fs.StringVarP(&f.namespace, "namespace", "n", "",


### PR DESCRIPTION
## Summary

- Add `-p` shorthand for `--path` and `-P` shorthand for `--path-orig` on the shared `bindCommon()` flag set (lights up across `build`, `test`, `diff`, `get`).
- Brings `--path` in line with every other commonly-paired flag (`-n`, `-o`, `-l`, `-a`, `-s`), which already have one-character forms.
- `-P` is case-distinct from `-p`; cobra is case-sensitive on shorthands, so the two coexist cleanly alongside the existing `-o`/`--output`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/cli/...`
- [x] `flate build all --help` shows `-p, --path` and `-P, --path-orig`
- [ ] Smoke a real invocation: `flate build all -p ./path/to/cluster`

🤖 Generated with [Claude Code](https://claude.com/claude-code)