### PR TITLE
refactor(manifest,loader): dedup parseSecret field loops and path resolution

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -196,6 +196,16 @@ func resolveDataPath(base, rel string) (string, bool) {
 // We still reject URLs and absolute paths — flate's loader only
 // follows local relative components.
 func resolveComponentPath(base, rel string) (string, bool) {
+	return resolvePath(base, rel)
+}
+
+// resolvePath joins rel under base, rejecting empty, absolute, and URL
+// refs (flate's loader only follows local relative paths). It permits
+// parent-directory escaping — both `components:` and directory
+// `resources:` legitimately reference `../...` and kustomize follows
+// them. The two public wrappers carry that intent at the call site;
+// centralizing the shared validation here keeps them from drifting.
+func resolvePath(base, rel string) (string, bool) {
 	if rel == "" || filepath.IsAbs(rel) || strings.Contains(rel, "://") {
 		return "", false
 	}
@@ -214,8 +224,5 @@ func resolveComponentPath(base, rel string) (string, bool) {
 // resources keep resolveDataPath's stricter policy (re-checked by the
 // caller after stat), so this is the dir-descent path only.
 func resolveResourcePath(base, rel string) (string, bool) {
-	if rel == "" || filepath.IsAbs(rel) || strings.Contains(rel, "://") {
-		return "", false
-	}
-	return filepath.Clean(filepath.Join(base, rel)), true
+	return resolvePath(base, rel)
 }

--- a/pkg/manifest/configmap.go
+++ b/pkg/manifest/configmap.go
@@ -103,28 +103,32 @@ func parseSecret(doc map[string]any, wipeSecrets bool) (*Secret, error) {
 	}
 	s := &Secret{Name: name, Namespace: ns}
 	if data, ok := doc["data"].(map[string]any); ok {
-		out := make(map[string]any, len(data))
-		for k, v := range data {
-			if wipeSecrets {
-				out[k] = base64.StdEncoding.EncodeToString(
-					fmt.Appendf(nil, ValuePlaceholderTemplate, k),
-				)
-			} else {
-				out[k] = v
-			}
-		}
-		s.Data = out
+		// .data values are base64-encoded per the Kubernetes Secret schema.
+		s.Data = wiperField(data, wipeSecrets, func(k string) any {
+			return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, ValuePlaceholderTemplate, k))
+		})
 	}
 	if sd, ok := doc["stringData"].(map[string]any); ok {
-		out := make(map[string]any, len(sd))
-		for k, v := range sd {
-			if wipeSecrets {
-				out[k] = fmt.Sprintf(ValuePlaceholderTemplate, k)
-			} else {
-				out[k] = v
-			}
-		}
-		s.StringData = out
+		// .stringData stays plaintext per the Kubernetes Secret schema.
+		s.StringData = wiperField(sd, wipeSecrets, func(k string) any {
+			return fmt.Sprintf(ValuePlaceholderTemplate, k)
+		})
 	}
 	return s, nil
+}
+
+// wiperField copies src, replacing each value with a per-key placeholder
+// (produced by encode) when wipeSecrets is set, else passing the original
+// value through. parseSecret calls it for both .data and .stringData —
+// the only difference between those fields is the encoding, via encode.
+func wiperField(src map[string]any, wipeSecrets bool, encode func(key string) any) map[string]any {
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		if wipeSecrets {
+			out[k] = encode(k)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## What

- **`manifest.parseSecret`**: the `.data` and `.stringData` loops were identical apart from the value encoding (`.data` base64, `.stringData` plaintext per the Kubernetes Secret schema). Extract `wiperField(src, wipeSecrets, encode)` and pass the per-field encoder as a closure — one copy of the allocate/iterate/wipe logic, same output.
- **`loader`**: `resolveComponentPath` and `resolveResourcePath` had byte-identical bodies (reject empty/absolute/URL, then `Join`+`Clean`, permitting `..`-escape). Factor the shared validation into a private `resolvePath`; keep both public names as thin wrappers so call sites still read as component-vs-resource intent and the two can't silently drift.

No behavior change.

## Verification

`gofmt`/`go build`/`go vet`/`go test -race` (manifest + loader)/`golangci-lint` → clean, 0 issues; `build all` content identical across drag0n141/aclerici38/onedr0p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)