### PR TITLE
fix(loader): attribute self-produced substituteFrom ConfigMaps across the bare-dir/component graph

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -49,6 +49,12 @@ type Controller struct {
 	// renderTracker receives every reconcilable child emitted during render.
 	renderTracker RenderTracker
 
+	// selfProduces reports whether a Kustomization's own render emits a
+	// given ConfigMap (see Options.SelfProduces). collectDeps consults it
+	// to drop a self-produced substituteFrom CM from the dep set. Nil when
+	// unset (tests / no repoRoot) → edge always added.
+	selfProduces func(cm, consumer manifest.NamedResource) bool
+
 	// workingTreeFPs memoizes workingTreeFingerprint results per source
 	// LocalPath for the life of the controller. resolveSourceRootAnd-
 	// Fingerprint runs once per Kustomization, and many KSes share the
@@ -105,6 +111,13 @@ type Options struct {
 	// orchestrator before reconcile. When set for an id, the controller
 	// marks the resource Failed and does not render it.
 	PreflightFailure func(manifest.NamedResource) (string, bool)
+	// SelfProduces reports whether consumer's OWN render emits cm. When
+	// it does, collectDeps drops cm from the dependency set — a KS can't
+	// hard-wait on a postBuild.substituteFrom ConfigMap that only its own
+	// render produces (the bjw-s/onedr0p self-substitute). Available in
+	// full mode (graph-aware index), unlike the changed-only producer
+	// skip. Nil → the edge is always added (pre-index behavior).
+	SelfProduces func(cm, consumer manifest.NamedResource) bool
 }
 
 // New constructs a Kustomization controller.
@@ -125,6 +138,7 @@ func (c *Controller) Configure(opts Options) {
 	c.SetPreflight(opts.PreflightFailure)
 	c.SetParentOf(opts.ParentOf)
 	c.renderTracker = opts.RenderTracker
+	c.selfProduces = opts.SelfProduces
 }
 
 // markRenderedBatch reports parent→child render emissions to the
@@ -345,7 +359,17 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 			continue
 		}
 		depID := manifest.NamedResource{Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name}
-		deps = append(deps, manifest.DependencyRef{NamedResource: depID})
+		// Drop the hard CM edge ONLY when THIS KS's own render subtree
+		// emits it (the bjw-s/onedr0p self-substitute: cluster-apps' bare-
+		// dir render produces ConfigMap/flux-system/cluster-settings via a
+		// component). Graph-aware and available in full mode, unlike the
+		// changed-only ProducersFor skip below. A CM produced by a
+		// DIFFERENT KS — or genuinely absent — keeps the edge and fails
+		// loudly: a KS waiting on a CM only its own render can emit would
+		// otherwise deadlock against itself.
+		if c.selfProduces == nil || !c.selfProduces(depID, ks.Named()) {
+			deps = append(deps, manifest.DependencyRef{NamedResource: depID})
+		}
 		// In changed-only mode, when the substituteFrom CM is rendered
 		// by another Flux Kustomization (the producer), wait on that
 		// producer too — the CM dep alone doesn't gate ordering when

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -53,6 +53,14 @@ type Result struct {
 	// file-loaded copy. Keyed by NamedResource so KS and HR entries
 	// never collide. Empty when no parent enforcement applies.
 	ParentOf map[manifest.NamedResource]manifest.NamedResource
+	// SelfProduce attributes each ConfigMap to the Kustomization(s)
+	// whose own render subtree emits it (bare-dir → subdir-base →
+	// component graph, with namespace propagation). collectDeps uses it
+	// to drop a self-produced postBuild.substituteFrom ConfigMap from
+	// the dependency set — a KS can't wait on a CM only its own render
+	// produces. Available in full mode, unlike the changed-only
+	// producer index.
+	SelfProduce *loader.SelfProduceIndex
 	// Existence holds every file-loaded object the DiscoveryOnly
 	// loader kept out of the Store: HRs, sources, CMs, Secrets, and
 	// raw manifests. depwait's missing-dep fallback consults it to
@@ -158,6 +166,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 		SourceFiles: d.sourceFiles,
 		SourceRefs:  d.sourceRefs,
 		ParentOf:    parentOf,
+		SelfProduce: loader.BuildSelfProduceIndex(d.cfg.Store, repoRoot),
 		Existence:   l.Existence,
 		WipeSecrets: cfg.WipeSecrets,
 	}, nil

