### PR TITLE
fix(change): keep a changed HelmRelease's chart source in changed-only mode

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -564,7 +564,17 @@ func (f *Filter) resolve(objs ObjectLister) {
 	// (intrange linter must not auto-fix this — see //nolint above).
 	for head := 0; head < len(queue); head++ { //nolint:intrange // queue grows during iteration
 		_, headPrimary := primary[queue[head]]
-		for _, d := range transitiveDeps(objs, queue[head]) {
+		// transitiveDeps reads the consumer from the Store; that covers
+		// Kustomizations but NOT HelmReleases, which are render-driven and
+		// absent from the Store at resolve() time (see the reverse-edge note
+		// above). consumerRefs is the discovery-supplied view of those
+		// consumer→source edges (chartRef / chart.spec.sourceRef / valuesFrom),
+		// keyed identically to the keep seed. Union it so a changed HelmRelease
+		// still pulls its chart source into keep; without it a one-file HR edit
+		// would leave its OCIRepository/HelmRepository unfetched.
+		deps := transitiveDeps(objs, queue[head])
+		deps = append(deps, f.consumerRefs[queue[head]]...)
+		for _, d := range deps {
 			if headPrimary {
 				enqueuePrimary(d)
 			} else {

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -745,6 +745,56 @@ func TestFilter_ReverseEdgeNoCascadeFromChangedConsumer(t *testing.T) {
 	}
 }
 
+// TestFilter_ForwardEdgeChangedHRKeepsChartRefSource is the forward
+// counterpart to the reverse edge: when a HelmRelease's OWN file changes, its
+// chartRef/sourceRef source must enter keep so the source controller fetches
+// the chart. HelmReleases are render-driven (absent from the store at
+// resolve()), so transitiveDeps' store lookup returns nil; the keep walk
+// relies on the discovery-supplied consumerRefs for the forward edge too.
+// Regression: a one-file HR edit left its OCIRepository unfetched and render
+// failed "artifact not available" (surfaced after #566 removed the anonymous
+// helm-registry fallback that had masked it). Mirrors k8s-gitops media/plex.
+func TestFilter_ForwardEdgeChangedHRKeepsChartRefSource(t *testing.T) {
+	const (
+		hrFile  = "kubernetes/apps/media/plex/app/helmrelease.yaml"
+		sibFile = "kubernetes/apps/media/other/app/helmrelease.yaml"
+		ociFile = "kubernetes/flux/repositories/app-template.yaml"
+	)
+	// Render-driven HRs are seeded with an empty namespace (discovery records
+	// them pre-inheritance); the shared chartRef OCIRepository lives elsewhere.
+	hr := manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "plex"}
+	sibling := manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "other"}
+	oci := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "app-template"}
+
+	f := NewFilterWithCache(
+		NewSet([]string{hrFile}), // only plex's file changed
+		map[manifest.NamedResource]string{
+			hr:      hrFile,
+			sibling: sibFile,
+			oci:     ociFile,
+		},
+		"",
+		testutil.EmptyLister(), // HR + OCIRepository absent from the store at resolve()
+		nil,
+		map[manifest.NamedResource][]manifest.NamedResource{
+			hr:      {oci},
+			sibling: {oci}, // shares the same chart source
+		},
+	)
+
+	if !f.ShouldReconcile(hr) {
+		t.Fatalf("changed HelmRelease must be in keep; keep=%v", f.KeepNames())
+	}
+	if !f.ShouldReconcile(oci) {
+		t.Fatalf("forward edge: the changed HR's chartRef OCIRepository must be in keep so its chart is fetched; keep=%v", f.KeepNames())
+	}
+	// Keeping the shared source via plex's forward edge must NOT reverse-
+	// cascade to a sibling HR that merely shares it (its file is unchanged).
+	if f.ShouldReconcile(sibling) {
+		t.Errorf("sibling HR sharing the chart source must NOT be pulled in; keep=%v", f.KeepNames())
+	}
+}
+
 // TestFilter_SubstituteFromConfigMapKeepsProducerKustomization pins
 // issue #418: a kept Kustomization with a non-Optional
 // postBuild.substituteFrom ConfigMap must pull the producer KS that

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -162,7 +162,7 @@ func (d *discoverer) applyNamespaces(repoRoot string) {
 	// targetNamespace and the leaf KS renders into the right namespace on
 	// its first pass (issue #528).
 	loader.StampTransformerTargetNamespaces(d.cfg.Store, d.sourceFiles, repoRoot)
-	loader.ApplyNamespaceInheritance(d.cfg.Store, d.sourceFiles, repoRoot)
+	loader.ApplyNamespaceInheritanceWithRefs(d.cfg.Store, d.sourceFiles, d.sourceRefs, repoRoot)
 	loader.ApplyDefaultNamespaces(d.cfg.Store, d.sourceFiles)
 }
 

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -13,16 +13,30 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// ApplyNamespaceInheritance fills empty metadata.namespace fields on
-// loaded resources from the nearest enclosing namespace directive —
-// either a Flux Kustomization's spec.targetNamespace or a
-// kustomization.yaml `namespace:` field. This is the load-time analog
-// of kustomize-controller's apply-time behavior, without which the
-// store ends up with two copies of the same resource (one with the
-// inherited namespace, one with namespace=""). repoRoot anchors the
-// kustomization.yaml lookups; sourceFiles is mutated as ids are
-// rewritten.
+// ApplyNamespaceInheritance is ApplyNamespaceInheritanceWithRefs without a
+// consumer→source ref map (sourceRefs resolution skipped).
 func ApplyNamespaceInheritance(s *store.Store, sourceFiles map[manifest.NamedResource]string, repoRoot string) {
+	ApplyNamespaceInheritanceWithRefs(s, sourceFiles, nil, repoRoot)
+}
+
+// ApplyNamespaceInheritanceWithRefs fills empty metadata.namespace fields on
+// loaded resources from the nearest enclosing namespace directive — either a
+// Flux Kustomization's spec.targetNamespace or a kustomization.yaml
+// `namespace:` field. This is the load-time analog of kustomize-controller's
+// apply-time behavior, without which the store ends up with two copies of the
+// same resource (one with the inherited namespace, one with namespace="").
+// repoRoot anchors the kustomization.yaml lookups; sourceFiles is mutated as
+// ids are rewritten.
+//
+// sourceRefs (the discovery-supplied consumer→source ref map; nil to skip) is
+// resolved in step with each consumer's inherited namespace: recordSourceRefs
+// captures those edges at PARSE time, so a chartRef/sourceRef that omits its
+// namespace carries an empty-namespace target. Render-driven HelmReleases are
+// never in the Store, so the Store-object pass below can't fix them — resolving
+// the target to the consumer's inherited namespace here (Flux semantics: an
+// omitted ref namespace tracks the consumer's namespace) keeps changed-only
+// mode's keep-set walk from missing a changed HelmRelease's chart source.
+func ApplyNamespaceInheritanceWithRefs(s *store.Store, sourceFiles map[manifest.NamedResource]string, sourceRefs map[manifest.NamedResource][]manifest.NamedResource, repoRoot string) {
 	if len(sourceFiles) == 0 {
 		return
 	}
@@ -57,6 +71,18 @@ func ApplyNamespaceInheritance(s *store.Store, sourceFiles map[manifest.NamedRes
 		updates = append(updates, update{old: id, new: next, file: file})
 	}
 	for _, u := range updates {
+		// Resolve the consumer's referenced sources whose namespace was
+		// omitted — they implicitly track the consumer's inherited namespace.
+		// Done before the Store check so it also covers render-driven consumers
+		// (HelmReleases) that are absent from the Store. refs aliases the map's
+		// backing array, so the in-place edit is visible to sourceRefs; a nil
+		// sourceRefs map yields a nil slice and skips the loop.
+		refs := sourceRefs[u.old]
+		for i := range refs {
+			if refs[i].Namespace == "" {
+				refs[i].Namespace = u.new.Namespace
+			}
+		}
 		obj := s.GetObject(u.old)
 		if obj == nil {
 			continue
@@ -79,11 +105,23 @@ func ApplyNamespaceInheritance(s *store.Store, sourceFiles map[manifest.NamedRes
 // inheritance has had a chance to project kustomize/Flux namespaces.
 func ApplyDefaultNamespaces(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
 	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSet](s, manifest.KindResourceSet),
-		func(o *manifest.ResourceSet) *manifest.ResourceSet { c := *o; c.Namespace = manifest.DefaultNamespace; return &c })
+		func(o *manifest.ResourceSet) *manifest.ResourceSet {
+			c := *o
+			c.Namespace = manifest.DefaultNamespace
+			return &c
+		})
 	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider),
-		func(o *manifest.ResourceSetInputProvider) *manifest.ResourceSetInputProvider { c := *o; c.Namespace = manifest.DefaultNamespace; return &c })
+		func(o *manifest.ResourceSetInputProvider) *manifest.ResourceSetInputProvider {
+			c := *o
+			c.Namespace = manifest.DefaultNamespace
+			return &c
+		})
 	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.HelmChartSource](s, manifest.KindHelmChart),
-		func(o *manifest.HelmChartSource) *manifest.HelmChartSource { c := *o; c.Namespace = manifest.DefaultNamespace; return &c })
+		func(o *manifest.HelmChartSource) *manifest.HelmChartSource {
+			c := *o
+			c.Namespace = manifest.DefaultNamespace
+			return &c
+		})
 }
 
 // applyDefaultNS assigns manifest.DefaultNamespace to every object in objs

