### PR TITLE
fix(loader): skip the bootstrap-sibling scan inside an already-rendered tree

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -398,6 +398,18 @@ func (w *walker) walkKustomize(ctx context.Context, dir string, k *kustomization
 // sources / data files. Gated on DiscoveryOnly so non-DiscoveryOnly
 // callers keep that strict semantic.
 func (w *walker) scanBootstrapFluxKS(dir string, k *kustomization, kpath string) int {
+	// A genuine bootstrap *entry* KS is a root — no other Kustomization's
+	// spec.path covers its directory. A KS commented-out of (excluded from)
+	// a kustomization.yaml lives inside a tree another KS already renders
+	// (e.g. cluster-apps' spec.path covers apps/<cluster>/<ns>/); real Flux
+	// renders that dir solely from its kustomization.yaml `resources:`, so a
+	// sibling KS left out of them is a disabled app, not a bootstrap entry.
+	// Surfacing it here is a false positive. Skip the scan when dir is already
+	// claimed by another loaded KS's spec.path — the same coverage predicate
+	// promoteOrphans applies via LongestParent.
+	if w.loader.dirCoveredByOtherKS(dir) {
+		return 0
+	}
 	seen := map[string]struct{}{kpath: {}}
 	for _, r := range k.Resources {
 		if abs, ok := resolveDataPath(dir, r); ok {
@@ -441,6 +453,37 @@ func (w *walker) scanBootstrapFluxKS(dir string, k *kustomization, kpath string)
 		}
 	}
 	return count
+}
+
+// dirCoveredByOtherKS reports whether dir (an absolute kustomize-package
+// directory) sits under some loaded Flux Kustomization's spec.path — i.e. it
+// is part of a tree another KS renders, where a sibling KS excluded from the
+// local kustomization.yaml is a disabled app rather than a bootstrap entry.
+// No-ops (returns false) when SourceRoot is unset, so SDK / unit-test callers
+// that set DiscoveryOnly without a repo root keep the legacy scan behavior.
+//
+// A KS being surfaced by scanBootstrapFluxKS is not yet in the Store at its
+// own dir's first scan, so a true entry KS reads as uncovered and is still
+// surfaced; only a strictly-enclosing (or equal) prefix from an already-loaded
+// KS marks the dir covered.
+func (l *Loader) dirCoveredByOtherKS(dir string) bool {
+	if l.SourceRoot == "" {
+		return false
+	}
+	rel, err := filepath.Rel(l.SourceRoot, dir)
+	if err != nil {
+		return false
+	}
+	dirRel := filepath.ToSlash(rel) + "/"
+	for _, ks := range store.ListAs[*manifest.Kustomization](l.Store, manifest.KindKustomization) {
+		if ks.Path == "" {
+			continue
+		}
+		if strings.HasPrefix(dirRel, NormalizePrefix(ks.Path)) {
+			return true
+		}
+	}
+	return false
 }
 
 // walkComponentData records direct ConfigMap/Secret resources from

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -7,10 +7,75 @@ import (
 	"path/filepath"
 	"testing"
 
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
+
+// TestLoader_DiscoveryOnlyBootstrapScanSkipsCoveredDir pins the coverage guard
+// on the bootstrap-sibling scan: a Flux Kustomization authored as a sibling of
+// a kustomization.yaml but excluded from its `resources:` is a bootstrap entry
+// ONLY when its directory isn't already rendered by another KS. Inside a covered
+// tree (here cluster-apps' spec.path apps/test) such a sibling is a
+// disabled/commented-out app — kustomize never includes it, so neither should
+// the scan. Counterpart to TestLoader_DiscoveryOnlyPicksUpBootstrapSiblingKS
+// (uncovered dir → still surfaced).
+func TestLoader_DiscoveryOnlyBootstrapScanSkipsCoveredDir(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "apps/test/network/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: network
+resources:
+  - ./echo.yaml
+  # - ./tunnel.yaml
+`)
+	testutil.WriteFile(t, dir, "apps/test/network/echo.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: echo, namespace: network}
+spec:
+  path: ./apps/base/echo
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	// Commented out of the kustomization above — a disabled app, not a
+	// bootstrap entry. Real kustomize never renders it.
+	testutil.WriteFile(t, dir, "apps/test/network/tunnel.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: tunnel, namespace: network}
+spec:
+  path: ./apps/base/tunnel
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+
+	s := store.New()
+	// The covering parent — cluster-apps renders apps/test (its spec.path
+	// covers apps/test/network/). Pre-seeded so the guard sees it regardless
+	// of walk order.
+	s.AddObject(&manifest.Kustomization{
+		Name:              "cluster-apps",
+		Namespace:         "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/test"},
+	})
+
+	l := New(s)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	l.SourceFiles = map[manifest.NamedResource]string{}
+	l.SourceRoot = dir
+	if _, err := l.Load(context.Background(), filepath.Join(dir, "apps/test")); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	echoID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "network", Name: "echo"}
+	if s.GetObject(echoID) == nil {
+		t.Errorf("listed KS echo must be loaded via resources")
+	}
+	tunnelID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "network", Name: "tunnel"}
+	if s.GetObject(tunnelID) != nil {
+		t.Errorf("commented-out sibling KS tunnel must NOT be surfaced inside a covered tree")
+	}
+}
 
 func TestLoader_Load(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -346,6 +346,78 @@ data: {k: v}
 	}
 }
 
+// TestOrchestrator_CommentedOutKSNotReconciled is the e2e fence for the
+// bootstrap-sibling over-discovery: a Flux Kustomization commented out of its
+// namespace's kustomization.yaml (a disabled app) that lives inside
+// cluster-apps' rendered tree must NOT be discovered or reconciled — real Flux
+// never deploys it. The entry is scoped to kubernetes/flux (with a .git marker
+// so spec.paths resolve against the repo root) so cluster-apps is discovered
+// before its subtree is scanned.
+func TestOrchestrator_CommentedOutKSNotReconciled(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, ".git/HEAD", "ref: refs/heads/main\n") // repo-root anchor
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster-apps.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./kubernetes/apps/test
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	// Bare apps/test → its network/ subdir is a kustomize base. echo is listed
+	// and rendered; tunnel is commented out (a disabled app).
+	testutil.WriteFile(t, dir, "kubernetes/apps/test/network/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: network
+resources:
+  - ./echo.yaml
+  # - ./tunnel.yaml
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/test/network/echo.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: echo, namespace: network}
+spec:
+  path: ./kubernetes/apps/base/echo
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/test/network/tunnel.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: tunnel, namespace: network}
+spec:
+  path: ./kubernetes/apps/base/tunnel
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/base/echo/kustomization.yaml", "resources:\n  - ./cm.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/base/echo/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: echo-cm}\ndata: {k: v}\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/base/tunnel/kustomization.yaml", "resources:\n  - ./cm.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/base/tunnel/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: tunnel-cm}\ndata: {k: v}\n")
+
+	o, err := New(Config{Path: dir + "/kubernetes/flux", WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := o.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// echo is listed → reconciled.
+	echoID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "network", Name: "echo"}
+	if _, ok := o.Store().GetStatus(echoID); !ok {
+		t.Errorf("listed KS echo should be reconciled")
+	}
+	// tunnel is commented out → never discovered or reconciled.
+	tunnelID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "network", Name: "tunnel"}
+	if o.Store().GetObject(tunnelID) != nil {
+		t.Errorf("commented-out KS tunnel must not reach the store")
+	}
+	if _, ok := o.Store().GetStatus(tunnelID); ok {
+		t.Errorf("commented-out KS tunnel must not be reconciled")
+	}
+}
+
 // The bjw-s/onedr0p self-substitute deadlock, in FULL mode: cluster-apps'
 // spec.path is a BARE dir whose flux-system group base pulls in a component
 // defining a namespace-less cluster-settings ConfigMap, which cluster-apps


### PR DESCRIPTION
## Problem

Running flate per-cluster on `joryirving/home-ops` surfaced spurious failures: `test` and `utility` each reported a HelmRelease failing `chart source OCIRepository/app-template not ready` — for apps (`cloudflare-tunnel`, `rtlamr2mqtt`) that are **commented out** of their namespace's `kustomization.yaml` (`# - ./cloudflare-tunnel.yaml`). Real Flux/kustomize never deploys them.

The tell: the over-discovered HRs are **namespace-less** (`HelmRelease/cloudflare-tunnel`) vs deployed siblings (`HelmRelease/network/echo`) — loaded outside their namespace's kustomize render, so their `chartRef` resolved to the empty namespace and "not found". Pure false positives.

## Root cause

`scanBootstrapFluxKS` (loader.go), gated on `DiscoveryOnly`, surfaces Flux **Kustomization** CRs that are siblings of a `kustomization.yaml` but absent from its `resources:`. That's the real bootstrap pattern (an entry KS kubectl-applied beside the package it renders), but it fired on **every** kustomize-package dir — so a KS commented out of a deep `kustomization.yaml` (a disabled app) was wrongly surfaced, and the discovery loop then expanded its `spec.path` and pulled in the namespace-less HelmRelease.

## Fix

A genuine bootstrap **entry** KS is a root — no other Kustomization's `spec.path` covers its directory. A disabled/commented-out KS lives **inside** a tree another KS already renders (`apps/test/network/` is covered by `cluster-apps`'s `spec.path apps/test`). That's the same coverage predicate `promoteOrphans` already uses via `LongestParent`.

New `Loader.dirCoveredByOtherKS` + a one-line guard at the top of `scanBootstrapFluxKS`: skip the scan when `dir` is already covered by a loaded KS's spec.path. No-ops when `SourceRoot` is unset (SDK/unit-test callers keep legacy behavior).

## Results (scoped, per-cluster)

| repo / cluster | before | after |
|---|---|---|
| joryirving `test` | 77 / **1** | **72 / 0** |
| joryirving `utility` | 142 / **1** | **135 / 0** |
| joryirving `main` | 330 / 0 | 330 / 0 |
| aclerici38 (`-p .`) | 286 / 0 | 280 / 0 (−6 phantom `Kustomization/*/patch` kustomize-patch fragments) |
| 8 other repos | — | byte-for-byte unchanged |

No repo regresses; the only deltas are removed false positives.

## Tests
- `pkg/loader/loader_test.go` — `TestLoader_DiscoveryOnlyBootstrapScanSkipsCoveredDir`: a sibling KS commented out of a kustomization inside a covered tree is **not** surfaced; the listed sibling **is**. `TestLoader_DiscoveryOnlyPicksUpBootstrapSiblingKS` (uncovered → surfaced) and the other bootstrap/orphan tests stay green.
- `pkg/orchestrator/orchestrator_test.go` — `TestOrchestrator_CommentedOutKSNotReconciled`: faithful topology (bare cluster dir → namespace subdir whose kustomization comments out an app) — the commented-out KS and its HR never reach the store. `TestOrchestrator_TwoKSSameSpecPathNoSpuriousTimeout` stays green.

`gofmt` / `go build·vet·test ./...` / `golangci-lint` (0 issues).

> Note: a residual phantom can survive a whole-repo `-p .` run when the initial ad-hoc filesystem walk reaches a covered dir before its covering KS is discovered — a pre-existing `-p .` ordering limitation (correct usage scopes to the flux entry path). Discovery membership is also already non-deterministic on `-p .` independent of this change; both are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)