### PR TITLE
perf(discovery): compute KS path prefixes once; defer namespace pass

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -150,16 +150,22 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	// helpers read each KS's spec.path joined under this root to
 	// follow `components:` entries; cfg.Path would misread when the
 	// user pointed --path at a subdir below the actual repo root.
+	// Compute the KS spec.path prefix list ONCE and reuse it across the
+	// KS-parent index, the HR-parent index, and orphan promotion. Each
+	// previously rebuilt the identical list (an O(KS) walk + sort +
+	// component reads); the shared ComponentCache deduped the file reads
+	// but not the iteration/sort/list construction.
+	prefixes := loader.KSPathPrefixesWithCache(d.cfg.Store, repoRoot, cfg.ComponentCache)
 	parentOf := mergeParents(
-		loader.BuildParentIndexForKindWithCache(d.cfg.Store, repoRoot, d.sourceFiles, manifest.KindKustomization, cfg.ComponentCache),
-		loader.BuildParentIndexForKindWithCache(d.cfg.Store, repoRoot, d.sourceFiles, manifest.KindHelmRelease, cfg.ComponentCache),
+		loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindKustomization),
+		loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease),
 	)
 	// Orphan promotion: every Existence entry whose file path is NOT
 	// under any KS spec.path will never reach the Store through KS
 	// render emission. Promote it now so standalone CRs (loose HR
 	// at repo root, sources next to flux-system/kustomization.yaml,
 	// etc.) keep working in DiscoveryOnly mode.
-	d.promoteOrphans()
+	d.promoteOrphans(prefixes)
 
 	return &Result{
 		RepoRoot:    repoRoot,
@@ -234,6 +240,14 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	if err := d.loadAt(ctx, l, scanRoot, scanned, &total); err != nil {
 		return err
 	}
+	// Apply namespaces once over the initially-scanned set so the
+	// bootstrap-source alias and the first expansion pass see populated
+	// namespaces. The fixed-point loop below intentionally does NOT
+	// re-run applyNamespaces per discovered spec.path — that was an
+	// O(N²) full-store rebuild on every newly-loaded KS. Namespace
+	// inheritance is idempotent and order-independent, so the single
+	// post-loop pass in Run (after the complete KS set is discovered)
+	// stamps every loop-discovered object correctly in one walk.
 	d.applyNamespaces(repoRoot)
 
 	// Fixed-point expansion: each pass renders Kustomizations the prior
@@ -287,7 +301,6 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			if err := d.loadAt(ctx, l, target, scanned, &total); err != nil {
 				return err
 			}
-			d.applyNamespaces(repoRoot)
 			added++
 		}
 		// Re-evaluate the convergence cache when new RSIPs arrived

--- a/pkg/discovery/orphans.go
+++ b/pkg/discovery/orphans.go
@@ -27,16 +27,14 @@ import (
 // post-reconcile failure demotion there) and must agree on the
 // same "under a KS path" predicate so an object can't be classified
 // orphan by one and parented by the other.
-func (d *discoverer) promoteOrphans() {
+func (d *discoverer) promoteOrphans(prefixes []loader.KSPathPrefix) {
 	if d.loader.Existence == nil {
 		return
 	}
-	// Same repoRoot argument as BuildParentIndexForKind — passing
-	// cfg.Path would misread component lookups when --path is a
-	// subdir below the actual repo root. Route through the shared
-	// component cache so the kustomization.yaml reads already done
-	// by the parent-index passes are served from memory.
-	prefixes := loader.KSPathPrefixesWithCache(d.cfg.Store, d.repoRoot, d.cfg.ComponentCache)
+	// prefixes is the same KS spec.path list discovery.Run computed for
+	// the parent-index passes (identical repoRoot + shared component
+	// cache). Reusing it keeps this and the parent index in lockstep on
+	// the "under a KS path" predicate and avoids a third rebuild.
 	for id := range d.loader.Existence.All() {
 		if d.cfg.Store.GetObject(id) != nil {
 			continue
@@ -52,4 +50,3 @@ func (d *discoverer) promoteOrphans() {
 		}
 	}
 }
-

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -210,7 +210,17 @@ func BuildParentIndexForKind(s *store.Store, repoRoot string, sourceFiles map[ma
 // passes — without sharing, each invocation walks the same KS list
 // and re-reads every kustomization.yaml's `components:` independently.
 func BuildParentIndexForKindWithCache(s *store.Store, repoRoot string, sourceFiles map[manifest.NamedResource]string, childKind string, cache *manifest.ComponentCache) map[manifest.NamedResource]manifest.NamedResource {
-	prefixes := KSPathPrefixesWithCache(s, repoRoot, cache)
+	return BuildParentIndexFromPrefixes(KSPathPrefixesWithCache(s, repoRoot, cache), s, sourceFiles, childKind)
+}
+
+// BuildParentIndexFromPrefixes is BuildParentIndexForKindWithCache with
+// the KS path-prefix list passed in precomputed. discovery.Run derives
+// the prefixes once (an O(KS) walk + sort + component reads) and reuses
+// them for the KS-parent index, the HR-parent index, AND orphan
+// promotion — three consumers that previously each rebuilt the identical
+// list. Standalone callers use BuildParentIndexForKind(WithCache), which
+// compute the prefixes for a single use.
+func BuildParentIndexFromPrefixes(prefixes []KSPathPrefix, s *store.Store, sourceFiles map[manifest.NamedResource]string, childKind string) map[manifest.NamedResource]manifest.NamedResource {
 	// Group each id's own claimed prefixes so a peer KS claiming the same
 	// spec.path directory isn't mistaken for an enclosing parent (which
 	// would mutually deadlock the pair through collectDeps). Children


### PR DESCRIPTION
## What

Two O(N²)→O(N) reductions in the discovery phase.

### 1. KS path-prefix dedup
`KSPathPrefixesWithCache` was rebuilt **three times** per run — for the KS-parent index, the HR-parent index, and orphan promotion — each an O(KS) walk + sort + component read (the shared `ComponentCache` deduped *file reads* but not the iteration/sort/list construction). Factor `BuildParentIndexFromPrefixes` out of `BuildParentIndexForKindWithCache`, compute the prefix list **once** in `discovery.Run`, and reuse it for all three consumers. `promoteOrphans` now takes the precomputed list (keeping it lockstep with the parent index on the "under a KS path" predicate). `BuildParentIndexForKind(WithCache)` stay as thin wrappers for standalone callers.

### 2. Namespace-pass deferral
`applyNamespaces` ran **inside** the fixed-point KS-expansion loop — once per newly-discovered `spec.path` — rebuilding the full namespace-inheritance index every iteration (1+2+…+N store walks). Namespace inheritance is idempotent and order-independent, and nothing in the loop body (spec.path follow, ResourceSet render) reads loop-discovered KS namespaces, so the single post-loop pass in `Run` (which already runs over the complete store) stamps every object correctly in one walk. The one pre-loop pass is kept so the bootstrap-source alias + first expansion iteration see populated namespaces.

## Verification

- `gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues.
- **Behavior-equivalence across all 12 sample repos** (`~/repos`): identical `get ks` + `get hr` membership everywhere; identical **normalized** `build all` content everywhere. The only run-to-run content deltas (drag0n141 `checksum/secrets`, zariel `genCA`/`genSelfSignedCert` `caBundle`/`tls.*`) are **pre-existing Helm chart non-determinism**, identical on `main` (verified: baseline binary flaps the same way), and disappear once those volatile fields are normalized out — at which point baseline and branch are byte-identical. Confirmed safe on ResourceSet-heavy repos (joryirving, drag0n141, tholinka-style patterns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)