### PR TITLE
fix(source/git): support HTTPS client certificates (mTLS) in secretRef

### DIFF
--- a/pkg/source/git/tls.go
+++ b/pkg/source/git/tls.go
@@ -14,12 +14,19 @@ import (
 // same gate without a circular import.
 
 // resolveTLS builds a *tls.Config from spec.secretRef for HTTPS
-// GitRepositories using a custom CA. Returns nil when no CA material
-// is present (anonymous / system-CA path). Matches Flux
-// source-controller key conventions: "ca.crt" (preferred) or
-// "caFile" (legacy alias).
+// GitRepositories. It reads both a custom CA ("ca.crt" preferred,
+// "caFile" legacy alias) AND a client certificate ("tls.crt" +
+// "tls.key") so HTTPS-with-mTLS repositories authenticate — matching
+// the cert-resolution schema the OCI and Bucket fetchers already use.
+// Returns nil when the secret carries no TLS material at all (the
+// anonymous / system-CA / SSH-identity / basic-auth path).
 //
-// SSH repositories ignore this — TLS doesn't apply to that transport.
+// Unlike OCI/Bucket this does NOT route through source.ResolveCertSecret:
+// a GitRepository's single secretRef carries auth credentials AND
+// optional TLS material together, so a secret holding only an SSH
+// identity or username/password must resolve to nil here rather than
+// erroring "no TLS material". The SSH-URL guard and the no-material
+// short-circuit below preserve that.
 func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) {
 	if repo.SecretRef == nil {
 		return nil, nil
@@ -37,11 +44,15 @@ func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) 
 		// resolveAuth reports the missing-secret error first.
 		return nil, nil
 	}
+	crt := source.StringFromSecret(sec, "tls.crt")
+	key := source.StringFromSecret(sec, "tls.key")
 	ca := cmp.Or(source.StringFromSecret(sec, "ca.crt"), source.StringFromSecret(sec, "caFile"))
-	if ca == "" {
+	if crt == "" && key == "" && ca == "" {
+		// No TLS material — the secret carries only SSH identity or
+		// basic-auth credentials. Anonymous / system-CA path.
 		return nil, nil
 	}
-	cfg, err := source.BuildTLSConfig("", "", ca)
+	cfg, err := source.BuildTLSConfig(crt, key, ca)
 	if err != nil {
 		return nil, fmt.Errorf("GitRepository %s/%s: secretRef %s/%s: %w",
 			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name, err)

--- a/pkg/source/git/tls_test.go
+++ b/pkg/source/git/tls_test.go
@@ -99,6 +99,43 @@ func TestFetcher_ResolveTLS_CAFromCAFileLegacyKey(t *testing.T) {
 	}
 }
 
+func TestFetcher_ResolveTLS_ClientCertMTLS(t *testing.T) {
+	crt, key := testutil.SelfSignedClientCert(t)
+	caPEM := testutil.SelfSignedCA(t)
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{
+				"tls.crt": crt, "tls.key": key, "ca.crt": caPEM,
+			}}
+		},
+	}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "creds")
+	cfg, err := f.resolveTLS(repo)
+	if err != nil {
+		t.Fatalf("resolveTLS: %v", err)
+	}
+	if cfg == nil || len(cfg.Certificates) != 1 {
+		t.Fatalf("expected one client certificate from tls.crt/tls.key: %+v", cfg)
+	}
+	if cfg.RootCAs == nil {
+		t.Errorf("expected RootCAs populated alongside the client cert")
+	}
+}
+
+func TestFetcher_ResolveTLS_ClientCertWithoutKeyErrors(t *testing.T) {
+	crt, _ := testutil.SelfSignedClientCert(t)
+	f := &Fetcher{
+		Secrets: func(_, _ string) *manifest.Secret {
+			return &manifest.Secret{StringData: map[string]any{"tls.crt": crt}}
+		},
+	}
+	repo := gitRepoWithSecret("g", "https://example.com/x.git", "creds")
+	_, err := f.resolveTLS(repo)
+	if err == nil || !strings.Contains(err.Error(), "tls.crt and tls.key") {
+		t.Errorf("expected paired-cert error; got %v", err)
+	}
+}
+
 func TestFetcher_ResolveTLS_InvalidPEM(t *testing.T) {
 	f := &Fetcher{
 		Secrets: func(_, _ string) *manifest.Secret {


### PR DESCRIPTION
## What

`git/tls.go` read only `ca.crt`/`caFile` from the GitRepository `secretRef` and **silently dropped** any `tls.crt` + `tls.key` — so an HTTPS repository requiring a **client certificate (mTLS)** failed auth, even though the OCI and Bucket fetchers already support full mTLS via `source.BuildTLSConfig`. Read `tls.crt`/`tls.key` alongside the CA and pass all three.

## Why inline, not `source.ResolveCertSecret`

A GitRepository's **single** `secretRef` carries auth credentials AND optional TLS material together (unlike OCI/Bucket, which have a separate `certSecretRef`). Routing through `ResolveCertSecret` would error `"no TLS material"` for a secret holding only an SSH identity or `username`/`password`. So the fix is inline: the SSH-URL guard and a no-TLS-material short-circuit keep those secrets resolving to `nil` (anonymous / system-CA path), while a half-configured cert (`tls.crt` without `tls.key`) now surfaces `BuildTLSConfig`'s paired-cert error — matching OCI/Bucket behavior.

## Verification

- `gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues.
- New tests: `…_ClientCertMTLS` (cert+key+CA → one `Certificates` entry + `RootCAs`), `…_ClientCertWithoutKeyErrors` (paired-cert error). Existing CA-only / no-CA / SSH / basic-auth tests still pass.
- No behavior change for repos without TLS secrets — `get ks`/`get hr`/`build all` identical across drag0n141/aclerici38/onedr0p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)