### PR TITLE
fix(kustomize): recursive working-tree fingerprint for stage cache

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -9,12 +9,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -45,6 +48,13 @@ type Controller struct {
 
 	// renderTracker receives every reconcilable child emitted during render.
 	renderTracker RenderTracker
+
+	// workingTreeFPs memoizes workingTreeFingerprint results per source
+	// LocalPath for the life of the controller. resolveSourceRootAnd-
+	// Fingerprint runs once per Kustomization, and many KSes share the
+	// bootstrap working-tree source — without this, every KS would
+	// re-walk the entire repo to derive the same fingerprint.
+	workingTreeFPs sync.Map // string -> string
 }
 
 // RenderTracker is the tiny seam the controller uses to report
@@ -398,10 +408,10 @@ func (c *Controller) resolveSourceRootAndFingerprint(ks *manifest.Kustomization)
 		// cache.
 		//
 		// The bootstrap source is the working-tree alias — fetchers
-		// don't run for it and Revision/Digest are empty. We compute
-		// a coarse (path + top-level dirent mtime tuple) hash so
+		// don't run for it and Revision/Digest are empty. We walk the
+		// tree and hash (relpath, mtime, size) per regular file so
 		// repeated invocations against an untouched tree still hit
-		// the cache, and any local edit invalidates it. Same
+		// the cache while any nested edit invalidates it. Same
 		// treatment applies to any other artifact that landed
 		// without a fetcher-supplied fingerprint
 		// (`overrideSelfReferentialGitRepositories`) — they too
@@ -411,7 +421,7 @@ func (c *Controller) resolveSourceRootAndFingerprint(ks *manifest.Kustomization)
 			fp = sourceFingerprintFromRevision(sa.Revision)
 		}
 		if fp == "" {
-			fp = workingTreeFingerprint(sa.LocalPath)
+			fp = c.cachedWorkingTreeFingerprint(sa.LocalPath)
 		}
 		return sa.LocalPath, fp, nil
 	}
@@ -436,15 +446,26 @@ func sourceFingerprintFromRevision(rev string) string {
 	return rev
 }
 