--- a/pkg/loader/inherit_test.go
+++ b/pkg/loader/inherit_test.go
@@ -210,6 +210,41 @@ func TestApplyNamespaceInheritance_HRChartRepoNamespaceTracksHR(t *testing.T) {
 	}
 }
 
+func TestApplyNamespaceInheritanceWithRefs_ResolvesOmittedChartRefNamespace(t *testing.T) {
+	// A render-driven HelmRelease (absent from the store, so the Store-object
+	// pass is skipped) whose chartRef OMITS its namespace: recordSourceRefs
+	// captured an empty-namespace target at parse time. After inheritance
+	// resolves the HR's namespace, the sourceRefs target must track it (Flux
+	// semantics: an omitted chartRef namespace follows the HR's). An
+	// explicit-namespace target must be left untouched.
+	root := t.TempDir()
+	writeFile(t, root, "apps/plex/kustomization.yaml", "namespace: media\n")
+	writeFile(t, root, "apps/grafana/kustomization.yaml", "namespace: monitoring\n")
+
+	s := store.New() // HRs intentionally NOT added — render-driven (hits the obj==nil path)
+	plex := manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "plex"}
+	grafana := manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "grafana"}
+	sourceFiles := map[manifest.NamedResource]string{
+		plex:    "apps/plex/helmrelease.yaml",
+		grafana: "apps/grafana/helmrelease.yaml",
+	}
+	omitted := manifest.NamedResource{Kind: manifest.KindOCIRepository, Name: "app-template"}                      // empty ns → tracks HR ns
+	explicit := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "shared"} // explicit → untouched
+	sourceRefs := map[manifest.NamedResource][]manifest.NamedResource{
+		plex:    {omitted},
+		grafana: {explicit},
+	}
+
+	ApplyNamespaceInheritanceWithRefs(s, sourceFiles, sourceRefs, root)
+
+	if got := sourceRefs[plex][0].Namespace; got != "media" {
+		t.Errorf("omitted chartRef namespace = %q, want media (tracks the HR's inherited ns)", got)
+	}
+	if got := sourceRefs[grafana][0].Namespace; got != "flux-system" {
+		t.Errorf("explicit chartRef namespace = %q, want flux-system (must be untouched)", got)
+	}
+}
+
 func TestApplyNamespaceInheritance_FluxOperatorAndHelmChartSource(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, "apps/platform/kustomization.yaml", "namespace: platform\n")


