### PR TITLE
perf(helm): drop CommonMetadata from the template-cache key (applied downstream)

### DIFF
--- a/pkg/helm/bench_test.go
+++ b/pkg/helm/bench_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	chartcommon "helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 
@@ -87,6 +88,58 @@ func BenchmarkTemplate_AppTemplateChartUncached(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
+		out, err := cli.Template(ctx, hr, values, Options{})
+		if err != nil {
+			b.Fatalf("Template: %v", err)
+		}
+		if !strings.Contains(out, "demo-cm") {
+			b.Fatalf("missing rendered name")
+		}
+	}
+}
+
+// BenchmarkTemplate_CommonMetadataVariants renders the same chart +
+// values + release through one warm cache while varying ONLY
+// hr.CommonMetadata each iteration. CommonMetadata is applied downstream
+// of Template (the controller's ApplyHRCommonMetadata) and never affects
+// the rendered bytes, so every iteration SHOULD be a cache hit. This
+// quantifies dropping CommonMetadata from the template-output key:
+// before, each distinct CommonMetadata forced a full
+// action.Install.RunWithContext (cache miss); after, they all hit.
+// benchstat against main shows the avoided-render win for HRs that set
+// spec.commonMetadata.
+func BenchmarkTemplate_CommonMetadataVariants(b *testing.B) {
+	chartDir := stageBenchChartDir(b)
+	cli, err := NewClient(cacheroot.New(b.TempDir()))
+	if err != nil {
+		b.Fatalf("NewClient: %v", err)
+	}
+	cli.SetSourceResolver(benchLocalChartResolver(b, "chart-repo", "flux-system", chartDir))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name:          "mychart",
+			RepoName:      "chart-repo",
+			RepoNamespace: "flux-system",
+			RepoKind:      manifest.KindGitRepository,
+		},
+	}
+	values := map[string]any{"greeting": "hello"}
+	ctx := context.Background()
+	// Prime the cache so b.Loop measures the warm path.
+	if _, err := cli.Template(ctx, hr, values, Options{}); err != nil {
+		b.Fatalf("warm Template: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	i := 0
+	for b.Loop() {
+		i++
+		// A distinct CommonMetadata each iteration: a cache MISS on the
+		// pre-fix key (CommonMetadata folded in), a HIT after the fix.
+		hr.CommonMetadata = &helmv2.CommonMetadata{Labels: map[string]string{"rev": fmt.Sprintf("%d", i)}}
 		out, err := cli.Template(ctx, hr, values, Options{})
 		if err != nil {
 			b.Fatalf("Template: %v", err)

--- a/pkg/helm/template_cache.go
+++ b/pkg/helm/template_cache.go
@@ -232,7 +232,22 @@ func chartFingerprint(ch *chart.Chart) string {
 //     Install.Replace, Upgrade.DisableHooks, Test.Enable,
 //     PostRenderers) — Template reads these straight off hr without
 //     funneling them through opts, so they have to land in the key
-//     independently
+//     independently. PostRenderers in particular DOES change the
+//     rendered bytes (kustomize patches/images run inside Template),
+//     so it stays.
+//
+// Deliberately EXCLUDED — the cache boundary:
+//   - CommonMetadata. The cached value is the pre-stamp render
+//     (releaseManifest); spec.commonMetadata is applied strictly
+//     downstream of TemplateDocs by the controller
+//     (helm.ApplyHRCommonMetadata at controllers/helmrelease/
+//     controller.go), on both the fresh-render and the
+//     fingerprint-dedup replay paths. It never reaches Template's
+//     output (neither newInstallAction nor newPostRenderer reads it),
+//     so folding it in would only force spurious misses for HRs that
+//     set it. Two renders that differ only in CommonMetadata share one
+//     cache entry whose bytes are correct for both; each caller stamps
+//     its own metadata afterward.
 //
 // Cost of computing the key: dominated by JSON-marshaling
 // finalValues when chartFP is precomputed. A 50 KB values map
@@ -279,19 +294,17 @@ func computeTemplateKey(chartFP string, ch *chart.Chart, finalValues map[string]
 		ChartValuesFiles         []string              `json:"chart_values_files,omitempty"`
 		IgnoreMissingValuesFiles bool                  `json:"ignore_missing_values_files,omitempty"`
 		PostRenderers            []helmv2.PostRenderer `json:"post_renderers,omitempty"`
-		CommonMetadata           *helmv2.CommonMetadata `json:"common_metadata,omitempty"`
 	}
 	khr := keyHR{
-		ReleaseName:      hr.ReleaseName(),
-		ReleaseNamespace: hr.ReleaseNamespace(),
-		CRDsPolicy:       hr.CRDsPolicy,
+		ReleaseName:              hr.ReleaseName(),
+		ReleaseNamespace:         hr.ReleaseNamespace(),
+		CRDsPolicy:               hr.CRDsPolicy,
 		DisableSchemaValidation:  hr.DisableSchemaValidation,
 		DisableOpenAPIValidation: hr.DisableOpenAPIValidation,
 		ChartVersion:             hr.Chart.Version,
 		ChartValuesFiles:         hr.ChartValuesFiles,
 		IgnoreMissingValuesFiles: hr.IgnoreMissingValuesFiles,
 		PostRenderers:            hr.PostRenderers,
-		CommonMetadata:           hr.CommonMetadata,
 	}
 	if hr.Install != nil {
 		khr.InstallDisableHooks = hr.Install.DisableHooks

--- a/pkg/helm/template_cache_test.go
+++ b/pkg/helm/template_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"testing"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	chartcommon "helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 
@@ -293,6 +294,41 @@ func TestComputeTemplateKey_DifferingFieldsDiverge(t *testing.T) {
 		alt.CRDsPolicy = "Skip"
 		if got := computeTemplateKey("fp", baseChart, baseValues, baseOpts, &alt); got == baseKey {
 			t.Error("different CRDsPolicy did not change the key")
+		}
+	})
+}
+
+// TestComputeTemplateKey_CommonMetadataExcluded pins the cache boundary:
+// spec.commonMetadata is applied DOWNSTREAM of Template (the controller's
+// helm.ApplyHRCommonMetadata, on both the fresh-render and dedup-replay
+// paths), never reaches the cached render, and so must NOT participate in
+// the key — otherwise every CommonMetadata-only change forces a spurious
+// full re-render. The control subtest asserts PostRenderers (which DOES
+// change the rendered bytes) still diverges the key, so this test cannot
+// pass by accident if a genuinely render-affecting input were dropped.
+func TestComputeTemplateKey_CommonMetadataExcluded(t *testing.T) {
+	ch := minimalChart()
+	values := map[string]any{"k": "v"}
+	opts := Options{KubeVersion: "1.33"}
+	base := minimalHR()
+	baseKey := computeTemplateKey("fp", ch, values, opts, base)
+
+	t.Run("CommonMetadata does not change the key", func(t *testing.T) {
+		alt := *base
+		alt.CommonMetadata = &helmv2.CommonMetadata{
+			Labels:      map[string]string{"team": "platform"},
+			Annotations: map[string]string{"note": "x"},
+		}
+		if got := computeTemplateKey("fp", ch, values, opts, &alt); got != baseKey {
+			t.Errorf("CommonMetadata must NOT affect the cache key (applied downstream of Template):\nbase=%s\nalt =%s", baseKey, got)
+		}
+	})
+
+	t.Run("control: PostRenderers still diverges", func(t *testing.T) {
+		alt := *base
+		alt.PostRenderers = []helmv2.PostRenderer{{Kustomize: &helmv2.Kustomize{}}}
+		if got := computeTemplateKey("fp", ch, values, opts, &alt); got == baseKey {
+			t.Error("PostRenderers changes rendered output and must still diverge the key (guards against dropping a real input)")
 		}
 	})
 }


### PR DESCRIPTION
## What

`computeTemplateKey` folded `hr.CommonMetadata` into the helm template-output cache key, but **CommonMetadata cannot affect the cached value**:

- The cached value is the **pre-stamp** render (`releaseManifest`). Neither `newInstallAction` nor `newPostRenderer` (reads only `r.Kustomize`) consumes CommonMetadata.
- It is applied strictly **downstream of `TemplateDocs`** by the controller — `helm.ApplyHRCommonMetadata` at `controllers/helmrelease/controller.go:416`, on both the fresh-render path and the fingerprint-dedup replay path (which replays already-stamped stored manifests).
- The key's own doc comment enumerated the "Template reads these straight off hr" fields and **omitted** CommonMetadata — it was a dead input from the cache's inception (#488), not a targeted fix.

So it only forced **spurious cache misses** for HRs that set `spec.commonMetadata`. This removes it from the `keyHR` struct + assignment and documents the cache boundary (`PostRenderers` **stays** — it *does* change rendered bytes).

**Why safe:** removing an input from a pure key function can only *merge* previously-distinct keys; merged entries are byte-identical for both callers, and each stamps its own CommonMetadata downstream → output unchanged.

## Impact

A CommonMetadata-only re-render now **hits** the template cache instead of running a full helm render. `BenchmarkTemplate_CommonMetadataVariants` (same chart/values/release, varying only CommonMetadata, warm cache), main vs. branch:

| | main (in key → miss) | branch (hit) | Δ |
|---|---|---|---|
| ns/op | ~264µs | ~6.8µs | **~39× faster** |
| B/op | ~971KB | ~5.7KB | **~170× less** |
| allocs/op | ~895 | 63 | **~14× fewer** |

Aggregate impact is bounded by how often *only* CommonMetadata changes, so the fix stands primarily on **correctness/clarity** (key exactly the output-affecting inputs); the speedup is the bonus.

## How it was found

A read-only pkg/helm perf/locking/dedup/correctness audit run as a Workflow (4 parallel finders → adversarial verify → synthesis): **17 findings → 1 confirmed, 16 refuted** as already-optimal or load-bearing (the postrender `BuildMutex` across `krusty.Run`, the `chartLoadLocks` singleflight, the disk-cache `atomic.WriteFile` durability, the three intentionally-divergent fingerprint schemes, …). pkg/helm is otherwise already well-optimized.

## Tests / verification

- New `TestComputeTemplateKey_CommonMetadataExcluded`: same key despite differing CommonMetadata; control asserts `PostRenderers` still **diverges** (guards against dropping a real input).
- Existing `TestComputeTemplateKey_DifferingFieldsDiverge` + the cached==uncached byte-identity integration test still pass.
- `gofmt`, `go build/vet`, `go test -race ./...` (37 pkgs), `golangci-lint` 0 issues.
- **Behavior-equivalence**: `get ks` / `get hr` + normalized `build all` identical across all 12 `~/repos` (incl. CommonMetadata-using charts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)