### PR TITLE
refactor: adopt Go 1.21+ stdlib idioms (clear, slices.Concat/Clone)

### DIFF
--- a/pkg/loader/ignore.go
+++ b/pkg/loader/ignore.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/fluxcd/pkg/sourceignore/gitignore"
@@ -73,6 +74,6 @@ func (i *ignoreSet) matches(path, root string, isDir bool) bool {
 	rootSlash := filepath.ToSlash(root)
 	domain := strings.Split(rootSlash, "/")
 	relParts := strings.Split(relSlash, "/")
-	segments := append(append([]string(nil), domain...), relParts...)
+	segments := slices.Concat(domain, relParts)
 	return i.matcher.Match(segments, isDir)
 }

--- a/pkg/source/ignore.go
+++ b/pkg/source/ignore.go
@@ -94,7 +94,7 @@ func walkAndDelete(root string, domain []string, matcher gitignore.Matcher) erro
 		if err != nil {
 			return err
 		}
-		segments := append(append([]string{}, domain...), strings.Split(rel, string(filepath.Separator))...)
+		segments := slices.Concat(domain, strings.Split(rel, string(filepath.Separator)))
 		if matcher.Match(segments, false) {
 			toRemove = append(toRemove, p)
 		}

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -357,9 +357,7 @@ func releaseListenerSnapshot(snap []Listener) {
 	}
 	// Clear listener references so the pool doesn't pin payload
 	// closures (each Listener may close over arbitrary state).
-	for i := range snap {
-		snap[i] = nil
-	}
+	clear(snap)
 	bucket := poolBucket(cap(snap))
 	snap = snap[:0]
 	listenerSnapshotPools[bucket].Put(&snap)

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"slices"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -268,9 +269,7 @@ func (s *Store) GetConditions(id manifest.NamedResource) []Condition {
 	if len(conds) == 0 {
 		return nil
 	}
-	out := make([]Condition, len(conds))
-	copy(out, conds)
-	return out
+	return slices.Clone(conds)
 }
 
 // conditionEqual reports whether two conditions carry the same

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -452,9 +452,7 @@ func (s *Store) Snapshot(id manifest.NamedResource) (manifest.BaseManifest, []Co
 	if len(conds) == 0 {
 		return obj, nil
 	}
-	out := make([]Condition, len(conds))
-	copy(out, conds)
-	return obj, out
+	return obj, slices.Clone(conds)
 }
 
 // DeleteObject removes the object stored under id. Returns whether


### PR DESCRIPTION
## What

No-behavior-change stdlib modernizations:

- **`clear(snap)`** for the manual nil-out loop in `store/events.go`'s listener-snapshot pool release.
- **`slices.Concat(domain, parts)`** for the nested `append(append([]string{...}, domain...), parts...)` segment builds in `loader/ignore.go` and `source/ignore.go` (both inputs come from `strings.Split`, always non-empty, so the result slice is identical).
- **`slices.Clone(conds)`** for the `make + copy` defensive `Condition` copies in `store.go` `Snapshot` and `status.go` `GetConditions` (both already guard `len == 0`, so `Clone` only runs on non-empty input — identical result).

## Intentionally skipped

The audit also suggested converting the `finalize`/`cycles`/`run` `ListObjects(kind)` loops to `store.ListAs`. **Evaluated and dropped**: those are unified `for kind in {KS, HR}` loops that only need `.Named()` or a centralized type-switch (`sameKindDepTargets`). `ListAs` is per-kind-typed, so adopting it would force duplicating each loop body per kind — net churn, not a simplification. The unified loop is the cleaner form.

## Verification

`gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues; `build all` content identical across drag0n141/aclerici38/onedr0p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)