### PR TITLE
refactor(source): share secret temp-file write helper across oci + helmchart

### DIFF
--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -2,7 +2,6 @@ package helmchart
 
 import (
 	"fmt"
-	"os"
 
 	"helm.sh/helm/v4/pkg/getter"
 
@@ -67,32 +66,13 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		return nil, noCleanup, source.MissingSecretErr("HelmRepository", r.Namespace, r.Name, r.CertSecretRef.Name, "not found")
 	}
 
-	var tmpFiles []string
-	cleanup := func() {
-		for _, p := range tmpFiles {
-			_ = os.Remove(p)
-		}
-	}
+	// Scope the materialized PEM files under the fetcher's per-fetch
+	// tmpDir; helm's getter only reads them. cleanup removes every file
+	// a successful writeKey registered (see source.TempFiles).
+	tf := source.NewTempFiles(f.tmpDir)
+	cleanup := tf.Cleanup
 	writeKey := func(key string) (string, error) {
-		v := source.StringFromSecret(sec, key)
-		if v == "" {
-			return "", nil
-		}
-		tmp, err := os.CreateTemp(f.tmpDir, "helm-tls-*.pem")
-		if err != nil {
-			return "", fmt.Errorf("temp %s: %w", key, err)
-		}
-		if _, err := tmp.WriteString(v); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
-			return "", fmt.Errorf("write %s: %w", key, err)
-		}
-		if err := tmp.Close(); err != nil {
-			_ = os.Remove(tmp.Name())
-			return "", fmt.Errorf("close %s: %w", key, err)
-		}
-		tmpFiles = append(tmpFiles, tmp.Name())
-		return tmp.Name(), nil
+		return tf.Write("helm-tls-*.pem", source.StringFromSecret(sec, key))
 	}
 
 	certPath, err := writeKey("tls.crt")

--- a/pkg/source/helmchart/auth_test.go
+++ b/pkg/source/helmchart/auth_test.go
@@ -1,0 +1,84 @@
+package helmchart
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// tlsPEMFiles returns the helm-tls-*.pem files the fetcher materialized
+// under its tmpDir.
+func tlsPEMFiles(t *testing.T, tmpDir string) []string {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(tmpDir, "helm-tls-*.pem"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	return matches
+}
+
+// TestHelmRepoTLSOptions_MaterializesPresentKeys checks that
+// helmRepoTLSOptions writes exactly the present TLS keys to temp files
+// (the empty-content keys produce no file), and that cleanup removes
+// them — exercising the source.TempFiles dedup through its helm caller.
+func TestHelmRepoTLSOptions_MaterializesPresentKeys(t *testing.T) {
+	cases := []struct {
+		name      string
+		data      map[string]any
+		wantFiles int
+	}{
+		{"all-three", map[string]any{"tls.crt": "CRT", "tls.key": "KEY", "ca.crt": "CA"}, 3},
+		{"cert-and-key", map[string]any{"tls.crt": "CRT", "tls.key": "KEY"}, 2},
+		{"ca-only", map[string]any{"ca.crt": "CA"}, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httpRepo("https://charts.example")
+			r.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+			data := tc.data
+			f := newHTTPFetcherWithSecrets(t, r, func(_, _ string) *manifest.Secret {
+				return &manifest.Secret{StringData: data}
+			})
+
+			opts, cleanup, err := f.helmRepoTLSOptions(r)
+			if err != nil {
+				t.Fatalf("helmRepoTLSOptions: %v", err)
+			}
+			if len(opts) != 1 {
+				t.Fatalf("opts = %d, want 1 (WithTLSClientConfig)", len(opts))
+			}
+			files := tlsPEMFiles(t, f.tmpDir)
+			if len(files) != tc.wantFiles {
+				t.Fatalf("materialized %d PEM file(s), want %d", len(files), tc.wantFiles)
+			}
+			cleanup()
+			if remaining := tlsPEMFiles(t, f.tmpDir); len(remaining) != 0 {
+				t.Fatalf("cleanup left %d PEM file(s)", len(remaining))
+			}
+		})
+	}
+}
+
+// TestHelmRepoTLSOptions_NoneFailsLoud pins that a certSecretRef Secret
+// carrying none of tls.crt/tls.key/ca.crt is malformed config and fails
+// loud (no ErrMissingSecret wrap, no files left behind).
+func TestHelmRepoTLSOptions_NoneFailsLoud(t *testing.T) {
+	r := httpRepo("https://charts.example")
+	r.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+	f := newHTTPFetcherWithSecrets(t, r, func(_, _ string) *manifest.Secret {
+		return &manifest.Secret{StringData: map[string]any{"unrelated": "x"}}
+	})
+
+	opts, cleanup, err := f.helmRepoTLSOptions(r)
+	defer cleanup()
+	if err == nil {
+		t.Fatal("expected a loud error for a TLS secret with none of the keys")
+	}
+	if opts != nil {
+		t.Fatalf("opts = %v, want nil on error", opts)
+	}
+	if files := tlsPEMFiles(t, f.tmpDir); len(files) != 0 {
+		t.Fatalf("error path left %d PEM file(s) behind", len(files))
+	}
+}

