### PR TITLE
perf(gittree): write blobs outside the object-read lock

### DIFF
--- a/pkg/source/gittree/bench_test.go
+++ b/pkg/source/gittree/bench_test.go
@@ -1,0 +1,101 @@
+package gittree
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+// benchRepo seeds a source repo with n blobs (a 90/10 small/large mix —
+// small ≤16KB land as in-memory pack objects, large ≥64KB take go-git's
+// FSObject reopen+inflate path), commits them, then CLONES it. A fresh
+// clone stores objects only in a packfile, so Materialize exercises the
+// same packfile-backed read path as a production source fetch (a loose
+// PlainInit repo would shadow the pack with unpacked objects and
+// understate the read cost).
+func benchRepo(b *testing.B, n int) (*git.Repository, plumbing.Hash) {
+	b.Helper()
+	src := b.TempDir()
+	repo, err := git.PlainInit(src, false)
+	if err != nil {
+		b.Fatalf("PlainInit: %v", err)
+	}
+	for i := range n {
+		size := 2 << 10 // 2KB
+		if i%10 == 0 {
+			size = 96 << 10 // 96KB → FSObject path
+		}
+		content := make([]byte, size)
+		for j := range content {
+			content[j] = byte((i*131 + j*7) % 251) // poorly-compressible fill
+		}
+		full := filepath.Join(src, fmt.Sprintf("d%02d", i%50), fmt.Sprintf("f%05d.bin", i))
+		if err := os.MkdirAll(filepath.Dir(full), 0o750); err != nil {
+			b.Fatal(err)
+		}
+		if err := os.WriteFile(full, content, 0o600); err != nil {
+			b.Fatal(err)
+		}
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		b.Fatalf("Worktree: %v", err)
+	}
+	if err := wt.AddWithOptions(&git.AddOptions{All: true}); err != nil {
+		b.Fatalf("Add: %v", err)
+	}
+	if _, err := wt.Commit("seed", &git.CommitOptions{
+		Author: &object.Signature{Name: "t", Email: "t@e", When: time.Unix(0, 0)},
+	}); err != nil {
+		b.Fatalf("Commit: %v", err)
+	}
+
+	clone := b.TempDir()
+	cloned, err := git.PlainClone(clone, false, &git.CloneOptions{URL: src})
+	if err != nil {
+		b.Fatalf("PlainClone: %v", err)
+	}
+	head, err := cloned.Head()
+	if err != nil {
+		b.Fatalf("Head: %v", err)
+	}
+	return cloned, head.Hash() // Materialize resolves the commit's tree itself
+}
+
+// BenchmarkMaterialize is the gate for the blob-write lock-narrowing.
+// Workers=1 has no lock contention (control); Workers=NumCPU is where
+// moving the per-blob disk write outside the object-read lock can pay
+// off. Compare current-vs-narrowed with benchstat over -count=10; ship
+// the narrowing only on a significant Workers=N improvement.
+func BenchmarkMaterialize(b *testing.B) {
+	repo, commit := benchRepo(b, 5000)
+	for _, workers := range []int{1, runtime.NumCPU()} {
+		b.Run(fmt.Sprintf("Workers=%d", workers), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				b.StopTimer()
+				dst, err := os.MkdirTemp("", "mat-bench-*")
+				if err != nil {
+					b.Fatal(err)
+				}
+				b.StartTimer()
+
+				if err := Materialize(context.Background(), repo, commit, dst, Options{Workers: workers}); err != nil {
+					b.Fatalf("Materialize: %v", err)
+				}
+
+				b.StopTimer()
+				_ = os.RemoveAll(dst)
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -73,9 +73,11 @@ func Materialize(ctx context.Context, repo *git.Repository, hash plumbing.Hash, 
 		entry object.TreeEntry
 	}
 	entries := make(chan item, opts.Workers*4)
-	// go-git's filesystem object storage reuses packfile scanners and
-	// caches internally, so keep repository reads single-threaded while
-	// preserving concurrent filesystem writes.
+	// go-git's packfile scanner and object cache are not safe for
+	// concurrent decodes, so each blob READ serializes on
+	// serializedObjectReader. The decode returns an independent
+	// in-memory reader (see blobBytes), so the per-blob disk WRITE runs
+	// OUTSIDE the lock and workers write in parallel.
 	objects := &serializedObjectReader{repo: repo}
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -142,32 +144,34 @@ func (r *serializedObjectReader) nextTreeEntry(walker *object.TreeWalker) (strin
 	return walker.Next()
 }
 
-func (r *serializedObjectReader) readBlobBytes(hash plumbing.Hash) ([]byte, error) {
+// blobBytes returns a blob's full contents. The go-git read (BlobObject
+// + decode + Reader) is serialized on r.mu because the packfile scanner
+// and object cache are not concurrency-safe; the returned slice is an
+// independent copy, so callers write it to disk after the lock is
+// released and concurrent workers write in parallel. Both regular files
+// and symlink targets route through here.
+//
+// The buffer is sized exactly from blob.Size and filled with
+// io.ReadFull rather than io.ReadAll, which would re-grow (and so
+// roughly double the bytes allocated for) every blob over its initial
+// capacity.
+func (r *serializedObjectReader) blobBytes(hash plumbing.Hash, name string) ([]byte, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	blob, err := r.repo.BlobObject(hash)
 	if err != nil {
-		return nil, fmt.Errorf("load symlink blob %s: %w", hash, err)
-	}
-	return readBlobBytes(blob)
-}
-
-func (r *serializedObjectReader) copyBlobTo(hash plumbing.Hash, name string, w io.Writer) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	blob, err := r.repo.BlobObject(hash)
-	if err != nil {
-		return fmt.Errorf("load blob %s for %q: %w", hash, name, err)
+		return nil, fmt.Errorf("load blob %s for %q: %w", hash, name, err)
 	}
 	reader, err := blob.Reader()
 	if err != nil {
-		return fmt.Errorf("blob reader %q: %w", name, err)
+		return nil, fmt.Errorf("blob reader %q: %w", name, err)
 	}
 	defer func() { _ = reader.Close() }()
-	if _, err := io.Copy(w, reader); err != nil {
-		return fmt.Errorf("copy blob %q: %w", name, err)
+	buf := make([]byte, blob.Size)
+	if _, err := io.ReadFull(reader, buf); err != nil {
+		return nil, fmt.Errorf("read blob %q: %w", name, err)
 	}
-	return nil
+	return buf, nil
 }
 
 // writeEntry materializes one tree entry — a symlink or a blob — at
@@ -176,7 +180,7 @@ func (r *serializedObjectReader) copyBlobTo(hash plumbing.Hash, name string, w i
 func writeEntry(objects *serializedObjectReader, entry object.TreeEntry, root, name string) error {
 	dst := filepath.Join(root, filepath.FromSlash(name))
 	if entry.Mode == filemode.Symlink {
-		target, err := objects.readBlobBytes(entry.Hash)
+		target, err := objects.blobBytes(entry.Hash, name)
 		if err != nil {
 			return fmt.Errorf("read symlink target for %q: %w", name, err)
 		}
@@ -188,29 +192,22 @@ func writeEntry(objects *serializedObjectReader, entry object.TreeEntry, root, n
 	return writeBlobTo(dst, objects, entry.Hash, entry.Mode, name)
 }
 
-// readBlobBytes returns the full contents of a blob. Used for symlink
-// targets which are bounded by PATH_MAX.
-func readBlobBytes(blob *object.Blob) ([]byte, error) {
-	r, err := blob.Reader()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = r.Close() }()
-	return io.ReadAll(r)
-}
-
-// writeBlobTo streams blob's content to dst with mode-derived
+// writeBlobTo writes blob's content to dst with mode-derived
 // permissions (executable bit preserved from filemode.Executable).
-// Caller (Materialize's walker) has already created the parent dir.
+// Caller (Materialize's walker) has already created the parent dir. The
+// blob is read under the object-read lock (blobBytes) and written here
+// outside it, so concurrent workers write to disk in parallel.
 func writeBlobTo(dst string, objects *serializedObjectReader, hash plumbing.Hash, mode filemode.FileMode, name string) error {
 	perm := os.FileMode(0o600)
 	if mode == filemode.Executable {
 		perm = 0o700
 	}
-	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm) //nolint:gosec // dst is built from the tree's commit object under the caller's root
+	data, err := objects.blobBytes(hash, name)
 	if err != nil {
-		return fmt.Errorf("create %s: %w", dst, err)
+		return err
 	}
-	defer func() { _ = out.Close() }()
-	return objects.copyBlobTo(hash, name, out)
+	if err := os.WriteFile(dst, data, perm); err != nil { //nolint:gosec // dst is built from the tree's commit object under the caller's root
+		return fmt.Errorf("write %s: %w", dst, err)
+	}
+	return nil
 }


### PR DESCRIPTION
## What

`serializedObjectReader` held its mutex across the entire per-blob path — `BlobObject` → `blob.Reader()` → **`io.Copy`** — so the worker goroutines serialized on the disk **write** as well as the read. The "concurrent writes" were effectively serial.

go-git's packfile scanner and object cache are not concurrency-safe, so the **read** must stay serialized. But the decode returns an **independent in-memory reader** (a `MemoryObject` for blobs ≤16KB; an `FSObject` that opens its own fd, fully materializes, and closes it for larger blobs — verified against go-git v5.19.1, flate's pinned version with default clone options). So this reads each blob fully **under** the lock — sized exactly from `blob.Size` via `io.ReadFull`, the same shape the existing symlink path already used — then writes the bytes **outside** the lock, letting workers write in parallel.

## Benchmark (the gate)

`BenchmarkMaterialize`: a 5000-blob cloned repo (90/10 small/large mix, so blobs exercise both the in-memory and `FSObject` read paths), `-count=10`, benchstat:

| | baseline | narrowed | Δ |
|---|---|---|---|
| **Workers=NumCPU** sec/op | 235.9m ±20% | 180.3m ±2% | **−23.56%** (p=0.000) |
| **Workers=1** sec/op (control) | 398.5m | 397.6m | ~ (p=0.393) |
| B/op | 39.6Mi | 95.2Mi | +140% |
| allocs/op | 283.6k | 288.7k | +1.8% |

The win is the lock-contention removal: at `Workers=NumCPU` the variance collapses from ±20% → ±2% (that variance *was* the contention), while `Workers=1` is unchanged. The cost is +140% B/op — one exact-sized content copy per blob (`io.ReadFull` avoids `io.ReadAll`'s doubling waste, hence near-flat alloc *count*). That's GC throughput on the **cache-miss** materialize path, not a peak-RSS change, and the wall-clock improves despite it.

## Safety + equivalence

- Output is **byte-identical** by construction (same bytes, same paths; only the lock scope changed). Guarded by the existing `-race` parallel-content test (`go test -race -count=5 ./pkg/source/gittree/` clean).
- **Behavior-equivalence across all 12 `~/repos`**: identical `get ks` / `get hr` and normalized `build all`. Two repos showed a `build all` diff that was proven pre-existing time-based non-determinism (an `unlock:` timestamp field that flaps in the baseline binary against itself); the `pre`-vs-`new` normalized diff is empty.
- Full `go test -race ./...` (37 pkgs) + `golangci-lint` 0 issues.

The benchmark ships regardless as regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)