### PR TITLE
chore(testutil,cli): dedup cert/file fixtures + profile file-open boilerplate

### DIFF
--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -43,7 +43,7 @@ dependency upgrade or a flate post-render change makes the on-disk
 entries semantically stale faster than the size cap would prune
 them.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			layout := cacheroot.New(cf.resolveRoot())
+			layout := cacheroot.New(cf.resolveCacheRoot())
 			dir := layout.RenderHelmCache()
 			// os.RemoveAll on a non-existent path returns nil — the
 			// "no cache to clear" idempotency is free. Any other
@@ -68,7 +68,10 @@ type cacheFlags struct {
 	cacheDir string
 }
 
-func (f *cacheFlags) resolveRoot() string {
+// resolveCacheRoot resolves the cache root, mirroring
+// commonFlags.resolveCacheRoot so both flag types expose the same
+// method name over the shared package-level helper.
+func (f *cacheFlags) resolveCacheRoot() string {
 	return resolveCacheRoot(&f.cacheDir)
 }
 
@@ -100,7 +103,7 @@ Set --dry-run to see what would be removed without touching disk.`,
 			if f.maxAge < 0 {
 				return errors.New("--max-age must be non-negative")
 			}
-			layout := cacheroot.New(cf.resolveRoot())
+			layout := cacheroot.New(cf.resolveCacheRoot())
 			res, err := source.Sweep(layout, source.SweepOpts{
 				MaxAge:         f.maxAge,
 				IncludeMirrors: f.includeMirrors,

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -29,7 +29,7 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 	path := filepath.Join(outDir, mode+".pprof")
 	switch mode {
 	case "cpu":
-		f, err := os.Create(path) //nolint:gosec // path is composed from the user-supplied --profile-out plus a fixed mode suffix
+		f, err := createProfileFile(path)
 		if err != nil {
 			return nil, err
 		}
@@ -40,7 +40,7 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 		return func() { pprof.StopCPUProfile(); _ = f.Close() }, nil
 	case "mem":
 		return func() {
-			f, err := os.Create(path) //nolint:gosec // path is composed from the user-supplied --profile-out plus a fixed mode suffix
+			f, err := createProfileFile(path)
 			if err != nil {
 				return
 			}
@@ -51,7 +51,7 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 	case "block":
 		runtime.SetBlockProfileRate(1)
 		return func() {
-			f, err := os.Create(path) //nolint:gosec // path is composed from the user-supplied --profile-out plus a fixed mode suffix
+			f, err := createProfileFile(path)
 			if err != nil {
 				return
 			}
@@ -62,7 +62,7 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 	case "mutex":
 		runtime.SetMutexProfileFraction(1)
 		return func() {
-			f, err := os.Create(path) //nolint:gosec // path is composed from the user-supplied --profile-out plus a fixed mode suffix
+			f, err := createProfileFile(path)
 			if err != nil {
 				return
 			}
@@ -71,7 +71,7 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 			_ = f.Close()
 		}, nil
 	case "trace":
-		f, err := os.Create(filepath.Join(outDir, "trace.out")) //nolint:gosec // path is composed from the user-supplied --profile-out plus a fixed filename
+		f, err := createProfileFile(filepath.Join(outDir, "trace.out"))
 		if err != nil {
 			return nil, err
 		}
@@ -82,4 +82,12 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 		return func() { trace.Stop(); _ = f.Close() }, nil
 	}
 	return nil, errors.New("--profile must be one of: cpu, mem, block, mutex, trace")
+}
+
+// createProfileFile opens path for writing a profile. The G304 nolint
+// is centralized here: every caller composes path from the trusted
+// --profile-out directory plus a fixed mode/filename suffix, so it is
+// not an attacker-controlled path.
+func createProfileFile(path string) (*os.File, error) {
+	return os.Create(path) //nolint:gosec // path = trusted --profile-out + fixed suffix
 }

--- a/internal/testutil/certs.go
+++ b/internal/testutil/certs.go
@@ -58,22 +58,36 @@ func pemKey(t *testing.T, priv *ecdsa.PrivateKey) string {
 }
 
 // SelfSignedCA returns a PEM-encoded CA certificate.
-func SelfSignedCA(t *testing.T) string {
+// makeCertificate builds a self-signed cert (signed by its own
+// ephemeral ECDSA key) with the given subject CN and usage flags,
+// returning the cert and key as PEM. The shared boilerplate — serial,
+// validity window, key generation, CreateCertificate, PEM encoding —
+// lives here; the exported helpers pass only the fields that vary.
+func makeCertificate(t *testing.T, cn string, keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage, isCA bool) (cert, key string) {
 	t.Helper()
 	priv := ecKey(t)
 	tmpl := &x509.Certificate{
 		SerialNumber: randomSerial(t),
-		Subject:      pkix.Name{CommonName: "flate-test-ca"},
+		Subject:      pkix.Name{CommonName: cn},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(certValidity),
-		KeyUsage:     x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
-		IsCA:         true,
+		KeyUsage:     keyUsage,
+		ExtKeyUsage:  extKeyUsage,
+		IsCA:         isCA,
 	}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
 	if err != nil {
 		t.Fatalf("CreateCertificate: %v", err)
 	}
-	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), pemKey(t, priv)
+}
+
+// SelfSignedCA returns a PEM-encoded CA certificate.
+func SelfSignedCA(t *testing.T) string {
+	t.Helper()
+	cert, _ := makeCertificate(t, "flate-test-ca",
+		x509.KeyUsageCertSign|x509.KeyUsageDigitalSignature, nil, true)
+	return cert
 }
 
 // SelfSignedServerCert returns a PEM-encoded server+client cert and
@@ -81,39 +95,16 @@ func SelfSignedCA(t *testing.T) string {
 // CA bundle (IsCA=true).
 func SelfSignedServerCert(t *testing.T) (cert, key string) {
 	t.Helper()
-	priv := ecKey(t)
-	tmpl := &x509.Certificate{
-		SerialNumber: randomSerial(t),
-		Subject:      pkix.Name{CommonName: "flate-test"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(certValidity),
-		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		IsCA:         true,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
-	if err != nil {
-		t.Fatalf("CreateCertificate: %v", err)
-	}
-	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), pemKey(t, priv)
+	return makeCertificate(t, "flate-test",
+		x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}, true)
 }
 
 // SelfSignedClientCert returns a PEM-encoded client cert and matching
 // ECDSA private key — ExtKeyUsage is ClientAuth only.
 func SelfSignedClientCert(t *testing.T) (cert, key string) {
 	t.Helper()
-	priv := ecKey(t)
-	tmpl := &x509.Certificate{
-		SerialNumber: randomSerial(t),
-		Subject:      pkix.Name{CommonName: "flate-test-client"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(certValidity),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
-	if err != nil {
-		t.Fatalf("CreateCertificate: %v", err)
-	}
-	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), pemKey(t, priv)
+	return makeCertificate(t, "flate-test-client",
+		x509.KeyUsageDigitalSignature,
+		[]x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, false)
 }

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -16,19 +16,20 @@ import (
 // part of the bench's setup phase, not the measured loop.
 func WriteFile(t testing.TB, root, rel, body string) {
 	t.Helper()
-	p := filepath.Join(root, rel)
-	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
-	}
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatalf("write %s: %v", p, err)
-	}
+	writeFileWithParents(t, filepath.Join(root, rel), body)
 }
 
 // WriteFileAt writes body to path (absolute or cwd-relative), creating
 // any missing parent directories. Companion to WriteFile for callers
 // that already hold a full path rather than a root+rel split.
 func WriteFileAt(t testing.TB, path, body string) {
+	t.Helper()
+	writeFileWithParents(t, path, body)
+}
+
+// writeFileWithParents is the shared mkdir-parents + write that both
+// WriteFile and WriteFileAt delegate to once they've computed the path.
+func writeFileWithParents(t testing.TB, path, body string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)


### PR DESCRIPTION
## What

Low-risk hygiene dedup surfaced by the audit.

**Test fixtures**
- `testutil/certs.go`: `SelfSignedCA`/`ServerCert`/`ClientCert` shared identical serial + validity + key-gen + `CreateCertificate` + PEM boilerplate, differing only in CN and usage flags. Extract `makeCertificate(t, cn, keyUsage, extKeyUsage, isCA)`; the three exported helpers pass only what varies.
- `testutil/fs.go`: `WriteFile` and `WriteFileAt` had identical mkdir+write bodies. Extract `writeFileWithParents`; both public helpers delegate after computing their path.

**CLI**
- `profile.go`: the 5 `os.Create(...) //nolint:gosec` sites collapse into a single `createProfileFile` helper carrying the nolint once. The immediate (cpu/trace) vs deferred (mem/block/mutex) control flow is unchanged.
- `cache.go`: rename `cacheFlags.resolveRoot` → `resolveCacheRoot` for symmetry with `commonFlags.resolveCacheRoot` (both wrap the same package-level helper).

## Verification

- `gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues.
- Confirmed `build`/`test`/`diff` still write profile artifacts (`cpu.pprof` identical on baseline vs branch); fixtures produce equivalent certs/files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)