### PR TITLE
perf(values): share cached valuesFrom trees via copy-on-collision merge

### DIFF
--- a/pkg/helm/helm_test.go
+++ b/pkg/helm/helm_test.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -57,6 +58,49 @@ data:
 	}
 	if !strings.Contains(out, "greeting: hello") {
 		t.Errorf("values not applied: %s", out)
+	}
+}
+
+// TestTemplate_DoesNotMutateInputValues guards the copy-on-collision
+// optimization's load-bearing assumption. ExpandValueReferences now SHARES
+// cached valuesFrom sub-trees into hr.Values by reference (instead of a full
+// per-HR deep copy), so the render pipeline MUST treat the passed values as
+// immutable — an in-place mutation would corrupt the shared cache canonical
+// across HRs. helm v4 deep-copies the input on entry (CoalesceValues ->
+// copystructure.Copy); this test renders with a nested map + slice values
+// tree and asserts it is byte-identical afterward, catching a future helm
+// bump that mutates the caller's map/sub-maps/slices.
+func TestTemplate_DoesNotMutateInputValues(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml",
+		"apiVersion: v2\nname: mychart\nversion: 0.1.0\ndescription: t\n")
+	testutil.WriteFile(t, dir, "mychart/values.yaml", "image:\n  tag: default\n")
+	testutil.WriteFile(t, dir, "mychart/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\ndata:\n  tag: {{ .Values.image.tag }}\n")
+
+	cli, err := NewClient(cacheroot.New(t.TempDir()))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "chart-repo", RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
+		},
+	}
+	vals := map[string]any{
+		"image": map[string]any{"tag": "v1", "repository": "nginx"},
+		"env":   []any{map[string]any{"name": "A", "value": "1"}},
+	}
+	snapshot := manifest.DeepCopyMap(vals)
+
+	if _, err := cli.Template(context.Background(), hr, vals, Options{}); err != nil {
+		t.Fatalf("Template: %v", err)
+	}
+	if !reflect.DeepEqual(vals, snapshot) {
+		t.Errorf("render mutated the input values map (helm no longer copies on entry?)\n before=%#v\n after =%#v", snapshot, vals)
 	}
 }
 

--- a/pkg/values/bench_test.go
+++ b/pkg/values/bench_test.go
@@ -2,12 +2,65 @@ package values
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 
 	"github.com/home-operations/flate/pkg/manifest"
 )
+
+// bigPlatformValuesYAML builds a large nested values document resembling a
+// platform-wide values ConfigMap that many HelmReleases reference via a
+// single whole-doc valuesFrom. Deep maps + lists, ~tens of KB, so the
+// per-HR DeepCopyMap of the cached parse is a measurable cost.
+func bigPlatformValuesYAML() string {
+	var b strings.Builder
+	b.WriteString("global:\n  domain: example.com\n  registry: ghcr.io\n")
+	for app := range 30 {
+		fmt.Fprintf(&b, "app%d:\n", app)
+		fmt.Fprintf(&b, "  image:\n    repository: ghcr.io/org/app%d\n    tag: v1.%d.0\n    pullPolicy: IfNotPresent\n", app, app)
+		fmt.Fprintf(&b, "  resources:\n    requests:\n      cpu: %dm\n      memory: %dMi\n    limits:\n      cpu: %dm\n      memory: %dMi\n", app*10, app*32, app*20, app*64)
+		b.WriteString("  env:\n")
+		for e := range 8 {
+			fmt.Fprintf(&b, "    - name: VAR_%d\n      value: \"value-%d-%d\"\n", e, app, e)
+		}
+		b.WriteString("  ingress:\n    enabled: true\n    hosts:\n")
+		for h := range 3 {
+			fmt.Fprintf(&b, "      - host: app%d-%d.example.com\n        paths: [\"/\"]\n", app, h)
+		}
+	}
+	return b.String()
+}
+
+// BenchmarkExpandValueReferences_SharedLargeCM is the gate for the
+// copy-on-collision optimization: N HelmReleases each reference ONE shared
+// large platform-values ConfigMap (whole-doc, no TargetPath), reusing a
+// single *Cache. After the first iteration the parse is cached, so each
+// subsequent iteration measures the per-HR cost the optimization targets —
+// today a full manifest.DeepCopyMap of the cached tree.
+func BenchmarkExpandValueReferences_SharedLargeCM(b *testing.B) {
+	cm := &manifest.ConfigMap{
+		Name: "platform-values", Namespace: "default",
+		Data: map[string]any{"values.yaml": bigPlatformValuesYAML()},
+	}
+	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
+	ref := manifest.ValuesReference{Kind: "ConfigMap", Name: "platform-values"}
+	cache := NewCache() // shared across all HRs, as in production (one per helm.Client)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		hr := &manifest.HelmRelease{
+			Name: "app", Namespace: "default",
+			HelmReleaseSpec: helmv2.HelmReleaseSpec{ValuesFrom: []manifest.ValuesReference{ref}},
+			Values:          map[string]any{"replicaCount": 2},
+		}
+		if err := ExpandValueReferences(hr, provider, cache); err != nil {
+			b.Fatalf("ExpandValueReferences: %v", err)
+		}
+	}
+}
 
 // BenchmarkExpandValueReferences_ManyFromRefs measures ExpandValueReferences
 // against an HR with 10 valuesFrom ConfigMap refs — each carrying a

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -237,6 +237,20 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider, cache *C
 	if hr == nil || len(hr.ValuesFrom) == 0 {
 		return nil
 	}
