### PR TITLE
fix(diff): strip checksum/ prefix so randAlphaNum churn stays out of diffs

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -41,16 +41,23 @@ func newDiffCmd() *cobra.Command {
 
 // defaultStripAttrs is the default `--strip-attr` list — annotations
 // and labels that Helm + kustomize rotate on every chart bump and
-// which contribute pure noise to PR-time diff review. checksum/*
-// annotations are templated as `sha256sum (include "secret.yaml")`
-// in many charts; the rendered Secret values flate sees are
-// wiped-to-PLACEHOLDER but the chart's helper pipeline still emits
-// non-stable bytes across runs (e.g. random suffix from sprig
-// randAlphaNum), producing churn-only diffs.
+// which contribute pure noise to PR-time diff review. The trailing-
+// slash "checksum/" is a prefix match (see StripResourceAttributes)
+// that covers every suffix charts emit — checksum/config,
+// checksum/secret, checksum/secrets, etc. — in one entry.
+//
+// These annotations are templated as `sha256sum (include "…" .)` over
+// a rendered ConfigMap/Secret. flate cannot make them stable: the
+// underlying value is genuinely per-render random in some charts
+// (e.g. matrix-synapse's `registration_shared_secret | default
+// (randAlphaNum 24)`, which sprig draws from crypto/rand — not
+// seedable, and Helm exposes no funcMap hook to override it). flate
+// faithfully mirrors Helm here, so raw `flate build` output is not
+// byte-stable for such charts; the on-disk render cache only masks it.
+// Stripping the annotation is what keeps `flate diff` churn-free.
 var defaultStripAttrs = []string{
 	"helm.sh/chart",
-	"checksum/config",
-	"checksum/secret",
+	"checksum/",
 	"app.kubernetes.io/version",
 	"chart",
 }

--- a/pkg/diff/normalize_test.go
+++ b/pkg/diff/normalize_test.go
@@ -41,6 +41,38 @@ func TestNormalize_StripAttrsRemovesNoise(t *testing.T) {
 	}
 }
 
+// TestNormalize_StripsChecksumPrefixOnPodTemplate pins the fix for the
+// matrix-synapse churn: a pod-template `checksum/secrets` annotation
+// (sha256 the chart recomputes every render from a randAlphaNum value)
+// must be normalized away by the "checksum/" prefix entry, so a rotated
+// hash yields no diff. The plural key previously slipped past the
+// exact-match list.
+func TestNormalize_StripsChecksumPrefixOnPodTemplate(t *testing.T) {
+	mk := func(sum string) []Doc {
+		return []Doc{{
+			Manifest: map[string]any{
+				"kind":     "Deployment",
+				"metadata": map[string]any{"name": "synapse", "namespace": "matrix"},
+				"spec": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"annotations": map[string]any{"checksum/secrets": sum},
+						},
+					},
+				},
+			},
+		}}
+	}
+	if s := renderDiff(t, mk("105231a7"), mk("3d60fcd0"),
+		Options{Format: FormatDiff, StripAttrs: []string{"checksum/"}}); s != "" {
+		t.Errorf("rotated checksum/secrets should produce no diff under checksum/ prefix, got:\n%s", s)
+	}
+	// Control: without the strip the same change DOES surface.
+	if s := renderDiff(t, mk("105231a7"), mk("3d60fcd0"), Options{Format: FormatDiff}); s == "" {
+		t.Error("control: unstripped checksum/secrets change should surface as a diff")
+	}
+}
+
 // TestNormalize_RedactsConfigMapBinaryData locks the ConfigMap.binaryData
 // redaction: each value is replaced with a content-derived summary before
 // the diff, so a rotated binary hook payload surfaces as a one-line

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1343,6 +1343,40 @@ func TestStripResourceAttributes_StatefulSetPVCs(t *testing.T) {
 	}
 }
 
