### PR TITLE
fix(orchestrator): make ResourceSet collision winner deterministic

### DIFF
--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -597,6 +597,66 @@ func TestExpandResourceSetsPostRun_RespectsCanceledContext(t *testing.T) {
 	}
 }
 
+// TestExpandResourceSetsPostRun_DeterministicCollisionWinner pins that
+// when two distinct ResourceSets emit the SAME object identity
+// (apiVersion|kind|ns|name) with DIFFERENT content, the global first-
+// wins dedup winner is deterministic — the ResourceSet that sorts first
+// in store order wins, independent of goroutine scheduling. Before the
+// serial-commit rework the winner was whichever render goroutine reached
+// the shared map first (an 8-way errgroup), so output could flip
+// run-to-run. A Widget (unmodeled kind) is used so ParseDoc yields a
+// RawObject — the only shape expandResourceSetsPostRun re-emits.
+func TestExpandResourceSetsPostRun_DeterministicCollisionWinner(t *testing.T) {
+	parent := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+	}
+	mkRS := func(name, owner string) *manifest.ResourceSet {
+		return &manifest.ResourceSet{
+			Name: name, Namespace: "flux-system",
+			ResourceSetSpec: fluxopv1.ResourceSetSpec{
+				ResourcesTemplate: "apiVersion: example.com/v1\nkind: Widget\nmetadata:\n  name: shared\n  namespace: default\nspec:\n  owner: " + owner + "\n",
+			},
+		}
+	}
+	// rs-a sorts before rs-b (same namespace, "rs-a" < "rs-b"), so the
+	// deterministic winner of the shared Widget must always be rs-a's.
+	rsA := mkRS("rs-a", "a-wins")
+	rsB := mkRS("rs-b", "b-loses")
+
+	newOrch := func() *Orchestrator {
+		o := &Orchestrator{
+			store:    store.New(),
+			rendered: newRenderedSet(),
+			sourceFiles: map[manifest.NamedResource]string{
+				rsA.Named(): "apps/rs-a.yaml",
+				rsB.Named(): "apps/rs-b.yaml",
+			},
+		}
+		o.store.AddObject(parent)
+		o.store.AddObject(rsA)
+		o.store.AddObject(rsB)
+		return o
+	}
+
+	// Many iterations (fresh orchestrator each) shake out any scheduling-
+	// dependent winner; the contract is that rs-a always wins.
+	for iter := range 50 {
+		o := newOrch()
+		if err := o.expandResourceSetsPostRun(context.Background()); err != nil {
+			t.Fatalf("iter %d: expandResourceSetsPostRun: %v", iter, err)
+		}
+		docs := o.rsExtensions[parent.Named()]
+		if len(docs) != 1 {
+			t.Fatalf("iter %d: rsExtensions[apps] = %d docs, want 1 (deduped to one winner)", iter, len(docs))
+		}
+		spec, _ := docs[0]["spec"].(map[string]any)
+		if got := spec["owner"]; got != "a-wins" {
+			t.Fatalf("iter %d: collision winner owner = %v, want a-wins (sorted-first RS) — non-deterministic", iter, got)
+		}
+	}
+}
+
 // TestOrchestrator_Render exercises the embed-friendly Render() entry:
 // one call drives Bootstrap + Run + result collection, and returns a
 // structured Result keyed by NamedResource. Embedders previously had

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -83,14 +82,18 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 	// who request serial/deterministic runs (Concurrency: 1) also get
 	// that here; default is rsExpansionDefaultConcurrency (8).
 	const rsExpansionDefaultConcurrency = 8