+	// A TargetPath ref writes through the accumulator in place (strvals
+	// navigates and mutates existing nodes), which is unsafe once the
+	// accumulator aliases shared cache sub-trees. Decide the merge
+	// strategy once for the whole HR: if NO ref has a TargetPath, share
+	// the cached canonicals by reference (cheap, the common platform-CM
+	// pattern); if ANY ref has one, keep the eager fully-owned copy so the
+	// in-place write can't reach the cache. See updateHelmReleaseValues.
+	share := true
+	for _, ref := range hr.ValuesFrom {
+		if ref.TargetPath != "" {
+			share = false
+			break
+		}
+	}
 	values := map[string]any{}
 	for _, ref := range hr.ValuesFrom {
 		found, err := lookupValueRef(ref, hr.Namespace, provider)
@@ -246,18 +260,24 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider, cache *C
 			}
 			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
-		if err := updateHelmReleaseValues(ref, found, values, hr.Namespace, cache); err != nil {
+		values, err = updateHelmReleaseValues(ref, found, values, hr.Namespace, cache, share)
+		if err != nil {
 			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
 	}
 	if len(hr.Values) > 0 {
-		// hr.Values is the inline-values map decoded from the HR
-		// manifest. The Prepare path clones hr before calling here
-		// (helm.Prepare in pkg/helm), so mutating hr.Values's
-		// sub-tree is safe; reaching values as the dst would
-		// however share sub-references back into hr.Values, so
-		// build the inline layer ON TOP of our owned values map.
-		DeepMergeInto(values, hr.Values)
+		// hr.Values is the inline-values map decoded from the HR manifest.
+		// The Prepare path clones hr before calling here, so its sub-trees
+		// are owned by this reconcile. Build the inline layer ON TOP of
+		// values (inline wins on collision). In the share path values may
+		// alias cache sub-trees, so use functional DeepMerge (no in-place
+		// mutation of a shared node); in the owned path DeepMergeInto is
+		// fine and avoids the extra top-level allocation.
+		if share {
+			values = DeepMerge(values, hr.Values)
+		} else {
+			DeepMergeInto(values, hr.Values)
+		}
 	}
 	hr.Values = values
 	return nil
@@ -409,10 +429,28 @@ func bagValueAsString(v any) (string, error) {
 // path bypasses the cache — strvals parsing already mutates values
 // in place per-call and is comparatively cheap (no map allocation
 // for the parsed tree).
-func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values map[string]any, namespace string, cache *Cache) error {
+// updateHelmReleaseValues merges one valuesFrom ref into the values
+// accumulator and returns the (possibly new) accumulator.
+//
+// share selects the merge strategy, decided once per HR by the caller:
+//   - share=true (the HR has NO TargetPath ref): functional DeepMerge,
+//     which SHARES the cached canonical's non-colliding sub-trees by
+//     reference instead of deep-copying them. Safe because nothing in
+//     this HR mutates the accumulator in place and the cache canonical
+//     is read-only downstream (helm copies the input on entry). M HRs
+//     referencing the same ConfigMap then share one parsed tree instead
+//     of each deep-copying it.
+//   - share=false (the HR has a TargetPath ref somewhere): eager
+//     DeepMergeInto over a DeepCopyMap of the canonical, so the
+//     accumulator is FULLY OWNED and the in-place strvals write that a
+//     TargetPath ref performs can't reach (and corrupt) the shared cache.
+func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values map[string]any, namespace string, cache *Cache, share bool) (map[string]any, error) {
 	if ref.TargetPath != "" {
+		// Only reached when share==false (the caller sets share false the
+		// moment any ref carries a TargetPath), so `values` is owned and
+		// the in-place strvals write below is safe.
 		_, err := replaceValueAtPath(values, ref.TargetPath, found)
-		return err
+		return values, err
 	}
 
 	// Wiped Secret values surface here as the literal placeholder
@@ -421,29 +459,29 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 	// `secretGenerator` wrapping a SOPS-encrypted values.yaml) doesn't
 	// block the whole HR render.
 	if manifest.IsValuePlaceholder(found) {
-		return nil
+		return values, nil
 	}
 	key := valuesRefCacheKey(ref.Kind, namespace, ref.Name, ref.GetValuesKey(), found)
-	if parsed, ok := cache.lookup(key); ok {
-		// Cached parse — clone before merge because DeepMergeInto
-		// inserts sub-maps by reference when no key collides; mutating
-		// the dst would corrupt the cached canonical for the next
-		// consumer.
-		DeepMergeInto(values, manifest.DeepCopyMap(parsed))
-		return nil
-	}
-	var parsed map[string]any
-	if err := yaml.Unmarshal([]byte(found), &parsed); err != nil {
-		return fmt.Errorf("expected '%s' values to be valid YAML: %w", ref.Name, err)
-	}
-	if parsed != nil {
-		// Cache the parsed tree first (canonical, untouched), then
-		// merge a clone into values so the cache entry stays
-		// immutable for later consumers.
+	parsed, ok := cache.lookup(key)
+	if !ok {
+		if err := yaml.Unmarshal([]byte(found), &parsed); err != nil {
+			return values, fmt.Errorf("expected '%s' values to be valid YAML: %w", ref.Name, err)
+		}
+		if parsed == nil {
+			return values, nil
+		}
+		// Cache the parsed tree (canonical, never mutated) before merging.
 		cache.store(key, parsed)
-		DeepMergeInto(values, manifest.DeepCopyMap(parsed))
 	}
-	return nil
+	if share {
+		// Shares parsed's non-colliding sub-trees by reference; collisions
+		// allocate fresh nodes. Never mutates parsed (the cache canonical).
+		return DeepMerge(values, parsed), nil
+	}
+	// Owned-accumulator path: clone the canonical so the later in-place
+	// TargetPath write can't corrupt the shared cache entry.
+	DeepMergeInto(values, manifest.DeepCopyMap(parsed))
+	return values, nil
 }
 
 // replaceValueAtPath writes value into values at path using Helm's

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -2,7 +2,9 @@ package values
 
 import (
 	"errors"
+	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -256,9 +258,12 @@ func TestExpandValueReferences_CacheHits(t *testing.T) {
 		t.Errorf("second: replicaCount=%v", b.Values["replicaCount"])
 	}
 
-	// Mutate a's result — the cache must hand out a clone so b is
-	// unaffected. (The previous call already returned; we cross-check
-	// a third HR.)
+	// Overwrite a TOP-LEVEL key on a's result. Each HR gets its own
+	// top-level values map (DeepMerge allocates a fresh one), so a
+	// top-level write never reaches the shared cache canonical — a third
+	// HR still sees the parsed value. (Nested sub-trees ARE shared with
+	// the canonical and must not be mutated in place — that contract is
+	// pinned by the TargetPath and concurrency tests below.)
 	a.Values["replicaCount"] = "stomped"
 	c := hr()
 	if err := ExpandValueReferences(c, provider, cache); err != nil {
@@ -474,4 +479,143 @@ func equalish(a, b any) bool {
 		}
 	}
 	return a == b
+}
+
+// TestDeepMergeMatchesDeepMergeInto pins the equivalence the copy-on-collision
+// optimization relies on: functional DeepMerge(base, override) produces the
+// SAME value graph as the eager DeepMergeInto(copy(base), copy(override)) the
+// share path replaced. If these ever diverge, render output would change.
+func TestDeepMergeMatchesDeepMergeInto(t *testing.T) {
+	cases := []struct {
+		name           string
+		base, override map[string]any
+	}{
+		{"disjoint", map[string]any{"a": 1.0}, map[string]any{"b": 2.0}},
+		{"scalar-over-scalar", map[string]any{"a": 1.0}, map[string]any{"a": 2.0}},
+		{"nested-collision", map[string]any{"m": map[string]any{"x": 1.0, "y": 2.0}}, map[string]any{"m": map[string]any{"y": 9.0, "z": 3.0}}},
+		{"list-replace", map[string]any{"l": []any{1.0, 2.0}}, map[string]any{"l": []any{3.0}}},
+		{"scalar-over-map", map[string]any{"k": map[string]any{"x": 1.0}}, map[string]any{"k": "scalar"}},
+		{"map-over-scalar", map[string]any{"k": "scalar"}, map[string]any{"k": map[string]any{"x": 1.0}}},
+		{"nil-override", map[string]any{"k": map[string]any{"x": 1.0}}, map[string]any{"k": nil}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			functional := DeepMerge(tc.base, tc.override)
+			eager := manifest.DeepCopyMap(tc.base)
+			DeepMergeInto(eager, manifest.DeepCopyMap(tc.override))
+			if !reflect.DeepEqual(functional, eager) {
+				t.Errorf("DeepMerge != DeepMergeInto\n functional=%#v\n eager=%#v", functional, eager)
+			}
+		})
+	}
+}
+
+// nestedValuesCM returns a ConfigMap whose values.yaml is a nested map +
+// list document — the shape a platform-wide values CM takes.
+func nestedValuesCM() *manifest.ConfigMap {
+	return &manifest.ConfigMap{
+		Name: "platform", Namespace: "default",
+		Data: map[string]any{"values.yaml": "image:\n  repository: nginx\n  tag: v1\nenv:\n  - name: A\n    value: \"1\"\n"},
+	}
+}
+
+func wholeDocHR() *manifest.HelmRelease {
+	return &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
+		},
+	}
+}
+
+// TestExpandValueReferences_ConcurrentSharedCache pins the concurrency
+// contract: many HRs referencing the same ConfigMap share ONE cached parsed
+// tree by reference (the optimization), and concurrent expansion must be
+// race-free and correct. Run under -race, this fails if any goroutine writes
+// through a shared cache sub-tree.
+func TestExpandValueReferences_ConcurrentSharedCache(t *testing.T) {
+	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{nestedValuesCM()}}
+	cache := NewCache()
+	const n = 64
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Go(func() {
+			hr := wholeDocHR()
+			if err := ExpandValueReferences(hr, provider, cache); err != nil {
+				errs[i] = err
+				return
+			}
+			img, ok := hr.Values["image"].(map[string]any)
+			if !ok || img["tag"] != "v1" || img["repository"] != "nginx" {
+				errs[i] = errInvalidResult
+				return
+			}
+			env, ok := hr.Values["env"].([]any)
+			if !ok || len(env) != 1 {
+				errs[i] = errInvalidResult
+			}
+		})
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+}
+
+var errInvalidResult = errors.New("unexpected merged values")
+
+// TestExpandValueReferences_TargetPathDoesNotCorruptSharedCache pins HOLE 1/2
+// of the design: an HR with a TargetPath ref takes the eager fully-owned path,
+// so its in-place strvals write into a key that ALSO exists in the cached
+// canonical must NOT leak into the cache (which whole-doc-only HRs share).
+func TestExpandValueReferences_TargetPathDoesNotCorruptSharedCache(t *testing.T) {
+	secret := &manifest.ConfigMap{
+		Name: "inject", Namespace: "default",
+		Data: map[string]any{"v": "Always"},
+	}
+	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{nestedValuesCM(), secret}}
+	cache := NewCache()
+
+	// Prime the cache with a whole-doc-only HR (shares the canonical).
+	a := wholeDocHR()
+	if err := ExpandValueReferences(a, provider, cache); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+
+	// HR with a TargetPath ref writing image.pullPolicy — image already
+	// exists in the cached canonical, so a sharing+in-place write would
+	// corrupt it. The TargetPath presence must force the eager path.
+	b := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "ConfigMap", Name: "platform"},
+				{Kind: "ConfigMap", Name: "inject", ValuesKey: "v", TargetPath: "image.pullPolicy"},
+			},
+		},
+	}
+	if err := ExpandValueReferences(b, provider, cache); err != nil {
+		t.Fatalf("targetpath: %v", err)
+	}
+	if img := b.Values["image"].(map[string]any); img["pullPolicy"] != "Always" {
+		t.Fatalf("targetpath write did not land: image=%#v", img)
+	}
+
+	// A third whole-doc-only HR must NOT see the injected pullPolicy — i.e.
+	// b's in-place write never reached the shared cache canonical.
+	c := wholeDocHR()
+	if err := ExpandValueReferences(c, provider, cache); err != nil {
+		t.Fatalf("recheck: %v", err)
+	}
+	img := c.Values["image"].(map[string]any)
+	if _, leaked := img["pullPolicy"]; leaked {
+		t.Errorf("TargetPath write corrupted the shared cache canonical: image=%#v", img)
+	}
+	// And the priming HR's view is likewise uncorrupted.
+	if _, leaked := a.Values["image"].(map[string]any)["pullPolicy"]; leaked {
+		t.Errorf("TargetPath write leaked into a prior HR's shared values: %#v", a.Values["image"])
+	}
 }


