### PR TITLE
feat(diff): expandable full-file context for `-o html`

### DIFF
--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -73,10 +73,14 @@ type htmlResource struct {
 	SRows    []sRow
 }
 
-// uRow is one unified-view row. Hunk marks a fold separator (the rest of
-// the fields are then unused).
+// uRow is one unified-view row. Hunk marks an expander (clickable fold
+// separator) carrying Fold+Count; Folded marks a context row hidden behind
+// the expander with that Fold id. An ordinary visible row sets neither.
 type uRow struct {
-	Hunk         bool
+	Hunk         bool   // expander row: reveals the rows sharing Fold
+	Folded       bool   // hidden context row belonging to gap Fold
+	Fold         string // resource-local gap id, e.g. "g2"
+	Count        int    // hidden line count, for the expander label
 	Kind         string // "ctx" | "add" | "del"
 	OldNo, NewNo int    // 1-based line numbers; 0 renders a blank gutter
 	HTML         template.HTML
@@ -89,9 +93,13 @@ type cell struct {
 	HTML template.HTML
 }
 
-// sRow is one side-by-side row. Hunk marks a fold separator.
+// sRow is one side-by-side row. Hunk marks an expander, Folded a hidden
+// context row behind it — both carry the gap's Fold id (see uRow).
 type sRow struct {
-	Hunk        bool
+	Hunk        bool   // expander row: reveals the rows sharing Fold
+	Folded      bool   // hidden context row belonging to gap Fold
+	Fold        string // resource-local gap id, e.g. "g2"
+	Count       int    // hidden line count, for the expander label
 	Left, Right cell
 }
 
@@ -166,8 +174,10 @@ func buildTree(res []htmlResource) []treeParent {
 }
 
 // buildHTMLResource diffs one resource's from/to YAML and pre-renders the rows
-// for both views. Context is folded to 3 lines per hunk (git-style), with a
-// separator row between hunks — see unifiedRows / sideRows.
+// for both views. Context is folded to 3 lines per hunk (git-style); the lines
+// trimmed before/between/after the hunks are emitted as collapsed rows behind
+// an expander so the whole file can be revealed in place — see unifiedRows /
+// sideRows.
 func buildHTMLResource(p pairedResource, from, to string, hl *highlighter) htmlResource {
 	a, b := difflib.SplitLines(from), difflib.SplitLines(to)
 	ah, bh := hl.lines(a), hl.lines(b)
@@ -195,15 +205,64 @@ func buildHTMLResource(p pairedResource, from, to string, hl *highlighter) htmlR
 	return res
 }
 
+// gap is one collapsed run of unchanged lines — the context GetGroupedOpCodes
+// trims before, between and after the hunks — tagged with a positional fold id
+// that both views share, so a single expand reveals the run in each.
+type gap struct {
+	id                 string
+	oldStart, newStart int
+	count              int
+}
+
+// foldGaps returns the trimmed unchanged runs indexed by the group they
+// precede: index 0 is the run before the first hunk, index gi the run between
+// groups gi-1 and gi, and index len(groups) the run after the last. Each is
+// everything between one group's last opcode and the next group's first — the
+// lines GetGroupedOpCodes drops. Empty runs stay zero-value (count 0) so the
+// row builders can index by position and skip them.
+func foldGaps(groups [][]difflib.OpCode, nOld int) []gap {
+	gaps := make([]gap, len(groups)+1)
+	set := func(pos, oldStart, oldEnd, newStart int) {
+		if oldEnd > oldStart {
+			gaps[pos] = gap{id: fmt.Sprintf("g%d", pos), oldStart: oldStart, newStart: newStart, count: oldEnd - oldStart}
+		}
+	}
+	for gi, group := range groups {
+		if gi == 0 {
+			set(0, 0, group[0].I1, 0)
+			continue
+		}
+		prev := groups[gi-1][len(groups[gi-1])-1]
+		set(gi, prev.I2, group[0].I1, prev.J2)
+	}
+	if n := len(groups); n > 0 {
+		last := groups[n-1][len(groups[n-1])-1]
+		set(n, last.I2, nOld, last.J2)
+	}
+	return gaps
+}
+
 // unifiedRows renders the grouped opcodes as the single-column unified view:
 // context lines carry both line numbers, deletes carry the old, inserts the
-// new, and a replace is all of its deletes followed by all of its inserts.
+// new, and a replace is all of its deletes followed by all of its inserts. The
+// runs foldGaps reports are emitted as collapsed context rows behind an
+// expander, so the rest of the file can be revealed in place.
 func unifiedRows(ah, bh []template.HTML, groups [][]difflib.OpCode) []uRow {
 	var rows []uRow
-	for gi, group := range groups {
-		if gi > 0 {
-			rows = append(rows, uRow{Hunk: true})
+	gaps := foldGaps(groups, len(ah))
+	fold := func(pos int) {
+		g := gaps[pos]
+		if g.count == 0 {
+			return
 		}
+		rows = append(rows, uRow{Hunk: true, Fold: g.id, Count: g.count})
+		for k := range g.count {
+			rows = append(rows, uRow{Folded: true, Fold: g.id, Kind: kindCtx,
+				OldNo: g.oldStart + k + 1, NewNo: g.newStart + k + 1, HTML: ah[g.oldStart+k]})
+		}
+	}
+	for gi, group := range groups {
+		fold(gi)
 		for _, op := range group {
 			if op.Tag == 'e' {
 				for k := range op.I2 - op.I1 {
@@ -223,18 +282,34 @@ func unifiedRows(ah, bh []template.HTML, groups [][]difflib.OpCode) []uRow {
 			}
 		}
 	}
+	fold(len(groups))
 	return rows
 }
 
 // sideRows renders the grouped opcodes as the two-column side-by-side view:
 // context mirrors both sides, a pure delete/insert blanks the opposite cell,
 // and a replace aligns line-for-line, padding the shorter side with blanks.
+// The runs foldGaps reports become collapsed context rows behind an expander,
+// sharing fold ids with unifiedRows so one expand reveals both views.
 func sideRows(ah, bh []template.HTML, groups [][]difflib.OpCode) []sRow {
 	var rows []sRow
-	for gi, group := range groups {
-		if gi > 0 {
-			rows = append(rows, sRow{Hunk: true})
+	gaps := foldGaps(groups, len(ah))
+	fold := func(pos int) {
+		g := gaps[pos]
+		if g.count == 0 {
+			return
 		}
+		rows = append(rows, sRow{Hunk: true, Fold: g.id, Count: g.count})
+		for k := range g.count {
+			rows = append(rows, sRow{
+				Folded: true, Fold: g.id,
+				Left:  cell{Kind: kindCtx, No: g.oldStart + k + 1, HTML: ah[g.oldStart+k]},
+				Right: cell{Kind: kindCtx, No: g.newStart + k + 1, HTML: bh[g.newStart+k]},
+			})
+		}
+	}
+	for gi, group := range groups {
+		fold(gi)
 		for _, op := range group {
 			switch op.Tag {
 			case 'e':
@@ -267,6 +342,7 @@ func sideRows(ah, bh []template.HTML, groups [][]difflib.OpCode) []sRow {
 			}
 		}
 	}
+	fold(len(groups))
 	return rows
 }
 
@@ -323,35 +399,33 @@ func (h *highlighter) emit(s string, lo, hi int) template.HTML {
 	if err != nil {
 		return rawHTML(template.HTMLEscapeString(s))
 	}
+	esc := func(r []rune) string { return template.HTMLEscapeString(string(r)) }
 	var b strings.Builder
 	pos := 0
 	for t := it(); t != chroma.EOF; t = it() {
 		rs := []rune(t.Value)
+		n := len(rs)
 		class := classFor(t.Type)
 		if class != "" {
 			b.WriteString(`<span class="`)
 			b.WriteString(class)
 			b.WriteString(`">`)
 		}
-		if loRel, hiRel := lo-pos, hi-pos; hi <= lo || hiRel <= 0 || loRel >= len(rs) {
-			b.WriteString(template.HTMLEscapeString(string(rs)))
-		} else {
-			if loRel < 0 {
-				loRel = 0
-			}
-			if hiRel > len(rs) {
-				hiRel = len(rs)
-			}
-			b.WriteString(template.HTMLEscapeString(string(rs[:loRel])))
+		// Wrap [lo,hi)'s overlap with this token (clamped to the token's rune
+		// span) in .wd; an empty overlap leaves the token plain.
+		if lo2, hi2 := max(0, min(n, lo-pos)), max(0, min(n, hi-pos)); lo2 < hi2 {
+			b.WriteString(esc(rs[:lo2]))
 			b.WriteString(`<span class="wd">`)
-			b.WriteString(template.HTMLEscapeString(string(rs[loRel:hiRel])))
+			b.WriteString(esc(rs[lo2:hi2]))
 			b.WriteString(`</span>`)
-			b.WriteString(template.HTMLEscapeString(string(rs[hiRel:])))
+			b.WriteString(esc(rs[hi2:]))
+		} else {
+			b.WriteString(esc(rs))
 		}
 		if class != "" {
 			b.WriteString(`</span>`)
 		}
-		pos += len(rs)
+		pos += n
 	}
 	return rawHTML(b.String())
 }

--- a/pkg/diff/html_test.go
+++ b/pkg/diff/html_test.go
@@ -1,6 +1,7 @@
 package diff
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -70,6 +71,49 @@ func TestRenderHTML_AddedAndRemoved(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("added/removed HTML missing %q", want)
+		}
+	}
+}
+
+func TestRenderHTML_FoldsContext(t *testing.T) {
+	t.Parallel()
+	// A single change surrounded by many unchanged lines: the context beyond 3
+	// lines is collapsed behind expanders, but the dropped lines stay embedded
+	// in the page so the whole file can be revealed in-browser.
+	const base = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: web
+  namespace: apps
+data:
+  k00: val00
+  k01: val01
+  k02: val02
+  k03: val03
+  k04: val04
+  k05: val05
+  k06: %s
+  k07: val07
+  k08: val08
+  k09: val09
+  k10: val10
+  k11: val11
+`
+	from := htmlDoc(t, fmt.Sprintf(base, "old06"))
+	to := htmlDoc(t, fmt.Sprintf(base, "new06"))
+	out := renderHTMLString(t, []Doc{from}, []Doc{to})
+
+	for _, want := range []string{
+		`data-fold="r0-g0"`,          // leading-gap expander (context above the change was folded)
+		`class="folded"`,             // collapsed context rows embedded, not dropped
+		"Expand",                     // expander label
+		"val00",                      // a line far above the change — present only if the whole file is embedded
+		"val11",                      // a line far below the change
+		`class="diff-code diff-del"`, // the change still renders
+		`class="diff-code diff-add"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("folded-context HTML missing %q", want)
 		}
 	}
 }

--- a/pkg/diff/templates/diff.html.tmpl
+++ b/pkg/diff/templates/diff.html.tmpl
@@ -145,7 +145,13 @@ td.diff-code.diff-del .wd, tr.row-del td.diff-code .wd { background: var(--del-w
 td.diff-code.diff-blank, td.diff-lineno.diff-blank {
   background-image: repeating-linear-gradient(45deg, transparent, transparent 5px, var(--hover) 5px, var(--hover) 6px);
 }
-tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; padding: 2px 0; }
+tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; padding: 0; }
+tr.folded { display: none; }
+.expander {
+  font: inherit; font-size: 11px; font-family: var(--mono); color: var(--accent);
+  background: none; border: 0; cursor: pointer; padding: 3px 8px; width: 100%;
+}
+.expander:hover { background: var(--hover); text-decoration: underline; }
 
 {{.ChromaCSS}}
 </style>
@@ -155,6 +161,7 @@ tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; p
   <span class="brand">flate diff</span>
   <span class="counts"><span class="c-changed">{{.Changed}} changed</span><span class="c-added">{{.Added}} added</span><span class="c-removed">{{.Removed}} removed</span></span>
   <span class="spacer"></span>
+  <button class="btn" id="expand-btn" type="button">Expand all</button>
   <button class="btn" id="view-btn" type="button">Unified</button>
   <button class="btn" id="theme-btn" type="button">🌙 Dark</button>
 </header>
@@ -177,14 +184,14 @@ tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; p
   </nav>
   <main class="content">
     <div class="placeholder" id="placeholder">Select a resource from the tree to view its diff.</div>
-    {{range .Resources}}
-    <section class="resource" id="{{.ID}}">
-      <h2 class="rhead"><span class="status status-{{.Status}}">{{.Status}}</span>{{.Title}}</h2>
-      <div class="rparent">{{.Parent}}</div>
+    {{range $res := .Resources}}
+    <section class="resource" id="{{$res.ID}}">
+      <h2 class="rhead"><span class="status status-{{$res.Status}}">{{$res.Status}}</span>{{$res.Title}}</h2>
+      <div class="rparent">{{$res.Parent}}</div>
       <table class="view side"><tbody>
-        {{- range .SRows}}
-        {{- if .Hunk}}<tr class="hunk"><td colspan="4">&#8943;</td></tr>
-        {{- else}}<tr>
+        {{- range $res.SRows}}
+        {{- if .Hunk}}<tr class="hunk" data-fold="{{$res.ID}}-{{.Fold}}"><td colspan="4"><button type="button" class="expander">&#8597; Expand {{.Count}} lines</button></td></tr>
+        {{- else}}<tr{{if .Folded}} class="folded" data-fold="{{$res.ID}}-{{.Fold}}"{{end}}>
           <td class="diff-lineno diff-{{.Left.Kind}}">{{if .Left.No}}{{.Left.No}}{{end}}</td>
           <td class="diff-code diff-{{.Left.Kind}}">{{.Left.HTML}}</td>
           <td class="diff-lineno diff-{{.Right.Kind}}">{{if .Right.No}}{{.Right.No}}{{end}}</td>
@@ -193,9 +200,9 @@ tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; p
         {{- end}}
       </tbody></table>
       <table class="view unified"><tbody>
-        {{- range .URows}}
-        {{- if .Hunk}}<tr class="hunk"><td colspan="3">&#8943;</td></tr>
-        {{- else}}<tr class="row-{{.Kind}}">
+        {{- range $res.URows}}
+        {{- if .Hunk}}<tr class="hunk" data-fold="{{$res.ID}}-{{.Fold}}"><td colspan="3"><button type="button" class="expander">&#8597; Expand {{.Count}} lines</button></td></tr>
+        {{- else}}<tr class="row-{{.Kind}}{{if .Folded}} folded{{end}}"{{if .Folded}} data-fold="{{$res.ID}}-{{.Fold}}"{{end}}>
           <td class="diff-lineno">{{if .OldNo}}{{.OldNo}}{{end}}</td>
           <td class="diff-lineno">{{if .NewNo}}{{.NewNo}}{{end}}</td>
           <td class="diff-code">{{.HTML}}</td>
@@ -252,6 +259,22 @@ tr.hunk td { background: var(--hunk); color: var(--muted); text-align: center; p
   const hashId = location.hash.slice(1);
   const initial = hashId && document.getElementById(hashId) ? hashId : sections[0]?.id;
   if (initial) select(initial);
+
+  // Collapsed context: an expander reveals the folded rows sharing its fold id
+  // (present in both the side and unified tables) and then drops itself. The
+  // toolbar "Expand all" does the same for every fold in one go.
+  const revealFold = (id) => {
+    document.querySelectorAll(`tr.folded[data-fold="${id}"]`).forEach((r) => r.classList.remove('folded'));
+    document.querySelectorAll(`tr.hunk[data-fold="${id}"]`).forEach((r) => r.remove());
+  };
+  content?.addEventListener('click', (event) => {
+    const row = event.target.closest('tr.hunk[data-fold]');
+    if (row) revealFold(row.dataset.fold);
+  });
+  document.getElementById('expand-btn')?.addEventListener('click', () => {
+    document.querySelectorAll('tr.folded').forEach((r) => r.classList.remove('folded'));
+    document.querySelectorAll('tr.hunk[data-fold]').forEach((r) => r.remove());
+  });
 
   // Sidebar filter: hide non-matching leaves, then empty kinds/parents; auto-open while filtering.
   const filter = document.getElementById('filter');


### PR DESCRIPTION
## Summary

- `flate diff -o html` previously showed only 3 lines of context around each change, so a reviewer couldn't read the rest of a rendered manifest without re-running against the raw files. The lines `GetGroupedOpCodes(3)` trims (before, between and after the hunks) are now embedded as collapsed rows behind GitHub-style **Expand N lines** controls, plus an **Expand all** toolbar button, so the whole file can be revealed in place.
- The side-by-side and unified views share fold ids, so one expand reveals the run in **both** views; **Expand all** opens everything at once.
- Scope is `-o html` only — the `-o diff` unified text output keeps its standard 3-line context.
- Internals: the gap arithmetic is centralized in a single `foldGaps` helper shared by both view builders, and the word-diff `emit` splice was tightened (clamped range + small escape helper).

## Test plan

- [x] `go test ./pkg/diff/... ./internal/cli/...` — adds `TestRenderHTML_FoldsContext`; existing HTML/diff/word-diff tests still pass
- [x] `golangci-lint run ./pkg/diff/...` (0 issues) and `gofmt` clean
- [ ] Manual: render a multi-hunk diff with `-o html`, then confirm:
  - each `↕ Expand N lines` reveals exactly that gap; **Expand all** reveals the whole file
  - an expanded gap stays expanded across the **Unified ⇄ Side-by-side** toggle and the light/dark switch
  - fully added/removed resources show full content with no expanders (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)