### PR TITLE
perf(kustomization): single-flight working-tree fingerprint

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -52,12 +53,20 @@ type Controller struct {
 	// unset (tests / no repoRoot) → edge always added.
 	selfProduces func(cm, consumer manifest.NamedResource) bool
 
-	// workingTreeFPs memoizes workingTreeFingerprint results per source
+	// workingTreeFPs single-flights workingTreeFingerprint per source
 	// LocalPath for the life of the controller. resolveSourceRootAnd-
-	// Fingerprint runs once per Kustomization, and many KSes share the
-	// bootstrap working-tree source — without this, every KS would
-	// re-walk the entire repo to derive the same fingerprint.
-	workingTreeFPs sync.Map // string -> string
+	// Fingerprint runs once per Kustomization, and dozens of KSes share
+	// the bootstrap working-tree source — they all reconcile at once
+	// under --concurrency, so a plain Load/Store memo lets them all miss
+	// before any Store lands and re-walk the entire repo in parallel.
+	// Storing a sync.OnceValue closure collapses that herd to one walk.
+	workingTreeFPs sync.Map // path string -> func() string (sync.OnceValue)
+
+	// walks counts actual workingTreeFingerprint executions (one per
+	// unique LocalPath, regardless of concurrent callers). Single-flight
+	// observability — asserted by TestCachedWorkingTreeFingerprint_SingleFlight;
+	// mirrors StagingCache.sweepKicks.
+	walks atomic.Int64
 }
 
 // Options carries the post-bootstrap state the orchestrator wires onto
@@ -438,17 +447,20 @@ func sourceFingerprintFromRevision(rev string) string {
 	return rev
 }
 
-// cachedWorkingTreeFingerprint memoizes workingTreeFingerprint by
+// cachedWorkingTreeFingerprint single-flights workingTreeFingerprint by
 // LocalPath. resolveSourceRootAndFingerprint runs once per Kustomization
-// and dozens of KSes share the bootstrap source — without this cache,
-// every reconcile re-walks the entire repo to derive the same hash.
+// and dozens of KSes share the bootstrap source, all reconciling
+// concurrently — a plain Load/miss/Store memo lets them all miss before
+// any value is stored and re-walk the entire repo in parallel (a
+// thundering herd that dominates warm-run CPU). LoadOrStore keeps exactly
+// one sync.OnceValue closure per path, so every concurrent caller invokes
+// the same closure and the walk runs once. Mirrors StagingCache's copyOnce.
 func (c *Controller) cachedWorkingTreeFingerprint(path string) string {
-	if v, ok := c.workingTreeFPs.Load(path); ok {
-		return v.(string)
-	}
-	fp := workingTreeFingerprint(path)
-	c.workingTreeFPs.Store(path, fp)
-	return fp
+	once, _ := c.workingTreeFPs.LoadOrStore(path, sync.OnceValue(func() string {
+		c.walks.Add(1)
+		return workingTreeFingerprint(path)
+	}))
+	return once.(func() string)()
 }
 
 // workingTreeFingerprint hashes every regular file under path with

--- a/pkg/controllers/kustomization/fingerprint_test.go
+++ b/pkg/controllers/kustomization/fingerprint_test.go
@@ -1,8 +1,10 @@
 package kustomization
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -70,8 +72,9 @@ func TestKustomizationFingerprint_SourceRootInputs(t *testing.T) {
 }
 
 // seedWorkingTree lays out a small tree under t.TempDir()-style root
