### PR TITLE
chore: gitignore Go test + profiling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ tmp/
 # Preserve files
 !.gitkeep
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Go test + profiling artifacts (go test -c binaries, coverage, pprof)
+*.test
 *.out
+*.prof
+*.pprof


### PR DESCRIPTION
## What

`*.test` (compiled `go test -c` binaries), `*.prof`, and `*.pprof` were not gitignored. A recent session left two stray binaries in the repo root (`loader.test` ~34MB, `orchestrator.test` ~113MB) that were nearly committed. Folds them into the existing coverage (`*.out`) entry under one "Go test + profiling artifacts" section.

```
# Go test + profiling artifacts (go test -c binaries, coverage, pprof)
*.test
*.out
*.prof
*.pprof
```

Verified: `git check-ignore` matches `*.test`/`*.prof`/`*.out`; `git status` clean; nothing of these types is currently tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)