### PR TITLE
fix(loader): follow ..-escaping directory resources includes

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -163,14 +163,16 @@ func stripFileEntryKey(s string) string {
 	return s
 }
 
-// resolveDataPath joins rel against base and cleans the result. An
-// empty rel is rejected (kustomize would reject it too). Absolute
-// paths pass through verbatim — kustomize doesn't forbid them and
-// some generated manifests use them. Relative paths that escape
-// base via `..` are rejected: the resolved key is only consulted
-// against tree-walk paths today (no escape can match a walked path
-// rooted at --path), but a future caller that opens the path would
-// otherwise hit a TOCTOU + path-traversal surface for free.
+// resolveDataPath joins rel against base and cleans the result, for
+// references that get *opened and read*: configMapGenerator /
+// secretGenerator data files and file `resources:`. An empty rel is
+// rejected (kustomize would reject it too). Absolute paths pass
+// through verbatim — kustomize doesn't forbid them and some generated
+// manifests use them. Relative paths that escape base via `..` are
+// rejected: a path that gets opened would otherwise hand a TOCTOU +
+// path-traversal surface for free. Directory `resources:` and
+// `components:` are merely descended into, never opened, so they use
+// the escape-permitting resolveResourcePath / resolveComponentPath.
 func resolveDataPath(base, rel string) (string, bool) {
 	if rel == "" {
 		return "", false
@@ -200,3 +202,20 @@ func resolveComponentPath(base, rel string) (string, bool) {
 	return filepath.Clean(filepath.Join(base, rel)), true
 }
 
+// resolveResourcePath is the directory counterpart for `resources:`.
+// A directory listed under `resources:` legitimately escapes the
+// calling kustomization's dir (overlays reference `../base`; Flux
+// repos reference `../../../deploy/...`), and kustomize follows it —
+// so the in-base constraint resolveDataPath enforces for opened data
+// *files* is wrong for a dir we only descend into. Escape is safe
+// here because descend() merely recurses under the visited-set + ctx
+// guard and never opens the path. URLs and absolute paths are still
+// rejected; flate's loader only follows local relative dirs. File
+// resources keep resolveDataPath's stricter policy (re-checked by the
+// caller after stat), so this is the dir-descent path only.
+func resolveResourcePath(base, rel string) (string, bool) {
+	if rel == "" || filepath.IsAbs(rel) || strings.Contains(rel, "://") {
+		return "", false
+	}
+	return filepath.Clean(filepath.Join(base, rel)), true
+}

--- a/pkg/loader/kustomization_test.go
+++ b/pkg/loader/kustomization_test.go
@@ -37,3 +37,35 @@ func TestResolveDataPath(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveResourcePath covers directory `resources:` path
+// resolution. Unlike resolveDataPath, a parent-escaping relative dir
+// RESOLVES — overlays reference ../base and the dir is only descended
+// into, never opened. Absolute paths and URLs are still rejected.
+func TestResolveResourcePath(t *testing.T) {
+	cases := []struct {
+		name    string
+		base    string
+		rel     string
+		wantAbs string
+		wantOK  bool
+	}{
+		{"relative under base", "/tmp/cluster/apps/foo", "sub/dir", "/tmp/cluster/apps/foo/sub/dir", true},
+		{"traversal parent resolves", "/tmp/cluster/apps/foo", "../bar", "/tmp/cluster/apps/bar", true},
+		{"traversal deep resolves", "/tmp/cluster/apps/foo", "../../../deploy/x", "/tmp/deploy/x", true},
+		{"absolute rejected", "/tmp/cluster/apps", "/etc/x", "", false},
+		{"url rejected", "/tmp/cluster/apps", "https://example.com/x", "", false},
+		{"empty rejected", "/tmp/cluster/apps", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			abs, ok := resolveResourcePath(tc.base, tc.rel)
+			if ok != tc.wantOK {
+				t.Fatalf("resolveResourcePath(%q, %q) ok = %v, want %v", tc.base, tc.rel, ok, tc.wantOK)
+			}
+			if ok && abs != tc.wantAbs {
+				t.Errorf("resolveResourcePath(%q, %q) = %q, want %q", tc.base, tc.rel, abs, tc.wantAbs)
+			}
+		})
+	}
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -306,11 +306,16 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 		if cerr := ctx.Err(); cerr != nil {
 			return count, cerr
 		}
-		abs, ok := resolveDataPath(dir, r)
+		// Resolve with the escape-permitting resolver so directory
+		// includes that point outside the package (overlays' ../base,
+		// Flux repos' ../../../deploy/...) are followed — kustomize
+		// follows them too. The file branch below re-imposes
+		// resolveDataPath's stricter opened-path policy.
+		abs, ok := resolveResourcePath(dir, r)
 		if !ok {
-			// URL resources, paths escaping the package, malformed
-			// entries — kustomize handles these at render time;
-			// the loader's job is to ignore them at discovery time.
+			// URLs, absolute paths, malformed entries — kustomize
+			// handles these at render time; the loader's job is to
+			// ignore them at discovery time.
 			continue
 		}
 		info, err := os.Stat(abs)
@@ -326,6 +331,11 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 				return count, err
 			}
 			count += n
+			continue
+		}
+		// File resource: re-impose the in-base constraint, since a
+		// file gets opened (resolveResourcePath only guards descent).
+		if _, ok := resolveDataPath(dir, r); !ok {
 			continue
 		}
 		if !isManifestFile(abs) {

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -48,6 +48,70 @@ data:
 	}
 }
 
