### PR TITLE
docs: fix stale/inaccurate comments

### DIFF
--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -237,9 +237,10 @@ func printResources[T manifest.BaseManifest](
 	if !nameExists {
 		return fmt.Errorf("no %s named %q in --path", kind, sel.Name)
 	}
-	// Store.ListObjects iterates a Go map (random order); sort the
-	// (row, doc) tuple so every output flavor — including yaml/json —
-	// is deterministic across runs.
+	// Sort the (row, doc) tuples by (namespace, name) so every output
+	// flavor — table/yaml/json — is deterministic across runs. (The rows
+	// are derived per-object, so sort them rather than rely on the store's
+	// listing order.)
 	slices.SortFunc(pairs, func(a, b pair) int {
 		return cmp.Or(
 			cmp.Compare(a.row["namespace"], b.row["namespace"]),

--- a/internal/testutil/certs.go
+++ b/internal/testutil/certs.go
@@ -57,7 +57,6 @@ func pemKey(t *testing.T, priv *ecdsa.PrivateKey) string {
 	return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
 }
 
-// SelfSignedCA returns a PEM-encoded CA certificate.
 // makeCertificate builds a self-signed cert (signed by its own
 // ephemeral ECDSA key) with the given subject CN and usage flags,
 // returning the cert and key as PEM. The shared boilerplate — serial,

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -144,7 +144,7 @@ func (c *Controller) Start(ctx context.Context) {
 // already in the store at Start time and kept current as new objects arrive.
 //
 // The index maps targetID → producer.Named(), mirroring the classification
-// logic in rawProducesValuesRef so generatedValuesProducer can be answered
+// logic in rawProducerTargetID so generatedValuesProducer can be answered
 // in O(1) without a full-store scan.
 func (c *Controller) onRawProducerAdded() store.Listener {
 	return func(_ manifest.NamedResource, payload any) {
@@ -162,7 +162,7 @@ func (c *Controller) onRawProducerAdded() store.Listener {
 
 // rawProducerTargetID returns the NamedResource of the Secret that raw
 // will produce, or (zero, false) when raw is not a recognised producer kind.
-// This mirrors the classification in rawProducesValuesRef but returns the
+// This mirrors the classification in rawProducerTargetID but returns the
 // target identity rather than a boolean, so the index can be keyed by it.
 func rawProducerTargetID(raw *manifest.RawObject) (manifest.NamedResource, bool) {
 	switch raw.Kind {

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -402,7 +402,7 @@ const maxSlugLen = 50
 //
 // Without the version strip, the OCI flow always presents
 // versionedURL (URL + ":" + tag) to slugifyRepo, and every OCI
-// slot ends up under `&lt;root&gt;/sources/&lt;tag&gt;/&lt;hash&gt;` — e.g. every
+// slot ends up under `<root>/sources/<tag>/<hash>` — e.g. every
 // app-template release piles under `5.0.1/`, `5.0.2/`, `5.0.3/`,
 // indistinguishable from any other chart pinned to those tags.
 // Functionally safe (hash is the real uniqueness key) but

--- a/pkg/source/cache_test.go
+++ b/pkg/source/cache_test.go
@@ -417,7 +417,7 @@ func TestSlugifyRepo(t *testing.T) {
 		// Tag suffix: versionedURL passes URL:tag into slugify
 		// for OCI fetches. Slug should be the chart name, NOT
 		// the tag — otherwise the cache layout collapses
-		// every release of every chart into the same `&lt;tag&gt;/`
+		// every release of every chart into the same `<tag>/`
 		// directory.
 		"oci://ghcr.io/bjw-s-labs/helm/app-template:5.0.1":     "app-template",
 		"oci://ghcr.io/bjw-s-labs/helm/app-template:1.2.3-rc4": "app-template",


### PR DESCRIPTION
Comment-only cleanups from a per-module cleanliness audit (zero behavior change):

- **`helmrelease/controller.go`** — two comments referenced a non-existent function `rawProducesValuesRef`; the real function is `rawProducerTargetID`.
- **`internal/cli/get.go`** — the sort comment claimed `ListObjects` returns a Go map in random order; since #584 it returns results sorted by `(namespace, name)`. Reworded to state the real reason the *derived* rows are sorted (output determinism across flavors); the sort itself is kept (defensive on derived display rows).
- **`internal/testutil/certs.go`** — removed an orphaned `// SelfSignedCA returns ...` doc line sitting above `makeCertificate` (`SelfSignedCA` has its own correct doc).
- **`source/cache.go` + `cache_test.go`** — replaced HTML entities (`&lt;`/`&gt;`) in plain-text comments with literal angle brackets.

## Verification
`gofmt`/`go build`/`go vet`/`go test -race` (affected pkgs)/`golangci-lint` → clean, 0 issues. Comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)