### PR DESCRIPTION
## Summary

In changed-only mode (`flate diff`, or any command with `--base`/`--path-orig`), a HelmRelease whose **own** file changed failed to pull its chart source into the keep-set, so the source controller never fetched it and render died with:

```
OCIRepository flux-system/app-template artifact not available for HelmRelease media/plex
```

…in both diff snapshots, even though only the HR's file changed. Full mode (`flate build hr …`) rendered fine — the failure was specific to changed-only.

## Root cause (two gaps)

1. **Forward edge.** The keep-set BFS (`change.resolve`) walks `transitiveDeps`, which reads the consumer from the **Store**. But HelmReleases are render-driven — they're materialized by their owning Kustomization at Run, not present in the Store at `resolve()` time — so `transitiveDeps(hr)` returns nil and the HR's `chartRef` / `chart.spec.sourceRef` was never followed. The discovery-supplied `consumerRefs` map *has* that edge but was consulted only by the **reverse** edge (source-changed → keep consumers), never the forward one (consumer-changed → keep its sources).
2. **Namespace.** `loader.recordSourceRefs` captures consumer→source edges at **parse** time, before namespace inheritance, so a `chartRef` that omits its namespace kept an empty-namespace target that wouldn't match the real source id. Inheritance only fixed Store objects, skipping render-driven HRs.

