### PR TITLE
fix(loader): resolve postBuild substitute vars in Kustomization dependsOn

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -121,6 +121,13 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	}
 	d.aliasBootstrapSources(repoRoot)
 	d.applyNamespaces(repoRoot)
+	// Resolve bare ${VAR} in Kustomization dependsOn against the
+	// cluster's postBuild substitute values, now that the full KS set is
+	// discovered (so the substitute union is complete and its conflict
+	// check is sound). Without this a child KS's
+	// `dependsOn: 0-${CLUSTER_NAME}-config` never matches the real
+	// 0-biohazard-config the parent's render would have substituted.
+	loader.ResolveDependsOnSubstitutions(d.cfg.Store)
 	// Materialize configMapGenerator / secretGenerator entries the
 	// file walker collected. The effective namespace comes from the
 	// enclosing Flux Kustomization, which is only known now that

--- a/pkg/loader/depsubst.go
+++ b/pkg/loader/depsubst.go
@@ -1,0 +1,120 @@
+package loader
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/fluxcd/pkg/envsubst"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/values"
+)
+
+// ResolveDependsOnSubstitutions resolves bare ${VAR} references in
+// Kustomization spec.dependsOn names/namespaces using the cluster's
+// postBuild substitute values, mirroring how kustomize-controller
+// substitutes a child KS's text (via its parent's postBuild) before the
+// dependency is ever matched. flate builds its dependency graph from the
+// raw file-parsed KS — where `dependsOn: 0-${CLUSTER_NAME}-config` (no
+// default) survives ResolveEnvsubstDefaults and never matches the real
+// `0-biohazard-config` — so without this pass the dependency is reported
+// "not found".
+//
+// ${VAR:=default} forms are already collapsed at parse time
+// (ResolveEnvsubstDefaults), so this pass only ever resolves *bare* vars,
+// drawing values from the union of every discovered KS's
+// spec.postBuild.substitute map. Two guards keep it from manufacturing a
+// false dependency match:
+//   - a var declared with conflicting values across Kustomizations (e.g.
+//     per-cluster CLUSTER_NAME in a multi-cluster repo) is dropped from
+//     the union and left literal;
+//   - a var with no value leaves envsubst.Eval in its error path, so the
+//     original name is kept verbatim rather than collapsed to empty.
+//
+// Run once, after the full KS set is discovered (so the union is complete
+// and the conflict check is sound) and before the dependency graph is
+// built. Idempotent: a KS's own name carries no var (templated names are
+// skipped at load), so its store id is invariant, and a resolved name
+// contains no ${ left to re-resolve.
+func ResolveDependsOnSubstitutions(s *store.Store) {
+	union := substituteUnion(s)
+	if len(union) == 0 {
+		return
+	}
+	mapping := func(name string) (string, bool) {
+		v, ok := union[name]
+		return v, ok
+	}
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		resolved := resolveDeps(ks.DependsOn, mapping)
+		if resolved == nil {
+			continue
+		}
+		// Store immutability contract: clone, mutate the copy, replace.
+		// The id is unchanged (own name has no var), so this is a
+		// same-key replace.
+		clone := ks.Clone()
+		clone.DependsOn = resolved
+		s.DeleteObject(ks.Named())
+		s.AddObject(clone)
+	}
+}
+
+// substituteUnion merges every Kustomization's postBuild.substitute map
+// into one var→value lookup, dropping any key whose value conflicts
+// across Kustomizations (left unresolved rather than guessed).
+func substituteUnion(s *store.Store) map[string]string {
+	union := map[string]string{}
+	conflicting := map[string]struct{}{}
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		for k, v := range values.VarsMap(ks.PostBuildSubstitute) {
+			if _, bad := conflicting[k]; bad {
+				continue
+			}
+			if prev, seen := union[k]; seen && prev != v {
+				delete(union, k)
+				conflicting[k] = struct{}{}
+				continue
+			}
+			union[k] = v
+		}
+	}
+	return union
+}
+
+// resolveDeps resolves ${VAR} in each dependsOn name/namespace via
+// mapping. Returns a fresh slice when anything changed, or nil when no
+// reference needed resolution — so the caller only clones a KS it must.
+// The input slice is never mutated.
+func resolveDeps(deps []manifest.DependencyRef, mapping func(string) (string, bool)) []manifest.DependencyRef {
+	var out []manifest.DependencyRef
+	for i, dep := range deps {
+		name := evalKeep(dep.Name, mapping)
+		ns := evalKeep(dep.Namespace, mapping)
+		if name == dep.Name && ns == dep.Namespace {
+			continue
+		}
+		if out == nil {
+			out = slices.Clone(deps)
+		}
+		out[i].Name = name
+		out[i].Namespace = ns
+	}
+	return out
+}
+
+// evalKeep resolves ${VAR} in s via mapping, returning s unchanged when
+// it has no template or when any referenced variable is unset
+// (envsubst.Eval errors on a bare unset var) — so an unresolvable name is
+// never collapsed to a partial or empty string.
+func evalKeep(s string, mapping func(string) (string, bool)) string {
+	if !strings.Contains(s, "${") {
+		return s
+	}
+	out, err := envsubst.Eval(s, mapping)
+	if err != nil {
+		return s
+	}
+	return out
+}

