### PR TITLE
fix(helm): default rendered objects to the HelmRelease release namespace

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -426,6 +426,12 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	docs = manifest.FlattenLists(docs)
 	helm.ApplyHRCommonMetadata(docs, hr.CommonMetadata)
 	helm.ApplyHROriginLabels(docs, hr)
+	// Default namespace-less rendered objects to the release namespace, like
+	// helm-controller does on apply — otherwise a chart that omits
+	// metadata.namespace renders objects with no namespace, and any version
+	// that toggles the explicit field shows up as a spurious delete+add in
+	// diff. Cluster-scoped kinds and explicit namespaces are left untouched.
+	manifest.StampNamespaces(docs, hr.ReleaseNamespace())
 	docs = manifest.DropKinds(docs, c.Options.SkipResourceKinds())
 
 	c.Store.UpdateStatus(id, store.StatusPending, fmt.Sprintf("applying %d objects", len(docs)))

--- a/pkg/manifest/namespace.go
+++ b/pkg/manifest/namespace.go
@@ -1,0 +1,64 @@
+package manifest
+
+// clusterScopedKinds is the set of well-known cluster-scoped Kubernetes and
+// common-ecosystem kinds. Namespace defaulting (StampNamespace) skips these so
+// a Namespace / ClusterRole / CRD never gets a spurious metadata.namespace —
+// matching kustomize-controller and helm-controller apply behavior. Kind-only
+// keying mirrors DropKinds; an offline renderer has no RESTMapper, so this is a
+// curated heuristic and unknown kinds default to namespaced.
+var clusterScopedKinds = map[string]struct{}{
+	"Namespace":                      {},
+	"Node":                           {},
+	"PersistentVolume":               {},
+	"StorageClass":                   {},
+	"PriorityClass":                  {},
+	"IngressClass":                   {},
+	"ClusterRole":                    {},
+	"ClusterRoleBinding":             {},
+	"CustomResourceDefinition":       {},
+	"MutatingWebhookConfiguration":   {},
+	"ValidatingWebhookConfiguration": {},
+	"APIService":                     {},
+	"ClusterIssuer":                  {}, // cert-manager.io
+	"ClusterSecretStore":             {}, // external-secrets.io
+	"ClusterPolicy":                  {}, // kyverno.io
+}
+
+// IsClusterScoped reports whether doc's kind is a well-known cluster-scoped
+// kind that must not carry a metadata.namespace.
+func IsClusterScoped(doc map[string]any) bool {
+	_, ok := clusterScopedKinds[DocKind(doc)]
+	return ok
+}
+
+// StampNamespace defaults doc's metadata.namespace to ns when it's a namespaced
+// kind that omits one — mirroring how kustomize-controller / helm-controller
+// namespace resources on apply, so an offline render matches the in-cluster
+// state. No-op when ns is empty, the doc already names a namespace, or the kind
+// is cluster-scoped. An explicit namespace (even a differing one) is preserved,
+// so this can never manufacture a diff.
+func StampNamespace(doc map[string]any, ns string) {
+	if ns == "" {
+		return
+	}
+	// Read metadata.namespace without creating the map — a nil-map lookup
+	// returns "" safely, so EnsureMetadata only runs when actually stamping.
+	md, _ := doc["metadata"].(map[string]any)
+	if cur, _ := md["namespace"].(string); cur != "" {
+		return
+	}
+	if IsClusterScoped(doc) {
+		return
+	}
+	EnsureMetadata(doc)["namespace"] = ns
+}
+
+// StampNamespaces applies StampNamespace to every doc in docs.
+func StampNamespaces(docs []map[string]any, ns string) {
+	if ns == "" {
+		return
+	}
+	for _, doc := range docs {
+		StampNamespace(doc, ns)
+	}
+}

