### PR TITLE
fix(loader): require a strict ancestor for the structural-parent index

### DIFF
--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -142,6 +142,33 @@ func LongestParent(prefixes []KSPathPrefix, file string, self manifest.NamedReso
 	return manifest.NamedResource{}, false
 }
 
+// longestStrictParent is LongestParent restricted to a *strict*
+// ancestor: besides skipping self, it skips any candidate whose prefix
+// the child itself claims (selfPrefixes). Two Kustomizations pointing
+// at the same spec.path directory each claim that directory, so each
+// would otherwise match the other as a parent — a mutual edge that
+// becomes a depwait deadlock in collectDeps (both wait on the other to
+// reach Ready, then both time out). Peers sharing a directory don't
+// render each other, so neither is the other's parent. selfPrefixes is
+// the set of prefixes the child contributes to KSPathPrefixes; nil/empty
+// (e.g. a HelmRelease child, which contributes none) reduces to
+// LongestParent.
+func longestStrictParent(prefixes []KSPathPrefix, file string, self manifest.NamedResource, selfPrefixes map[string]struct{}) (manifest.NamedResource, bool) {
+	slashFile := filepath.ToSlash(file)
+	for _, p := range prefixes {
+		if p.ID == self {
+			continue
+		}
+		if _, claimed := selfPrefixes[p.Prefix]; claimed {
+			continue
+		}
+		if strings.HasPrefix(slashFile, p.Prefix) {
+			return p.ID, true
+		}
+	}
+	return manifest.NamedResource{}, false
+}
+
 // BuildParentIndexForKind maps each childKind resource to its
 // enclosing Flux Kustomization — the KS whose spec.path or component
 // directory is the deepest strict ancestor of the child's source
