### PR TITLE
fix(change): resolve an emitted child's chart source off its manifest

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -248,10 +248,15 @@ func (f *Filter) producersFor(id manifest.NamedResource) []manifest.NamedResourc
 // cascading those siblings through the keep set turns a one-file
 // change into a full-tree reconcile.
 //
-// child inherits the emitter's primacy: AddEmitted walks
-// transitiveDeps recursively for sourceRef / chartRef / valuesFrom
-// (issue #260) and marks every newly-added entry primary so their
-// own future emissions cascade correctly.
+// child inherits the emitter's primacy: AddEmitted walks the child's
+// sourceRef / chartRef / valuesFrom edges recursively (issue #260) and
+// marks every newly-added entry primary so their own future emissions
+// cascade correctly. Those edges are read straight off the child
+// manifest (transitiveDepsOf), NOT via a Store lookup — a render-emitted
+// child is kept here BEFORE its Store.AddObject (the ordering contract
+// below), so it isn't yet visible to the Store, and its namespace-
+// stamped chart source (e.g. a shared OCIRepository) would otherwise go
+// unkept and unfetched.
 //
 // Used by the KS controller when a parent KS in the keep set
 // renders and emits id as a child. Covers the kustomize
@@ -273,7 +278,7 @@ func (f *Filter) producersFor(id manifest.NamedResource) []manifest.NamedResourc
 // keep set and short-circuits to Ready/"unchanged".
 //
 // No-op when the filter is disabled. Safe for concurrent use.