--- a/pkg/source/oci/auth.go
+++ b/pkg/source/oci/auth.go
@@ -69,21 +69,14 @@ func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, f
 		// path would leave the actual reporter's case still failing.
 		return "", noCleanup, source.MissingSecretErr("OCIRepository", repo.Namespace, repo.Name, repo.SecretRef.Name, "missing .dockerconfigjson (must be type kubernetes.io/dockerconfigjson)")
 	}
-	tmp, err := os.CreateTemp("", "flate-oci-creds-*.json")
+	// System temp (dir ""): the docker credential store only needs the
+	// file to exist for the duration of the pull.
+	tf := source.NewTempFiles("")
+	path, err := tf.Write("flate-oci-creds-*.json", configJSON)
 	if err != nil {
-		return "", noCleanup, fmt.Errorf("temp docker config: %w", err)
+		return "", noCleanup, err
 	}
-	if _, err := tmp.WriteString(configJSON); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmp.Name())
-		return "", noCleanup, fmt.Errorf("write temp docker config: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmp.Name())
-		return "", noCleanup, fmt.Errorf("close temp docker config: %w", err)
-	}
-	cleanup := func() { _ = os.Remove(tmp.Name()) }
-	return tmp.Name(), cleanup, nil
+	return path, tf.Cleanup, nil
 }
 
 // loadCredentials returns a credentials.Store backed by the given config