--- a/pkg/loader/selfproduce.go
+++ b/pkg/loader/selfproduce.go
@@ -1,0 +1,219 @@
+package loader
+
+import (
+	"cmp"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// SelfProduceIndex maps a ConfigMap id (kind + resolved namespace +
+// name) to the Flux Kustomization(s) whose OWN render subtree emits it.
+//
+// It exists for one job: let collectDeps tell a self-substitute apart
+// from a cross-KS substituteFrom. A Kustomization that renders the very
+// ConfigMap it lists in postBuild.substituteFrom (the bjw-s/onedr0p
+// `cluster-apps` → `cluster-settings` pattern: a bare-dir spec.path whose
+// subdir bases pull in a component defining the CM) must NOT hard-wait on
+// that CM — no other reconcile can produce it, so depwait would deadlock
+// the consumer against its own render. A CM produced by a DIFFERENT KS,
+// or genuinely absent, is left out of this index so its dependency edge
+// stays and still fails loudly.
+//
+// Built once per Bootstrap (in discovery.Run) and read-only afterwards.
+type SelfProduceIndex struct {
+	byID map[manifest.NamedResource][]manifest.NamedResource
+}
+
+// ProducedBy returns the Kustomizations whose render subtree emits cm.
+// Nil-safe: a nil index (no repoRoot, stripped-down tests) produces no
+// matches, so collectDeps falls back to the always-add edge behavior.
+func (i *SelfProduceIndex) ProducedBy(cm manifest.NamedResource) []manifest.NamedResource {
+	if i == nil {
+		return nil
+	}
+	return i.byID[cm]
+}
+
+// BuildSelfProduceIndex resolves, per Flux Kustomization with a spec.path,
+// which ConfigMaps its own kustomize render emits and in which namespace —
+// by walking the render graph the loader's discovery pass does not attribute
+// to a producer: bare-dir base generation (each immediate subdir holding a
+// kustomization file becomes a base, mirroring Flux's own generator),
+// recursion through `resources:` (files + nested bases) and `components:`,
+// and propagation of each layer's `namespace:` transformer. repoRoot anchors
+// the on-disk reads; an empty repoRoot yields an empty (but usable) index.
+func BuildSelfProduceIndex(s *store.Store, repoRoot string) *SelfProduceIndex {
+	idx := &SelfProduceIndex{byID: map[manifest.NamedResource][]manifest.NamedResource{}}
+	if repoRoot == "" {
+		return idx
+	}
+	b := &selfProduceBuilder{
+		repoRoot: repoRoot,
+		dirs:     map[string]cachedDir{},
+		idx:      idx,
+	}
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		if ks.Path == "" {
+			continue
+		}
+		b.walkRoot(ks)
+	}
+	return idx
+}
+
+type cachedDir struct {
+	d  kustomizeDirectives
+	ok bool
+}
+
+type selfProduceBuilder struct {
+	repoRoot string
+	// dirs memoizes whole-file kustomization reads (namespace / resources /
+	// components) keyed by repo-relative dir, so subtrees shared across the
+	// KS list — every app group's substitutions component, say — are read
+	// once. Discovery is serial, so no lock is needed.
+	dirs map[string]cachedDir
+	idx  *SelfProduceIndex
+}
+
+// directives returns the (memoized) kustomization directives at the
+// repo-relative dir; ok is false when no kustomization file is present.
+func (b *selfProduceBuilder) directives(dir string) (kustomizeDirectives, bool) {
+	if c, ok := b.dirs[dir]; ok {
+		return c.d, c.ok
+	}
+	d, ok := readKustomizeDirectives(b.repoRoot, dir)
+	b.dirs[dir] = cachedDir{d: d, ok: ok}
+	return d, ok
+}
+
+// walkRoot enumerates the base(s) of a Flux Kustomization's spec.path and
+// walks each. A spec.path that holds a kustomization file is itself the
+// single base; a bare spec.path (no kustomization file — Flux's generator
+// synthesizes one listing the subdirs) contributes each immediate subdir
+// that holds a kustomization file. The root imposes no namespace of its
+// own (Flux's generated kustomization sets only `resources:`); rootNS is
+// the consumer-side fallback for a ConfigMap that no layer ever stamps.
+func (b *selfProduceBuilder) walkRoot(ks *manifest.Kustomization) {
+	id := ks.Named()
+	rootNS := cmp.Or(ks.TargetNamespace, ks.Namespace)
+	specDir := strings.TrimSuffix(NormalizePrefix(ks.Path), "/")
+	visited := map[string]struct{}{}
+
+	if _, ok := b.directives(specDir); ok {
+		b.walkBase(specDir, "", rootNS, id, visited)
+		return
+	}
+	entries, err := os.ReadDir(filepath.Join(b.repoRoot, specDir))
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sub := path.Join(specDir, e.Name())
+		if _, ok := b.directives(sub); ok {
+			b.walkBase(sub, "", rootNS, id, visited)
+		}
+	}
+}
+
+// walkBase walks one kustomize base (or component) at the repo-relative
+// dir, recording the ConfigMaps it emits for ks. parentNS is the namespace
+// inherited from the enclosing layer; baseNS applies the kustomize-faithful
+// rule that the OUTER (ancestor) `namespace:` wins — once an ancestor set
+// one it is locked, so an inner base's directive cannot override it.
+func (b *selfProduceBuilder) walkBase(dir, parentNS, rootNS string, ks manifest.NamedResource, visited map[string]struct{}) {
+	if dir == "" || strings.HasPrefix(dir, "..") {
+		return // outside the repo root — never read
+	}
+	// Key the cycle guard by (dir, inherited namespace): a shared component
+	// (e.g. ../../components/substitutions) is legitimately included by every
+	// app group, each stamping its own `namespace:` — so the SAME dir under a
+	// DIFFERENT inherited namespace produces a DIFFERENT ConfigMap id and must
+	// be walked again. Keying by dir alone would attribute the CM to whichever
+	// group walked the component first.
+	key := dir + "\x00" + parentNS
+	if _, seen := visited[key]; seen {
+		return // cycle / repeated-under-same-namespace guard
+	}
+	visited[key] = struct{}{}
+
+	d, ok := b.directives(dir)
+	if !ok {
+		return
+	}
+	baseNS := cmp.Or(parentNS, d.Namespace)
+
+	for _, r := range d.Resources {
+		resolved, ok := resolveResourcePath(dir, r)
+		if !ok {
+			continue
+		}
+		resolved = filepath.ToSlash(resolved)
+		info, err := os.Stat(filepath.Join(b.repoRoot, resolved))
+		if err != nil {
+			continue
+		}
+		if info.IsDir() {
+			b.walkBase(resolved, baseNS, rootNS, ks, visited)
+			continue
+		}
+		// File resource — re-impose the stricter, escape-rejecting policy
+		// used for paths that get opened (resolveResourcePath permits
+		// escapes for the dir-descent case only).
+		if _, ok := resolveDataPath(dir, r); !ok {
+			continue
+		}
+		b.recordConfigMaps(resolved, baseNS, rootNS, ks)
+	}
+
+	for _, c := range d.Components {
+		resolved, ok := resolveComponentPath(dir, c)
+		if !ok {
+			continue
+		}
+		// A component carries no namespace of its own that wins over the
+		// including base — baseNS flows in as the parent and stays locked.
+		b.walkBase(filepath.ToSlash(resolved), baseNS, rootNS, ks, visited)
+	}
+}
+
+// recordConfigMaps parses a file `resources:` entry and records every
+// ConfigMap it defines under its resolved namespace. The active namespace
+// transformer (baseNS) overrides a resource's own metadata.namespace —
+// matching kustomize; rootNS is the final fallback when no layer stamps a
+// namespace (so a self-produced, namespace-less CM still matches the
+// consumer's own-namespace substituteFrom lookup).
+func (b *selfProduceBuilder) recordConfigMaps(relFile, baseNS, rootNS string, ks manifest.NamedResource) {
+	objs, err := parseFile(filepath.Join(b.repoRoot, relFile), manifest.ParseDocOptions{WipeSecrets: true})
+	if err != nil {
+		return
+	}
+	for _, obj := range objs {
+		cm, ok := obj.(*manifest.ConfigMap)
+		if !ok {
+			continue
+		}
+		ns := cmp.Or(baseNS, cm.Namespace, rootNS)
+		if ns == "" {
+			continue
+		}
+		id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: ns, Name: cm.Name}
+		b.idx.byID[id] = appendUniqueProducer(b.idx.byID[id], ks)
+	}
+}
+
+func appendUniqueProducer(dst []manifest.NamedResource, v manifest.NamedResource) []manifest.NamedResource {
+	if slices.Contains(dst, v) {
+		return dst
+	}
+	return append(dst, v)
+}

