### PR TITLE
fix(change): re-render consumers when a referenced source changes

### DIFF
--- a/pkg/change/doc.go
+++ b/pkg/change/doc.go
@@ -12,4 +12,11 @@
 // GitRepository) is also marked needed so the actual chart still gets
 // downloaded. Likewise, a Kustomization's sourceRef and dependsOn
 // ancestors are kept ready so downstream waits succeed.
+//
+// The cascade also runs in reverse: when the changed file IS a source
+// resource, every HelmRelease/Kustomization that references it is kept
+// so its render re-runs against the new source spec. This catches the
+// centralized-source layout where an OCIRepository lives in its own
+// Kustomization tree, separate from the HelmReleases that chartRef it —
+// bumping the OCIRepository's tag must still re-render those consumers.
 package change

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -34,6 +34,13 @@ type Filter struct {
 	sourceFiles map[manifest.NamedResource]string
 	repoRoot    string
 
+	// consumerRefs maps each consumer (HelmRelease / Kustomization) to
+	// the source resources it references — supplied by discovery because
+	// HelmReleases are absent from the Store at resolve() time under
+	// render-driven discovery. resolve() inverts it (source -> consumers)
+	// to drive the reverse edge. Nil disables reverse propagation.
+	consumerRefs map[manifest.NamedResource][]manifest.NamedResource
+
 	// objs is captured from NewFilter so runtime AddEmitted can
 	// walk transitiveDeps without the caller re-supplying it. The
 	// pointer is set once at construction and never reassigned —
@@ -115,8 +122,17 @@ type nameKey struct{ kind, name string }
 //     land before the leaf renders. See #58.
 //  4. BFS over chart sources, sourceRef, and valuesFrom to pull in
 //     upstream dependencies. dependsOn is intentionally excluded.
+//  5. Reverse edge: when a changed file IS itself a source resource
+//     (OCIRepository / HelmRepository / GitRepository / Bucket /
+//     ExternalArtifact / HelmChart), every HelmRelease and
+//     Kustomization that references it is kept primary so its render
+//     re-runs against the new source spec — e.g. an OCIRepository
+//     spec.ref.tag bump pulls a different chart version. Only fires
+//     for a source whose OWN file changed (not one merely pulled in as
+//     a forward dep of step 4), so a single HR edit can't reverse-
+//     cascade into every sibling sharing its source.
 func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister) *Filter {
-	return NewFilterWithCache(changes, sourceFiles, repoRoot, objs, nil)
+	return NewFilterWithCache(changes, sourceFiles, repoRoot, objs, nil, nil)
 }
 
 // NewFilterWithCache is NewFilter with a shared
@@ -126,15 +142,22 @@ func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repo
 // kustomization.yaml's `components:` field is read once across the
 // entire Bootstrap (vs. once per consumer: loader's parent index,
 // discovery's orphan promotion, and the Filter's ownership index all
-// previously re-read disk). Pass nil to fall back to a per-resolve
+// previously re-read disk). Pass nil cache to fall back to a per-resolve
 // local cache.
-func NewFilterWithCache(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister, cache *manifest.ComponentCache) *Filter {
+//
+// consumerRefs maps each consumer (HelmRelease / Kustomization) to the
+// source resources it references; discovery supplies it because
+// HelmReleases are absent from the Store at resolve() time. It drives
+// the reverse edge (step 5 above). Pass nil to disable reverse
+// propagation (the default for tests that don't exercise it).
+func NewFilterWithCache(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister, cache *manifest.ComponentCache, consumerRefs map[manifest.NamedResource][]manifest.NamedResource) *Filter {
 	f := &Filter{
 		changes:        changes,
 		sourceFiles:    sourceFiles,
 		repoRoot:       repoRoot,
 		objs:           objs,
 		componentCache: cache,
+		consumerRefs:   consumerRefs,
 	}
 	if changes == nil {
 		return f
@@ -494,6 +517,45 @@ func (f *Filter) resolve(objs ObjectLister) {
 				enqueuePrimary(id)
 				break
 			}
+		}
+	}
+
+	// Reverse edge: when a changed file IS the source a HelmRelease or
+	// Kustomization references, that consumer must re-render — the
+	// forward transitiveDeps walk only goes consumer→source, so a
+	// centralized source (an OCIRepository in its own Kustomization tree,
+	// separate from the HelmReleases that chartRef it) would otherwise
+	// leave its consumers out of the keep set entirely. consumerRefs is
+	// the only view of these edges at resolve() time: HelmReleases are
+	// absent from the Store under render-driven discovery. Iterating it
+	// and testing the referenced source's file directly also gives the
+	// guard for free — a consumer is pulled only when a source it
+	// references actually changed on disk, never when its own edit
+	// merely drags the source in as a forward dep.
+	//
+	// The consumer is primary: its render (an HR's helm template against
+	// the new chart version) differs from baseline, and its namespace
+	// must enter KeepNamespaces for diff scoping. Its owner Kustomization
+	// is ancestor-only — it must render to emit the HR into the Store,
+	// but its own kustomize output is unchanged (the HR manifest is
+	// identical; only the downstream helm render moved), so it must not
+	// cascade unrelated siblings into keep (the #58/#204 rationale).
+	for consumer, sources := range f.consumerRefs {
+		for _, src := range sources {
+			sf, ok := f.sourceFiles[src]
+			if !ok || !f.changes.Contains(sf) {
+				continue
+			}
+			enqueuePrimary(consumer)
+			if cf, ok := f.sourceFiles[consumer]; ok {
+				for _, owner := range owners.ownersOf(cf) {
+					enqueueAncestor(owner)
+				}
+				for _, ancestor := range owners.ancestorsOf(cf) {
+					enqueueAncestor(ancestor)
+				}
+			}
+			break
 		}
 	}
 

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -636,6 +636,115 @@ func TestFilter_TransitiveDepsHelmReleaseViaHelmChartCRD(t *testing.T) {
 	}
 }
 
