### PR TITLE
fix(cli): validate --profile at flag-parse time

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -122,7 +122,7 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 		"maximum backoff between source-fetch retries")
 	fs.Float64Var(&f.sourceRetryJitter, "source-retry-jitter", 0.1,
 		"jitter fraction [0,1] applied to source-fetch retry backoff")
-	fs.StringVar(&f.profileMode, "profile", "",
+	fs.Var(&profileValue{target: &f.profileMode}, "profile",
 		"write a runtime profile: cpu, mem, block, mutex, or trace (off by default)")
 	fs.StringVar(&f.profileOut, "profile-out", ".",
 		"directory to write profile files into (used with --profile)")
@@ -442,6 +442,29 @@ func (o *outputValue) Set(v string) error {
 		names[i] = string(a)
 	}
 	return fmt.Errorf("must be one of: %s", strings.Join(names, ", "))
+}
+
+// profileModes are the runtime profiles --profile accepts. The empty
+// string (the default) means no profiling; startProfile treats it as a
+// no-op.
+var profileModes = []string{"cpu", "mem", "block", "mutex", "trace"}
+
+// profileValue is the pflag.Value backing --profile: a string
+// constrained to profileModes (or "" for off). Set rejects anything
+// else, so cobra surfaces the error (with usage) at parse time, before
+// the command runs — instead of deferring to startProfile's runtime
+// default case after all other init has happened. Mirrors outputValue.
+type profileValue struct{ target *string }
+
+func (p *profileValue) String() string { return *p.target }
+func (p *profileValue) Type() string   { return "string" }
+
+func (p *profileValue) Set(v string) error {
+	if v == "" || slices.Contains(profileModes, v) {
+		*p.target = v
+		return nil
+	}
+	return fmt.Errorf("must be one of: %s", strings.Join(profileModes, ", "))
 }
 
 // runOrchestratorCfg routes the CLI through the embed-friendly

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -277,3 +277,26 @@ func TestOutputValue_Validates(t *testing.T) {
 		t.Errorf("error should name the accepted set: %q", err)
 	}
 }
+
+func TestProfileValue_Validates(t *testing.T) {
+	var mode string
+	v := &profileValue{target: &mode}
+
+	for _, ok := range []string{"cpu", "mem", "block", "mutex", "trace", ""} {
+		mode = "sentinel"
+		if err := v.Set(ok); err != nil {
+			t.Errorf("%q should be accepted: %v", ok, err)
+		}
+		if mode != ok {
+			t.Errorf("Set(%q) should update target, got %q", ok, mode)
+		}
+	}
+
+	err := v.Set("heap")
+	if err == nil {
+		t.Fatal("invalid mode should be rejected at parse time")
+	}
+	if !strings.Contains(err.Error(), "must be one of: cpu, mem, block, mutex, trace") {
+		t.Errorf("error should name the accepted set: %q", err)
+	}
+}


### PR DESCRIPTION
## What

`--profile` was a plain `StringVar`; an invalid mode (e.g. `--profile=heap`) was accepted at parse time and only rejected at **runtime** inside `startProfile`'s default case — after all other init had already run. Add a `profileValue` `pflag.Value` (mirroring the existing `outputValue` enum) that rejects anything outside `{cpu, mem, block, mutex, trace}` (or `""` for off) at parse time, so cobra surfaces the error with the flag name and usage before the command runs.

```
$ flate get ks --profile=heap
flate error: invalid argument "heap" for "--profile" flag: must be one of: cpu, mem, block, mutex, trace
```

## Verification

- `gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues; added `TestProfileValue_Validates`.
- Functional: invalid mode rejected at parse (shown above); `--profile=cpu` still works. No render behavior change — `build all` content identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)