Net: the chart source was never kept → never fetched → depwait existence-promoted it → render hit the hard error. This was **surfaced by #566** removing `helm.Client`'s anonymous-registry-pull fallback, which had silently masked the gap by pulling the chart anyway. The hard error is correct; the keep-set gap is the bug.

## Fix

- **`pkg/change/filter.go`** — union `consumerRefs[head]` into the forward dep walk in `resolve()`, alongside `transitiveDeps`. Key-consistent (both keyed by the parse-time id), dedup'd by the existing `enqueue*` helpers, and the source is a leaf so the #58/#204 no-cascade guarantee holds. Also fixes a changed HR backed by a `chart.spec.sourceRef` HelmRepository.
- **`pkg/loader/inherit.go`** — add `ApplyNamespaceInheritanceWithRefs` (the existing `ApplyNamespaceInheritance` delegates with `nil`, mirroring `NewFilter`/`NewFilterWithCache`); resolve omitted ref-target namespaces to the consumer's inherited namespace, for render-driven HRs absent from the Store too. Keep-set/ref **keys are deliberately left empty-namespace** — that's an already-handled shape (`keepByName` fallback + the working reverse edge).
- **`pkg/discovery/discovery.go`** — `applyNamespaces` passes `d.sourceRefs`.

## Tests
- `pkg/change/filter_test.go`: `TestFilter_ForwardEdgeChangedHRKeepsChartRefSource` — a changed (render-driven, store-absent) HR keeps its `chartRef` OCIRepository, and a sibling sharing that source is **not** reverse-cascaded in.
- `pkg/loader/inherit_test.go`: `TestApplyNamespaceInheritanceWithRefs_ResolvesOmittedChartRefNamespace` — an omitted-namespace chartRef resolves to the HR's inherited namespace; an explicit one is untouched.

## Verification
Full suite passes; `golangci-lint` clean. End-to-end:
- `k8s-gitops` (the repro): `flate diff all` on a plex-only edit now exits 0 and renders the chart delta; the changed-only keep-set includes `OCIRepository/flux-system/app-template` (size 4→5).
- `boemeltrein/TalosCluster`: full `test all` = 154 passed/0 failed; changed-only behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)