### PR TITLE
fix: drop kustomize.config build directives from rendered output

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -477,6 +477,9 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			slog.Debug("helmrelease: skipped doc", "id", id.String(), "err", err)
 			continue
 		}
+		if manifest.IsKustomizeBuildDirective(obj) {
+			continue // build input, not a cluster resource — never store it
+		}
 		// docs is retained on the HelmReleaseArtifact.Manifests; do
 		// NOT return any entry to the decoded-map pool here.
 		if isFluxSourceKind(obj) {

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -46,6 +46,9 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			slog.Debug("kustomization: skipped doc", "id", id.String(), "err", err)
 			continue
 		}
+		if manifest.IsKustomizeBuildDirective(obj) {
+			continue // build input, not a cluster resource — never store it
+		}
 		objs = append(objs, parsed{obj: obj, reconcilable: shouldDispatchAsObject(obj)})
 	}
 	// Accumulate every reconcilable child's id across both passes so

--- a/pkg/controllers/kustomization/dispatch_test.go
+++ b/pkg/controllers/kustomization/dispatch_test.go
@@ -127,6 +127,49 @@ func TestEmitRenderedChildrenBatchesLeafDispatch(t *testing.T) {
 	}
 }
 
+// TestEmitRenderedChildren_DropsKustomizeBuildDirective regresses the phantom
+// "Kustomization//" Store entry: a kustomization.yaml self-referenced in its
+// own resources: makes `kustomize build` emit a kustomize.config.k8s.io
+// Kustomization. That's a build input, not a cluster resource — it must never
+// reach the Store (it arrives nameless and surfaces as "FAILED (no status
+// reported)"). A real Flux Kustomization in the same batch is still emitted.
+func TestEmitRenderedChildren_DropsKustomizeBuildDirective(t *testing.T) {
+	s := store.New()
+	c := &Controller{Controller: base.New(s, task.New())}
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "parent"}
+
+	var leaked bool
+	s.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
+		if id.Kind == manifest.KindKustomization && id.Name == "" {
+			leaked = true
+		}
+	}, false)
+
+	c.emitRenderedChildren(parent, []map[string]any{
+		kustomizeConfigDoc(),                 // build directive — must be dropped
+		fluxKustomizationDoc("real", "real"), // real child — must be stored
+	})
+
+	if leaked {
+		t.Error("kustomize.config build directive was emitted to the store (phantom Kustomization//)")
+	}
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "real"}) == nil {
+		t.Error("real Flux Kustomization child was not stored")
+	}
+}
+
+// kustomizeConfigDoc is the shape `kustomize build` emits when a
+// kustomization.yaml lists itself in resources: a kustomize.config.k8s.io
+// build directive (here with the helm-repos metadata seen in the wild).
+func kustomizeConfigDoc() map[string]any {
+	return map[string]any{
+		"apiVersion": "kustomize.config.k8s.io/v1beta1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "helm-repos", "namespace": "ns"},
+		"resources":  []any{"a.yaml", "kustomization.yaml"},
+	}
+}
+
 func fluxKustomizationDoc(name, dep string) map[string]any {
 	return map[string]any{
 		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1672,3 +1672,25 @@ spec:
 		t.Errorf("alias key not resolved to scalar; controllers=%v", controllers)
 	}
 }
+
+func TestIsKustomizeBuildDirective(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  BaseManifest
+		want bool
+	}{
+		{"kustomize-config Kustomization", &RawObject{Kind: "Kustomization", APIVersion: "kustomize.config.k8s.io/v1beta1"}, true},
+		{"kustomize-config Component", &RawObject{Kind: "Component", APIVersion: "kustomize.config.k8s.io/v1alpha1"}, true},
+		{"flux Kustomization (typed)", &Kustomization{}, false},
+		{"unknown resource RawObject", &RawObject{Kind: "Widget", APIVersion: "example.com/v1"}, false},
+		{"helmrelease (typed)", &HelmRelease{}, false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsKustomizeBuildDirective(tc.obj); got != tc.want {
+				t.Errorf("IsKustomizeBuildDirective = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -142,6 +142,18 @@ func ParseDoc(doc map[string]any, opts ParseDocOptions) (BaseManifest, error) {
 	return parseRawObject(doc)
 }
 
+// IsKustomizeBuildDirective reports whether obj is a kustomize.config.k8s.io
+// build directive (a Kustomization or Component). ParseDoc preserves these as
+// metadata-less RawObjects — they're build inputs, not cluster resources, and
+// the loader drops them during discovery. Render paths must drop them too: a
+// kustomization.yaml self-referenced in its own resources: makes `kustomize
+// build` emit one, which would otherwise land in the Store as a phantom,
+// nameless object (id "<kind>//") that no controller ever reconciles.
+func IsKustomizeBuildDirective(obj BaseManifest) bool {
+	raw, ok := obj.(*RawObject)
+	return ok && strings.HasPrefix(raw.APIVersion, KustomizeDomain)
+}
+
 // checkAPIVersion enforces an api group prefix on a raw document.
 func checkAPIVersion(doc map[string]any, want string) error {
 	v := DocAPIVersion(doc)


### PR DESCRIPTION
## Problem

`flate test` reported a phantom `Kustomization/` (empty namespace **and** name) as `FAILED (no status reported)`.

Root cause: a `kustomization.yaml` that lists itself in `resources:` makes `kustomize build` emit the build config as a `kustomize.config.k8s.io/v1beta1 Kustomization` object (confirmed against real `kustomize`). flate already drops these build directives at file-load, but **not** in the render-emit path — so one landed in the Store as a metadata-less RawObject that no controller reconciles.

## Fix

- Add `manifest.IsKustomizeBuildDirective` — identifies a `kustomize.config.k8s.io` build directive (the metadata-less RawObject `ParseDoc` produces for one).
- Skip such docs in both render-emit paths (`kustomization` and `helmrelease` controllers), consistent with how the loader drops them during discovery.

## Tests

- Unit test for the predicate.
- Controller test: a build directive in rendered output is dropped while a real Flux Kustomization in the same batch is still emitted.

Full suite passes; `golangci-lint` clean. Verified against a real cluster repo — the phantom failure is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
