### PR TITLE
docs: pin BuildMutex, kustomize-caching, and rawProducerIndex contracts

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -54,6 +54,14 @@ type Controller struct {
 	// Key:   manifest.NamedResource — the generated Secret's identity
 	//        (Kind=KindSecret, Namespace, Name)
 	// Value: manifest.NamedResource — the producer's identity
+	//
+	// Coverage is intentionally limited to ExternalSecret and SealedSecret
+	// (see rawProducerTargetID). A future producer kind that generates a
+	// Secret is NOT indexed until added there; generatedValuesProducer then
+	// returns (zero, false) for it and the --allow-missing-secrets omit
+	// path treats the ref as non-generated. That is degraded behavior, not
+	// a correctness bug — but the coverage must be extended in lockstep
+	// with any new producer kind.
 	rawProducerIndex sync.Map
 }
 

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -79,6 +79,11 @@ func (c *Controller) valuesRefExists(id manifest.NamedResource) bool {
 	return c.Store.GetByName(id.Kind, id.Namespace, id.Name) != nil
 }
 
+// generatedValuesProducer reports the producer that would generate the
+// Secret identified by id, if one is indexed. Coverage is limited to the
+// kinds rawProducerTargetID recognises (ExternalSecret, SealedSecret);
+// any other kind returns (zero, false) and is treated as non-generated —
+// see the rawProducerIndex field comment for why that is safe-but-degraded.
 func (c *Controller) generatedValuesProducer(id manifest.NamedResource) (manifest.NamedResource, bool) {
 	if v, ok := c.rawProducerIndex.Load(id); ok {
 		return v.(manifest.NamedResource), true

--- a/pkg/kustomize/doc.go
+++ b/pkg/kustomize/doc.go
@@ -7,11 +7,30 @@
 //     inline Contents.
 //   - Prepare: the standard pre-render dance (Clone + expand
 //     postBuild.substituteFrom) for embedders rendering a single
-//     Kustomization. Mirrors helm.Prepare for HelmReleases.
+//     Kustomization. Symmetric to helm.Prepare for HelmReleases, minus
+//     a values cache — the substituteFrom path has no YAML parse to
+//     memoize; see Prepare's docstring.
 //   - Substitute: envsubst-style "${VAR}" / "${VAR:=default}" used
 //     for Flux post-build substitutions.
 //
-// Concurrent builds against the same path are serialized via an
-// internal per-path lock — krusty mutates the workspace and concurrent
-// invocations against the same directory race.
+// Concurrency. Two locks guard krusty's non-thread-safety:
+//
+//   - A per-path lock (stageLocks) serializes builds against the SAME
+//     staged directory, which krusty mutates in place.
+//   - The process-wide BuildMutex (flux.go) serializes EVERY krusty
+//     invocation flate runs — including the helm post-renderer's
+//     krusty.Run in pkg/helm — because kustomize's package-global state
+//     (the openapi schema registry, builtin plugin/transformer
+//     factories) is not goroutine-safe. fluxcd/pkg/kustomize guards its
+//     own SecureBuild for the same reason; every flate-owned krusty
+//     entrypoint MUST hold BuildMutex.
+//
+// Caching boundary. kustomize output caching is deferred to the
+// controller layer (the Kustomization controller's spec+source
+// fingerprint dedup), NOT memoized inside this package the way
+// helm.Client caches template output. RenderFlux mutates the staged
+// workspace and krusty plugins/generators are not guaranteed
+// deterministic, so the stable point to memoize is the coarse
+// spec+source hash the controller already computes — not the render
+// engine's fluid internals.
 package kustomize


### PR DESCRIPTION
## What

Surface three design contracts the architecture audit had to reverse-engineer from the code (comments only, no code change):

- **`pkg/kustomize/doc.go`** — document the process-wide `BuildMutex` (every flate-owned krusty entrypoint, including the helm post-renderer's `krusty.Run`, must hold it because kustomize's package globals aren't goroutine-safe) and the caching boundary (kustomize output dedup lives at the Kustomization controller's spec+source fingerprint, not engine-level like helm, because the staged workspace is mutated and krusty plugins aren't deterministic). Also soften the "mirrors helm.Prepare" line to note the deliberate no-values-cache asymmetry.
- **`helmrelease` `rawProducerIndex` + `generatedValuesProducer`** — document that index coverage is limited to `ExternalSecret`/`SealedSecret`, and an unindexed producer kind degrades to "non-generated" (safe-but-degraded, not a bug) and must be extended in lockstep with new producer kinds.

## Verification

`gofmt`/`go build`/`go vet`/`go test -race`/`golangci-lint` → clean, 0 issues. Comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)