### PR TITLE
perf(store,orchestrator): drop redundant work in ListObjects + finalize

### DIFF
--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -53,9 +53,9 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 // point reads as start → drain → finalize.
 func (o *Orchestrator) finalize() error {
 	failed := o.store.FailedResources()
-	o.cascadeParentFailures(failed)
+	ksCount, hrCount := o.cascadeParentFailures(failed)
 	o.demoteOrphans(failed)
-	o.logSummary(failed)
+	o.logSummary(failed, ksCount, hrCount)
 	o.logResourceFailures(failed)
 
 	// Compose any unattributed panic count with the aggregated
@@ -87,7 +87,7 @@ func (o *Orchestrator) finalize() error {
 // Walks the ParentOf chain per child so a deep render tree (grand-
 // parent → parent → child) propagates failures all the way down in
 // one pass. Cycle-guard via a visited set keeps the walk bounded.
-func (o *Orchestrator) cascadeParentFailures(failed map[manifest.NamedResource]store.StatusInfo) {
+func (o *Orchestrator) cascadeParentFailures(failed map[manifest.NamedResource]store.StatusInfo) (ksCount, hrCount int) {
 	ancestorFailure := func(child manifest.NamedResource) (manifest.NamedResource, store.StatusInfo, bool) {
 		visited := map[manifest.NamedResource]struct{}{child: {}}
 		cur := child
@@ -126,11 +126,23 @@ func (o *Orchestrator) cascadeParentFailures(failed map[manifest.NamedResource]s
 			"parent", parent.String(),
 			"reason", parentInfo.Message)
 	}
+	// Count KS/HR while we already hold the listings, so logSummary
+	// doesn't re-scan the store for the same two counts. cascade only
+	// mutates status (never adds/removes objects), so these counts equal
+	// what a later ListObjects would report.
 	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
-		for _, obj := range o.store.ListObjects(kind) {
+		objs := o.store.ListObjects(kind)
+		switch kind {
+		case manifest.KindKustomization:
+			ksCount = len(objs)
+		case manifest.KindHelmRelease:
+			hrCount = len(objs)
+		}
+		for _, obj := range objs {
 			cascade(obj.Named())
 		}
 	}
+	return ksCount, hrCount
 }
 
 // demoteOrphans filters out resources whose source files sit under
@@ -152,9 +164,9 @@ func (o *Orchestrator) demoteOrphans(failed map[manifest.NamedResource]store.Sta
 	}
 }
 
-func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.StatusInfo) {
-	ksCount := len(o.store.ListObjects(manifest.KindKustomization))
-	hrCount := len(o.store.ListObjects(manifest.KindHelmRelease))
+func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.StatusInfo, ksCount, hrCount int) {
+	// ksCount/hrCount are passed in from cascadeParentFailures, which
+	// already listed both kinds — no redundant re-scan here.
 	slog.Debug("reconcile complete",
 		"kustomizations", ksCount,
 		"helm_releases", hrCount,

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"cmp"
 	"hash/fnv"
 	"reflect"
 	"slices"
@@ -522,8 +523,20 @@ func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 		}
 		s.rUnlockAll()
 	}
-	slices.SortFunc(out, func(a, b manifest.BaseManifest) int {
-		return a.Named().Compare(b.Named())
-	})
+	if kind != "" {
+		// All results share the queried Kind (byName[kind] index), so
+		// NamedResource.Compare's leading Kind comparison is always 0 here.
+		// Sort by (Namespace, Name) directly — identical order, one fewer
+		// string compare per element. This path runs per-kind in hot
+		// orchestrator loops (cycles, finalize, render collection).
+		slices.SortFunc(out, func(a, b manifest.BaseManifest) int {
+			an, bn := a.Named(), b.Named()
+			return cmp.Or(cmp.Compare(an.Namespace, bn.Namespace), cmp.Compare(an.Name, bn.Name))
+		})
+	} else {
+		slices.SortFunc(out, func(a, b manifest.BaseManifest) int {
+			return a.Named().Compare(b.Named())
+		})
+	}
 	return out
 }


### PR DESCRIPTION
## What

Two micro-optimizations, both **provably output-identical**.

- **`store.ListObjects(kind)`**: when a kind is queried, every result already shares that Kind (the `byName[kind]` index), so `NamedResource.Compare`'s leading `Kind` comparison is always 0. Sort by `(Namespace, Name)` directly — same order (the full Compare reduces to exactly this for same-Kind elements), one fewer string compare per element. This path runs per-kind in hot orchestrator loops (`cycles`, `finalize`, render collection). The `kind == ""` path keeps the full `(Kind, Namespace, Name)` sort.

- **`finalize`**: `cascadeParentFailures` already lists Kustomizations and HelmReleases to walk them; have it return the two counts so `logSummary` consumes them instead of re-listing both kinds. `cascade` only mutates status (never adds/removes objects), so the counts are identical to a re-scan.

## Verification

- `gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues (store determinism tests still pass — order unchanged).
- `get ks`/`get hr` membership + normalized `build all` content identical across drag0n141/aclerici38/onedr0p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)