--- a/pkg/source/tempfile.go
+++ b/pkg/source/tempfile.go
@@ -1,0 +1,69 @@
+package source
+
+import (
+	"fmt"
+	"os"
+)
+
+// TempFiles collects temp files written from secret material so a
+// fetcher can hand their paths to a downstream tool that expects
+// on-disk files — helm's getter (WithTLSClientConfig takes paths) or
+// docker's file-backed credential store — then remove them all once
+// the fetch completes.
+//
+// dir selects the parent passed to os.CreateTemp: "" uses the system
+// temp dir; a non-empty dir scopes the files under a caller-owned
+// location (e.g. helm's per-fetch tmpDir). Files land with
+// os.CreateTemp's default 0o600 perms.
+//
+// One TempFiles belongs to one in-flight fetch; it is not safe for
+// concurrent use.
+type TempFiles struct {
+	dir   string
+	files []string
+}
+
+// NewTempFiles returns a collector that writes into dir. An empty dir
+// uses the system temp directory.
+func NewTempFiles(dir string) *TempFiles {
+	return &TempFiles{dir: dir}
+}
+
+// Write materializes content to a fresh temp file (os.CreateTemp
+// pattern semantics — the last "*" is replaced by a random string) and
+// returns its path, registering it for Cleanup.
+//
+// Empty content writes no file and returns ("", nil): callers
+// materializing an optional secret key (e.g. ca.crt with no key) rely
+// on the empty path to mean "absent". A write that fails removes only
+// the partial file it just created; files from earlier successful
+// Writes stay registered so the caller's deferred Cleanup reaps them.
+func (t *TempFiles) Write(pattern, content string) (string, error) {
+	if content == "" {
+		return "", nil
+	}
+	f, err := os.CreateTemp(t.dir, pattern)
+	if err != nil {
+		return "", fmt.Errorf("create temp %s: %w", pattern, err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("write temp %s: %w", pattern, err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return "", fmt.Errorf("close temp %s: %w", pattern, err)
+	}
+	t.files = append(t.files, f.Name())
+	return f.Name(), nil
+}
+
+// Cleanup removes every file a successful Write registered. It is a
+// no-op when nothing was written, so it is safe to defer immediately
+// after construction.
+func (t *TempFiles) Cleanup() {
+	for _, p := range t.files {
+		_ = os.Remove(p)
+	}
+}

--- a/pkg/source/tempfile_test.go
+++ b/pkg/source/tempfile_test.go
@@ -1,0 +1,120 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTempFiles_WritePermsAndContent(t *testing.T) {
+	tf := NewTempFiles(t.TempDir())
+	path, err := tf.Write("creds-*.json", "hello")
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if path == "" {
+		t.Fatal("expected non-empty path for non-empty content")
+	}
+	b, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(b) != "hello" {
+		t.Fatalf("content = %q, want %q", b, "hello")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	// os.CreateTemp yields 0o600; the helper must not loosen it since it
+	// holds secret material.
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("perm = %o, want 0600", perm)
+	}
+}
+
+func TestTempFiles_DirIsRespected(t *testing.T) {
+	dir := t.TempDir()
+	tf := NewTempFiles(dir)
+	path, err := tf.Write("tls-*.pem", "pem")
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := filepath.Dir(path); got != dir {
+		t.Fatalf("file written to %q, want under %q", got, dir)
+	}
+}
+
+func TestTempFiles_EmptyContentWritesNoFile(t *testing.T) {
+	dir := t.TempDir()
+	tf := NewTempFiles(dir)
+	path, err := tf.Write("ca-*.pem", "")
+	if err != nil {
+		t.Fatalf("Write(empty): %v", err)
+	}
+	if path != "" {
+		t.Fatalf("empty content produced path %q, want \"\"", path)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("empty content created %d file(s), want 0", len(entries))
+	}
+	// Cleanup is a no-op when nothing was written.
+	tf.Cleanup()
+}
+
+func TestTempFiles_CleanupRemovesAll(t *testing.T) {
+	tf := NewTempFiles(t.TempDir())
+	var paths []string
+	for _, c := range []string{"a", "b", "c"} {
+		p, err := tf.Write("f-*.txt", c)
+		if err != nil {
+			t.Fatalf("Write %q: %v", c, err)
+		}
+		paths = append(paths, p)
+	}
+	tf.Cleanup()
+	for _, p := range paths {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("file %q still present after Cleanup (err=%v)", p, err)
+		}
+	}
+}
+
+// TestTempFiles_FailedWriteKeepsPriorForCleanup is the load-bearing
+// contract: a mid-sequence Write failure must NOT discard files from
+// earlier successful Writes — the caller reaps them with a deferred
+// Cleanup. A pattern containing a path separator makes os.CreateTemp
+// fail deterministically without touching the filesystem.
+func TestTempFiles_FailedWriteKeepsPriorForCleanup(t *testing.T) {
+	tf := NewTempFiles(t.TempDir())
+	first, err := tf.Write("ok-*.pem", "first")
+	if err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if _, err := tf.Write("bad/slash-*.pem", "second"); err == nil {
+		t.Fatal("expected error from pattern with path separator, got nil")
+	}
+	// The failed Write created no file and left the prior registration
+	// intact; Cleanup must still remove the first file.
+	tf.Cleanup()
+	if _, err := os.Stat(first); !os.IsNotExist(err) {
+		t.Fatalf("first file not cleaned after a later failed Write (err=%v)", err)
+	}
+}
+
+func TestTempFiles_CreateTempErrorReturnsNoPath(t *testing.T) {
+	tf := NewTempFiles(filepath.Join(t.TempDir(), "does-not-exist"))
+	path, err := tf.Write("x-*.tmp", "data")
+	if err == nil {
+		t.Fatal("expected error writing into a non-existent dir, got nil")
+	}
+	if path != "" {
+		t.Fatalf("error path returned %q, want \"\"", path)
+	}
+	// Nothing registered, so Cleanup is a harmless no-op.
+	tf.Cleanup()
+}


### PR DESCRIPTION
## What

The `os.CreateTemp → WriteString → (unwind: Close+Remove on error) → Close → register-for-cleanup` boilerplate was copied in two source backends:

- **oci** `resolveRegistryConfig` — one `.dockerconfigjson` file in system temp.
- **helmchart** `helmRepoTLSOptions` — up to three `tls.crt`/`tls.key`/`ca.crt` files under the fetcher's `tmpDir`.

This lifts it into `source.TempFiles`, a per-fetch collector parameterized by output directory, and rewires both call sites. Net −39 lines of duplicated unwind logic for a tested, reusable helper.

## Behavior preserved (the traps)

- **Caller-supplied dir** per instance: oci passes `""` (system temp), helmchart passes `f.tmpDir`.
- **Empty content → `("", nil)` no file** — helm's optional-key semantics; the caller relies on empty paths to feed `WithTLSClientConfig` and to detect "none of the three present".
- **Error-unwind split stays:** a failed `Write` removes only its own partial file; files from earlier successful writes stay registered so the caller's deferred `Cleanup()` reaps them.
- **0o600 perms** (asserted in a test).

## Tests

- `pkg/source/tempfile_test.go`: perms+content, dir respected, empty→no-file, `Cleanup` removes all, a mid-sequence failed `Write` keeps prior files for `Cleanup`, CreateTemp-error returns no path.
- `pkg/source/helmchart/auth_test.go` (new): TLS materialization for all-three / cert+key / ca-only shapes (exact file count) + none-present fails loud with no files left behind.
- oci's existing `TestFetcher_ResolveConfig_SecretWritesTempFile` exercises the helper through the oci caller (content + cleanup).

Pure refactor of the credential/TLS temp-file path, which is not exercised by offline `build all` (no secrets are fetched offline) — render output is byte-identical by construction. Verified: gofmt, `go build/vet`, `go test -race ./...` (37 pkgs), `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)