### PR TITLE
refactor(manifest): extract SHA256Hex for render-input fingerprints

### DIFF
--- a/pkg/controllers/helmrelease/fingerprint.go
+++ b/pkg/controllers/helmrelease/fingerprint.go
@@ -1,8 +1,6 @@
 package helmrelease
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -22,8 +20,7 @@ func helmReleaseFingerprint(hr *manifest.HelmRelease) string {
 	if err != nil {
 		return ""
 	}
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:])
+	return manifest.SHA256Hex(raw)
 }
 
 func helmReleaseFingerprintPayload(hr *manifest.HelmRelease) any {

--- a/pkg/controllers/kustomization/fingerprint.go
+++ b/pkg/controllers/kustomization/fingerprint.go
@@ -1,8 +1,6 @@
 package kustomization
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -37,6 +35,5 @@ func kustomizationFingerprint(ks *manifest.Kustomization, sourceRoot string) str
 	if err != nil {
 		return ""
 	}
-	sum := sha256.Sum256(raw)
-	return hex.EncodeToString(sum[:])
+	return manifest.SHA256Hex(raw)
 }

--- a/pkg/manifest/hash.go
+++ b/pkg/manifest/hash.go
@@ -1,0 +1,19 @@
+package manifest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SHA256Hex returns the hex-encoded SHA-256 digest of data. It is the
+// one-shot full-buffer digest the controllers' render-input
+// fingerprints use (kustomizationFingerprint / helmReleaseFingerprint)
+// to dedup re-renders whose effective inputs are byte-identical.
+//
+// This is deliberately NOT for streaming/incremental hashing (e.g. a
+// file-tree walk that feeds bytes into a running sha256.Hash) — those
+// callers keep their own hasher.
+func SHA256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/pkg/manifest/hash_test.go
+++ b/pkg/manifest/hash_test.go
@@ -1,0 +1,18 @@
+package manifest
+
+import "testing"
+
+func TestSHA256Hex(t *testing.T) {
+	// Known vector: sha256("") and sha256("abc").
+	if got := SHA256Hex(nil); got != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("SHA256Hex(nil) = %q", got)
+	}
+	if got := SHA256Hex([]byte("abc")); got != "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad" {
+		t.Errorf("SHA256Hex(abc) = %q", got)
+	}
+	// Stable + deterministic across calls.
+	a, b := SHA256Hex([]byte("flate")), SHA256Hex([]byte("flate"))
+	if a != b {
+		t.Errorf("not deterministic: %q != %q", a, b)
+	}
+}


### PR DESCRIPTION
## What

`kustomizationFingerprint` and `helmReleaseFingerprint` shared the identical `sha256.Sum256(raw)` → `hex.EncodeToString(sum[:])` tail. Extract `manifest.SHA256Hex([]byte) string` (the `manifest` package is already imported by both) and call it from both, dropping the duplicated `crypto/sha256` + `encoding/hex` imports.

Deliberately scoped to the **one-shot full-buffer** digest. The streaming/incremental hasher in `workingTreeFingerprint` (which feeds a file-tree walk into a running `sha256.Hash`) is a different operation and keeps its own hasher — unifying it would be force-fitting.

## Verification

- `gofmt`/`go build`/`go vet`/`go test -race` (manifest + controllers)/`golangci-lint` → clean, 0 issues; added `TestSHA256Hex` (known vectors + determinism).
- Output is byte-identical (same algorithm) — fingerprint dedup behavior unchanged; `get ks`/`get hr` membership + normalized `build all` content identical across drag0n141/aclerici38/onedr0p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)