-// for workingTreeFingerprint tests. Returns the absolute root.
-func seedWorkingTree(t *testing.T) string {
+// for workingTreeFingerprint tests. Returns the absolute root. Takes
+// testing.TB so benchmarks can share it.
+func seedWorkingTree(t testing.TB) string {
 	t.Helper()
 	root := t.TempDir()
 	mustMkdir := func(p string) {
@@ -196,5 +199,88 @@ func TestWorkingTreeFingerprint_EmptyOnMissingPath(t *testing.T) {
 	}
 	if fp := workingTreeFingerprint(filepath.Join(t.TempDir(), "no-such-dir")); fp != "" {
 		t.Errorf("workingTreeFingerprint(nonexistent) = %q, want \"\"", fp)
+	}
+}
+
+// TestCachedWorkingTreeFingerprint_SingleFlight is the regression fence
+// for the warm-run thundering herd: dozens of KSes share one bootstrap
+// working-tree source and all reconcile at once under --concurrency.
+// The memo MUST collapse them to a single tree walk — a plain
+// Load/miss/Store memo lets every caller miss before the first Store
+// lands and re-walk the whole repo in parallel, which dominated warm-run
+// CPU. Asserts the walk runs exactly once and every caller agrees on the
+// value.
+func TestCachedWorkingTreeFingerprint_SingleFlight(t *testing.T) {
+	root := seedWorkingTree(t)
+	want := workingTreeFingerprint(root) // reference value, computed off the memo
+
+	c := &Controller{}
+	const callers = 64
+	results := make([]string, callers)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Go(func() {
+			<-start // line every goroutine up so they all race the Load
+			results[i] = c.cachedWorkingTreeFingerprint(root)
+		})
+	}
+	close(start)
+	wg.Wait()
+
+	if got := c.walks.Load(); got != 1 {
+		t.Errorf("workingTreeFingerprint walked %d times under %d concurrent callers; want 1 (single-flight broken)", got, callers)
+	}
+	for i, got := range results {
+		if got != want {
+			t.Fatalf("caller %d got fingerprint %q; want %q", i, got, want)
+		}
+	}
+
+	// A later call for the same path stays a memo hit — no extra walk.
+	if got := c.cachedWorkingTreeFingerprint(root); got != want {
+		t.Fatalf("post-herd call got %q; want %q", got, want)
+	}
+	if got := c.walks.Load(); got != 1 {
+		t.Errorf("walk count rose to %d on a memo hit; want 1", got)
+	}
+}
+
+// seedBenchTree lays out a wider tree (nested dirs + many files) so the
+// per-walk cost is meaningful — the cold-herd benchmark measures how
+// many of those walks the memo elides under concurrency.
+func seedBenchTree(b *testing.B, files int) string {
+	b.Helper()
+	root := b.TempDir()
+	for i := range files {
+		dir := filepath.Join(root, fmt.Sprintf("ns%02d", i%16), fmt.Sprintf("app%02d", i%8))
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			b.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("r%04d.yaml", i)), []byte("kind: ConfigMap\n"), 0o600); err != nil {
+			b.Fatalf("write: %v", err)
+		}
+	}
+	return root
+}
+
+// BenchmarkCachedWorkingTreeFingerprint_ColdHerd measures the realistic
+// access pattern a fresh `flate build` run hits: a fresh controller (cold
+// memo) with many concurrent reconciles racing on one shared bootstrap
+// source. Each iteration is a fresh herd, so single-flight shows as one
+// walk per iteration versus up to `callers` walks pre-fix.
+func BenchmarkCachedWorkingTreeFingerprint_ColdHerd(b *testing.B) {
+	root := seedBenchTree(b, 256)
+	const callers = 64
+	b.ReportAllocs()
+	for b.Loop() {
+		c := &Controller{}
+		var wg sync.WaitGroup
+		for range callers {
+			wg.Go(func() {
+				_ = c.cachedWorkingTreeFingerprint(root)
+			})
+		}
+		wg.Wait()
 	}
 }


### PR DESCRIPTION
## What

`cachedWorkingTreeFingerprint` memoized the working-tree hash per source `LocalPath` but was **not single-flighted** — a plain `Load → miss → walk → Store`. Dozens of Kustomizations share the bootstrap working-tree source and all reconcile at once under `--concurrency`, so every caller missed the `Load` before the first `Store` landed and **re-walked the entire repo tree in parallel** — a thundering herd.

This stores a `sync.OnceValue` closure via `LoadOrStore`, so every concurrent caller invokes the *same* closure and the walk runs exactly once. Mirrors `StagingCache`'s existing `copyOnce` idiom. The fingerprint **value is unchanged** — only the number of times it's computed drops from N to 1.

## Why — measured, not assumed

This started as an investigation into a kustomize *render-output* disk cache (mirroring `--helm-render-cache-mb`). A warm CPU profile of `joryirving build all` (163 KS, local source) **disproved that premise** and surfaced the real hot spot:

- **~80% cumulative** in `workingTreeFingerprint` → `filepath.WalkDir` / `os.ReadDir` / `os.Lstat` (`syscall.rawsyscalln` 86% flat).
- kustomize `SecureBuild` / `RenderFlux`: **does not appear** (below the 12.85ms drop threshold) — warm krusty render is already cheap.
- helm: ~6.6%, almost all `LoadChart` (archive read), not render — the helm render disk cache already absorbs the expensive part.

So a kustomize render-output cache would save ≈0% warm. The herd was the actual cost, and it's purely redundant work.

## Numbers

**Cold-herd benchmark** (64 callers, fresh memo, 256-file tree — checked in as `BenchmarkCachedWorkingTreeFingerprint_ColdHerd`):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 25,091,047 | 14,770,361 | 127,755 |
| after | 1,016,406 | 267,876 | 2,588 |

**~24.7× faster, ~55× fewer bytes, ~49× fewer allocs.**

**Warm `joryirving build all --concurrency 64`** (the default):

| | wall (real) | CPU (user) |
|---|---|---|
| main | ~0.44s | ~0.64s |
| this PR | ~0.27s | ~0.46s |

**~39% wall-time, ~28% CPU.** The default concurrency no longer trails `--concurrency 4` (the herd previously made 64 *slower* than 4 by saturating cores on duplicate walks).

## Tests

- `TestCachedWorkingTreeFingerprint_SingleFlight` — 64 goroutines race the memo for one path; asserts the walk runs **exactly once** (via a new `walks atomic.Int64` counter, mirroring `StagingCache.sweepKicks`) and every caller agrees on the value. Runs under `-race`.
- `BenchmarkCachedWorkingTreeFingerprint_ColdHerd` — the gate above.

## Verification

- `gofmt` clean / `go build ./...` / `go vet ./...` / full `go test -race ./...` ✅ / `golangci-lint run ./pkg/... ./internal/...` → **0 issues**.
- **Behavior-equivalence**: warm `build all` output **byte-identical** to `main` across the rendering corpus (joryirving 48338, billimek 57227, zariel 1122, boemeltrein 822 lines).

## Out of scope

- Kustomize render-output disk cache — profiled as a dud (render invisible warm); not pursued.
- Collapsing the *cold* double-walk (fingerprint walk + staging copy-walk) — a cold-only follow-up needing `Stage` to return the fingerprint (cross-package API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)