--- a/pkg/manifest/namespace_test.go
+++ b/pkg/manifest/namespace_test.go
@@ -1,0 +1,93 @@
+package manifest
+
+import "testing"
+
+func TestStampNamespace(t *testing.T) {
+	const ns = "storage"
+	cases := []struct {
+		name string
+		doc  map[string]any
+		want string // expected metadata.namespace after stamping ("" = absent)
+	}{
+		{
+			name: "namespaced kind omitting namespace gets stamped",
+			doc:  map[string]any{"kind": "ServiceAccount", "metadata": map[string]any{"name": "x"}},
+			want: ns,
+		},
+		{
+			name: "namespaced kind with no metadata block gets stamped",
+			doc:  map[string]any{"kind": "Deployment"},
+			want: ns,
+		},
+		{
+			name: "explicit namespace preserved (even when it differs)",
+			doc:  map[string]any{"kind": "ConfigMap", "metadata": map[string]any{"namespace": "kube-system"}},
+			want: "kube-system",
+		},
+		{
+			name: "cluster-scoped ClusterRole never stamped",
+			doc:  map[string]any{"kind": "ClusterRole", "metadata": map[string]any{"name": "x"}},
+			want: "",
+		},
+		{
+			name: "cluster-scoped CRD never stamped",
+			doc:  map[string]any{"kind": "CustomResourceDefinition"},
+			want: "",
+		},
+		{
+			name: "cluster-scoped Namespace never stamped",
+			doc:  map[string]any{"kind": "Namespace", "metadata": map[string]any{"name": "x"}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			StampNamespace(tc.doc, ns)
+			if _, got := DocMetadata(tc.doc); got != tc.want {
+				t.Errorf("namespace = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStampNamespace_EmptyNamespaceIsNoop(t *testing.T) {
+	doc := map[string]any{"kind": "ServiceAccount", "metadata": map[string]any{"name": "x"}}
+	StampNamespace(doc, "")
+	if _, ns := DocMetadata(doc); ns != "" {
+		t.Errorf("empty release namespace must be a no-op; got %q", ns)
+	}
+}
+
+func TestStampNamespaces_MixedSlice(t *testing.T) {
+	docs := []map[string]any{
+		{"kind": "ServiceAccount", "metadata": map[string]any{"name": "sa"}},
+		{"kind": "ClusterRole", "metadata": map[string]any{"name": "cr"}},
+		{"kind": "Deployment", "metadata": map[string]any{"name": "d", "namespace": "explicit"}},
+	}
+	StampNamespaces(docs, "storage")
+	if _, ns := DocMetadata(docs[0]); ns != "storage" {
+		t.Errorf("namespaced SA should be stamped storage; got %q", ns)
+	}
+	if _, ns := DocMetadata(docs[1]); ns != "" {
+		t.Errorf("cluster-scoped ClusterRole must stay namespace-less; got %q", ns)
+	}
+	if _, ns := DocMetadata(docs[2]); ns != "explicit" {
+		t.Errorf("explicit namespace must be preserved; got %q", ns)
+	}
+}
+
+func TestIsClusterScoped(t *testing.T) {
+	for kind, want := range map[string]bool{
+		"ClusterRole":              true,
+		"CustomResourceDefinition": true,
+		"ClusterSecretStore":       true, // ecosystem addition
+		"ClusterPolicy":            true, // ecosystem addition
+		"Deployment":               false,
+		"ServiceAccount":           false,
+		"ConfigMap":                false,
+	} {
+		if got := IsClusterScoped(map[string]any{"kind": kind}); got != want {
+			t.Errorf("IsClusterScoped(%s) = %v, want %v", kind, got, want)
+		}
+	}
+}

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -24,49 +24,6 @@ func DedupKey(doc map[string]any) string {
 	return manifest.DocAPIVersion(doc) + "|" + kind + "|" + ns + "|" + name
 }
 
-func defaultNamespace(doc map[string]any, ns string) {
-	if ns == "" {
-		return
-	}
-	// Read existing metadata.namespace without creating one — if the
-	// doc already names a namespace, we're done. A nil-map lookup
-	// returns the zero value, so this is safe pre-ensure.
-	md, _ := doc["metadata"].(map[string]any)
-	if cur, _ := md["namespace"].(string); cur != "" {
-		return
-	}
-	// Don't inject a namespace on cluster-scoped kinds — match the
-	// upstream operator behavior of leaving Namespace, ClusterRole etc.
-	// without a metadata.namespace.
-	if isClusterScoped(doc) {
-		return
-	}
-	manifest.EnsureMetadata(doc)["namespace"] = ns
-}
-
-// clusterScopedKinds is the set of well-known cluster-scoped Kubernetes
-// kinds. Using a map gives O(1) lookup vs the O(n) switch it replaces.
-var clusterScopedKinds = map[string]struct{}{
-	"Namespace":                       {},
-	"ClusterRole":                     {},
-	"ClusterRoleBinding":              {},
-	"CustomResourceDefinition":        {},
-	"PersistentVolume":                {},
-	"StorageClass":                    {},
-	"PriorityClass":                   {},
-	"IngressClass":                    {},
-	"ClusterIssuer":                   {},
-	"MutatingWebhookConfiguration":   {},
-	"ValidatingWebhookConfiguration": {},
-	"APIService":                      {},
-	"Node":                            {},
-}
-
-func isClusterScoped(doc map[string]any) bool {
-	_, ok := clusterScopedKinds[manifest.DocKind(doc)]
-	return ok
-}
-
 func applyCommonMetadata(doc map[string]any, cm *fluxopv1.CommonMetadata) {
 	if cm == nil || (len(cm.Labels) == 0 && len(cm.Annotations) == 0) {
 		return

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -111,7 +111,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	}
 
 	for _, doc := range docs {
-		defaultNamespace(doc, rs.Namespace)
+		manifest.StampNamespace(doc, rs.Namespace)
 		applyOwnerLabels(doc, rs)
 		applyCommonMetadata(doc, rs.CommonMetadata)
 	}


### PR DESCRIPTION
## Summary

`flate diff` showed a chart's namespaced objects as a **full delete + full add** whenever a chart toggled an explicit `metadata.namespace` between versions — e.g. on `ishioni/homelab-ops` PR #5142 (openebs OCIRepository `4.4.0 → 4.5.0`):

```
- v1/ServiceAccount/openebs-localpv-provisioner          (no namespace)
+ v1/ServiceAccount/storage/openebs-localpv-provisioner  (namespace=storage)
```

**Root cause:** the openebs chart omits `metadata.namespace` on its SA/Deployment in 4.4.0 and sets it in 4.5.0. flate renders each faithfully — like `helm template`, which does **not** inject the release namespace onto objects that leave it blank. The diff keys objects by `(apiVersion, kind, namespace, name)` (`pkg/diff/pair.go`), so the empty-ns baseline and the `storage` current object are distinct → spurious delete+add around the one real change. In a real cluster, helm-controller / `kubectl apply` namespaces resources lacking an explicit namespace into the release namespace, so both versions actually live in `storage`.

## Fix

After an HR renders, stamp the HR's release namespace (`cmp.Or(targetNamespace, namespace)`) onto **namespaced** rendered objects that omit `metadata.namespace`, right after the origin-label pass in the HR controller. Cluster-scoped kinds and explicit namespaces (even differing ones) are untouched, so it can never manufacture a diff. Always-on (matches in-cluster reality and the existing ResourceSet behavior).

The cluster-scoped logic already existed for ResourceSet output (`clusterScopedKinds` + `isClusterScoped` + `defaultNamespace`); this **lifts it into `pkg/manifest`** as shared `IsClusterScoped` / `StampNamespace` / `StampNamespaces`, repoints `pkg/resourceset` to it (behavior-preserving), and adds `ClusterSecretStore` (external-secrets) + `ClusterPolicy` (kyverno) to the set. The Kustomization path needs nothing — kustomize already stamps `targetNamespace` at build.

## Tests
- `pkg/manifest/namespace_test.go`: omitted→stamped, explicit→preserved (incl. a differing ns), cluster-scoped (ClusterRole/CRD/Namespace)→skipped, empty release-ns→no-op, `IsClusterScoped` incl. the ecosystem additions.
- `pkg/resourceset` tests stay green (refactor is behavior-preserving).

## Verification
Full suite passes; `golangci-lint` clean. End-to-end on the openebs repro: `flate diff hr --base master` collapses **88 → 37 lines** — the SA/Deployment delete+add is gone (SA is otherwise unchanged; the Deployment is now an in-place `storage`-namespaced env/image diff), leaving only the genuine ClusterRole `configmaps`-rule change. `flate build hr openebs` now shows the SA/Deployment with `namespace: storage` and the ClusterRole correctly without one. No regressions on `boemeltrein/TalosCluster` (154/0) or `k8s-gitops`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)