### PR TITLE
fix(kustomize): serialize all krusty builds behind a process-wide mutex

### DIFF
--- a/pkg/helm/postrender.go
+++ b/pkg/helm/postrender.go
@@ -9,8 +9,11 @@ import (
 	"github.com/fluxcd/pkg/apis/kustomize"
 	"helm.sh/helm/v4/pkg/postrenderer"
 	"sigs.k8s.io/kustomize/api/krusty"
+	"sigs.k8s.io/kustomize/api/resmap"
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+
+	flatekustomize "github.com/home-operations/flate/pkg/kustomize"
 )
 
 // kustomizePostRenderer pipes helm's rendered output through one or
@@ -83,7 +86,15 @@ func runKustomizePostRender(in *bytes.Buffer, k *helmv2.Kustomize) (*bytes.Buffe
 		LoadRestrictions: kustypes.LoadRestrictionsNone,
 		PluginConfig:     kustypes.DisabledPluginConfig(),
 	}
-	rm, err := krusty.MakeKustomizer(opts).Run(fs, ".")
+	// kustomize's krusty pipeline mutates package-global state that is
+	// not goroutine-safe. Hold the shared build mutex so this HR
+	// post-render never runs concurrently with a Kustomization's
+	// SecureBuild (or another HR's post-render) — see kustomize.BuildMutex.
+	rm, err := func() (resmap.ResMap, error) {
+		flatekustomize.BuildMutex.Lock()
+		defer flatekustomize.BuildMutex.Unlock()
+		return krusty.MakeKustomizer(opts).Run(fs, ".")
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("postRenderer: kustomize build: %w", err)
 	}

--- a/pkg/helm/postrender_test.go
+++ b/pkg/helm/postrender_test.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	"github.com/fluxcd/pkg/apis/kustomize"
+
+	flatekustomize "github.com/home-operations/flate/pkg/kustomize"
 )
 
 func TestNewPostRenderer_NilWhenNoKustomize(t *testing.T) {
@@ -50,6 +53,51 @@ data:
 	got := out.String()
 	if !strings.Contains(got, "greeting: bonjour") {
 		t.Errorf("patch not applied:\n%s", got)
+	}
+}
+
+// TestKustomizePostRenderer_HoldsBuildMutex pins the serialization contract
+// behind the non-determinism fix: the helm kustomize post-render runs krusty,
+// which mutates kustomize's process-global state, so it MUST hold the shared
+// kustomize.BuildMutex — otherwise it races a Kustomization's SecureBuild and
+// corrupts renders run-to-run. With the mutex held, Run blocks; once released
+// it completes. A regression (missing lock) lets a trivial post-render finish
+// while the mutex is held, tripping the first select.
+func TestKustomizePostRenderer_HoldsBuildMutex(t *testing.T) {
+	pr := newPostRenderer([]helmv2.PostRenderer{{
+		Kustomize: &helmv2.Kustomize{
+			Patches: []kustomize.Patch{{
+				Patch: `- op: replace
+  path: /data/greeting
+  value: bonjour`,
+				Target: &kustomize.Selector{Kind: "ConfigMap", Name: "app"},
+			}},
+		},
+	}})
+	if pr == nil {
+		t.Fatal("expected non-nil post renderer")
+	}
+	in := bytes.NewBufferString("apiVersion: v1\nkind: ConfigMap\nmetadata: {name: app, namespace: default}\ndata: {greeting: hello}\n")
+
+	flatekustomize.BuildMutex.Lock()
+	done := make(chan struct{})
+	go func() {
+		_, _ = pr.Run(in)
+		close(done)
+	}()
+	// Mutex held → the krusty build must block (pre-lock work is fast; a
+	// no-lock regression would let this trivial post-render complete here).
+	select {
+	case <-done:
+		flatekustomize.BuildMutex.Unlock()
+		t.Fatal("post-render completed while BuildMutex was held — it does not serialize on the shared krusty lock")
+	case <-time.After(300 * time.Millisecond):
+	}
+	flatekustomize.BuildMutex.Unlock()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("post-render did not complete after releasing BuildMutex")
 	}
 }
 

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"sync"
 
 	fluxkustomize "github.com/fluxcd/pkg/kustomize"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,6 +36,20 @@ import (
 // that could otherwise have run in parallel are now sequenced.
 // Correctness is the priority — the previous parallelism was incorrect.
 var stageLocks = keylock.New[string]()
+
+// BuildMutex serializes every krusty/kustomize build flate runs in a
+// process. kustomize's krusty pipeline mutates package-global state
+// (the openapi schema registry + builtin-plugin/transformer factories)
+// that is NOT goroutine-safe — fluxcd/pkg/kustomize guards its own
+// SecureBuild with an internal mutex for exactly this reason, but that
+// mutex does not extend to OTHER krusty entrypoints in the same
+// process (flate's helm postRenderer runs krusty.Run directly). Two
+// concurrent builds — one KS SecureBuild, one HR postRender — race on
+// the shared globals and produce nondeterministic corruption: empty /
+// torn rendered output surfacing as "missing metadata.name" decode
+// errors, dropped resources, or cascade failures that flip run-to-run.
+// Every flate-owned krusty invocation MUST hold this lock.
+var BuildMutex sync.Mutex
 
 // RenderFlux renders a Flux kustomize.toolkit.fluxcd.io Kustomization
 // using the same library that Flux's kustomize-controller uses
@@ -135,7 +150,11 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, sourceFing
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	rm, err := fluxkustomize.SecureBuild(staged, stagedSub, false)
+	rm, err := func() (resmap.ResMap, error) {
+		BuildMutex.Lock()
+		defer BuildMutex.Unlock()
+		return fluxkustomize.SecureBuild(staged, stagedSub, false)
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("kustomize build %s: %w", subPath, err)
 	}


### PR DESCRIPTION
## What

kustomize's krusty pipeline mutates package-global state (the openapi schema registry and the builtin plugin/transformer factories) that is **not goroutine-safe**. `fluxcd/pkg/kustomize` guards its own `SecureBuild` with an internal `kustomizeBuildMutex` for exactly this reason — but that lock does not extend to *other* krusty entrypoints in the same process. flate's helm post-renderer (`pkg/helm/postrender.go`) calls `krusty.Run` directly and **unguarded**, reached concurrently by the reconcile pool. Two concurrent builds — a Kustomization `SecureBuild` and an HR post-render, or two HR post-renders — race on the shared globals and can produce torn/empty rendered output.

## Change

- Add a process-wide `kustomize.BuildMutex`.
- Hold it around both the `fluxcd.SecureBuild` call (`pkg/kustomize/flux.go`) and the helm post-render `krusty.Run` (`pkg/helm/postrender.go`), so every flate-owned krusty invocation is serialized.
- `TestKustomizePostRenderer_HoldsBuildMutex` pins the contract: with the mutex held the post-render blocks; once released it completes (a missing-lock regression lets the trivial post-render finish while held, tripping the assertion).

## Validation

- `gofmt` / `go build` / `go vet` / full `go test ./...` (incl. `-race` on `pkg/helm` + `pkg/kustomize`) / `golangci-lint` → all clean, 0 issues.
- Race is real at the code level (fluxcd precedent guards the identical path). It was not reproduced by `-race` or cascade-repro on the test repos, but a data race is undefined behavior regardless of whether the timing window opened during a given run.
- Wall-time cost measured on a post-render-heavy repo: **+2.5% (~27ms on a ~1.1s run)** — negligible, consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)