+// TestStripResourceAttributes_ChecksumPrefix pins the trailing-slash
+// prefix match: a single "checksum/" entry drops every suffix charts
+// emit (config, secret, secrets, …). The plural "checksum/secrets"
+// (matrix-synapse) used to slip past the exact-match list and churn
+// `flate diff`; non-checksum annotations must survive untouched.
+func TestStripResourceAttributes_ChecksumPrefix(t *testing.T) {
+	r := map[string]any{
+		"kind": "Deployment",
+		"spec": map[string]any{
+			"template": map[string]any{
+				"metadata": map[string]any{
+					"annotations": map[string]any{
+						"checksum/config":            "a",
+						"checksum/secret":            "b",
+						"checksum/secrets":           "c",
+						"reloader.stakater.com/auto": "true",
+					},
+				},
+			},
+		},
+	}
+	StripResourceAttributes(r, []string{"checksum/"})
+
+	ann := r["spec"].(map[string]any)["template"].(map[string]any)["metadata"].(map[string]any)["annotations"].(map[string]any)
+	for _, k := range []string{"checksum/config", "checksum/secret", "checksum/secrets"} {
+		if _, ok := ann[k]; ok {
+			t.Errorf("prefix strip left %q behind", k)
+		}
+	}
+	if ann["reloader.stakater.com/auto"] != "true" {
+		t.Errorf("non-checksum annotation should survive prefix strip; got %v", ann)
+	}
+}
+
 // TestRawObject_DoesNotAliasParsedDoc pins the deep-copy fix: a
 // RawObject.Spec must not alias the loader's parsed YAML map.
 // Previously r.Spec = doc["spec"].(map[string]any) shared the map

--- a/pkg/manifest/strip.go
+++ b/pkg/manifest/strip.go
@@ -1,5 +1,10 @@
 package manifest
 
+import (
+	"maps"
+	"strings"
+)
+
 // StripResourceAttributes removes the listed annotation/label keys
 // from a raw Kubernetes resource's metadata and the pod-template
 // metadata for every workload shape Helm charts decorate. Used to cut
@@ -8,6 +13,11 @@ package manifest
 // identifier but still flags string-value changes verbatim, so
 // annotations whose values rotate on every chart update would
 // otherwise produce one entry per resource.
+//
+// An attr ending in "/" is a prefix match (e.g. "checksum/" drops
+// checksum/config, checksum/secret, checksum/secrets, and any other
+// chart-specific suffix in one entry); every other attr is an exact
+// key match.
 //
 // Coverage:
 //
@@ -80,6 +90,14 @@ func stripAttrs(metadata map[string]any, attrs []string) {
 			continue
 		}
 		for _, a := range attrs {
+			// Trailing "/" → prefix match (covers every checksum/<x>
+			// suffix charts emit); otherwise an exact key delete.
+			if strings.HasSuffix(a, "/") {
+				maps.DeleteFunc(val, func(k string, _ any) bool {
+					return strings.HasPrefix(k, a)
+				})
+				continue
+			}
 			delete(val, a)
 		}
 		if len(val) == 0 {


### PR DESCRIPTION
## Problem

On `drag0n141/home-ops`, `flate diff` intermittently surfaced a churn-only change for the `synapse-matrix-synapse` Deployment: its pod-template `checksum/secrets` annotation flapped between two sha256 values (~10% of renders).

### Root cause (not a flate map-ordering bug)

The `matrix-synapse` chart recomputes that annotation every render:

```
# templates/deployment.yaml
checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
# templates/secrets.yaml
registration_shared_secret: {{ .Values.config.registrationSharedSecret | default (randAlphaNum 24) | quote }}
```

`registrationSharedSecret` is unset, so each render draws a fresh `randAlphaNum 24`. sprig pulls that from **`crypto/rand`** (via goutils) — not seedable — and Helm v4's `action.Install` exposes no funcMap hook to override it. flate faithfully mirrors Helm; the on-disk render cache only *masks* the variance (proven: caches off → 12/12 distinct hashes; warm cache → 18/20 stable, 2/20 leak).

### The actual flate-side bug

`defaultStripAttrs` already targets this noise (its comment even names sprig `randAlphaNum`), but it listed the **singular** `checksum/config` / `checksum/secret`, and `stripAttrs` matched keys **exactly** — so the **plural** `checksum/secrets` slipped through.

## Fix

- `pkg/manifest/strip.go`: a `--strip-attr` entry ending in `/` is now a **prefix** match; everything else stays an exact match.
- `internal/cli/diff.go`: collapse `checksum/config` + `checksum/secret` into a single `checksum/`, covering `config` / `secret` / `secrets` / any chart suffix. Comment refreshed to document the Helm-inherent non-determinism (raw `flate build` stays faithful by design).

## Verification

- `flate diff all -p <repo> -P <repo>` (two independent renders): **old binary 2/5 runs churned** on `checksum/secrets`; **new binary 0/20**, and no `synapse` resource surfaces at all.
- New tests: `TestStripResourceAttributes_ChecksumPrefix` (prefix drops all suffixes, non-checksum annotations survive) and `TestNormalize_StripsChecksumPrefixOnPodTemplate` (rotated `checksum/secrets` → no diff; control still surfaces).
- Gate: `gofmt -l` clean, `go build/vet`, `go test -race ./...` all pass, `golangci-lint run ./pkg/... ./internal/...` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)