### PR TITLE
docs(manifest): document that retained pooled docs are intentional (with benchmark)

### DIFF
--- a/pkg/manifest/bench_test.go
+++ b/pkg/manifest/bench_test.go
@@ -47,6 +47,85 @@ data:
 	}
 }
 
+// renderDocsBlob builds a 50-doc multi-document YAML stream resembling
+// a chart render that a controller retains on its artifact.
+func renderDocsBlob() []byte {
+	var buf bytes.Buffer
+	for i := range 50 {
+		if i > 0 {
+			buf.WriteString("---\n")
+		}
+		fmt.Fprintf(&buf, `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-%d
+  namespace: ns
+  labels:
+    app.kubernetes.io/name: app-%d
+spec:
+  replicas: %d
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: app-%d
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: app-%d
+    spec:
+      containers:
+        - name: main
+          image: registry.example.com/app:%d
+          env:
+            - name: FOO
+              value: bar-%d
+`, i, i, i, i, i, i, i)
+	}
+	return buf.Bytes()
+}
+
+// BenchmarkArtifactRetain_Current models the production controller path:
+// SplitDocs then retain the slice on the artifact WITHOUT releasing the
+// pooled maps (they are owned by the artifact for the run's lifetime).
+//
+// BenchmarkArtifactRetain_DeepCopyRelease models the audit's proposed
+// "fix" — deep-copy each retained doc into a fresh non-pooled map, then
+// release the pooled originals so the pool can reuse them. The pair
+// proves the fix is net-NEGATIVE: returning the pooled map for reuse
+// can at best save one 16-bucket alloc per doc, while the deep copy
+// allocates the entire nested tree per doc. So flate keeps the docs
+// straight off the pool (drawing from it still skips the initial map
+// alloc; retaining them is correct, not a leak). See io.go.
+func BenchmarkArtifactRetain_Current(b *testing.B) {
+	data := renderDocsBlob()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		docs, err := SplitDocs(data)
+		if err != nil {
+			b.Fatalf("SplitDocs: %v", err)
+		}
+		_ = docs // retained on the artifact; not released
+	}
+}
+
+func BenchmarkArtifactRetain_DeepCopyRelease(b *testing.B) {
+	data := renderDocsBlob()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		docs, err := SplitDocs(data)
+		if err != nil {
+			b.Fatalf("SplitDocs: %v", err)
+		}
+		retained := make([]map[string]any, len(docs))
+		for i, d := range docs {
+			retained[i] = DeepCopyMap(d) // break the pool alias
+			ReleaseDoc(d)                // return the original for reuse
+		}
+		_ = retained
+	}
+}
+
 // BenchmarkParseDoc_Kustomization measures ParseDoc dispatch + the
 // kustomize-controller typed decode for a Flux Kustomization document.
 func BenchmarkParseDoc_Kustomization(b *testing.B) {

--- a/pkg/manifest/io.go
+++ b/pkg/manifest/io.go
@@ -88,6 +88,16 @@ func ReleaseIfNotRetained(doc map[string]any, obj BaseManifest) {
 // pipeline returns them via ReleaseIfNotRetained after ParseDoc;
 // external callers that mutate / retain the returned slice should
 // NOT release (the entries are still owned by them).
+//
+// Retained-and-never-released is the CORRECT lifecycle, not a leak: a
+// controller that stores SplitDocs output on a render artifact owns
+// those maps for the run, so they legitimately never return to the
+// pool. Drawing from the pool still pays off — it skips the initial
+// 16-bucket allocation on every Get, retained or not. Deep-copying a
+// retained doc just to recycle the pooled original is net-negative: the
+// copy allocates the whole nested tree, far more than the single map
+// alloc it would recover (see BenchmarkArtifactRetain_Current vs
+// _DeepCopyRelease — the copy path costs more time, memory, and allocs).
 func DecodeDocs(r io.Reader) ([]map[string]any, error) {
 	dec := yaml.NewDecoder(r)
 	var out []map[string]any


### PR DESCRIPTION
## What

The audit flagged decoded docs retained on render artifacts as a "`sync.Pool` leak" (rated high value) and proposed deep-copying each retained doc to return the pooled original for reuse.

**Benchmarked before acting** (`BenchmarkArtifactRetain_Current` vs `_DeepCopyRelease`):

| | time | memory | allocs |
|---|---|---|---|
| Current (retain, no release) | 935,939 ns | 969 KB | 16,477 |
| Proposed (deep-copy + release) | 1,002,622 ns | 1,115 KB | 17,686 |

The proposed fix is **net-negative on all three metrics**. Returning a pooled map can at best recover one 16-bucket allocation, while the deep copy allocates the entire nested tree per doc.

It was never a leak: a controller that stores `SplitDocs` output on an artifact **owns** those maps for the run, so they correctly never return to the pool. Drawing from the pool still pays off — it skips the initial map allocation on every `Get`, retained or not.

## Change

Strengthen the `DecodeDocs` docstring to state the retained-and-never-released lifecycle is intentional, and keep the benchmark as evidence so a future contributor doesn't reintroduce the regression. No production behavior change.

## Verification

`gofmt`/`go build`/`go vet`/`go test -race` (manifest)/`golangci-lint` → clean, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)