### PR TITLE
refactor(controllers): lift shared render helpers into base.Controller

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -29,6 +29,20 @@ import (
 	"github.com/home-operations/flate/pkg/task"
 )
 
+// RenderTracker is the seam a controller uses to report
+// "this child id was emitted by THIS parent's render" to the
+// orchestrator. Nil is OK — the controller no-ops.
+//
+// The parent linkage feeds detectOrphans, the structural-parent
+// resolver, and ResourceSet extension attribution for render-emitted
+// resources. Both the KS and HR controllers report through it
+// identically; MarkRenderedBatch records multiple children under a
+// single lock acquisition so a render emitting N children pays one
+// tracker round-trip rather than N.
+type RenderTracker interface {
+	MarkRenderedBatch(parent manifest.NamedResource, children []manifest.NamedResource)
+}
+
 // Controller is the embeddable lifecycle harness. Construct via New,
 // install reconcile-shaping config via SetFilter (panics if called
 // after Start), then Start to register listeners.
@@ -82,6 +96,11 @@ type Controller struct {
 	renders   depwait.RenderInflight
 	preflight func(manifest.NamedResource) (string, bool)
 	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
+
+	// renderTracker receives every reconcilable/source child a render
+	// emits. Set via SetRenderTracker before Start; read-only after.
+	// nil is fine — markRenderedBatch no-ops.
+	renderTracker RenderTracker
 }
 
 // New constructs a base controller. Concrete controllers call this
@@ -126,6 +145,43 @@ func (c *Controller) SetParentOf(f func(manifest.NamedResource) (manifest.NamedR
 		panic("controller: SetParentOf called after Start")
 	}
 	c.parentOf = f
+}
+
+// SetRenderTracker installs the render-emission tracker. Panics after
+// Start — reconcile-shaping config is frozen once dispatch begins.
+func (c *Controller) SetRenderTracker(rt RenderTracker) {
+	if c.started.Load() {
+		panic("controller: SetRenderTracker called after Start")
+	}
+	c.renderTracker = rt
+}
+
+// KeepEmitted extends the change filter's keep set so render-emitted
+// children pass the changed-only-mode PreGate check. Without this, a
+// parent whose render emits a child that wasn't on disk at filter-build
+// time (kustomize component+replacement KSes, charts that render source
+// CRs) would silently drop that child from the diff comparison. Routed
+// through Filter.AddEmitted so an ancestor-only parent doesn't cascade
+// unrelated file-loaded children into keep (#204/#260/#308).
+//
+// MUST be called BEFORE Store.AddObject so the listener that fires
+// synchronously during AddObject sees the extended keep set.
+func (c *Controller) KeepEmitted(parent, child manifest.NamedResource) {
+	if f := c.Filter(); f != nil {
+		f.AddEmitted(parent, child)
+	}
+}
+
+// ReportRendered reports parent→child render emissions to the
+// configured RenderTracker; no-op when none is wired or there are no
+// children. The emit loop accumulates every child it emits and flushes
+// through this helper exactly once, holding the tracker's lock for one
+// acquisition instead of N.
+func (c *Controller) ReportRendered(parent manifest.NamedResource, children []manifest.NamedResource) {
+	if c.renderTracker == nil || len(children) == 0 {
+		return
+	}
+	c.renderTracker.MarkRenderedBatch(parent, children)
 }
 
 // LookupParent reports the structural parent KS of id via the

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -25,22 +25,6 @@ import (
 	"github.com/home-operations/flate/pkg/values"
 )
 