--- a/pkg/loader/selfproduce_test.go
+++ b/pkg/loader/selfproduce_test.go
@@ -1,0 +1,90 @@
+package loader
+
+import (
+	"slices"
+	"testing"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func cmID(ns string) manifest.NamedResource {
+	return manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: ns, Name: "cluster-settings"}
+}
+
+// The bjw-s/onedr0p topology: a root KS with a BARE spec.path (no
+// kustomization.yaml) whose per-namespace subdir bases each stamp their own
+// `namespace:` and pull in a shared substitutions component defining a
+// namespace-LESS ConfigMap. The index must attribute that ConfigMap — in
+// EACH group's resolved namespace — back to the root KS whose own render
+// emits it, resolving the bare-dir → subdir-base → component → namespace
+// chain that no path-prefix index can see.
+func TestBuildSelfProduceIndex_BareDirComponentNamespace(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kubernetes/apps/flux-system/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: flux-system\ncomponents:\n  - ../../components/substitutions\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/default/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: default\ncomponents:\n  - ../../components/substitutions\n")
+	testutil.WriteFile(t, dir, "kubernetes/components/substitutions/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1alpha1\nkind: Component\nresources:\n  - ./cluster-settings.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/components/substitutions/cluster-settings.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cluster-settings\ndata:\n  CLUSTER_NAME: home\n")
+
+	s := store.New()
+	clusterApps := &manifest.Kustomization{
+		Name:              "cluster-apps",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+	}
+	s.AddObject(clusterApps)
+
+	idx := BuildSelfProduceIndex(s, dir)
+
+	// Produced in EVERY group's namespace (the namespace transformer stamps
+	// the component's namespace-less ConfigMap per base) — not just the first.
+	for _, ns := range []string{"flux-system", "default"} {
+		if got := idx.ProducedBy(cmID(ns)); !slices.Contains(got, clusterApps.Named()) {
+			t.Errorf("ProducedBy(ConfigMap/%s/cluster-settings) = %v, want to contain cluster-apps", ns, got)
+		}
+	}
+	// A namespace no base stamps is not attributed.
+	if got := idx.ProducedBy(cmID("kube-system")); len(got) != 0 {
+		t.Errorf("ProducedBy(ConfigMap/kube-system/cluster-settings) = %v, want empty", got)
+	}
+}
+
+// A substituteFrom ConfigMap defined OUTSIDE the KS's own render subtree —
+// i.e. produced by a different KS — must NOT be attributed to this KS, so its
+// dependency edge survives and a real failure stays loud. Here the root KS's
+// spec.path holds only its own kustomization with no component, so it produces
+// nothing.
+func TestBuildSelfProduceIndex_NonProducerNotAttributed(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kubernetes/apps/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: flux-system\nresources: []\n")
+
+	s := store.New()
+	ks := &manifest.Kustomization{
+		Name:              "cluster-apps",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+	}
+	s.AddObject(ks)
+
+	idx := BuildSelfProduceIndex(s, dir)
+	if got := idx.ProducedBy(cmID("flux-system")); len(got) != 0 {
+		t.Errorf("ProducedBy = %v, want empty (KS produces no cluster-settings)", got)
+	}
+}
+
+// Nil index is safe — collectDeps falls back to always-add (the pre-index
+// behavior) when no repoRoot produced an index.
+func TestSelfProduceIndex_NilSafe(t *testing.T) {
+	var idx *SelfProduceIndex
+	if got := idx.ProducedBy(cmID("flux-system")); got != nil {
+		t.Errorf("nil index ProducedBy = %v, want nil", got)
+	}
+}

