### PR TITLE
fix(diff): emit nothing for `-o html` when there is no diff

### DIFF
--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -98,7 +98,8 @@ type sRow struct {
 // renderHTML produces a self-contained HTML diff document: the same resource
 // pairing and line diff as FormatDiff, rendered with YAML syntax highlighting,
 // a left navigation tree, a side-by-side ⇄ unified toggle, and a light/dark
-// theme. Identical resources are dropped, matching renderUnified.
+// theme. Identical resources are dropped, matching renderUnified; an empty
+// diff produces no output at all, like the other formats.
 func renderHTML(left, right []Doc, opts Options) ([]byte, error) {
 	left = normalizeDocs(left, opts.StripAttrs)
 	right = normalizeDocs(right, opts.StripAttrs)
@@ -132,6 +133,9 @@ func renderHTML(left, right []Doc, opts Options) ([]byte, error) {
 		default:
 			data.Changed++
 		}
+	}
+	if len(data.Resources) == 0 {
+		return nil, nil // no diff — emit nothing, matching the other formats
 	}
 	data.Tree = buildTree(data.Resources)
 

--- a/pkg/diff/html_test.go
+++ b/pkg/diff/html_test.go
@@ -77,10 +77,7 @@ func TestRenderHTML_Identical(t *testing.T) {
 	d := htmlDoc(t, "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: web\n  namespace: apps\ndata:\n  k: v\n")
 	out := renderHTMLString(t, []Doc{d}, []Doc{d})
 
-	if strings.Contains(out, `class="view side"`) {
-		t.Error("identical docs should render no diff tables")
-	}
-	if !strings.Contains(out, "no differences") {
-		t.Errorf("identical docs should report no differences:\n%s", out)
+	if len(out) != 0 {
+		t.Errorf("identical docs should render empty, got:\n%s", out)
 	}
 }

--- a/pkg/diff/templates/diff.html.tmpl
+++ b/pkg/diff/templates/diff.html.tmpl
@@ -69,7 +69,6 @@ body.chroma {
 .tree-leaf.current .leaf-stat { color: #fff; }
 
 .placeholder { color: var(--muted); padding: 24px 4px; font-size: 14px; }
-.empty { color: var(--muted); padding: 32px 20px; font-size: 14px; }
 .resource { display: none; }
 .resource.active { display: block; }
 .rhead { font-family: var(--mono); margin: 0 0 5px; font-size: 15px; }
@@ -112,12 +111,11 @@ tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; p
 <body class="chroma light">
 <header class="topbar">
   <span class="brand">flate diff</span>
-  <span class="counts">{{if .Resources}}<span class="c-changed">{{.Changed}} changed</span> · <span class="c-added">{{.Added}} added</span> · <span class="c-removed">{{.Removed}} removed</span>{{else}}no differences{{end}}</span>
+  <span class="counts"><span class="c-changed">{{.Changed}} changed</span> · <span class="c-added">{{.Added}} added</span> · <span class="c-removed">{{.Removed}} removed</span></span>
   <span class="spacer"></span>
-  {{if .Resources}}<button class="btn" id="view-btn" type="button">Unified</button>{{end}}
+  <button class="btn" id="view-btn" type="button">Unified</button>
   <button class="btn" id="theme-btn" type="button">🌙 Dark</button>
 </header>
-{{if .Resources}}
 <div class="layout">
   <nav class="sidebar">
     {{range .Tree}}
@@ -213,8 +211,5 @@ tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; p
   if (initial) select(initial);
 })();
 </script>
-{{else}}
-<p class="empty">The two revisions render identically.</p>
-{{end}}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- `flate diff -o html` rendered a full page reading "no differences" even when the two sides were identical — out of line with every other format (the dyff text styles and unified `-o diff` already produce empty output on no diff).
- `renderHTML` now returns early with no output once it finds no differing resources, so an empty diff produces nothing on stdout regardless of format.
- Removed the now-unreachable empty-state markup from `diff.html.tmpl` (the `{{else}}no differences{{end}}` branch, the `{{if .Resources}}` guards around the layout/view button, the "render identically" paragraph, and the dead `.empty` CSS rule).

## Test plan
- [x] `go test ./...` — all pass; `TestRenderHTML_Identical` updated to assert empty output (matching `TestUnified_NoChange`).
- [x] `mise lint` — 0 issues.
- [x] Offline: `diff ks -o html` on identical paths prints 0 bytes to stdout (same as the default format); the real-diff render path is unchanged (`TestDiff_OutputStyles`, `TestRenderHTML_Changed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)