### PR DESCRIPTION
## What

`ExpandValueReferences` deep-copied the **entire** cached parsed-YAML tree (`manifest.DeepCopyMap`) on every `valuesFrom` merge — so M HelmReleases referencing the same platform values ConfigMap each paid a full copy of the shared canonical. This was the deferred audit item (`perf-hot-deepcopymap-cache-hit`); the naive "copy only merged leaves" fix it floated would corrupt the cross-HR cache.

The fix uses the **existing functional `DeepMerge`** — the copy-on-collision primitive already in the file: it allocates new nodes only on collision paths and shares non-colliding sub-trees **by reference**, never mutating the cached canonical. M HRs then share one parsed tree read-only.

**Per-HR branch (the one safety subtlety):** a `TargetPath` ref writes through the accumulator in place via `strvals`, which would corrupt a shared cache sub-tree. So the merge strategy is decided **once per HR**: whole-doc-only HRs (the common `valuesFrom: [{ConfigMap, cluster-values}]` pattern) share; an HR with **any** `TargetPath` ref keeps today's eager fully-owned copy. Stateless, and the cache is never reachable from an in-place write.

## Why it's safe

- `DeepMerge` ≡ `DeepMergeInto(dst, DeepCopyMap(parsed))` in produced values (precedence, map recursion, list/scalar replacement) — pinned by `TestDeepMergeMatchesDeepMergeInto`.
- The same `*Cache` is shared across concurrent HR-reconcile goroutines; functional merges only **read** the shared canonical → race-free (`TestExpandValueReferences_ConcurrentSharedCache`, `-race`).
- Downstream is read-only: helm v4 deep-copies the input on entry (`CoalesceValues` → `copystructure.Copy`). Guarded against a future helm bump by `TestTemplate_DoesNotMutateInputValues` (renders a nested+slice values tree, asserts the input is unmutated).
- `TestExpandValueReferences_TargetPathDoesNotCorruptSharedCache` proves a `TargetPath` write never leaks into the shared canonical.

## Benchmark (`BenchmarkExpandValueReferences_SharedLargeCM` — HRs sharing one large nested CM)

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before (eager `DeepCopyMap`) | ~98,500 | 189,748 | 1342 |
| after (functional sharing) | ~25,000 | 5,621 | 15 |

**~4× faster, ~34× less memory, ~89× fewer allocations.**

## Verification

- `gofmt` / `go build` / `go vet` / full **`go test -race ./...`** / `golangci-lint` → clean, 0 issues.
- **Behavior-equivalence across all 12 `~/repos`**: identical `get hr` membership + normalized `build all` content vs `main` (0 diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)