### PR TITLE
feat(diff): strip volatile spec field-paths (default volsync restic unlock)

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -62,13 +62,33 @@ var defaultStripAttrs = []string{
 	"chart",
 }
 
+// defaultStripFields is the default `--strip-field` list — dotted spec
+// field-paths whose value a chart templates from the render clock and
+// so rotates on every render. Same unfixable-at-render class as the
+// randAlphaNum annotations above (Helm exposes no funcMap hook): the
+// TrueCharts common library emits
+//
+//	spec.restic.unlock: {{ now | date "20060102150405" }}
+//
+// on every volsync ReplicationSource, so two diff sides rendered a
+// second apart (cold cache, or across machines) would otherwise show a
+// spurious `~ spec.restic.unlock` per backed-up app. Deleting the leaf
+// keeps the diff churn-free; raw `flate build` output still mirrors
+// Helm (the render cache masks it there).
+var defaultStripFields = []string{
+	"spec.restic.unlock",
+}
+
 type diffFlags struct {
-	stripAttrs []string
+	stripAttrs  []string
+	stripFields []string
 }
 
 func bindDiffFlags(cmd *cobra.Command, d *diffFlags) {
 	cmd.Flags().StringArrayVar(&d.stripAttrs, "strip-attr", defaultStripAttrs,
 		"metadata annotation/label key to strip before diffing (repeatable; supplying any value replaces the default set)")
+	cmd.Flags().StringArrayVar(&d.stripFields, "strip-field", defaultStripFields,
+		"dotted spec field-path to delete before diffing, e.g. spec.restic.unlock (repeatable; supplying any value replaces the default set)")
 }
 
 func diffCmd(use string, aliases []string, short, kind string) *cobra.Command {
@@ -196,8 +216,9 @@ func runDiff(cmd *cobra.Command, c *commonFlags, h *helmFlags, d *diffFlags, kin
 
 	out := diff.Format(c.output)
 	formatted, err := diff.RenderDocs(origDocs, currentDocs, diff.Options{
-		StripAttrs: d.stripAttrs,
-		Format:     out,
+		StripAttrs:  d.stripAttrs,
+		StripFields: d.stripFields,
+		Format:      out,
 	})
 	if err != nil {
 		return errors.Join(err, diffRunErr)

--- a/pkg/diff/bench_test.go
+++ b/pkg/diff/bench_test.go
@@ -80,7 +80,7 @@ func BenchmarkNormalizeDocs(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_ = normalizeDocs(docs, attrs)
+		_ = normalizeDocs(docs, attrs, nil)
 	}
 }
 

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -34,6 +34,14 @@ type Options struct {
 	// reports string-value changes verbatim, so this pre-filter still
 	// earns its keep.
 	StripAttrs []string
+	// StripFields lists dotted spec field-paths (e.g.
+	// "spec.restic.unlock") deleted from each manifest before the diff
+	// is computed. Same rationale as StripAttrs but for volatile values
+	// charts template into the spec rather than metadata — notably
+	// volsync's `unlock: {{ now }}`, which rotates every render and
+	// cannot be stabilized at render time (Helm exposes no funcMap
+	// hook). See manifest.StripResourceFields.
+	StripFields []string
 	// Format selects the output style (see the Format constants). The
 	// zero value renders the human default.
 	Format Format

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -109,8 +109,8 @@ type sRow struct {
 // theme. Identical resources are dropped, matching renderUnified; an empty
 // diff produces no output at all, like the other formats.
 func renderHTML(left, right []Doc, opts Options) ([]byte, error) {
-	left = normalizeDocs(left, opts.StripAttrs)
-	right = normalizeDocs(right, opts.StripAttrs)
+	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields)
+	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields)
 
 	hl, css, err := newHighlighter()
 	if err != nil {

--- a/pkg/diff/native.go
+++ b/pkg/diff/native.go
@@ -19,11 +19,11 @@ import (
 // document-level "order changed" note. Both are rare in practice for
 // content diffs.
 func renderNative(left, right []Doc, opts Options) ([]byte, error) {
-	from, err := multiDocInput("from", normalizeDocs(left, opts.StripAttrs))
+	from, err := multiDocInput("from", normalizeDocs(left, opts.StripAttrs, opts.StripFields))
 	if err != nil {
 		return nil, err
 	}
-	to, err := multiDocInput("to", normalizeDocs(right, opts.StripAttrs))
+	to, err := multiDocInput("to", normalizeDocs(right, opts.StripAttrs, opts.StripFields))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -19,14 +19,15 @@ import (
 // like kube-prometheus-stack's CRD upgrade bundle). Deep-copies so
 // the original tree (shared with other consumers in the same
 // orchestrator run) is untouched.
-func normalizeDocs(docs []Doc, attrs []string) []Doc {
-	if len(attrs) == 0 && !docsContainBinaryData(docs) {
+func normalizeDocs(docs []Doc, attrs, fields []string) []Doc {
+	if len(attrs) == 0 && len(fields) == 0 && !docsContainBinaryData(docs) {
 		return docs
 	}
 	out := make([]Doc, len(docs))
 	for i, d := range docs {
 		copyDoc := manifest.DeepCopyMap(d.Manifest)
 		manifest.StripResourceAttributes(copyDoc, attrs)
+		manifest.StripResourceFields(copyDoc, fields)
 		redactBinaryData(copyDoc)
 		out[i] = Doc{Manifest: copyDoc, Parent: d.Parent}
 	}

--- a/pkg/diff/normalize_test.go
+++ b/pkg/diff/normalize_test.go
@@ -73,6 +73,47 @@ func TestNormalize_StripsChecksumPrefixOnPodTemplate(t *testing.T) {
 	}
 }
 
+// TestNormalize_StripsSpecFieldPath pins Options.StripFields: a volatile
+// spec field a chart stamps from the render clock — volsync's
+// spec.restic.unlock = {{ now }} — is deleted before the diff, so a
+// rotated timestamp yields no diff, while a genuinely-changed sibling
+// spec field still surfaces.
+func TestNormalize_StripsSpecFieldPath(t *testing.T) {
+	mk := func(unlock, repo string) []Doc {
+		return []Doc{{
+			Manifest: map[string]any{
+				"apiVersion": "volsync.backube/v1alpha1",
+				"kind":       "ReplicationSource",
+				"metadata":   map[string]any{"name": "app-config", "namespace": "app"},
+				"spec": map[string]any{
+					"sourcePVC": "app-config",
+					"restic": map[string]any{
+						"unlock":     unlock,
+						"repository": repo,
+					},
+				},
+			},
+		}}
+	}
+	fields := []string{"spec.restic.unlock"}
+
+	// Only the {{ now }}-derived unlock rotated → stripped → no diff.
+	if s := renderDiff(t, mk("20260606112230", "app-restic"), mk("20260606112233", "app-restic"),
+		Options{Format: FormatDiff, StripFields: fields}); s != "" {
+		t.Errorf("rotated spec.restic.unlock should produce no diff under StripFields, got:\n%s", s)
+	}
+	// Control: without the strip, the rotated unlock DOES surface.
+	if s := renderDiff(t, mk("20260606112230", "app-restic"), mk("20260606112233", "app-restic"),
+		Options{Format: FormatDiff}); s == "" {
+		t.Error("control: unstripped spec.restic.unlock change should surface as a diff")
+	}
+	// A genuinely-changed sibling field still surfaces even with unlock stripped.
+	if s := renderDiff(t, mk("20260606112230", "app-restic"), mk("20260606112233", "other-restic"),
+		Options{Format: FormatDiff, StripFields: fields}); s == "" {
+		t.Error("a real spec.restic.repository change must still surface under StripFields")
+	}
+}
+
 // TestNormalize_RedactsConfigMapBinaryData locks the ConfigMap.binaryData
 // redaction: each value is replaced with a content-derived summary before
 // the diff, so a rotated binary hook payload surfaces as a one-line

--- a/pkg/diff/unified.go
+++ b/pkg/diff/unified.go
@@ -20,8 +20,8 @@ func joinNS(ns, name string) string {
 // changed pair's YAML, and concatenates the bodies. Identical resources
 // are dropped. Not Kubernetes-aware — see unifiedBody.
 func renderUnified(left, right []Doc, opts Options) ([]byte, error) {
-	left = normalizeDocs(left, opts.StripAttrs)
-	right = normalizeDocs(right, opts.StripAttrs)
+	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields)
+	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields)
 	var b bytes.Buffer
 	first := true
 	for _, p := range pair(left, right) {
@@ -89,4 +89,3 @@ func marshalForUnified(m map[string]any) (string, error) {
 	}
 	return string(b), nil
 }
-

--- a/pkg/manifest/strip.go
+++ b/pkg/manifest/strip.go
@@ -106,6 +106,43 @@ func stripAttrs(metadata map[string]any, attrs []string) {
 	}
 }
 
+// StripResourceFields deletes each dotted field path from resource.
+// A path like "spec.restic.unlock" navigates nested maps and deletes
+// the leaf key from its parent map; a segment that is absent or whose
+// value is not a map stops that path (no-op). Only the leaf is removed
+// — parent maps are left in place, so both sides of a diff collapse to
+// the same shape rather than one side losing an emptied parent.
+//
+// Navigation is map-only (no list indexing or wildcards), which covers
+// the case it exists for: chart-emitted volatile scalars whose value
+// rotates every render, e.g. volsync's
+// spec.restic.unlock: {{ now | date "20060102150405" }}. This is the
+// spec-field analogue of StripResourceAttributes (metadata keys); the
+// diff layer applies both before handing docs to the diff backend.
+func StripResourceFields(resource map[string]any, paths []string) {
+	for _, p := range paths {
+		if p == "" {
+			continue
+		}
+		deleteFieldPath(resource, strings.Split(p, "."))
+	}
+}
+
+// deleteFieldPath removes the leaf named by segs from the nested map m,
+// walking map-typed segments only. No-op when a segment is missing or
+// not a map.
+func deleteFieldPath(m map[string]any, segs []string) {
+	if len(segs) == 1 {
+		delete(m, segs[0])
+		return
+	}
+	child, ok := m[segs[0]].(map[string]any)
+	if !ok {
+		return
+	}
+	deleteFieldPath(child, segs[1:])
+}
+
 // EnsureMetadata returns doc["metadata"] as a map[string]any, lazily
 // creating one when absent (or when present as a non-map). Used by
 // writers that mutate metadata.labels / metadata.annotations; readers

--- a/pkg/manifest/strip_test.go
+++ b/pkg/manifest/strip_test.go
@@ -1,0 +1,86 @@
+package manifest
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripResourceFields(t *testing.T) {
+	newDoc := func() map[string]any {
+		return map[string]any{
+			"apiVersion": "volsync.backube/v1alpha1",
+			"kind":       "ReplicationSource",
+			"metadata":   map[string]any{"name": "app-config"},
+			"spec": map[string]any{
+				"sourcePVC": "app-config",
+				"trigger":   map[string]any{"schedule": "0 * * * *"},
+				"restic": map[string]any{
+					"unlock":     "20260606112230",
+					"repository": "app-restic-secret",
+					"retain":     map[string]any{"daily": 7},
+				},
+			},
+		}
+	}
+
+	t.Run("deletes nested leaf, leaves siblings + parents", func(t *testing.T) {
+		d := newDoc()
+		StripResourceFields(d, []string{"spec.restic.unlock"})
+
+		restic := d["spec"].(map[string]any)["restic"].(map[string]any)
+		if _, ok := restic["unlock"]; ok {
+			t.Fatal("spec.restic.unlock not deleted")
+		}
+		if restic["repository"] != "app-restic-secret" {
+			t.Errorf("sibling spec.restic.repository was disturbed: %v", restic["repository"])
+		}
+		if _, ok := restic["retain"]; !ok {
+			t.Error("sibling spec.restic.retain was disturbed")
+		}
+		// Parent map is kept (leaf-only delete) so both diff sides match.
+		if _, ok := d["spec"].(map[string]any)["restic"]; !ok {
+			t.Error("parent spec.restic should not be pruned")
+		}
+	})
+
+	t.Run("no-op when a segment is absent", func(t *testing.T) {
+		d := newDoc()
+		before := DeepCopyMap(d)
+		StripResourceFields(d, []string{"spec.absent.field", "metadata.annotations.x"})
+		if !reflect.DeepEqual(d, before) {
+			t.Error("absent-path strip mutated the doc")
+		}
+	})
+
+	t.Run("no-op when a segment is not a map", func(t *testing.T) {
+		d := newDoc()
+		before := DeepCopyMap(d)
+		// spec.sourcePVC is a string; descending through it must not panic
+		// or mutate.
+		StripResourceFields(d, []string{"spec.sourcePVC.deeper"})
+		if !reflect.DeepEqual(d, before) {
+			t.Error("non-map segment strip mutated the doc")
+		}
+	})
+
+	t.Run("multiple paths + empty path ignored", func(t *testing.T) {
+		d := newDoc()
+		StripResourceFields(d, []string{"", "spec.restic.unlock", "spec.trigger.schedule"})
+		restic := d["spec"].(map[string]any)["restic"].(map[string]any)
+		if _, ok := restic["unlock"]; ok {
+			t.Error("spec.restic.unlock not deleted")
+		}
+		trig := d["spec"].(map[string]any)["trigger"].(map[string]any)
+		if _, ok := trig["schedule"]; ok {
+			t.Error("spec.trigger.schedule not deleted")
+		}
+	})
+
+	t.Run("top-level leaf", func(t *testing.T) {
+		d := newDoc()
+		StripResourceFields(d, []string{"kind"})
+		if _, ok := d["kind"]; ok {
+			t.Error("top-level kind not deleted")
+		}
+	})
+}


### PR DESCRIPTION
## What

Some charts template the render clock into the **spec**, not just metadata. TrueCharts' common library emits

```yaml
spec:
  restic:
    unlock: {{ now | date "20060102150405" }}   # → "20260606113459"
```

on every volsync `ReplicationSource`. Sprig's `now` is live `time.Now()` at render time, and Helm v4 exposes **no funcMap hook** to pin it (the same unfixable class as the `randAlphaNum`-derived `checksum/*` annotations already documented in `diff.go`). So two `flate diff` sides rendered a second apart — cold cache, or across machines — show a spurious `~ spec.restic.unlock` entry on **every backed-up app**.

The existing `--strip-attr` / `StripResourceAttributes` only covers **metadata** annotation/label keys. This adds the spec-field analogue.

## Change

- **`manifest.StripResourceFields(resource, paths)`** — deletes dotted field-paths (`spec.restic.unlock`), leaf-only, map navigation; no-op when a segment is absent or not a map. Parents aren't pruned, so both diff sides collapse to the same shape.
- Threaded through **`diff.Options.StripFields`** → `normalizeDocs` (applied right after `StripResourceAttributes`).
- New **`--strip-field`** flag, mirroring `--strip-attr` semantics (repeatable; supplying any value replaces the default set). Default: `[spec.restic.unlock]`.

**Diff-only** — raw `flate build` still mirrors Helm verbatim (the render cache masks the volatility there; that's the documented build-side behavior).

## Why not fix it at render time

`flate build` output for these charts is inherently non-deterministic: Helm has no hook to make `now` deterministic, confirmed empirically (with `--helm-render-cache-mb 0 --helm-template-cache-mb 0`, fresh renders stamp the advancing wall-clock). The render cache freezes the first value per `(chart,values,opts,HR)` key, which is why steady-state runs look stable. The real user-facing harm is diff noise, which this removes.

## Tests + proof

- `pkg/manifest`: `TestStripResourceFields` (leaf delete; no-op on absent / non-map segment; multiple paths; siblings + parents preserved; top-level leaf).
- `pkg/diff`: `TestNormalize_StripsSpecFieldPath` — two `ReplicationSource` docs differing only in `spec.restic.unlock` normalize to **equal** under the default; a genuinely-changed sibling still surfaces; control (no strip) shows the diff.
- **Real repo (boemeltrein):** with caches disabled so the two sides render at different seconds — control (`--strip-field` overridden) shows `unlock: …459 → …458` churn on `ReplicationSource`s; the default run is **empty**. Non-volsync repos are unaffected (path absent → no-op).
- gofmt, `go build/vet`, `go test -race ./...` (37 pkgs), `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)