+// TestFilter_ReverseEdgeCentralizedOCIRepository pins the reverse-edge
+// fix: when a centralized OCIRepository (its own Kustomization tree,
+// separate from the consuming HelmReleases) has its spec.ref.tag
+// bumped, the HelmRelease that chartRefs it must re-render even though
+// the HR's own files didn't change. Pre-fix the filter walked only
+// consumer→source edges, so the changed OCIRepository never reached its
+// consumer and `diff hr` printed nothing.
+//
+// Mirrors github.com/Boemeltrein/TalosCluster: OCIRepository under
+// repositories/oci owned by a `repositories` KS, HelmRelease under
+// clusters/.../envoy-gateway/app owned by a different KS. The HR is NOT
+// in the store at resolve() time (render-driven discovery); the reverse
+// edge is driven by the discovery-supplied consumerRefs instead.
+func TestFilter_ReverseEdgeCentralizedOCIRepository(t *testing.T) {
+	const (
+		ociFile = "repositories/oci/envoy-gateway.yaml"
+		hrFile  = "clusters/main/kubernetes/networking/envoy-gateway/app/helm-release.yaml"
+		sibFile = "clusters/main/kubernetes/networking/envoy-gateway/app/other-hr.yaml"
+	)
+	oci := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "envoy-gateway"}
+	hr := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "envoy-gateway", Name: "envoy-gateway"}
+	// Sibling HR under the SAME owner KS that consumes a DIFFERENT source
+	// — it must stay out of keep (the owner KS is ancestor-only, so it
+	// can't cascade unrelated siblings in).
+	sibling := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "envoy-gateway", Name: "other"}
+	otherOCI := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "something-else"}
+	reposKS := &manifest.Kustomization{Name: "repositories", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "repositories"}}
+	appKS := &manifest.Kustomization{Name: "envoy-gateway", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "clusters/main/kubernetes/networking/envoy-gateway/app"}}
+
+	f := NewFilterWithCache(
+		NewSet([]string{ociFile}),
+		map[manifest.NamedResource]string{
+			oci:             ociFile,
+			hr:              hrFile,
+			sibling:         sibFile,
+			reposKS.Named(): "repositories/flux-entry.yaml",
+			appKS.Named():   "clusters/main/kubernetes/networking/envoy-gateway/ks.yaml",
+		},
+		"",
+		testutil.MapLister{reposKS.Named(): reposKS, appKS.Named(): appKS},
+		nil,
+		map[manifest.NamedResource][]manifest.NamedResource{
+			hr:      {oci},
+			sibling: {otherOCI},
+		},
+	)
+
+	if !f.ShouldReconcile(oci) {
+		t.Fatalf("changed OCIRepository must be in keep; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(hr) {
+		t.Fatalf("reverse edge: HR consuming the changed OCIRepository must be in keep; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(appKS.Named()) {
+		t.Errorf("HR owner KS must render (ancestor) to emit the HR; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(sibling) {
+		t.Errorf("sibling HR consuming an unchanged source must NOT be pulled in; keep=%v", f.KeepNames())
+	}
+	// Namespace scoping (scopedNamespaces → KeepNamespaces) gates diff
+	// output: without the HR's namespace the command would scope it out
+	// even if ShouldReconcile passed.
+	if ns := f.KeepNamespaces(); ns != nil {
+		if _, ok := ns["envoy-gateway"]; !ok {
+			t.Errorf("HR namespace must be in keep-namespaces for diff scoping; got %v", ns)
+		}
+	} else {
+		t.Errorf("KeepNamespaces returned nil; expected envoy-gateway in scope")
+	}
+}
+
+// TestFilter_ReverseEdgeNoCascadeFromChangedConsumer pins the guard on
+// the reverse edge: it fires ONLY for a source whose OWN file changed,
+// never for a source merely referenced by a changed consumer. Two
+// HelmReleases share one OCIRepository; editing hrA's file must keep
+// hrA but must NOT drag hrB in via the shared source — otherwise a
+// single app edit would reverse-cascade every sibling sharing a common
+// app-template source.
+func TestFilter_ReverseEdgeNoCascadeFromChangedConsumer(t *testing.T) {
+	shared := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "app-template"}
+	aID := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "apps", Name: "a"}
+	bID := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "apps", Name: "b"}
+
+	f := NewFilterWithCache(
+		NewSet([]string{"apps/a/hr.yaml"}),
+		map[manifest.NamedResource]string{
+			aID:    "apps/a/hr.yaml",
+			bID:    "apps/b/hr.yaml",
+			shared: "repositories/oci/app-template.yaml",
+		},
+		"",
+		testutil.EmptyLister(),
+		nil,
+		map[manifest.NamedResource][]manifest.NamedResource{
+			aID: {shared},
+			bID: {shared},
+		},
+	)
+
+	if !f.ShouldReconcile(aID) {
+		t.Fatalf("changed HR a must be in keep; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(bID) {
+		t.Errorf("unchanged sibling HR b reverse-cascaded via shared source; keep=%v", f.KeepNames())
+	}
+}
+
 // TestFilter_SubstituteFromConfigMapKeepsProducerKustomization pins
 // issue #418: a kept Kustomization with a non-Optional
 // postBuild.substituteFrom ConfigMap must pull the producer KS that

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -34,6 +34,13 @@ type Result struct {
 	// SourceFiles maps each loaded resource to the repo-relative path
 	// it was parsed from. Consumed by the change filter.
 	SourceFiles map[manifest.NamedResource]string
+	// SourceRefs maps each loaded consumer (HelmRelease / Kustomization)
+	// to the source resources it references. Consumed by the change
+	// filter's reverse edge so a changed source re-renders the
+	// HelmReleases that chartRef it even when the source lives in a
+	// separate Kustomization tree (and the HR never reached the Store
+	// under DiscoveryOnly).
+	SourceRefs map[manifest.NamedResource][]manifest.NamedResource
 	// ParentOf maps each reconcilable resource (Kustomization or
 	// HelmRelease) to its structural-parent Kustomization — the KS
 	// whose spec.path is the deepest strict ancestor of the child's
@@ -102,6 +109,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 		cfg:         cfg,
 		loader:      l,
 		sourceFiles: map[manifest.NamedResource]string{},
+		sourceRefs:  map[manifest.NamedResource][]manifest.NamedResource{},
 	}
 	repoRoot, err := d.seedBootstrapSource()
 	if err != nil {
@@ -141,6 +149,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	return &Result{
 		RepoRoot:    repoRoot,
 		SourceFiles: d.sourceFiles,
+		SourceRefs:  d.sourceRefs,
 		ParentOf:    parentOf,
 		Existence:   l.Existence,
 		WipeSecrets: cfg.WipeSecrets,
@@ -172,6 +181,7 @@ type discoverer struct {
 	cfg         Config
 	loader      *loader.Loader
 	sourceFiles map[manifest.NamedResource]string
+	sourceRefs  map[manifest.NamedResource][]manifest.NamedResource
 	// repoRoot is the resolved .git ancestor of cfg.Path (or cfg.Path
 	// when no .git exists). Stored here because every consumer of
 	// loader.BuildParentIndexForKind / loader.KSPathPrefixes needs the
@@ -190,6 +200,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	l := d.loader
 	l.SourceRoot = repoRoot
 	l.SourceFiles = d.sourceFiles
+	l.SourceRefs = d.sourceRefs
 
 	scanRoot := repoRoot
 	if d.cfg.Path != "" {

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -76,6 +76,16 @@ type Loader struct {
 	// the parsed resource's NamedResource. Nil disables tracking.
 	SourceFiles map[manifest.NamedResource]string
 
+	// SourceRefs maps each loaded consumer (HelmRelease / Kustomization)
+	// to the source resources it references — an HR's chart source, a
+	// KS's spec.sourceRef. Captured at parse time because under
+	// DiscoveryOnly an HR never reaches the Store, yet the change
+	// filter's reverse edge needs to know which HelmReleases a changed
+	// source feeds (so bumping a centralized OCIRepository's tag
+	// re-renders its consumers). Nil disables tracking. Keyed by the
+	// consumer's NamedResource; mirrors SourceFiles' lifecycle.
+	SourceRefs map[manifest.NamedResource][]manifest.NamedResource
+
 	// PreferExisting suppresses overwrites of resources already in
 	// the store (and their SourceFiles entries). Used by the
 	// orchestrator's recursive spec.path discovery so the initial
@@ -523,10 +533,12 @@ func (l *Loader) loadFile(path string) (int, error) {
 			// on demand without deadlocking the producing KS.
 			l.Existence.Record(id, path)
 			l.recordSource(id, path)
+			l.recordSourceRefs(obj)
 			continue
 		}
 		l.Store.AddObject(obj)
 		l.recordSource(id, path)
+		l.recordSourceRefs(obj)
 		count++
 	}
 	return count, nil
@@ -672,6 +684,37 @@ func (l *Loader) recordSource(id manifest.NamedResource, absPath string) {
 	l.SourceFiles[id] = filepath.ToSlash(rel)
 }
 
+// recordSourceRefs captures the source resources obj references — a
+// HelmRelease's chart source, a Kustomization's spec.sourceRef — so the
+// change filter can resolve the reverse edge from a changed source back
+// to its consumers. No-op for non-consumer kinds or when tracking is
+// disabled. The chart ref is read from the parse-time projection
+// (chartFromHelmRelease), which is populated whether or not the HR
+// reaches the Store.
+func (l *Loader) recordSourceRefs(obj manifest.BaseManifest) {
+	if l.SourceRefs == nil {
+		return
+	}
+	var refs []manifest.NamedResource
+	switch o := obj.(type) {
+	case *manifest.HelmRelease:
+		if o.Chart.RepoKind != "" && o.Chart.RepoName != "" {
+			refs = append(refs, manifest.NamedResource{
+				Kind: o.Chart.RepoKind, Namespace: o.Chart.RepoNamespace, Name: o.Chart.RepoName,
+			})
+		}
+	case *manifest.Kustomization:
+		if o.SourceKind != "" && o.SourceName != "" {
+			refs = append(refs, manifest.NamedResource{
+				Kind: o.SourceKind, Namespace: o.SourceNamespace, Name: o.SourceName,
+			})
+		}
+	}
+	if len(refs) > 0 {
+		l.SourceRefs[obj.Named()] = refs
+	}
+}
+
 // isDiscoveryKind reports whether obj belongs to the discovery-meta
 // kind set the loader keeps in the Store under DiscoveryOnly:
 //
@@ -735,4 +778,3 @@ func (w *walker) shouldSkipDir(name, full string) bool {
 	}
 	return w.ignoreMatches(full, true)
 }
-

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -535,6 +535,50 @@ spec:
 	}
 }
 
+// TestLoader_DiscoveryOnlyRecordsSourceRefs pins the reverse-edge
+// plumbing: under DiscoveryOnly a HelmRelease never reaches the Store,
+// yet its chart source reference must still be captured in SourceRefs
+// so the change filter can re-render the HR when its (centralized)
+// OCIRepository changes. The ref is read from the parse-time chart
+// projection, not the Store.
+func TestLoader_DiscoveryOnlyRecordsSourceRefs(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "apps/envoy/helm-release.yaml", `apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway
+  namespace: envoy-gateway
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: envoy-gateway
+    namespace: flux-system
+`)
+	s := store.New()
+	l := New(s)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	l.SourceFiles = map[manifest.NamedResource]string{}
+	l.SourceRefs = map[manifest.NamedResource][]manifest.NamedResource{}
+	l.SourceRoot = dir
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	hrID := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "envoy-gateway", Name: "envoy-gateway"}
+	if s.GetObject(hrID) != nil {
+		t.Fatalf("HR must NOT be in Store under DiscoveryOnly (existence-only)")
+	}
+	refs, ok := l.SourceRefs[hrID]
+	if !ok {
+		t.Fatalf("HR chart source ref must be captured in SourceRefs; got %v", l.SourceRefs)
+	}
+	want := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "envoy-gateway"}
+	if len(refs) != 1 || refs[0] != want {
+		t.Errorf("SourceRefs[HR] = %v; want [%v]", refs, want)
+	}
+}
+
 // TestLoader_DiscoveryOnlyRecordsNestedComponentData pins the
 // Component-of-Component recursion in walkComponentData: an outer
 // Component that references an inner Component via `components:`

