### PR TITLE
ci: adopt the mise / unified-Go-version pattern

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,12 +30,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
+          experimental: true
+          install_args: --locked
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        with:
-          version: v2.12.2
+        run: mise run lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,33 @@ on:
       - published
 
 jobs:
+  versions:
+    name: Versions
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      go-version: ${{ steps.versions.outputs.go-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          cache: false
+          experimental: true
+          install: false
+
+      - name: Resolve versions
+        id: versions
+        run: echo "go-version=$(mise config get tools.go)" >> "$GITHUB_OUTPUT"
+
   release:
     name: Release
+    needs: versions
     permissions:
       contents: read
       id-token: write
@@ -22,6 +47,7 @@ jobs:
       build-args: |
         VERSION=${{ github.ref_name }}
         REVISION=${{ github.sha }}
+        GO_VERSION=${{ needs.versions.outputs.go-version }}
       meta-images: ghcr.io/${{ github.repository }}
       meta-tags: |
         type=semver,pattern={{version}}
@@ -52,11 +78,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - name: Setup Mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          go-version-file: go.mod
-          cache: false
+          cache: false # publishing job — avoid restoring a poisonable cache
+          experimental: true
+          install_args: --locked
 
       - name: Install UPX
         uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Setup Mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          cache: false # publishing job — avoid restoring a poisonable cache
+          cache: false
           experimental: true
           install_args: --locked
 

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,11 +1,3 @@
-# mise is the single source of truth for the Go toolchain (and project tools)
-# across developer shells, CI, and the container build. The `go` version here
-# matches go.mod's `go` directive; Renovate keeps the two in lockstep via the
-# "Go Toolchain Group" rule in .renovaterc.json5. The Dockerfile and release
-# workflow read it with `mise config get tools.go`.
-#
-# `mise tasks` lists tasks; `mise run <task>` runs one.
-
 [tools]
 go = "1.26.4"
 golangci-lint = "2.12.2"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,3 +1,11 @@
+# mise is the single source of truth for the Go toolchain (and project tools)
+# across developer shells, CI, and the container build. The `go` version here
+# matches go.mod's `go` directive; Renovate keeps the two in lockstep via the
+# "Go Toolchain Group" rule in .renovaterc.json5. The Dockerfile and release
+# workflow read it with `mise config get tools.go`.
+#
+# `mise tasks` lists tasks; `mise run <task>` runs one.
+
 [tools]
 go = "1.26.4"
 golangci-lint = "2.12.2"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -4,17 +4,12 @@
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
   packageRules: [
     {
-      // Bump the Go version in .mise/config.toml and go.mod together, in one
-      // reviewed PR, so the two never drift (mise is the source of truth; the
-      // Dockerfile + release workflow read tools.go from it). matchDepNames
-      // ["go"] matches the dep in both the mise and gomod managers.
       description: "Go Toolchain Group",
       matchManagers: ["mise", "gomod"],
       matchDepNames: ["go"],
       matchFileNames: [".mise/config.toml", "go.mod"],
       groupName: "Go toolchain",
       groupSlug: "go-toolchain",
-      automerge: false,
     },
   ],
 }

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,4 +2,19 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
+  packageRules: [
+    {
+      // Bump the Go version in .mise/config.toml and go.mod together, in one
+      // reviewed PR, so the two never drift (mise is the source of truth; the
+      // Dockerfile + release workflow read tools.go from it). matchDepNames
+      // ["go"] matches the dep in both the mise and gomod managers.
+      description: "Go Toolchain Group",
+      matchManagers: ["mise", "gomod"],
+      matchDepNames: ["go"],
+      matchFileNames: [".mise/config.toml", "go.mod"],
+      groupName: "Go toolchain",
+      groupSlug: "go-toolchain",
+      automerge: false,
+    },
+  ],
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26-alpine AS build
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-alpine AS build
 ARG VERSION=dev
 ARG REVISION=dev
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/flate
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
Brings `flate` in line with the shared home-ops Go pattern (konflate, tuppr, kromgo) for **mise in CI** and **a single, unified Go version**.

## Why
mise was already the source of truth for the Go version, but `go.mod` had **drifted** — `.mise/config.toml` pinned `1.26.4` while `go.mod` said `1.26.3` — because the Renovate grouping that keeps them in lockstep was missing. CI also bypassed mise in two jobs (`actions/setup-go`), so the Go version came from several places.

## Changes
- **Unify the Go version** — `go.mod` `1.26.3 → 1.26.4` to match `.mise/config.toml`; added the source-of-truth comment to the mise config.
- **Renovate "Go Toolchain Group"** — new `packageRules` entry so `.mise/config.toml` and `go.mod` bump together in one reviewed PR and never drift again (matches konflate/tuppr/kromgo; flate has no `node`, so only the Go rule).
- **Dockerfile reads the version from mise** — `ARG GO_VERSION` + `FROM golang:${GO_VERSION}-alpine`, replacing the hardcoded `golang:1.26-alpine` (kept the alpine base).
- **Workflows use mise, not `setup-go`**:
  - `lint.yaml` → mise-action + `mise run lint` (Go *and* golangci-lint from mise; drops the separately-pinned `golangci-lint v2.12.2`).
  - `release.yaml` → a `versions` job resolves `go-version` via `mise config get tools.go` and feeds `GO_VERSION` to the image build; GoReleaser installs Go via mise (kept `cache: false` for the publishing job).

## Testing
- `go mod tidy` clean (only the go directive), `go build ./...` + `go vet ./...` pass.
- `mise run lint` → **0 issues** (the exact command the new lint workflow runs).
- Commit passed lefthook: **zizmor** clean on both workflows, yaml/json formatters clean.

## Note
The Dockerfile's `ARG GO_VERSION` has no default (so a BuildKit `--check` flags it) — that's intentional and identical to konflate: the version must come from mise, and the release workflow always passes `GO_VERSION`. Builds succeed with the arg; the warning doesn't fail the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