--- a/pkg/loader/depsubst_test.go
+++ b/pkg/loader/depsubst_test.go
@@ -1,0 +1,103 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func ksWithDeps(name, ns string, sub map[string]any, depNames ...string) *manifest.Kustomization {
+	deps := make([]manifest.DependencyRef, len(depNames))
+	for i, dn := range depNames {
+		deps[i] = manifest.DependencyRef{
+			NamedResource: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: ns, Name: dn},
+		}
+	}
+	return &manifest.Kustomization{
+		Name: name, Namespace: ns,
+		PostBuildSubstitute: sub,
+		DependsOn:           deps,
+	}
+}
+
+func firstDepName(t *testing.T, s *store.Store, ns, name string) string {
+	t.Helper()
+	ks, ok := store.GetByName[*manifest.Kustomization](s, manifest.KindKustomization, ns, name)
+	if !ok {
+		t.Fatalf("Kustomization %s/%s missing from store", ns, name)
+	}
+	if len(ks.DependsOn) == 0 {
+		t.Fatalf("Kustomization %s/%s has no dependsOn", ns, name)
+	}
+	return ks.DependsOn[0].Name
+}
+
+// A bare ${VAR} in a child KS's dependsOn (no default) resolves to the
+// real KS name once a discovered KS supplies the value — the rook-ceph
+// `0-${CLUSTER_NAME}-config` case.
+func TestResolveDependsOnSubstitutions_ResolvesBareVar(t *testing.T) {
+	s := store.New()
+	s.AddObject(ksWithDeps("0-biohazard-config", "flux-system", map[string]any{"CLUSTER_NAME": "biohazard"}))
+	s.AddObject(ksWithDeps("rook-ceph-app", "flux-system", nil, "0-${CLUSTER_NAME}-config"))
+
+	ResolveDependsOnSubstitutions(s)
+
+	if got := firstDepName(t, s, "flux-system", "rook-ceph-app"); got != "0-biohazard-config" {
+		t.Errorf("dependsOn name = %q, want 0-biohazard-config", got)
+	}
+	// Idempotent: a second pass is a no-op (resolved name has no ${).
+	ResolveDependsOnSubstitutions(s)
+	if got := firstDepName(t, s, "flux-system", "rook-ceph-app"); got != "0-biohazard-config" {
+		t.Errorf("second pass changed result: %q", got)
+	}
+}
+
+// A var no KS supplies leaves envsubst.Eval in its error path, so the
+// reference is kept verbatim rather than collapsed to empty.
+func TestResolveDependsOnSubstitutions_UnsetVarStaysLiteral(t *testing.T) {
+	s := store.New()
+	s.AddObject(ksWithDeps("app", "flux-system", nil, "0-${UNKNOWN}-config"))
+
+	ResolveDependsOnSubstitutions(s)
+
+	if got := firstDepName(t, s, "flux-system", "app"); got != "0-${UNKNOWN}-config" {
+		t.Errorf("unset var must stay literal; got %q", got)
+	}
+}
+
+// A var declared with conflicting values across Kustomizations (a
+// multi-cluster repo's per-cluster CLUSTER_NAME) is dropped from the
+// union and left literal — never resolved to one cluster's value.
+func TestResolveDependsOnSubstitutions_ConflictingVarDropped(t *testing.T) {
+	s := store.New()
+	s.AddObject(ksWithDeps("cfg-a", "prod", map[string]any{"CLUSTER_NAME": "prod"}))
+	s.AddObject(ksWithDeps("cfg-b", "staging", map[string]any{"CLUSTER_NAME": "staging"}))
+	s.AddObject(ksWithDeps("app", "flux-system", nil, "0-${CLUSTER_NAME}-config"))
+
+	ResolveDependsOnSubstitutions(s)
+
+	if got := firstDepName(t, s, "flux-system", "app"); got != "0-${CLUSTER_NAME}-config" {
+		t.Errorf("conflicting var must be dropped (stay literal); got %q", got)
+	}
+}
+
+// A KS whose dependsOn carries no template is left untouched (no clone /
+// no store churn), and a literal-but-equal redeclaration of the same var
+// across KSes is not a conflict.
+func TestResolveDependsOnSubstitutions_NoTemplateUntouchedAndAgreeingVarOK(t *testing.T) {
+	s := store.New()
+	s.AddObject(ksWithDeps("cfg-a", "flux-system", map[string]any{"CLUSTER_NAME": "biohazard"}))
+	s.AddObject(ksWithDeps("cfg-b", "flux-system", map[string]any{"CLUSTER_NAME": "biohazard"})) // agrees, not a conflict
+	s.AddObject(ksWithDeps("plain", "flux-system", nil, "0-biohazard-config"))
+	s.AddObject(ksWithDeps("templated", "flux-system", nil, "0-${CLUSTER_NAME}-config"))
+
+	ResolveDependsOnSubstitutions(s)
+
+	if got := firstDepName(t, s, "flux-system", "plain"); got != "0-biohazard-config" {
+		t.Errorf("literal dependsOn must be untouched; got %q", got)
+	}
+	if got := firstDepName(t, s, "flux-system", "templated"); got != "0-biohazard-config" {
+		t.Errorf("agreeing var must still resolve; got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

A child Kustomization's `dependsOn: 0-${CLUSTER_NAME}-config` — a **bare** `${VAR}` with no default — survives parse-time `ResolveEnvsubstDefaults` and never matches the real `0-biohazard-config` that the parent's postBuild render would have substituted before apply. flate builds its dependency graph from the raw file-parsed KS, so it reported the dependency `not found`.

## Fix

A discovery pass `ResolveDependsOnSubstitutions(store)` resolves bare `${VAR}` in `dependsOn` names/namespaces against the **union of every discovered Kustomization's `spec.postBuild.substitute`**. Two guards prevent a false match:

- **conflict-drop**: a var declared with differing values across Kustomizations (e.g. per-cluster `CLUSTER_NAME` in a multi-cluster repo) is dropped from the union and left literal;
- **strict mapper**: an unset var leaves `envsubst.Eval` in its error path, so the reference is kept verbatim rather than collapsed to empty/partial.

Runs **once** in `discovery.Run` after the full KS set is discovered (complete union → sound conflict check) and before the dependency graph is built. `${VAR:=default}` forms are already collapsed at parse time, so this only ever resolves bare vars. Idempotent (resolved names contain no `${`; KS ids are invariant).

## Tests

`pkg/loader/depsubst_test.go`: bare var resolves (`0-${CLUSTER_NAME}-config` → `0-biohazard-config`) + idempotency; unset var stays literal; conflicting var dropped; literal dependsOn untouched and agreeing redeclarations aren't conflicts.

`go build`/`vet`/`test ./...` green; `golangci-lint run ./pkg/... ./internal/...` → 0 issues. Regression-checked on TalosCluster + k8s-gitops (unchanged, 0 failures).

## Note on the Biohazard storage cascade

On Biohazard this correctly collapses every `0-${CLUSTER_NAME}-config` reference. The rook-ceph→storage cascade does **not** fully clear, but for a **separate, pre-existing** reason: `0-biohazard-config` and `0-biohazard-soft-serve` both set `spec.path: ./kube/clusters/biohazard/flux` (a dual git-source redundancy pattern), so each renders the directory that defines them both — a mutual render-emission cycle flate resolves via a 30s timeout. That render-cycle is independent of this change and out of scope here.