### PR TITLE
fix(loader): don't surface path-less Kustomization patch fragments as Flux KSes

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -439,7 +439,18 @@ func (w *walker) scanBootstrapFluxKS(dir string, k *kustomization, kpath string)
 			continue
 		}
 		for _, obj := range objs {
-			if _, ok := obj.(*manifest.Kustomization); !ok {
+			ks, ok := obj.(*manifest.Kustomization)
+			if !ok {
+				continue
+			}
+			// A genuine bootstrap entry KS always carries a spec.path (and a
+			// sourceRef). A kind: Kustomization with neither is a kustomize
+			// patch fragment — a patch.yaml referenced via `patches:` whose
+			// body happens to use the Flux Kustomization GVK as the patch
+			// target — never a reconcilable Flux Kustomization. Skipping it
+			// is order-independent (it reads only the parsed object), unlike
+			// the dir-coverage guard above.
+			if ks.Path == "" && ks.SourceKind == "" && ks.SourceName == "" {
 				continue
 			}
 			id := obj.Named()

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -77,6 +77,62 @@ spec:
 	}
 }
 
+// TestLoader_DiscoveryOnlyBootstrapScanSkipsPatchFragment pins the no-path
+// guard: a sibling YAML that is a kind: Kustomization with only spec.patches
+// (no spec.path, no spec.sourceRef) is a kustomize patch fragment — referenced
+// via `patches:`, never a reconcilable Flux KS — and must NOT be surfaced by
+// the bootstrap-sibling scan, even though a real entry KS sibling is. No
+// covering KS is pre-seeded, so this pins the order-independence (the guard
+// reads only the parsed object, unlike the dir-coverage guard).
+func TestLoader_DiscoveryOnlyBootstrapScanSkipsPatchFragment(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cm.yaml
+patches:
+  - path: ./patch.yaml
+`)
+	testutil.WriteFile(t, dir, "apps/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: cm, namespace: apps}\n")
+	// Real bootstrap-entry sibling KS (has spec.path) — must still surface.
+	testutil.WriteFile(t, dir, "apps/entry.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: entry, namespace: flux-system}
+spec:
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system}
+`)
+	// Patch fragment: kind: Kustomization, only spec.patches, no path/source.
+	testutil.WriteFile(t, dir, "apps/patch.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: patch}
+spec:
+  patches:
+    - patch: |-
+        apiVersion: helm.toolkit.fluxcd.io/v2
+        kind: HelmRelease
+        metadata: {name: not-used}
+      target: {kind: HelmRelease}
+`)
+
+	s := store.New()
+	l := New(s)
+	l.Options.DiscoveryOnly = true
+	l.Existence = NewExistenceIndex()
+	l.SourceFiles = map[manifest.NamedResource]string{}
+	l.SourceRoot = dir
+	if _, err := l.Load(context.Background(), dir); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "entry"}) == nil {
+		t.Errorf("real bootstrap-entry KS (has spec.path) must surface")
+	}
+	if got := s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "", Name: "patch"}); got != nil {
+		t.Errorf("path-less/source-less patch-fragment Kustomization must NOT be surfaced; got %v", got)
+	}
+}
+
 func TestLoader_Load(t *testing.T) {
 	dir := t.TempDir()
 	testutil.WriteFile(t, dir, "ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1


### PR DESCRIPTION
## Problem

`scanBootstrapFluxKS` surfaces sibling Flux `Kustomization` CRs authored next to a `kustomization.yaml` but not listed in its `resources:` — the real bootstrap pattern (an entry KS kubectl-applied beside the package it renders).

But a `patch.yaml` referenced via `patches:` is commonly authored as a `kind: Kustomization` (the Flux GVK, used as the patch *target*) with only `spec.patches` — **no `spec.path`, no `sourceRef`**. That's a kustomize patch fragment, never a reconcilable Flux Kustomization. The bootstrap-sibling scan was surfacing it as a phantom `Kustomization/<ns>/patch`.

## Fix

Skip any bootstrap-sibling `Kustomization` that has no `spec.path` **and** no `sourceRef`. The check reads only the parsed object, so it's **order-independent** — complementing the dir-coverage guard from #575 (which handles disabled apps that *do* have a `spec.path`).

## Results

`aclerici38/home-ops` (`-p .`): **7 phantom `Kustomization/*/patch` → 0.** joryirving (per-cluster: 330/72/135, 0 failed) and the other repos (onedr0p, drag0n141, bjw, zariel) unchanged.

## Tests
- `pkg/loader/loader_test.go` — `TestLoader_DiscoveryOnlyBootstrapScanSkipsPatchFragment`: a path-less/source-less `kind: Kustomization` patch fragment is **not** surfaced, while a real entry KS sibling (has `spec.path`) still is — with **no covering KS pre-seeded**, pinning order-independence. Existing bootstrap/coverage tests (`…PicksUpBootstrapSiblingKS`, `…SkipsCoveredDir`, `…HonorsKrmignore`) stay green.

`gofmt` / `go build·vet·test ./...` / `golangci-lint` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)