### PR TITLE
refactor(kustomize): single-source the staging skip-set

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -464,9 +464,9 @@ func (c *Controller) cachedWorkingTreeFingerprint(path string) string {
 }
 
 // workingTreeFingerprint hashes every regular file under path with
-// (relpath, mtime, size). The skip set — `.git`, `node_modules`,
-// dot-prefixed dirs — mirrors copyTreeInto exactly: the fingerprint and
-// the staged tree MUST see the same files, or a cache hit can land a
+// (relpath, mtime, size). The directory skip set is shared with the
+// staged copy via kustomize.SkipStageDir — the fingerprint and the
+// staged tree MUST see the same files, or a cache hit can land a
 // structurally broken stage (e.g. a kustomization.yaml that references
 // a directory the stage omits). Cost is amortized against a cache miss,
 // which would walk the same tree anyway to copy.
@@ -485,8 +485,9 @@ func workingTreeFingerprint(path string) string {
 			return err
 		}
 		if d.IsDir() {
-			base := d.Name()
-			if p != abs && (base == "node_modules" || strings.HasPrefix(base, ".")) {
+			// Share the exclusion set with the staged copy; the root
+			// (abs) is never skipped even if its base is dot-prefixed.
+			if p != abs && kustomize.SkipStageDir(d.Name()) {
 				return fs.SkipDir
 			}
 			return nil

--- a/pkg/kustomize/copytree.go
+++ b/pkg/kustomize/copytree.go
@@ -14,6 +14,18 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// SkipStageDir reports whether a directory base name is excluded from
+// the staged copy: `node_modules` and every dot-prefixed dir (which
+// captures `.git`, `.flate-cache`, IDE state, etc.). It is the single
+// source of truth for that set — the working-tree fingerprint that keys
+// the persistent stage cache (kustomization controller) MUST apply the
+// identical rule, or a cache hit can land a stage missing a directory the
+// fingerprint counted (or vice-versa), yielding a structurally broken
+// tree. Apply to non-root directories only; callers own root detection.
+func SkipStageDir(base string) bool {
+	return base == "node_modules" || strings.HasPrefix(base, ".")
+}
+
 // copyTreeInto materializes every regular file from src into dst.
 // Symlinks are dereferenced, dotfiles are skipped to keep stages
 // clean. Caller owns dst — copyTreeInto neither creates nor removes
@@ -47,9 +59,10 @@ func (c *StagingCache) copyTreeInto(src, dst string) error {
 		}
 		base := d.Name()
 		if d.IsDir() {
-			// Skip anything that isn't user content: .git / node_modules
-			// and every dot-prefixed dir (which captures .flate-cache).
-			if base == "node_modules" || strings.HasPrefix(base, ".") {
+			// Skip anything that isn't user content (see SkipStageDir).
+			// The root is already handled by the rel == "." early return
+			// above, so this only fires on subdirectories.
+			if SkipStageDir(base) {
 				return fs.SkipDir
 			}
 			return os.MkdirAll(filepath.Join(dst, rel), 0o750)

--- a/pkg/kustomize/copytree_test.go
+++ b/pkg/kustomize/copytree_test.go
@@ -1,0 +1,29 @@
+package kustomize
+
+import "testing"
+
+// TestSkipStageDir locks the shared staging exclusion set. It is the
+// single source of truth for both the staged copy (copyTreeInto) and the
+// working-tree fingerprint that keys the persistent stage cache; the two
+// MUST agree, so this guards the contract in one place.
+func TestSkipStageDir(t *testing.T) {
+	cases := []struct {
+		base string
+		want bool
+	}{
+		{"node_modules", true},
+		{".git", true},
+		{".flate-cache", true},
+		{".vscode", true},
+		{".", true}, // dot-prefixed; callers exclude the root before calling
+		{"apps", false},
+		{"node_modulesx", false}, // only an exact match is excluded
+		{"my.app", false},        // dot must be the leading char
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := SkipStageDir(c.base); got != c.want {
+			t.Errorf("SkipStageDir(%q) = %v; want %v", c.base, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

The staged copy (`copyTreeInto`, `pkg/kustomize/copytree.go`) and the working-tree fingerprint that keys the persistent stage cache (`workingTreeFingerprint`, `pkg/controllers/kustomization/controller.go`) each carried their **own inline copy** of the directory exclusion set — `node_modules` + dot-prefixed dirs.

These two MUST agree: if the fingerprint counts a directory the staged copy omits (or vice-versa), a cache hit can land a **structurally broken stage** (a `kustomization.yaml` referencing a directory that isn't there). That parity was enforced only by a comment ("mirrors copyTreeInto exactly") and manual vigilance.

This extracts one exported predicate, `kustomize.SkipStageDir`, as the single source of truth and calls it from both walks. Each site keeps its own root guard (`copyTreeInto`'s `rel == "."` early return; the fingerprint's `p != abs` check) — only the base-name test is shared.

## Why

Surfaced while investigating (and rejecting, on profiling evidence) the cold double-walk collapse: the cold redundancy isn't worth a refactor, but the duplicate-skip-set hazard it depends on is worth removing cheaply. No walk-merge, no API churn — just one predicate instead of two.

## Out of scope

The other `node_modules`/dot-dir skips are deliberately **different** sets for different purposes and are untouched: `pkg/change/detect.go` (`node_modules`, `vendor`), `pkg/loader/loader.go` (`.git`, `node_modules`, `.cache`), `pkg/helm/oci_chart.go`.

## Tests

- New `TestSkipStageDir` table test locks the predicate (`node_modules`/dot-dirs → true; ordinary names, `node_modulesx`, `my.app`, `""` → false).
- Existing parity tests pass unchanged: `TestWorkingTreeFingerprint_StableOnDotPrefixedNoise`, `TestWorkingTreeFingerprint_StableOnNodeModules`.

## Verification

- `gofmt` clean / `go build ./...` / `go vet ./...` / full `go test -race ./...` ✅ / `golangci-lint run ./pkg/... ./internal/...` → **0 issues**.
- Pure refactor: warm `build all` output **byte-identical** to `main` (joryirving 48338, billimek 57227 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)