--- a/pkg/orchestrator/changefilter.go
+++ b/pkg/orchestrator/changefilter.go
@@ -27,7 +27,7 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	if changes == nil {
 		return nil
 	}
-	f := change.NewFilterWithCache(changes, o.sourceFiles, repoRoot, o.store, o.componentCache)
+	f := change.NewFilterWithCache(changes, o.sourceFiles, repoRoot, o.store, o.componentCache, o.sourceRefs)
 	// Wire OnAdd so a runtime keep-set extension (KS controller's
 	// emitRenderedChildren → keepEmitted) refires any source whose
 	// listener already short-circuited via PreGate before the

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -145,6 +145,12 @@ type Orchestrator struct {
 	// to construct the immutable change.Filter.
 	sourceFiles map[manifest.NamedResource]string
 
+	// sourceRefs maps each loaded consumer (HelmRelease / Kustomization)
+	// to the source resources it references. Populated during discovery
+	// and consumed once by Bootstrap to give the change.Filter its
+	// reverse edge (changed source -> consuming HelmReleases).
+	sourceRefs map[manifest.NamedResource][]manifest.NamedResource
+
 	// parentOf is the structural-parent index Bootstrap computes after
 	// loadManifests + namespace inheritance — keyed by every
 	// reconcilable id that uses a parent gate (KS and HR). KS lookups
@@ -421,6 +427,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	}
 	o.repoRoot = res.RepoRoot
 	o.sourceFiles = res.SourceFiles