+// TestLoader_FollowsEscapingDirResource pins the Biohazard healthcheck
+// fix: a directory listed under `resources:` via a parent-escaping
+// path is descended into, so a Flux Kustomization defined there reaches
+// the store even though nothing points spec.path at it and a tree walk
+// would never reach it (it's only a kustomize resources: include).
+func TestLoader_FollowsEscapingDirResource(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, "entry/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../gate/
+`)
+	testutil.WriteFile(t, root, "gate/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ks.yaml
+`)
+	testutil.WriteFile(t, root, "gate/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: crds
+  namespace: flux-system
+spec:
+  path: ./blank
+`)
+
+	s := store.New()
+	if _, err := New(s).Load(t.Context(), filepath.Join(root, "entry")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "crds"}) == nil {
+		t.Fatal("escaping dir resource not followed: Kustomization flux-system/crds missing from store")
+	}
+}
+
+// TestLoader_EscapingFileResourceStillRejected guards the asymmetry at
+// the heart of the fix: directory resources may escape (descend-only),
+// but a parent-escaping FILE resource gets opened, so resolveDataPath's
+// TOCTOU/path-traversal rejection must still apply.
+func TestLoader_EscapingFileResourceStillRejected(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, "entry/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../escape.yaml
+`)
+	testutil.WriteFile(t, root, "escape.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: escaped
+  namespace: flux-system
+spec:
+  path: ./x
+`)
+
+	s := store.New()
+	if _, err := New(s).Load(t.Context(), filepath.Join(root, "entry")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "escaped"}) != nil {
+		t.Fatal("escaping FILE resource was loaded; the opened-path escape guard regressed")
+	}
+}
+
 func TestLoader_SkipsTemplatesDir(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "chart", "templates"), 0o750); err != nil {


### PR DESCRIPTION
## Problem

A Flux `Kustomization` reachable only as a **parent-escaping kustomize `resources:` directory include** was never registered in flate's store. Concretely, a cluster `kustomization.yaml` that lists `- ../../../deploy/core/flux-system/healthcheck/` (where `healthcheck/ks.yaml` defines gate Kustomizations like `crds`/`storage-ready`) fell through *every* discovery mechanism:

1. **Kustomize-graph walk** skipped it — `walkKustomize` resolved every `resources:` entry through `resolveDataPath`, which rejects `..`-escaping paths.
2. **Ad-hoc filesystem walk** couldn't reach it — its parent package (`flux-system/`) `SkipDir`s the whole subtree, and that package's own `kustomization.yaml` doesn't list the sibling `healthcheck/`.
3. It's **not any Kustomization's `spec.path`**, so iterative spec.path discovery never loaded it.

Every Kustomization that `dependsOn` the gate defined there then failed with `dependency not found`.

## Fix

Add `resolveResourcePath` — the escape-permitting **directory** counterpart to `resolveDataPath`, mirroring the existing `resolveComponentPath` (kustomize follows `../base` overlays and `../../../deploy/...` includes too). `walkKustomize` now resolves with it and follows escaping **directory** includes, while **file** resources re-check `resolveDataPath` so the opened-path TOCTOU/path-traversal rejection is preserved byte-for-byte. Data-file/generator handling is untouched.

The one intentional behavior delta: an *absolute* path in `resources:` is now rejected (was accepted) — an effectively-nonexistent case for `resources:`, and consistent with the `components:` precedent.

## Impact

flate now traverses the full cluster resource graph faithfully instead of relying on the ad-hoc filesystem walk to backfill it. On a real cluster repo this took discovered Kustomizations from **76 → the graph-faithful ~194** (entering at the cluster entrypoint went from 2 → 194), surfacing pre-existing real issues that were previously invisible (dangling/archived refs, templated-`dependsOn` gaps handled in follow-up PRs).

## Tests

- `TestResolveResourcePath` — escape resolves; absolute/URL/empty rejected.
- `TestLoader_FollowsEscapingDirResource` — a KS defined behind an escaping dir include reaches the store.
- `TestLoader_EscapingFileResourceStillRejected` — pins the asymmetry: escaping *file* resources stay rejected.

`go build`/`vet`/`test ./...` green; `golangci-lint run ./pkg/... ./internal/...` → 0 issues. Regression-checked against two other cluster repos (counts unchanged, 0 failures).