### PR TITLE
refactor: drop dead/redundant code in build + baseline

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -105,14 +105,10 @@ func collectRendered(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 	// that didn't render (failed reconcile, suspended, no docs) still
 	// counts as a match — without this the typo-detection error below
 	// would also fire for failed-but-existing resources.
+	// Store.ListObjects(kind) already returns results sorted by
+	// (namespace, name) (store.go), so single-kind output is deterministic
+	// across runs without a re-sort here.
 	objs := o.Store().ListObjects(kind)
-	// Sort by (namespace, name) so output is deterministic across runs
-	// — Store.ListObjects iterates the byName map and would otherwise
-	// produce a different ordering each invocation, breaking shell-piped
-	// diffs and CI consumers.
-	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
-		return a.Named().Compare(b.Named())
-	})
 	skipKinds := c.skipResourceKinds()
 	matched := 0
 	var out []map[string]any

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -197,7 +197,11 @@ func relToRepo(repoRoot, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if rel != ".." && !filepath.IsAbs(rel) && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	// filepath.Rel returns a relative path on success (it errors
+	// otherwise, handled above), so no IsAbs check is needed — reject
+	// only the repo-escaping ".." and "../…" forms. A dir literally named
+	// "..foo" is in-repo and stays accepted.
+	if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return rel, nil
 	}
 	return "", fmt.Errorf("--path %q is outside the git repo at %q; pass --path-orig explicitly", path, repoRoot)


### PR DESCRIPTION
Two behavior-equivalent simplifications from a per-module cleanliness audit:

- **`internal/cli/build.go`** — drop the redundant re-sort of `ListObjects(kind)` output. Since #584, `Store.ListObjects(kind)` already returns results sorted by `(namespace, name)`; the extra `slices.SortFunc(Named().Compare)` is identical order for a single-kind query (Kind is constant). Also corrects the now-stale comment claiming `ListObjects` is unordered.
- **`pkg/baseline/baseline.go`** — remove the dead `filepath.IsAbs(rel)` check in `relToRepo`. `filepath.Rel` returns a relative path on success (errors otherwise, already handled), so `IsAbs` is always false. The precise `..` / `../…` escape check is **kept verbatim** so a dir literally named `..foo` stays correctly in-repo (the broader "collapse to one `HasPrefix`" the audit floated would have wrongly rejected it).

## Verification
`gofmt`/`go build`/`go vet`/full **`go test -race ./...`**/`golangci-lint` → clean, 0 issues. Output byte-identical (`get ks` + normalized `build all`) across drag0n141/aclerici38/onedr0p/joryirving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)