### PR TITLE
ci: v-prefix release tags so the module is go-gettable by semver

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -184,8 +184,6 @@ runs:
           DL_DIR="$(mktemp -dt flate-XXXXXX)"
           trap 'rm -rf "${DL_DIR}"' EXIT
 
-          BASE_URL="https://github.com/home-operations/flate/releases/download/${VERSION}"
-
           max_retries=5
           retry_delay=5
           download() {
@@ -203,8 +201,20 @@ runs:
             return 1
           }
 
-          download "${BASE_URL}/${ARCHIVE}" "${DL_DIR}/${ARCHIVE}"
-          download "${BASE_URL}/${ARCHIVE}.sha256" "${DL_DIR}/${ARCHIVE}.sha256"
+          # Release tags are v-prefixed (release-please include-v-in-tag); older
+          # releases used a bare version. Asset names stay v-less (goreleaser's
+          # .Version) — only the tag segment in the path changes — so try the
+          # v-prefixed tag first and fall back to the bare one.
+          fetch_from() {
+            local base="https://github.com/home-operations/flate/releases/download/$1"
+            download "${base}/${ARCHIVE}" "${DL_DIR}/${ARCHIVE}" \
+              && download "${base}/${ARCHIVE}.sha256" "${DL_DIR}/${ARCHIVE}.sha256"
+          }
+
+          fetch_from "v${VERSION}" || fetch_from "${VERSION}" || {
+            echo "Failed to download flate (tried tags v${VERSION} and ${VERSION})"
+            exit 1
+          }
 
           echo "Verifying checksum"
           if command -v sha256sum > /dev/null; then

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,8 +16,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
-      "include-v-in-tag": false,
-      "include-v-in-release-name": false,
+      "include-v-in-tag": true,
+      "include-v-in-release-name": true,
       "always-update": true
     }
   },


### PR DESCRIPTION
## Why
Go modules only recognize `vX.Y.Z` tags as semver versions. flate tags releases **without** the `v` (`include-v-in-tag: false`), so Go can't resolve a real version — consumers like konflate are stuck on pseudo-versions (`v0.0.0-2026…-<sha>`) in `go.mod`. Switching to `v`-prefixed tags lets them pin a clean `github.com/home-operations/flate vX.Y.Z`.

## Changes
- **`release-please-config.json`** — `include-v-in-tag` and `include-v-in-release-name` → `true`. The next release will be tagged `vX.Y.Z` (flate is at `0.2.12`, i.e. v0, so `v0.2.x` is a valid module version — no `/vN` path suffix needed).
- **`action/action.yml`** (the install action) — fixed for the new tag format. goreleaser already names assets with the v-stripped `{{ .Version }}` and attaches them to release-please's release (`release: keep-existing`), so **asset names are unchanged** (`flate_0.2.13_…`); only the **release-tag segment** of the download URL gains the `v`. The action now downloads from the v-prefixed tag and **falls back to the bare tag**, so pins to existing (pre-v) releases keep working.

goreleaser itself needs no change — `vX.Y.Z` is its native tag convention (`.Version` is already v-stripped).

## Testing
Ran the action's download logic against the real `0.2.12` release (which is still bare-tagged): `v0.2.12` 404s → falls back to `0.2.12` → downloads the archive + `.sha256`, **checksum verifies**. So the legacy path is intact; a future `v0.2.13` release will hit the v-prefixed URL on the first try. JSON/YAML formatters clean.

## Follow-up
`include-v-in-tag` applies to the **next** release. Since this is a `ci:` change, release-please won't cut a release on its own — the next `feat:`/`fix:` (or a manual release-please run) produces the first `vX.Y.Z` tag. After that, konflate (and other consumers) can `go get github.com/home-operations/flate@vX.Y.Z` for a semver `go.mod` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
