### PR TITLE
fix(helm): resolve envsubst defaults in HelmRelease valuesFrom keys

### DIFF
--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -298,6 +298,17 @@ func parseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 	if cr.Name == "" {
 		return nil, inputf("HelmRelease missing metadata.name")
 	}
+	// Resolve ${VAR:=default} / ${VAR:-default} on valuesFrom refs,
+	// mirroring the Kustomization spec.path / dependsOn precedent
+	// (kustomization.go). A configMapGenerator emits a literal key
+	// (e.g. biohazard.yaml); a valuesKey "${CLUSTER_NAME:=biohazard}.yaml"
+	// must collapse to it so the lookup matches. Resolved here once so
+	// both the value lookup and its cache key see the same string. Bare
+	// ${VAR} (no default) is left for postBuild substitution.
+	for i := range cr.Spec.ValuesFrom {
+		cr.Spec.ValuesFrom[i].ValuesKey = ResolveEnvsubstDefaults(cr.Spec.ValuesFrom[i].ValuesKey)
+		cr.Spec.ValuesFrom[i].Name = ResolveEnvsubstDefaults(cr.Spec.ValuesFrom[i].Name)
+	}
 	// metadata.namespace is optional — Flux Kustomizations commonly
 	// inject it via spec.targetNamespace. Treat the empty string as
 	// "inherit later".

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -158,6 +158,41 @@ spec:
 `)
 }
 
+func TestParseHelmRelease_ValuesFromEnvsubstDefault(t *testing.T) {
+	cases := []struct {
+		name      string
+		valuesKey string
+		refName   string
+		wantKey   string
+		wantName  string
+	}{
+		{"default := resolves", "${CLUSTER_NAME:=biohazard}.yaml", "cm", "biohazard.yaml", "cm"},
+		{"default :- resolves", "${X:-foo}.yaml", "cm", "foo.yaml", "cm"},
+		{"literal key untouched", "biohazard.yaml", "cm", "biohazard.yaml", "cm"},
+		{"bare var left for postBuild", "${CLUSTER_NAME}.yaml", "cm", "${CLUSTER_NAME}.yaml", "cm"},
+		{"templated name default resolves", "values.yaml", "${ENV:=prod}-cm", "values.yaml", "prod-cm"},
+		{"bare var name untouched", "values.yaml", "${ENV}-cm", "values.yaml", "${ENV}-cm"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := "  valuesFrom:\n    - kind: ConfigMap\n      name: \"" + tc.refName + "\"\n      valuesKey: \"" + tc.valuesKey + "\"\n"
+			hr, err := parseHelmRelease(helmReleaseDoc(t, spec))
+			if err != nil {
+				t.Fatalf("parseHelmRelease: %v", err)
+			}
+			if len(hr.ValuesFrom) != 1 {
+				t.Fatalf("expected 1 valuesFrom, got %d", len(hr.ValuesFrom))
+			}
+			if got := hr.ValuesFrom[0].ValuesKey; got != tc.wantKey {
+				t.Errorf("valuesKey = %q, want %q", got, tc.wantKey)
+			}
+			if got := hr.ValuesFrom[0].Name; got != tc.wantName {
+				t.Errorf("name = %q, want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
 func TestParseHelmRelease_CRDsPolicy(t *testing.T) {
 	cases := []struct {
 		name     string


### PR DESCRIPTION
## Problem

A HelmRelease `valuesFrom` `valuesKey` (or `name`) carrying an envsubst expression with a default — e.g. `valuesKey: "${CLUSTER_NAME:=biohazard}.yaml"` against a configMapGenerator that emits a literal `biohazard.yaml` key — reached the ConfigMap/Secret lookup **literally** and missed, failing the HelmRelease build with `key "${CLUSTER_NAME:=biohazard}.yaml" not found`.

flate already resolves `${VAR:=default}` / `${VAR:-default}` on Kustomization `spec.path` / `sourceRef` / `dependsOn` at parse time (`kustomization.go`) — but not on HelmRelease `valuesFrom`.

## Fix

In `parseHelmRelease`, apply the existing `ResolveEnvsubstDefaults` to each `valuesFrom` `ValuesKey` and `Name`. Resolving once at parse time means both the value lookup and its cache key see the same collapsed string. Scope is **defaults only** — a bare `${VAR}` (no default) is left untouched for postBuild substitution; literal keys are unchanged.

## Tests

`TestParseHelmRelease_ValuesFromEnvsubstDefault`: `${X:=v}.yaml`→`v.yaml`, `${X:-v}`→`v`, literal key unchanged, bare `${VAR}` unchanged, templated `name` default resolves, bare-`${VAR}` name unchanged.

`go build`/`vet`/`test ./...` green; `golangci-lint run ./pkg/... ./internal/...` → 0 issues. End-to-end: `flate build hr cilium -n kube-system` now renders (was `valuesKey not found`), and `cilium` is `PASSED` in `flate test all`.