@@ -184,6 +211,20 @@ func BuildParentIndexForKind(s *store.Store, repoRoot string, sourceFiles map[ma
 // and re-reads every kustomization.yaml's `components:` independently.
 func BuildParentIndexForKindWithCache(s *store.Store, repoRoot string, sourceFiles map[manifest.NamedResource]string, childKind string, cache *manifest.ComponentCache) map[manifest.NamedResource]manifest.NamedResource {
 	prefixes := KSPathPrefixesWithCache(s, repoRoot, cache)
+	// Group each id's own claimed prefixes so a peer KS claiming the same
+	// spec.path directory isn't mistaken for an enclosing parent (which
+	// would mutually deadlock the pair through collectDeps). Children
+	// that contribute no prefixes (HelmReleases) get an empty set, so
+	// their attribution is unchanged.
+	ownPrefixes := make(map[manifest.NamedResource]map[string]struct{})
+	for _, p := range prefixes {
+		set := ownPrefixes[p.ID]
+		if set == nil {
+			set = make(map[string]struct{})
+			ownPrefixes[p.ID] = set
+		}
+		set[p.Prefix] = struct{}{}
+	}
 	out := map[manifest.NamedResource]manifest.NamedResource{}
 	for _, obj := range s.ListObjects(childKind) {
 		id := obj.Named()
@@ -191,7 +232,7 @@ func BuildParentIndexForKindWithCache(s *store.Store, repoRoot string, sourceFil
 		if !ok {
 			continue
 		}
-		if parent, ok := LongestParent(prefixes, file, id); ok {
+		if parent, ok := longestStrictParent(prefixes, file, id, ownPrefixes[id]); ok {
 			out[id] = parent
 		}
 	}

--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -105,6 +105,68 @@ func TestBuildParentIndex_NoSelfMatch(t *testing.T) {
 	}
 }
 
+func TestBuildParentIndex_PeersSharingSamePathHaveNoParent(t *testing.T) {
+	// Two Kustomizations defined in the same file and pointing at the
+	// SAME spec.path (a dual git-source redundancy pattern) are peers,
+	// not parent/child — neither renders the other. A mutual parent edge
+	// would deadlock the pair through collectDeps (each waits on the
+	// other to reach Ready, then both time out).
+	s := store.New()
+	config := &manifest.Kustomization{
+		Name:              "0-config",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./clusters/main/flux"},
+	}
+	softServe := &manifest.Kustomization{
+		Name:              "0-soft-serve",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./clusters/main/flux"},
+	}
+	s.AddObject(config)
+	s.AddObject(softServe)
+	sourceFiles := map[manifest.NamedResource]string{
+		config.Named():    "clusters/main/flux/flux-repo.yaml",
+		softServe.Named(): "clusters/main/flux/flux-repo.yaml",
+	}
+	parents := BuildParentIndexForKind(s, "", sourceFiles, manifest.KindKustomization)
+	if p, ok := parents[config.Named()]; ok {
+		t.Errorf("same-spec.path peer must not be a parent: 0-config.parent = %+v", p)
+	}
+	if p, ok := parents[softServe.Named()]; ok {
+		t.Errorf("same-spec.path peer must not be a parent: 0-soft-serve.parent = %+v", p)
+	}
+}
+
+func TestBuildParentIndex_RendererOfDefinitionFileStillParents(t *testing.T) {
+	// A KS whose definition file lives under another KS's spec.path — but
+	// whose OWN spec.path is a different directory — must still be
+	// attributed to that renderer. The peer-exclusion keys on the child's
+	// own claimed prefix (./apps), not on its source-file directory, so
+	// this strict-ancestor edge must survive.
+	s := store.New()
+	root := &manifest.Kustomization{
+		Name:              "0-config",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./clusters/main/flux"},
+	}
+	app := &manifest.Kustomization{
+		Name:              "app",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	s.AddObject(root)
+	s.AddObject(app)
+	sourceFiles := map[manifest.NamedResource]string{
+		root.Named(): "clusters/main/flux/flux-repo.yaml",
+		// app is defined in the dir root renders, but claims ./apps.
+		app.Named(): "clusters/main/flux/app-ks.yaml",
+	}
+	parents := BuildParentIndexForKind(s, "", sourceFiles, manifest.KindKustomization)
+	if got, want := parents[app.Named()], root.Named(); got != want {
+		t.Errorf("app.parent = %+v; want %+v (the KS that renders app's definition dir)", got, want)
+	}
+}
+
 func TestBuildParentIndex_NoSourceFileSkipped(t *testing.T) {
 	// A KS without a recorded source file (e.g. lifted purely from a
 	// parent's render output, no annotation propagated to the orchestrator)
@@ -165,7 +227,7 @@ func TestKSPathPrefixes_SortsLongestFirst(t *testing.T) {
 	}
 }
 
-// TestKSPathPrefixes_SkipsEmptyPath confirms the "ks.Path == ''"
+// TestKSPathPrefixes_SkipsEmptyPath confirms the "ks.Path == ”"
 // guard: a Kustomization without a spec.path (chart-of-charts style,
 // or chained-via-sourceRef-only) doesn't contribute a prefix that
 // would silently swallow files at the repo root.

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	fluxopv1 "github.com/controlplaneio-fluxcd/flux-operator/api/v1"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -263,6 +264,84 @@ data: {k: v}
 		info, ok := o.Store().GetStatus(id)
 		if !ok || info.Status != store.StatusReady {
 			t.Fatalf("%s status = (%+v, %v), want Ready", id, info, ok)
+		}
+	}
+}
+
+// TestOrchestrator_TwoKSSameSpecPathNoSpuriousTimeout reproduces the
+// dual git-source redundancy pattern: two Kustomizations defined in the
+// same file and pointing at the SAME spec.path. They are peers (neither
+// renders the other), so they must not be wired as each other's
+// structural parent — a mutual parent edge deadlocks the pair in
+// collectDeps until the 30s per-dep timeout, cascading to anything that
+// dependsOn one of them. The run context is bounded so a regression
+// fails fast instead of riding the full DefaultTimeout.
+func TestOrchestrator_TwoKSSameSpecPathNoSpuriousTimeout(t *testing.T) {
+	dir := t.TempDir()
+	// Two KSes, same spec.path ./flux, both defined in flux/repo.yaml so
+	// both source files sit under their shared spec.path prefix — the
+	// file-prefix parent index would otherwise make each the other's
+	// structural parent and deadlock the pair. repo.yaml is intentionally
+	// NOT listed in flux/kustomization.yaml (it's surfaced by the
+	// bootstrap-sibling scan), so rendering ./flux does not re-emit the
+	// peers — isolating the file-index parent edge this fix targets.
+	testutil.WriteFile(t, dir, "flux/repo.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: config-a, namespace: flux-system}
+spec:
+  path: ./flux
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: config-b, namespace: flux-system}
+spec:
+  path: ./flux
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "flux/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "flux/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: flux-cm}
+data: {k: v}
+`)
+	// Downstream consumer dependsOn one of the peers — the cascade victim
+	// if config-a deadlocks.
+	testutil.WriteFile(t, dir, "consumer.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: consumer, namespace: flux-system}
+spec:
+  path: ./apps
+  dependsOn:
+    - name: config-a
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello}
+data: {k: v}
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	// Bounded so a regressed mutual-parent deadlock fails in seconds, not
+	// the full 30s depwait.DefaultTimeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := o.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, name := range []string{"config-a", "config-b", "consumer"} {
+		id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+		info, ok := o.Store().GetStatus(id)
+		if !ok || info.Status != store.StatusReady {
+			t.Fatalf("%s status = (%+v, %v), want Ready (mutual-parent deadlock regressed?)", id, info, ok)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Two Kustomizations defined in the same file and pointing at the **same `spec.path`** — a dual git-source redundancy pattern (a cluster config mirrored across two `GitRepository` sources, e.g. `0-biohazard-config` from `flux-system` and `0-biohazard-soft-serve` from a `soft-serve` mirror) — each produce the *identical* `KSPathPrefixes` entry. `LongestParent` skips `self` but matches the **peer's identical prefix**, so `BuildParentIndexForKind` made each KS the *other's* structural parent.

`collectDeps` turns a structural parent into a **hard depwait dependency**, so the pair mutually waited on each other to reach `Ready` and both rode the 30s per-dep `DefaultTimeout` — cascading to every Kustomization that `dependsOn` either of them, and leaving both demoted to `PASSED` while logged `WARN resource orphaned … timeout`. The bootstrap cycle detector misses it because it only inspects explicit `spec.dependsOn`, not the structural-parent graph.

## Fix

A structural parent must be a **strict ancestor** that *renders* the child (the gate exists so parent-render-time spec mutations are visible to the child's first reconcile); same-directory peers don't render each other. Restrict the parent index — new unexported `longestStrictParent` — to exclude any candidate whose claimed prefix the child *itself* claims. Scoped to `BuildParentIndexForKindWithCache` only; the exported `LongestParent` and its orphan-coverage / namespace-resolution callers are unchanged, so there is **no scheduler-side risk**.

Effect: same-`spec.path` peers get no mutual parent edge → each reconciles on its own merits (one renders, the other fast-skips its unavailable source), the 30s window vanishes, and the dependent cascade clears.

## Impact (real cluster repo)

`flate test all` drops from **~30s → ~7s** and **~34 spurious dependency-timeout failures clear** (48 → 15 residual, the rest being genuine repo dangling-refs and real chart/upstream issues).

## Tests

- `pkg/loader/parent_test.go`: `TestBuildParentIndex_PeersSharingSamePathHaveNoParent` (direct lock); `TestBuildParentIndex_RendererOfDefinitionFileStillParents` (no-regression: a KS defined under another's `spec.path` but claiming a *different* path still gets that renderer as parent); existing strict-nesting tests stay green.
- `pkg/orchestrator/orchestrator_test.go`: `TestOrchestrator_TwoKSSameSpecPathNoSpuriousTimeout` — end-to-end, context-bounded so a regression fails fast instead of hanging the full `DefaultTimeout`.

`go build`/`vet`/`test ./...` green; `golangci-lint run ./pkg/... ./internal/...` → 0 issues. Regression-checked on TalosCluster + k8s-gitops (unchanged, 0 failures, ~1-2s).

## Known limitation (out of scope)

The rarer case where **both** same-`spec.path` peers have *available* sources (so both render and re-emit each other) forms an analogous mutual edge through the render-emission set (`renderedSet`) rather than the file index; that needs a deeper render-driven-discovery change and is left for a separate evaluation. The common redundancy shape (one source offline/skipped, as here) is fully resolved.