-// workingTreeFingerprint computes a coarse fingerprint of the working
-// tree at path: a hash of (absPath, top-level entry names + mtimes).
-// Cheap (one ReadDir, no recursive walk) and good enough to invalidate
-// the persistent stage on the editor-save / git-checkout cases that
-// matter for repeat-render usage. A user who edits a deeply-nested
-// file without touching anything at the root would slip past — that's
-// an accepted limitation; the working tree was never a clean
-// content-addressed surface to begin with. The expensive fix would be
-// a full-tree content hash; not worth it for a soft cache invalidator.
+// cachedWorkingTreeFingerprint memoizes workingTreeFingerprint by
+// LocalPath. resolveSourceRootAndFingerprint runs once per Kustomization
+// and dozens of KSes share the bootstrap source — without this cache,
+// every reconcile re-walks the entire repo to derive the same hash.
+func (c *Controller) cachedWorkingTreeFingerprint(path string) string {
+	if v, ok := c.workingTreeFPs.Load(path); ok {
+		return v.(string)
+	}
+	fp := workingTreeFingerprint(path)
+	c.workingTreeFPs.Store(path, fp)
+	return fp
+}
+
+// workingTreeFingerprint hashes every regular file under path with
+// (relpath, mtime, size). The skip set — `.git`, `node_modules`,
+// dot-prefixed dirs — mirrors copyTreeInto exactly: the fingerprint and
+// the staged tree MUST see the same files, or a cache hit can land a
+// structurally broken stage (e.g. a kustomization.yaml that references
+// a directory the stage omits). Cost is amortized against a cache miss,
+// which would walk the same tree anyway to copy.
 func workingTreeFingerprint(path string) string {
 	if path == "" {
 		return ""
@@ -453,28 +474,56 @@ func workingTreeFingerprint(path string) string {
 	if err != nil {
 		return ""
 	}
-	entries, err := os.ReadDir(abs)
-	if err != nil {
-		return ""
-	}
 	h := sha256.New()
 	_, _ = h.Write([]byte(abs))
-	for _, e := range entries {
-		// Skip dot-prefixed entries (.git, .flate-cache, IDE state)
-		// so the cache survives changes inside those — they're not
-		// inputs to the kustomize build.
-		if strings.HasPrefix(e.Name(), ".") {
-			continue
-		}
-		info, err := e.Info()
+	walkErr := filepath.WalkDir(abs, func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
-			continue
+			return err
 		}
-		_, _ = h.Write([]byte(e.Name()))
+		if d.IsDir() {
+			base := d.Name()
+			if p != abs && (base == "node_modules" || strings.HasPrefix(base, ".")) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		// Mirror copyTreeInto's symlink handling: dereference, then
+		// only hash if the target is a regular file. Broken symlinks
+		// are silently skipped — otherwise a dangling editor lockfile
+		// would error out and empty the fingerprint, routing every
+		// run to per-process scratch staging.
+		var info fs.FileInfo
+		if d.Type()&fs.ModeSymlink != 0 {
+			info, err = os.Stat(p)
+			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
+				return err
+			}
+			if !info.Mode().IsRegular() {
+				return nil
+			}
+		} else {
+			if !d.Type().IsRegular() {
+				return nil
+			}
+			info, err = d.Info()
+			if err != nil {
+				return nil
+			}
+		}
+		rel, relErr := filepath.Rel(abs, p)
+		if relErr != nil {
+			return relErr
+		}
+		_, _ = h.Write([]byte(rel))
 		_, _ = h.Write([]byte(info.ModTime().UTC().Format(time.RFC3339Nano)))
-		if !e.IsDir() {
-			_, _ = h.Write([]byte(strconv.FormatInt(info.Size(), 10)))
-		}
+		_, _ = h.Write([]byte(strconv.FormatInt(info.Size(), 10)))
+		return nil
+	})
+	if walkErr != nil {
+		return ""
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/controllers/kustomization/fingerprint_test.go
+++ b/pkg/controllers/kustomization/fingerprint_test.go
@@ -1,6 +1,8 @@
 package kustomization
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -64,5 +66,135 @@ func TestKustomizationFingerprint_SourceRootInputs(t *testing.T) {
 	}
 	if a, b := kustomizationFingerprint(ks, "/repo-a"), kustomizationFingerprint(ks, "/repo-b"); a == b {
 		t.Errorf("fingerprint must differ across distinct sourceRoots; both = %q", a)
+	}
+}
+
+// seedWorkingTree lays out a small tree under t.TempDir()-style root
+// for workingTreeFingerprint tests. Returns the absolute root.
+func seedWorkingTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	mustMkdir := func(p string) {
+		if err := os.MkdirAll(filepath.Join(root, p), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+	mustWrite := func(p, body string) {
+		if err := os.WriteFile(filepath.Join(root, p), []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	mustMkdir("a/b")
+	mustWrite("a/b/c.yaml", "x: 1\n")
+	mustWrite("top.yaml", "y: 2\n")
+	return root
+}
+
+// TestWorkingTreeFingerprint_NestedFileChangeBustsCache is the
+// regression fence for #ceph-csi-drivers: adding a deeply-nested
+// file MUST change the fingerprint so the persistent stage cache
+// doesn't reuse a stale (structurally broken) copy of the tree.
+func TestWorkingTreeFingerprint_NestedFileChangeBustsCache(t *testing.T) {
+	root := seedWorkingTree(t)
+	before := workingTreeFingerprint(root)
+
+	if err := os.MkdirAll(filepath.Join(root, "a/b/d"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a/b/d/new.yaml"), []byte("z: 3\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if after := workingTreeFingerprint(root); after == before {
+		t.Errorf("fingerprint must change when a nested file is added; got %q before and after", after)
+	}
+}
+
+// TestWorkingTreeFingerprint_NestedFileEditBustsCache locks the
+// editor-save invalidation case: rewriting an existing nested file
+// (same path, different size + mtime) must invalidate the cache.
+func TestWorkingTreeFingerprint_NestedFileEditBustsCache(t *testing.T) {
+	root := seedWorkingTree(t)
+	before := workingTreeFingerprint(root)
+
+	if err := os.WriteFile(filepath.Join(root, "a/b/c.yaml"), []byte("x: 1\nadded: true\n"), 0o600); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	if after := workingTreeFingerprint(root); after == before {
+		t.Errorf("fingerprint must change when a nested file is edited; got %q before and after", after)
+	}
+}
+
+// TestWorkingTreeFingerprint_StableOnDotPrefixedNoise locks the
+// existing dotfile-skip contract: edits to `.git/`, `.flate-cache/`,
+// IDE state etc. don't influence kustomize input, so the stage cache
+// must survive them. Mirrors copyTreeInto's `strings.HasPrefix(base, ".")`
+// rule.
+func TestWorkingTreeFingerprint_StableOnDotPrefixedNoise(t *testing.T) {
+	root := seedWorkingTree(t)
+	for _, p := range []string{".git", ".flate-cache", ".vscode"} {
+		if err := os.MkdirAll(filepath.Join(root, p), 0o750); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+	before := workingTreeFingerprint(root)
+
+	for _, p := range []string{".git/HEAD", ".flate-cache/blob", ".vscode/settings.json"} {
+		if err := os.WriteFile(filepath.Join(root, p), []byte("noise\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	if after := workingTreeFingerprint(root); after != before {
+		t.Errorf("fingerprint must be stable across dot-prefixed dir noise; before=%q after=%q", before, after)
+	}
+}
+
+// TestWorkingTreeFingerprint_StableOnNodeModules mirrors copyTreeInto's
+// node_modules skip: front-end deps land in node_modules/ but are
+// never kustomize input, so the cache key must ignore them.
+func TestWorkingTreeFingerprint_StableOnNodeModules(t *testing.T) {
+	root := seedWorkingTree(t)
+	if err := os.MkdirAll(filepath.Join(root, "node_modules/pkg"), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	before := workingTreeFingerprint(root)
+
+	if err := os.WriteFile(filepath.Join(root, "node_modules/pkg/index.js"), []byte("module.exports = 1\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if after := workingTreeFingerprint(root); after != before {
+		t.Errorf("fingerprint must be stable across node_modules/ writes; before=%q after=%q", before, after)
+	}
+}
+
+// TestWorkingTreeFingerprint_BrokenSymlinkDoesNotEmpty guards against
+// a regression mode where a dangling editor lockfile or stray symlink
+// caused the walk to error, returning "" — which silently downgrades
+// every Stage call to per-process scratch and tanks repeat-run perf.
+// Matches copyTreeInto's broken-symlink tolerance (copytree.go:79).
+func TestWorkingTreeFingerprint_BrokenSymlinkDoesNotEmpty(t *testing.T) {
+	root := seedWorkingTree(t)
+	if err := os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(root, "a/dangling")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if fp := workingTreeFingerprint(root); fp == "" {
+		t.Errorf("fingerprint must remain non-empty in the presence of a broken symlink")
+	}
+}
+
+// TestWorkingTreeFingerprint_EmptyOnMissingPath locks the defensive
+// degradation path: empty input or a nonexistent root returns "" so
+// the caller falls back to per-process scratch staging instead of
+// keying the persistent cache on garbage.
+func TestWorkingTreeFingerprint_EmptyOnMissingPath(t *testing.T) {
+	if fp := workingTreeFingerprint(""); fp != "" {
+		t.Errorf(`workingTreeFingerprint("") = %q, want ""`, fp)
+	}
+	if fp := workingTreeFingerprint(filepath.Join(t.TempDir(), "no-such-dir")); fp != "" {
+		t.Errorf("workingTreeFingerprint(nonexistent) = %q, want \"\"", fp)
 	}
 }


### PR DESCRIPTION
## Summary

- `workingTreeFingerprint` hashed only top-level entries' mtimes. POSIX directory mtimes don't propagate up, so a nested add (new Kustomization dir) or nested edit left the fingerprint unchanged, the persistent stage cache hit, and `copyTreeInto` was skipped — reusing a stale stage that referenced files it never copied. Symptom: kustomize accumulation failure cascading the whole dependency graph as orphaned.
- Replace the shallow hash with a recursive `filepath.WalkDir` that hashes `(relpath, mtime, size)` per regular file. Skip rules (`.git`, `node_modules`, dot-prefixed) and broken-symlink tolerance mirror `copyTreeInto` exactly — fingerprint and staged set must see the same files or the next cache hit lands the next broken stage.
- Memoize per `LocalPath` on the Controller (`sync.Map`) so the walk runs once per source per orchestrator pass, not once per KS.

Existing cache entries keyed by the old (shallow) fingerprint orphan and reclaim via the existing LRU sweep + `cache gc` paths; no migration needed.

## Test plan

- [x] `mise lint` — 0 issues
- [x] `mise test` — all packages green including `test/e2e` CLI-diff harness
- [x] Six new tests in `fingerprint_test.go` cover: nested add (regression fence), nested edit, `.git`/`.vscode`/`.flate-cache` stability, `node_modules` stability, broken-symlink non-empty, empty/missing-path safety
- [x] Manual repro against a real Flux repo: cleared the stale stage, ran `flate diff all --base HEAD~1`, confirmed the new Kustomization renders correctly with no orphan warnings; warm rerun is byte-identical at ~1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)