-// RenderTracker is the seam the controller uses to report
-// "this child id was emitted by THIS parent HR's render" to the
-// orchestrator. Nil is OK — the controller no-ops.
-//
-// Mirrors kustomization.RenderTracker; the parent linkage feeds
-// detectOrphans, the parent resolver, and ResourceSet extension
-// attribution for charts that render source CRs (tofu-controller's
-// OCIRepository pattern, ESO's HelmRepository fallback).
-//
-// MarkRenderedBatch records multiple children under a single lock
-// acquisition — used by the emit loop to avoid N round-trips on the
-// renderedSet mutex when a render emits N source-kind children.
-type RenderTracker interface {
-	MarkRenderedBatch(parent manifest.NamedResource, children []manifest.NamedResource)
-}
-
 // Controller orchestrates HelmRelease reconciliation. Reconcile-shaping
 // state (Filter, ParentOf) flows in via Configure exactly once before Start.
 type Controller struct {
@@ -58,9 +42,6 @@ type Controller struct {
 	// allowMissingSecrets extends the source-controller flag to
 	// HelmRelease valuesFrom refs that cannot be resolved offline.
 	allowMissingSecrets bool
-
-	// renderTracker receives every source-kind child emitted during render.
-	renderTracker RenderTracker
 
 	// rawProducerIndex is an in-memory index populated by the store
 	// listener in Start. It maps the target NamedResource (the Secret
@@ -92,7 +73,7 @@ type ReconcileOptions struct {
 	// render. Mirrors kustomization.Options.RenderTracker; feeds the
 	// orchestrator's parent-provenance index (detectOrphans, parent
 	// resolver, ResourceSet attribution). Nil is OK — no-op.
-	RenderTracker RenderTracker
+	RenderTracker base.RenderTracker
 	// Existence is the file-existence lookup the orchestrator wires
 	// against the loader's ExistenceIndex. depwait uses it to lazy-
 	// promote file-indexed deps (HelmRepository, OCIRepository,
@@ -134,7 +115,7 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 	c.SetPreflight(opts.PreflightFailure)
 	c.SetParentOf(opts.ParentOf)
 	c.allowMissingSecrets = opts.AllowMissingSecrets
-	c.renderTracker = opts.RenderTracker
+	c.SetRenderTracker(opts.RenderTracker)
 }
 
 // Start registers the listeners. The controller runs until Close.
@@ -500,10 +481,10 @@ func (c *Controller) materializeHelmChartSource(id manifest.NamedResource, hr *m
 	}
 	syn := helmchart.Synthesize(r, hr.Chart.Name, hr.Chart.Version)
 	synID := syn.Named()
-	// keepEmitted BEFORE AddObject so the synchronous source-controller
+	// keep-emit BEFORE AddObject so the synchronous source-controller
 	// listener sees the extended changed-only keep set (mirrors
 	// emitRenderedChildren).
-	c.keepEmitted(id, synID)
+	c.KeepEmitted(id, synID)
 	c.Store.AddObject(syn)
 	// Seed a Pending status ONLY on first materialization — when no status
 	// exists yet — to close the window between AddObject (which dispatches an
@@ -570,43 +551,14 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			// keep set when it invokes PreGate. Mirrors the ordering
 			// in kustomization.emitRenderedChildren.
 			childID := obj.Named()
-			c.keepEmitted(id, childID)
+			c.KeepEmitted(id, childID)
 			c.Store.AddObject(obj)
 			rendered = append(rendered, childID)
 		} else {
 			c.Store.AddRendered(obj)
 		}
 	}
