### PR TITLE
fix(diff): blank line between docs in unified output

### DIFF
--- a/pkg/diff/diff_test.go
+++ b/pkg/diff/diff_test.go
@@ -62,6 +62,24 @@ func TestUnified_AddedAndRemoved(t *testing.T) {
 	}
 }
 
+// TestUnified_BlankLineBetweenDocs pins that consecutive document bodies
+// are separated by a blank line so the next `--- ` header is easy to
+// spot when scanning multi-resource output.
+func TestUnified_BlankLineBetweenDocs(t *testing.T) {
+	left := []Doc{cm("a", "ns", "owner", "v1"), cm("b", "ns", "owner", "v1")}
+	right := []Doc{cm("a", "ns", "owner", "v2"), cm("b", "ns", "owner", "v2")}
+	s := unified(t, left, right)
+	if !strings.Contains(s, "\n\n--- ConfigMap ns/b") {
+		t.Errorf("second doc header should be preceded by a blank line:\n%s", s)
+	}
+	if strings.HasPrefix(s, "\n") {
+		t.Errorf("output should not start with a blank line:\n%s", s)
+	}
+	if strings.HasSuffix(s, "\n\n") {
+		t.Errorf("output should end with a single newline, not a trailing blank line:\n%s", s)
+	}
+}
+
 // TestUnified_Deletion verifies a wholly-removed resource shows its full
 // content (so reviewers don't have to chase the original separately).
 func TestUnified_Deletion(t *testing.T) {

--- a/pkg/diff/unified.go
+++ b/pkg/diff/unified.go
@@ -3,7 +3,6 @@ package diff
 import (
 	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/pmezard/go-difflib/difflib"
 	"sigs.k8s.io/yaml"
@@ -24,6 +23,7 @@ func renderUnified(left, right []Doc, opts Options) ([]byte, error) {
 	left = normalizeDocs(left, opts.StripAttrs)
 	right = normalizeDocs(right, opts.StripAttrs)
 	var b bytes.Buffer
+	first := true
 	for _, p := range pair(left, right) {
 		body, err := unifiedBody(p.a, p.b, p.kind+" "+joinNS(p.namespace, p.name))
 		if err != nil {
@@ -32,7 +32,11 @@ func renderUnified(left, right []Doc, opts Options) ([]byte, error) {
 		if body == "" {
 			continue // identical resources
 		}
-		writeBody(&b, body)
+		if !first {
+			b.WriteByte('\n')
+		}
+		b.WriteString(body)
+		first = false
 	}
 	return b.Bytes(), nil
 }
@@ -86,11 +90,3 @@ func marshalForUnified(m map[string]any) (string, error) {
 	return string(b), nil
 }
 
-// writeBody appends a diff body to b, guaranteeing a single trailing
-// newline so concatenated bodies stay aligned.
-func writeBody(b *bytes.Buffer, body string) {
-	b.WriteString(body)
-	if !strings.HasSuffix(body, "\n") {
-		b.WriteByte('\n')
-	}
-}


### PR DESCRIPTION
## Summary
- `flate diff -o diff` concatenated per-resource bodies with only a single trailing newline, so the next document's `--- Kind ns/name` header sat flush against the previous body's last `+`/`-` line. This change inserts a blank line before every header except the first, so multi-resource output is easier to scan.
- Drops `writeBody` along the way — its trailing-newline guard defended against a case that can't happen (both `difflib.GetUnifiedDiffString` and `yaml.Marshal` always emit a trailing newline), so the single call inlines cleanly as `b.WriteString(body)`.
- New test `TestUnified_BlankLineBetweenDocs` pins the separator behavior at the boundaries (blank between docs, no leading blank, no trailing blank).

### Before
```
        - name: UMASK_SET
--- Deployment cloudflareddns/cloudflareddns
+++ Deployment cloudflareddns/cloudflareddns
```

### After
```
        - name: UMASK_SET

--- Deployment cloudflareddns/cloudflareddns
+++ Deployment cloudflareddns/cloudflareddns
```

Other `-o` formats (dyff human/github/gitlab/gitea/brief) go through `renderNative` and are unaffected.

## Test plan
- [x] `go test ./pkg/diff/...` — new and existing tests pass
- [x] `go test ./internal/cli/...` — `TestDiff_OutputStyles` and `TestRun_DiffKS_ExplicitDiffOutput` still pass
- [ ] Manual: `flate diff -o diff` against a kustomization that mutates two Deployments shows a blank line between the two `--- Deployment …` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)