-	var (
-		mu   sync.Mutex
-		seen = map[string]struct{}{}
-		out  = map[manifest.NamedResource][]map[string]any{}
-	)
+	type emit struct {
+		key string
+		doc map[string]any
+	}
+	type rsResult struct {
+		parentKS manifest.NamedResource
+		pending  []emit
+	}
+	results := make([]rsResult, len(rsList))
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(cmp.Or(o.cfg.Concurrency, rsExpansionDefaultConcurrency))
-	for _, rs := range rsList {
+	for i, rs := range rsList {
 		g.Go(func() error {
 			if err := gctx.Err(); err != nil {
 				return err
@@ -117,21 +120,16 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 					return nil
 				}
 				slashFile := filepath.ToSlash(file)
-				i := slices.IndexFunc(owners, func(w owner) bool {
+				idx := slices.IndexFunc(owners, func(w owner) bool {
 					return strings.HasPrefix(slashFile, w.prefix)
 				})
-				if i < 0 {
+				if idx < 0 {
 					return nil
 				}
-				parentKS = owners[i].id
+				parentKS = owners[idx].id
 			}
-			// Filter docs to RawObjects + collect dedup keys
-			// outside the mutex; the mutex only holds for the
-			// commit-to-shared-state step.
-			type emit struct {
-				key string
-				doc map[string]any
-			}
+			// Filter docs to RawObjects + collect dedup keys into this
+			// RS's own slot; the deterministic commit happens below.
 			pending := make([]emit, 0, len(docs))
 			for _, doc := range docs {
 				parsed, perr := manifest.ParseDoc(doc, manifest.ParseDocOptions{WipeSecrets: o.cfg.WipeSecrets})
@@ -147,22 +145,29 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 				}
 				pending = append(pending, emit{key, doc})
 			}
-			if len(pending) == 0 {
-				return nil
-			}
-			mu.Lock()
-			defer mu.Unlock()
-			for _, e := range pending {
-				if _, dup := seen[e.key]; dup {
-					continue
-				}
-				seen[e.key] = struct{}{}
-				out[parentKS] = append(out[parentKS], e.doc)
-			}
+			// Each goroutine writes only its own results[i] slot (distinct
+			// indices — no shared mutable state, no mutex needed).
+			results[i] = rsResult{parentKS: parentKS, pending: pending}
 			return nil
 		})
 	}
 	err := g.Wait()
+	// Commit serially in rsList order (sorted by namespace,name via
+	// store.ListAs) AFTER g.Wait establishes happens-before: the first RS
+	// to claim a DedupKey wins, deterministically, regardless of which
+	// goroutine finished first. A name-grouped RS rendering the same
+	// child from each namespace variant still collapses to one doc.
+	seen := map[string]struct{}{}
+	out := map[manifest.NamedResource][]map[string]any{}
+	for _, r := range results {
+		for _, e := range r.pending {
+			if _, dup := seen[e.key]; dup {
+				continue
+			}
+			seen[e.key] = struct{}{}
+			out[r.parentKS] = append(out[r.parentKS], e.doc)
+		}
+	}
 	o.rsExtensions = out
 	if err != nil {
 		failed := map[manifest.NamedResource]store.StatusInfo{}


### PR DESCRIPTION
## What

`expandResourceSetsPostRun` re-renders ResourceSets in parallel (errgroup, default 8) and committed each one's emitted RawObjects to a shared `seen` dedup set + `out[parentKS]` map **under a mutex, in goroutine-completion order**. `DedupKey` is pure identity (`apiVersion|kind|ns|name`), so when two distinct ResourceSets emit the same object with different content, the first-write-wins winner was chosen by goroutine scheduling, not deterministically.

This reworks the commit so the winner is deterministic — and **removes the mutex**:
- **Parallel phase:** each goroutine renders its RS, resolves `parentKS`, builds its `pending` RawObjects, and writes **only its own `results[i]` slot** (distinct indices → no shared mutable state).
- **Serial commit after `g.Wait()`:** iterate `results` in `rsList` order (sorted by namespace,name via `store.ListAs`); first RS to claim a `DedupKey` wins. Scheduling-independent.

## Why

Determinism-hardening, **not** a fix for an observed break — no repo in the corpus has a cross-RS same-identity collision today. It guarantees scheduling-independent output for the latent case, matching the project's determinism discipline (krusty BuildMutex, sorted output). Surfaced by a read-only 3-subsystem ultracode audit (kustomize/orchestrator/loader+discovery: 64 findings → 2 confirmed, 62 refuted as already-optimal); this was the one substantive survivor.

## Tests / verification

- New `TestExpandResourceSetsPostRun_DeterministicCollisionWinner`: two RSes emit the same `Widget` (unmodeled kind → RawObject) with different content; 50 iterations assert the sorted-first RS always wins. `-race` clean (distinct-index writes).
- `gofmt`, `go build/vet`, `go test -race ./...` (37 pkgs), `golangci-lint` 0 issues.
- **Behavior-equivalence:** `get ks` / `get hr` + normalized `build all` identical across all 12 `~/repos` (caches disabled; trailing-comma-normalized to factor out a *pre-existing, unrelated* `GrafanaDashboard` embedded-JSON map-order non-determinism — see below). The change is a no-op for the 9 non-ResourceSet repos and output-identical for the 3 that use ResourceSets (none has a collision today).

## Out of scope (separate pre-existing finding)

While verifying, I found a distinct, pre-existing non-determinism: `GrafanaDashboard` (and similar embedded-JSON) resources re-serialize with non-deterministic map-key order → trailing-comma churn, normally masked by the render cache (exposed only on a cold/evicted cache). Unrelated to this change; flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)