-	c.markRenderedBatch(id, rendered)
-}
-
-// keepEmitted extends the change filter's keep set so render-emitted
-// source children pass the changed-only-mode PreGate check. Without
-// this, a chart that renders a source CR (tofu-controller's
-// OCIRepository, ESO's HelmRepository) would silently drop that child
-// from the diff comparison in changed-only mode. Mirrors
-// kustomization.keepEmitted (issue #260/#308).
-//
-// Called BEFORE Store.AddObject so the listener that fires
-// synchronously during AddObject sees the extended keep set.
-func (c *Controller) keepEmitted(parent, child manifest.NamedResource) {
-	if f := c.Filter(); f != nil {
-		f.AddEmitted(parent, child)
-	}
-}
-
-// markRenderedBatch reports parent→child render emissions to the
-// orchestrator's tracker if one is wired; no-op otherwise.
-// Centralizes the nil-check and empty-slice guard so the reconcile
-// body stays readable. The emit loop accumulates every source-kind
-// child it emits and flushes through this helper exactly once,
-// holding the renderedSet lock for one acquisition instead of N.
-// Mirrors kustomization.markRenderedBatch.
-func (c *Controller) markRenderedBatch(parent manifest.NamedResource, children []manifest.NamedResource) {
-	if c.renderTracker == nil || len(children) == 0 {
-		return
-	}
-	c.renderTracker.MarkRenderedBatch(parent, children)
+	c.ReportRendered(id, rendered)
 }
 
 // collectHRDeps returns hr's typed dependsOn entries (carrying any

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -46,9 +46,6 @@ type Controller struct {
 	// parsing rendered manifests.
 	WipeSecrets bool
 
-	// renderTracker receives every reconcilable child emitted during render.
-	renderTracker RenderTracker
-
 	// selfProduces reports whether a Kustomization's own render emits a
 	// given ConfigMap (see Options.SelfProduces). collectDeps consults it
 	// to drop a self-produced substituteFrom CM from the dep set. Nil when
@@ -63,23 +60,6 @@ type Controller struct {
 	workingTreeFPs sync.Map // string -> string
 }
 
-// RenderTracker is the tiny seam the controller uses to report
-// "this child id was emitted by THIS parent KS's render" to the
-// orchestrator. Nil is OK — the controller no-ops.
-//
-// The parent linkage is consumed by detectOrphans, the parent
-// resolver (combined with the file-loaded path-prefix index), and
-// ResourceSet extension attribution — every place that needs to
-// query parent provenance for render-emitted resources.
-//
-// MarkRenderedBatch records multiple children under a single lock
-// acquisition — used by emitRenderedChildren to avoid N round-trips
-// on the renderedSet mutex when a render emits N reconcilable
-// children.
-type RenderTracker interface {
-	MarkRenderedBatch(parent manifest.NamedResource, children []manifest.NamedResource)
-}
-
 // Options carries the post-bootstrap state the orchestrator wires onto
 // the controller before Start. Filter narrows reconciliation to
 // changed resources in changed-only mode. ParentOf maps each Flux
@@ -92,7 +72,7 @@ type RenderTracker interface {
 type Options struct {
 	Filter        *change.Filter
 	ParentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
-	RenderTracker RenderTracker
+	RenderTracker base.RenderTracker
 	// Existence is the file-existence lookup the orchestrator wires
 	// against the loader's ExistenceIndex. depwait uses it to lazy-
 	// promote file-indexed deps and to distinguish render-only
@@ -137,21 +117,8 @@ func (c *Controller) Configure(opts Options) {
 	c.SetDepwait(opts.Existence, opts.Renders)
 	c.SetPreflight(opts.PreflightFailure)
 	c.SetParentOf(opts.ParentOf)
-	c.renderTracker = opts.RenderTracker
+	c.SetRenderTracker(opts.RenderTracker)
 	c.selfProduces = opts.SelfProduces
-}
-
-// markRenderedBatch reports parent→child render emissions to the
-// orchestrator's tracker if one is wired; no-op otherwise.
-// Centralizes the nil-check and empty-slice guard so the reconcile
-// body stays readable. The emit loop accumulates every reconcilable
-// child it emits and flushes through this helper exactly once,
-// holding the renderedSet lock for one acquisition instead of N.
-func (c *Controller) markRenderedBatch(parent manifest.NamedResource, children []manifest.NamedResource) {
-	if c.renderTracker == nil || len(children) == 0 {
-		return
-	}
-	c.renderTracker.MarkRenderedBatch(parent, children)
 }
 
 // Start registers the listener that drives reconciliation.

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -64,7 +64,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		}
 		if p.reconcilable {
 			childID := p.obj.Named()
-			c.keepEmitted(id, childID)
+			c.KeepEmitted(id, childID)
 			c.Store.AddObject(p.obj)
 			rendered = append(rendered, childID)
 		} else {
@@ -76,37 +76,13 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			childID := p.obj.Named()
-			c.keepEmitted(id, childID)
+			c.KeepEmitted(id, childID)
 			rendered = append(rendered, childID)
 			leaves = append(leaves, p.obj)
 		}
 	}
-	c.markRenderedBatch(id, rendered)
+	c.ReportRendered(id, rendered)
 	c.Store.AddObjects(leaves)
-}
-
-// keepEmitted extends the change filter's keep set so render-emitted
-// children pass the changed-only-mode PreGate check. Without this,
-// kustomize component+replacement patterns (parent KS emitting a
-// per-app KS via ConfigMap-driven replacements) produce silent gaps
-// in `flate diff`: the leaf KS isn't keep-set'd at filter-build time
-// because it didn't exist on disk, never reconciles, and its render
-// output never reaches the diff comparison. Issue #204.
-//
-// Routed through Filter.AddEmitted so an ancestor-only parent
-// (kept for #58's patch-propagation but with no file change of its
-// own) doesn't cascade unrelated file-loaded children into keep on
-// every render. Primary parents — those whose own file changed or
-// that share an owner with a changed file — still propagate their
-// emissions normally.
-//
-// Called BEFORE Store.AddObject so the listener that fires
-// synchronously during AddObject sees the extended keep set when it
-// invokes PreGate.
-func (c *Controller) keepEmitted(parent, child manifest.NamedResource) {
-	if f := c.Filter(); f != nil {
-		f.AddEmitted(parent, child)
-	}
 }
 
 // shouldDispatchAsObject reports whether a render-emitted Flux


### PR DESCRIPTION
## What

`keepEmitted`, the render-emission batch report, and the `RenderTracker` interface were **byte-identical** in the Kustomization and HelmRelease controllers (only the doc comments differed). Lift them onto the embedded `base.Controller`, which already owns the shared lifecycle harness (`Submit`/`PreGate`/`Await`/`Filter`/`SetFilter`/`SetDepwait`/`SetPreflight`/`SetParentOf`):

- `base.RenderTracker` — the shared interface; both `kustomization.Options` and `helmrelease.ReconcileOptions` now reference it (the orchestrator's `*renderedSet` satisfies it structurally, unchanged).
- `SetRenderTracker` — panic-after-`Start` guard, matching the other `Set*` setters.
- `KeepEmitted` + `ReportRendered` — **exported** (an unexported method on an embedded type from another package does not promote across the package boundary; the existing shared base methods are all exported for the same reason).

## Not changed (intentional difference preserved)

The KS **two-pass** (data-before-leaf) vs HR **single-pass** (source-kinds-only) `emitRenderedChildren` ordering is untouched — that's a documented ordering contract, not duplication. `ReportRendered` is named distinctly from the `RenderTracker.MarkRenderedBatch` sink it delegates to, so `Controller` does not accidentally satisfy its own tracker interface (no self-wiring footgun).

## Verification

- `gofmt`, `go build`, `go vet`, full **`go test -race ./...`**, `golangci-lint` → all clean, 0 issues.
- Behavior-equivalence on drag0n141 / aclerici38 / onedr0p: identical `get ks` + `get hr` membership; identical **sorted** `build all` content hash (raw `build all` block order is pre-existingly non-deterministic on main — the resource *set* is what's stable, and it is unchanged).

Net −49 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)