+	o.sourceRefs = res.SourceRefs
 	o.parentOf = res.ParentOf
 	o.existence = res.Existence
 


### PR DESCRIPTION
## Summary

In changed-only mode (`flate diff hr`, and `--base`/`--path-orig` on build/get/test), the change filter only walked **forward** edges (consumer → source). Bumping a centralized OCIRepository's `spec.ref.tag` therefore never reached the HelmReleases that `chartRef` it from a *separate* Kustomization tree, so `flate diff hr` rendered nothing even though the chart version moved.

Reproduced against [Boemeltrein/TalosCluster](https://github.com/Boemeltrein/TalosCluster): the OCIRepository lives under `repositories/` (its own Flux Kustomization) while the HelmRelease lives under `clusters/main/.../envoy-gateway/app`. The changed file marked only the OCIRepository + its owner KS (both `flux-system`) primary; the HR (namespace `envoy-gateway`) never entered the keep set and was scoped out of the diff. Repos that co-locate the source with the HR under one Kustomization were unaffected — the existing sibling rule already pulls the HR in.

A complicating factor: under render-driven discovery, HelmReleases are **absent from the Store** at filter-build time (they materialize only when their owner Kustomization renders), so the reverse index can't be built from the Store.

### Fix
- Capture each HelmRelease/Kustomization → source reference at discovery **parse time** into a new `SourceRefs` map (the loader already parses every HR for its id), and thread it to the filter as `consumerRefs`.
- `Filter.resolve()` adds a **reverse edge**: when a referenced source's *own file* changes, the consumer is kept **primary** (so it re-renders and its namespace enters the diff scope) and its owner Kustomization is kept **ancestor-only** (so it renders to emit the HR without cascading unrelated siblings — preserving the #58/#204 keep-cascade guarantees).
- Applies to all source kinds (OCIRepository / HelmRepository / GitRepository / Bucket / ExternalArtifact / HelmChart). Benefits every changed-only command, since the filter is shared.

The filter-side logic is a single direct loop over `consumerRefs` — no inverted index, kind-guard, or name-fallback needed.

## Test plan
- [x] New unit tests in `pkg/change/filter_test.go`: reverse edge pulls in a centralized-source consumer (+ owner KS + namespace scope); a changed *consumer* does **not** reverse-cascade siblings sharing its source.
- [x] New `pkg/loader` test: `SourceRefs` captures the HR chart-source edge under `DiscoveryOnly` (HR stays out of the Store).
- [x] `go test ./...` passes; `golangci-lint` + `go vet` clean; `BenchmarkFilterResolve` shows no regression.
- [x] End-to-end against the repro: `flate diff hr` now shows the envoy-gateway HelmRelease delta (`gateway:v1.8.0→v1.7.3`, ratelimit image digests, ClusterRole rules); no-change still yields an empty diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)