--- a/pkg/loader/transformer_ns.go
+++ b/pkg/loader/transformer_ns.go
@@ -212,17 +212,19 @@ func resolveRef(baseDir, ref string) (string, bool) {
 }
 
 // kustomizeDirectives is the subset of a kustomization.yaml that
-// transformer-namespace resolution reads.
+// transformer-namespace resolution and self-production attribution read.
 type kustomizeDirectives struct {
 	Namespace    string   `yaml:"namespace"`
 	Resources    []string `yaml:"resources"`
 	Transformers []string `yaml:"transformers"`
+	Components   []string `yaml:"components"`
 }
 
 // readKustomizeDirectives reads the kustomization file in dir (resolved
-// under repoRoot) and returns its namespace/resources/transformers
-// fields. ok is false when no kustomization file is present or it can't
-// be parsed — pure best-effort, same contract as readKustomizeNamespace.
+// under repoRoot) and returns its namespace/resources/transformers/
+// components fields. ok is false when no kustomization file is present or
+// it can't be parsed — pure best-effort, same contract as
+// readKustomizeNamespace.
 func readKustomizeDirectives(repoRoot, dir string) (kustomizeDirectives, bool) {
 	for _, name := range manifest.KustomizeBuilderFilenames {
 		data, err := os.ReadFile(filepath.Join(repoRoot, dir, name)) //nolint:gosec // path composed from known cluster layout

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -164,6 +164,12 @@ type Orchestrator struct {
 	// wiring symmetric.
 	parentOf map[manifest.NamedResource]manifest.NamedResource
 
+	// selfProduce attributes each ConfigMap to the Kustomization(s) whose
+	// own render emits it (resolved across the bare-dir/component graph).
+	// The KS controller consults it to drop a self-produced
+	// postBuild.substituteFrom ConfigMap from the dependency set.
+	selfProduce *loader.SelfProduceIndex
+
 	// rendered tracks IDs the KS controller emitted from a parent
 	// render (vs. only loaded by the file walker). detectOrphans reads
 	// it to demote stale-on-disk resources to "orphan" rather than
@@ -439,6 +445,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	o.sourceFiles = res.SourceFiles
 	o.sourceRefs = res.SourceRefs
 	o.parentOf = res.ParentOf
+	o.selfProduce = res.SelfProduce
 	o.existence = res.Existence
 
 	o.failDependsOnCycles()

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -346,6 +346,100 @@ data: {k: v}
 	}
 }
 
+// The bjw-s/onedr0p self-substitute deadlock, in FULL mode: cluster-apps'
+// spec.path is a BARE dir whose flux-system group base pulls in a component
+// defining a namespace-less cluster-settings ConfigMap, which cluster-apps
+// then lists in postBuild.substituteFrom. That CM is produced only by
+// cluster-apps' own render, so a hard dependency edge would dead-lock it
+// against itself ("ConfigMap/flux-system/cluster-settings: dependency not
+// found"). The graph-aware self-production index must drop the self-edge so
+// cluster-apps renders and emits the CM.
+func TestOrchestrator_SelfSubstituteBareDirNoDeadlock(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster-apps.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./kubernetes/apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/flux-system/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: flux-system\ncomponents:\n  - ../../components/substitutions\n")
+	testutil.WriteFile(t, dir, "kubernetes/components/substitutions/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1alpha1\nkind: Component\nresources:\n  - ./cluster-settings.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/components/substitutions/cluster-settings.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cluster-settings\ndata:\n  CLUSTER_NAME: home\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	// Bounded so a regressed self-deadlock fails fast, not at the full 30s cap.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := o.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	if info, ok := o.Store().GetStatus(ksID); !ok || info.Status != store.StatusReady {
+		t.Fatalf("cluster-apps status = (%+v, %v), want Ready (self-substitute deadlock regressed?)", info, ok)
+	}
+	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings"}
+	if got := o.Store().GetObject(cmID); got == nil {
+		t.Errorf("cluster-apps render did not emit %s", cmID)
+	}
+}
+
+// The guard: a substituteFrom ConfigMap that NO KS self-produces (and no
+// producer emits) must keep its hard dependency edge and fail loudly. The
+// graph-aware self-edge drop must not turn a genuinely-absent CM into a
+// silent pass. Same shape as above but the group base pulls in no
+// cluster-settings, so nothing produces ConfigMap/flux-system/cluster-settings.
+func TestOrchestrator_SelfSubstituteAbsentCMFailsLoud(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster-apps.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./kubernetes/apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/flux-system/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: flux-system\nresources:\n  - ./cm.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/flux-system/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: other\ndata:\n  k: v\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = o.Run(ctx) // reconcile failure is recorded in status, not returned
+	ksID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	info, ok := o.Store().GetStatus(ksID)
+	if !ok || info.Status != store.StatusFailed {
+		t.Fatalf("cluster-apps status = (%+v, %v), want Failed (absent substituteFrom CM must fail loud)", info, ok)
+	}
+	if !strings.Contains(info.Message, "cluster-settings") {
+		t.Errorf("cluster-apps failure message = %q, want it to mention cluster-settings", info.Message)
+	}
+}
+
 func TestOrchestrator_RunReturnsContextCancellation(t *testing.T) {
 	dir := t.TempDir()
 	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"maps"
 	"runtime"
+	"slices"
 
 	"golang.org/x/sync/errgroup"
 
@@ -187,6 +188,14 @@ func (o *Orchestrator) configureControllers() {
 		wipeSecrets: o.cfg.WipeSecrets,
 	}
 	renders := &orchestratorRenderInflight{tasks: o.tasks}
+	// selfProduces reports whether consumer's OWN render emits cm — the
+	// graph-aware self-substitute signal collectDeps uses to drop a
+	// self-produced postBuild.substituteFrom ConfigMap from the dep set.
+	// Nil-safe: a nil index (no repoRoot) yields false, so the edge is
+	// kept (the pre-index always-add behavior).
+	selfProduces := func(cm, consumer manifest.NamedResource) bool {
+		return slices.Contains(o.selfProduce.ProducedBy(cm), consumer)
+	}
 	o.ksc.Configure(kustomization.Options{
 		Filter:           o.filter,
 		ParentOf:         parentResolver,
@@ -194,6 +203,7 @@ func (o *Orchestrator) configureControllers() {
 		Existence:        existence,
 		Renders:          renders,
 		PreflightFailure: o.preflightFailure,
+		SelfProduces:     selfProduces,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
 		Filter:              o.filter,


### PR DESCRIPTION
## Problem

`flate test all` on an onedr0p/bjw-s cluster (`drag0n141/home-ops`) failed with one error:

```
Kustomization/flux-system/cluster-apps: dependencies failed:
  ConfigMap/flux-system/cluster-settings: dependency not found
```

`cluster-apps` (ns `flux-system`, `spec.path: ./kubernetes/apps` — a **bare dir** with no kustomization.yaml) lists `cluster-settings` in `postBuild.substituteFrom`. That CM is produced **only** by `cluster-apps`'s own render: Flux's bare-dir generator turns each subdir-with-a-kustomization into a base; the `flux-system` group base (`namespace: flux-system`, `components: - ../../components/substitutions`) pulls in a **namespace-less** `cluster-settings` ConfigMap that the base's namespace transformer stamps into `flux-system`.

`collectDeps` added that CM as a hard depwait edge unconditionally, but no other reconcile can produce it — so the wait drained to "dependency not found", a self-referential deadlock. The pre-existing self-producer skip ran only in changed-only mode and only via a path-prefix producer index, which cannot attribute a **component-included, namespace-transformed** resource (the component file lives outside the consuming KS's `spec.path`).

## Fix

A graph-aware **self-production index** (`loader.BuildSelfProduceIndex`) walks each Kustomization's render subtree — bare-dir base generation, subdir bases, and component references — propagating each layer's `namespace:` transformer (outer/ancestor wins), and records which ConfigMaps (name + **resolved** namespace) each KS's own render emits. Built once per Bootstrap (mirroring the structural-parent `ParentOf` index) and threaded to the KS controller.

`collectDeps` consults it in full mode to drop the hard substituteFrom-CM edge **only** when the consuming KS itself self-produces it. A CM produced by a *different* KS — or genuinely absent — keeps its edge and still fails loudly; depwait is left strict.

## Results

| repo | before | after |
|------|--------|-------|
| `drag0n141/home-ops` | 252 passed / **1 failed** | **446 passed / 0 failed** |
| 10 other Flux repos (onedr0p, joryirving, Biohazard, …) | — | byte-for-byte unchanged |

Beyond clearing the failure, `cluster-apps` now renders its full child tree with correct `cluster-settings` substitution.

## Tests
- `pkg/loader/selfproduce_test.go` — bare-dir → subdir-base → component → per-namespace attribution; non-producer not attributed; nil-safe.
- `pkg/orchestrator/orchestrator_test.go` — `TestOrchestrator_SelfSubstituteBareDirNoDeadlock` (full-mode end-to-end), `TestOrchestrator_SelfSubstituteAbsentCMFailsLoud` (genuinely-absent CM still fails loudly).

Verified: `gofmt`, `go build/vet/test ./...`, `golangci-lint run ./pkg/... ./internal/...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)