-func (f *Filter) AddEmitted(emitter, child manifest.NamedResource) {
+func (f *Filter) AddEmitted(emitter manifest.NamedResource, child manifest.BaseManifest) {
 	if !f.Enabled() {
 		return
 	}
@@ -296,13 +301,24 @@ func (f *Filter) AddEmitted(emitter, child manifest.NamedResource) {
 // primary[emitter] and the recurse for child without dropping the
 // lock between them. Returns the slice of newly-keep'd ids so the
 // caller can fire OnAdd outside the lock.
-func (f *Filter) addEmittedLocked(emitter, child manifest.NamedResource) []manifest.NamedResource {
+func (f *Filter) addEmittedLocked(emitter manifest.NamedResource, child manifest.BaseManifest) []manifest.NamedResource {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if _, primaryEmitter := f.primary[emitter]; !primaryEmitter {
 		return nil
 	}
-	return f.addRecursiveLocked(child)
+	added := f.addRecursiveLocked(child.Named())
+	// addRecursiveLocked resolves deps via the Store, but a render-emitted
+	// child is kept here BEFORE its Store.AddObject (the ordering contract
+	// above), so the Store can't see it yet. Walk the child's own
+	// chartRef / sourceRef / valuesFrom straight off the manifest so a
+	// shared, namespace-stamped source (e.g. an OCIRepository every
+	// HelmRelease chartRefs) still joins keep — and OnAdd refires the
+	// fetch its listener PreGate-skipped before the consumer joined keep.
+	for _, dep := range transitiveDepsOf(child) {
+		added = append(added, f.addRecursiveLocked(dep)...)
+	}
+	return added
 }
 
 // addUngated unconditionally extends the keep set with id (and its
@@ -756,42 +772,46 @@ func appendUniqueProducers(dst []manifest.NamedResource, src []manifest.NamedRes
 	return dst
 }
 
-// transitiveDeps returns the references id needs to render — chart
+// transitiveDeps returns the references the resource id needs to render,
+// resolved from the Store. Thin wrapper over transitiveDepsOf — see it
+// for the edge set. Returns nil when id isn't in the Store (a render-
+// emitted child not yet AddObject'd); callers that hold the manifest
+// should use transitiveDepsOf directly so those deps aren't missed.
+func transitiveDeps(objs ObjectLister, id manifest.NamedResource) []manifest.NamedResource {
+	return transitiveDepsOf(objs.GetObject(id))
+}
+
+// transitiveDepsOf returns the references obj needs to render — chart
 // sources, KS sourceRef, valuesFrom, and non-Optional
-// postBuild.substituteFrom ConfigMaps. dependsOn is intentionally
-// excluded: it's a reconcile-ordering signal in real Flux, not a
-// content dependency, so it adds nothing to an offline render.
+// postBuild.substituteFrom ConfigMaps. Reading straight off the manifest
+// (rather than a Store id lookup) lets the runtime keep-extension resolve
+// a render-emitted child's deps BEFORE it lands in the Store, where the
+// child's namespace-stamped chart source is the authority. dependsOn is
+// intentionally excluded: it's a reconcile-ordering signal in real Flux,
+// not a content dependency, so it adds nothing to an offline render.
 // Skipped resources still get marked Ready by their controllers, so
 // downstream depwait completes naturally.
-func transitiveDeps(objs ObjectLister, id manifest.NamedResource) []manifest.NamedResource {
-	switch id.Kind {
-	case manifest.KindHelmRelease:
-		hr, _ := objs.GetObject(id).(*manifest.HelmRelease)
-		if hr == nil {
-			return nil
-		}
+func transitiveDepsOf(obj manifest.BaseManifest) []manifest.NamedResource {
+	switch o := obj.(type) {
+	case *manifest.HelmRelease:
 		out := []manifest.NamedResource{{
-			Kind: hr.Chart.RepoKind, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
+			Kind: o.Chart.RepoKind, Namespace: o.Chart.RepoNamespace, Name: o.Chart.RepoName,
 		}}
-		for _, ref := range hr.ValuesFrom {
+		for _, ref := range o.ValuesFrom {
 			out = append(out, manifest.NamedResource{
-				Kind: ref.Kind, Namespace: hr.Namespace, Name: ref.Name,
+				Kind: ref.Kind, Namespace: o.Namespace, Name: ref.Name,
 			})
 		}
 		return out
 
-	case manifest.KindKustomization:
-		ks, _ := objs.GetObject(id).(*manifest.Kustomization)
-		if ks == nil {
-			return nil
-		}
+	case *manifest.Kustomization:
 		var out []manifest.NamedResource
-		if ks.SourceKind != "" && ks.SourceName != "" {
+		if o.SourceKind != "" && o.SourceName != "" {
 			out = append(out, manifest.NamedResource{
-				Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
+				Kind: o.SourceKind, Namespace: o.SourceNamespace, Name: o.SourceName,
 			})
 		}
-		for _, ref := range ks.PostBuildSubstituteFrom {
+		for _, ref := range o.PostBuildSubstituteFrom {
 			// Mirrors collectDeps in pkg/controllers/kustomization:
 			// Optional refs are best-effort; Secrets are SOPS/ExternalSecret-
 			// managed and can't be materialized offline; empty Name is
@@ -800,12 +820,12 @@ func transitiveDeps(objs ObjectLister, id manifest.NamedResource) []manifest.Nam
 				continue
 			}
 			out = append(out, manifest.NamedResource{
-				Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name,
+				Kind: ref.Kind, Namespace: o.Namespace, Name: ref.Name,
 			})
 		}
 		return out
 
-	case manifest.KindHelmChart:
+	case *manifest.HelmChartSource:
 		// A HelmRelease chartRef pointing at a HelmChart CRD lands the
 		// HelmChart in the BFS via the HR's RepoKind=KindHelmChart edge
 		// above. The chart's actual bytes come from the HelmChart's own
@@ -814,15 +834,11 @@ func transitiveDeps(objs ObjectLister, id manifest.NamedResource) []manifest.Nam
 		// source alive. Without this, the HelmChart sits in keep but
 		// the source artifact is PreGate-skipped and render fails
 		// "artifact not found."
-		hc, _ := objs.GetObject(id).(*manifest.HelmChartSource)
-		if hc == nil {
-			return nil
-		}
-		if hc.SourceRef.Name == "" {
+		if o.SourceRef.Name == "" {
 			return nil
 		}
 		return []manifest.NamedResource{{
-			Kind: hc.SourceRef.Kind, Namespace: hc.Namespace, Name: hc.SourceRef.Name,
+			Kind: o.SourceRef.Kind, Namespace: o.Namespace, Name: o.SourceRef.Name,
 		}}
 	}
 	return nil

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// refObj wraps a NamedResource as a minimal BaseManifest for AddEmitted
+// call sites that exercise only keep-set membership — the emitted child's
+// own chartRef/sourceRef is resolved from the Store-backed ObjectLister
+// these tests construct, not off the manifest. Tests covering a render-
+// driven child whose deps must come from the manifest build a real typed
+// object instead (see TestAddEmitted_StampedHelmReleasePullsChartSource).
+func refObj(id manifest.NamedResource) manifest.BaseManifest {
+	return &manifest.RawObject{Kind: id.Kind, Namespace: id.Namespace, Name: id.Name}
+}
+
 func TestFilter_DisabledKeepsEverything(t *testing.T) {
 	var f Filter
 	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "x"}
@@ -430,7 +440,7 @@ func TestFilter_AddEmittedRejectsAncestorOnlyEmitter(t *testing.T) {
 
 	// Simulate cluster-apps rendering and emitting the file-loaded
 	// sibling. AddEmitted must NOT keep-add it.
-	f.AddEmitted(clusterApps, siblingApp)
+	f.AddEmitted(clusterApps, refObj(siblingApp))
 	if f.ShouldReconcile(siblingApp) {
 		t.Errorf("AddEmitted(ancestor, sibling) over-extended keep set; sibling should remain SKIPPED; keep=%v", f.KeepNames())
 	}
@@ -439,7 +449,7 @@ func TestFilter_AddEmittedRejectsAncestorOnlyEmitter(t *testing.T) {
 	// still rejected because the emitter (ancestor) is not primary
 	// and an unchanged emitter wouldn't produce a different child.
 	renderOnly := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "rendered", Name: "from-replacement"}
-	f.AddEmitted(clusterApps, renderOnly)
+	f.AddEmitted(clusterApps, refObj(renderOnly))
 	if f.ShouldReconcile(renderOnly) {
 		t.Errorf("AddEmitted(ancestor, render-only) should reject when ancestor is not primary; keep=%v", f.KeepNames())
 	}
@@ -515,12 +525,12 @@ func TestFilter_AddEmittedNoCascadeAcrossDeepAncestorChain(t *testing.T) {
 	// its children — including the unrelated siblings. Walking
 	// the chain top-down so we cover the worst case where a
 	// primary could theoretically leak through an upper ancestor.
-	f.AddEmitted(clusterApps, kubeSystem)
-	f.AddEmitted(clusterApps, mediaSibling)
-	f.AddEmitted(kubeSystem, reloader)
-	f.AddEmitted(kubeSystem, spegelSibling)
-	f.AddEmitted(reloader, reloaderApp)
-	f.AddEmitted(reloader, reloaderSibling)
+	f.AddEmitted(clusterApps, refObj(kubeSystem))
+	f.AddEmitted(clusterApps, refObj(mediaSibling))
+	f.AddEmitted(kubeSystem, refObj(reloader))
+	f.AddEmitted(kubeSystem, refObj(spegelSibling))
+	f.AddEmitted(reloader, refObj(reloaderApp))
+	f.AddEmitted(reloader, refObj(reloaderSibling))
 
 	// Each ancestor (clusterApps, kubeSystem, reloader) is in
 	// keep only as ancestor-only — none of their AddEmitted calls
@@ -557,9 +567,59 @@ func TestFilter_AddEmittedFromPrimaryParent(t *testing.T) {
 		t.Fatalf("parent must be primary from direct file change; keep=%v", f.KeepNames())
 	}
 
-	f.AddEmitted(parent, child)
+	f.AddEmitted(parent, refObj(child))
 	if !f.ShouldReconcile(child) {
 		t.Errorf("AddEmitted(primary parent, child) should keep-add child; keep=%v", f.KeepNames())
+	}
+}
+
+// TestAddEmitted_StampedHelmReleasePullsChartSource is the regression
+// fence for the k8s-gitops "OCIRepository <ns>/app-template artifact not
+// available" failures under `flate diff/test --base main`. A primary
+// parent KS emits a HelmRelease at render time: the HR carries no
+// metadata.namespace in source but is stamped to its parent KS's
+// targetNamespace on emit, so its emitted id differs from any discovery-
+// recorded one — AND it is not yet in the Store when AddEmitted runs (the
+// ordering contract). Its chartRef points at a SHARED OCIRepository
+// produced by a separate, unchanged Kustomization, so that source was
+// PreGate-skipped at startup. AddEmitted MUST read the chart source
+// straight off the emitted manifest (not the Store, which lacks the HR,
+// nor consumerRefs, keyed by the un-stamped id) so the source joins keep
+// and OnAdd refires its fetch. The ObjectLister is intentionally empty
+// and no consumerRefs are wired — proving the fix relies on the manifest.
+func TestAddEmitted_StampedHelmReleasePullsChartSource(t *testing.T) {
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	hr := &manifest.HelmRelease{
+		Name: "sonarr", Namespace: "media", // stamped from the parent KS's targetNamespace
+		Chart: manifest.HelmChart{
+			RepoKind: manifest.KindOCIRepository, RepoName: "app-template", RepoNamespace: "flux-system",
+		},
+	}
+	chartSrc := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "app-template"}
+
+	f := NewFilter(
+		NewSet([]string{"apps/media/kustomization.yaml"}),
+		map[manifest.NamedResource]string{parent: "apps/media/kustomization.yaml"},
+		"",
+		testutil.EmptyLister(),
+	)
+	if !f.ShouldReconcile(parent) {
+		t.Fatalf("parent must be primary from direct file change; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(chartSrc) {
+		t.Fatalf("precondition: shared chart source must NOT be in keep before emission; keep=%v", f.KeepNames())
+	}
+
+	var refired []manifest.NamedResource
+	f.OnAdd = func(id manifest.NamedResource) { refired = append(refired, id) }
+
+	f.AddEmitted(parent, hr)
+
+	if !f.ShouldReconcile(chartSrc) {
+		t.Errorf("emitted HR's chart source not kept — it stays PreGate-skipped and render fails 'artifact not available'; keep=%v", f.KeepNames())
+	}
+	if !slices.Contains(refired, chartSrc) {
+		t.Errorf("OnAdd did not fire for chart source %s, so Store.Refire never re-fetches it; fired=%v", chartSrc, refired)
 	}
 }
 
@@ -879,7 +939,7 @@ func TestFilter_SubstituteFromConfigMapKeepsProducerKustomization(t *testing.T) 
 	// The producer is ancestor-only: AddEmitted from cluster-vars
 	// to a sentinel child must reject (producer is NOT primary).
 	sentinel := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "unrelated", Name: "sentinel"}
-	f.AddEmitted(clusterVars, sentinel)
+	f.AddEmitted(clusterVars, refObj(sentinel))
 	if f.ShouldReconcile(sentinel) {
 		t.Errorf("producer cluster-vars must be ancestor-only (NOT primary) — AddEmitted leaked sentinel into keep; keep=%v", f.KeepNames())
 	}
@@ -936,7 +996,7 @@ func TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly(t *testing.T
 	// Primary parent emits child at render time. AddEmitted walks
 	// child's transitiveDeps, hits the substituteFrom CM, and pulls
 	// the producer in dependency-only.
-	f.AddEmitted(parent, child)
+	f.AddEmitted(parent, refObj(child))
 
 	if !f.ShouldReconcile(child) {
 		t.Errorf("child must be in keep after AddEmitted from primary parent; keep=%v", f.KeepNames())
@@ -947,7 +1007,7 @@ func TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly(t *testing.T
 	// Producer is dependency-only: AddEmitted from producer to a
 	// sentinel child must reject because producer is not primary.
 	sentinel := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "unrelated", Name: "sentinel"}
-	f.AddEmitted(producer, sentinel)
+	f.AddEmitted(producer, refObj(sentinel))
 	if f.ShouldReconcile(sentinel) {
 		t.Errorf("producer must be dependency-only (NOT primary) — AddEmitted leaked sentinel into keep; keep=%v", f.KeepNames())
 	}
@@ -992,7 +1052,7 @@ func TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer(t *testing.T) {
 		added = append(added, id)
 	}
 
-	f.AddEmitted(parent, child)
+	f.AddEmitted(parent, refObj(child))
 
 	if !slices.Contains(added, producer) {
 		t.Errorf("OnAdd must fire for the runtime-added producer KS; added=%v", added)

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -166,7 +166,7 @@ func (c *Controller) SetRenderTracker(rt RenderTracker) {
 //
 // MUST be called BEFORE Store.AddObject so the listener that fires
 // synchronously during AddObject sees the extended keep set.
-func (c *Controller) KeepEmitted(parent, child manifest.NamedResource) {
+func (c *Controller) KeepEmitted(parent manifest.NamedResource, child manifest.BaseManifest) {
 	if f := c.Filter(); f != nil {
 		f.AddEmitted(parent, child)
 	}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -492,7 +492,7 @@ func (c *Controller) materializeHelmChartSource(id manifest.NamedResource, hr *m
 	// keep-emit BEFORE AddObject so the synchronous source-controller
 	// listener sees the extended changed-only keep set (mirrors
 	// emitRenderedChildren).
-	c.KeepEmitted(id, synID)
+	c.KeepEmitted(id, syn)
 	c.Store.AddObject(syn)
 	// Seed a Pending status ONLY on first materialization — when no status
 	// exists yet — to close the window between AddObject (which dispatches an
@@ -559,7 +559,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			// keep set when it invokes PreGate. Mirrors the ordering
 			// in kustomization.emitRenderedChildren.
 			childID := obj.Named()
-			c.KeepEmitted(id, childID)
+			c.KeepEmitted(id, obj)
 			c.Store.AddObject(obj)
 			rendered = append(rendered, childID)
 		} else {

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -64,7 +64,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		}
 		if p.reconcilable {
 			childID := p.obj.Named()
-			c.KeepEmitted(id, childID)
+			c.KeepEmitted(id, p.obj)
 			c.Store.AddObject(p.obj)
 			rendered = append(rendered, childID)
 		} else {
@@ -76,7 +76,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			childID := p.obj.Named()
-			c.KeepEmitted(id, childID)
+			c.KeepEmitted(id, p.obj)
 			rendered = append(rendered, childID)
 			leaves = append(leaves, p.obj)
 		}


### PR DESCRIPTION
## Symptom

In changed-only mode (`flate diff/test --base main`), commenting out **one** app in a namespace `kustomization.yaml` produced **30 failures**, all:

```
OCIRepository flux-system/app-template artifact not available for HelmRelease <x>
```

across every namespace. Full-tree `flate test all` passed cleanly, and the diff itself was correct ("one document removed: Kustomization/media/prowlarr"). So the bug was in the changed-only keep-set, not rendering.

## Root cause

`app-template` is a single shared `OCIRepository` chartRef'd by ~31 HelmReleases and produced by a *separate* Kustomization (`flux-repositories`) that's correctly SKIPPED as unchanged — so the source's listener `PreGate`-skips at startup and never fetches the artifact.

The big `cluster-apps` KS owns the changed file, so it re-renders and emits every app's HR. The runtime keep-set extension (`Filter.AddEmitted` → `addRecursiveLocked`) is *supposed* to pull each emitted HR's chart source into keep and fire `OnAdd`→`Store.Refire` so the source gets fetched. But it resolved the child's deps via a **Store lookup** — and `AddEmitted` runs **before** the emitting `Store.AddObject` (a documented ordering contract, so the child's own `PreGate` sees it kept). The child isn't in the Store yet.

For a HelmRelease the miss is permanent: the source manifest has no `metadata.namespace` and is **stamped** to the parent KS's `targetNamespace` on emit, so the emitted id (`HelmRelease/media/sonarr`) never matches the discovery-recorded one (`consumerRefs` is keyed by the un-stamped id) either. The chart source was therefore never kept, `OnAdd`/`Refire` never fired, and the source stayed unfetched.

## Fix

Thread the emitted child **object** through `KeepEmitted` → `AddEmitted` and read its `chartRef`/`sourceRef`/`valuesFrom` straight off the manifest (`transitiveDepsOf`) instead of a Store id lookup. The emitted manifest carries the authoritative, namespace-stamped chart source. The forward edge set is unchanged — the HR pulls only its own source (no consumer fan-out, no keep-set over-expansion). `transitiveDeps` is refactored into the object-based `transitiveDepsOf` plus a thin Store-backed wrapper (still used by `resolve()`).

## Verification

- **Reporting repo**, `test all --base main`: **140 passed / 30 failed → 171 passed / 0 failed**; `OCIRepository/flux-system/app-template` now **PASSED** (fetched). The diff still shows only the prowlarr removal.
- Confirmed **pre-existing** (reproduces on a pre-session binary), not a regression from recent work.
- Full gate: `gofmt` / `go build` / `go vet` / full `go test -race ./...` ✅ / `golangci-lint` → **0 issues**.
- **Full-tree output byte-identical** to `main` across repos (joryirving, billimek) — the fix only makes previously-failing sources resolve.
- New `TestAddEmitted_StampedHelmReleasePullsChartSource` (empty `ObjectLister`, no `consumerRefs` — proving the fix relies on the manifest) **fails without the fix**, passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)