### PR TITLE
feat(diff): public structured Changes API for SDK consumers

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -39,55 +39,15 @@ func newDiffCmd() *cobra.Command {
 	return cmd
 }
 
-// defaultStripAttrs is the default `--strip-attr` list — annotations
-// and labels that Helm + kustomize rotate on every chart bump and
-// which contribute pure noise to PR-time diff review. The trailing-
-// slash "checksum/" is a prefix match (see StripResourceAttributes)
-// that covers every suffix charts emit — checksum/config,
-// checksum/secret, checksum/secrets, etc. — in one entry.
-//
-// These annotations are templated as `sha256sum (include "…" .)` over
-// a rendered ConfigMap/Secret. flate cannot make them stable: the
-// underlying value is genuinely per-render random in some charts
-// (e.g. matrix-synapse's `registration_shared_secret | default
-// (randAlphaNum 24)`, which sprig draws from crypto/rand — not
-// seedable, and Helm exposes no funcMap hook to override it). flate
-// faithfully mirrors Helm here, so raw `flate build` output is not
-// byte-stable for such charts; the on-disk render cache only masks it.
-// Stripping the annotation is what keeps `flate diff` churn-free.
-var defaultStripAttrs = []string{
-	"helm.sh/chart",
-	"checksum/",
-	"app.kubernetes.io/version",
-	"chart",
-}
-
-// defaultStripFields is the default `--strip-field` list — dotted spec
-// field-paths whose value a chart templates from the render clock and
-// so rotates on every render. Same unfixable-at-render class as the
-// randAlphaNum annotations above (Helm exposes no funcMap hook): the
-// TrueCharts common library emits
-//
-//	spec.restic.unlock: {{ now | date "20060102150405" }}
-//
-// on every volsync ReplicationSource, so two diff sides rendered a
-// second apart (cold cache, or across machines) would otherwise show a
-// spurious `~ spec.restic.unlock` per backed-up app. Deleting the leaf
-// keeps the diff churn-free; raw `flate build` output still mirrors
-// Helm (the render cache masks it there).
-var defaultStripFields = []string{
-	"spec.restic.unlock",
-}
-
 type diffFlags struct {
 	stripAttrs  []string
 	stripFields []string
 }
 
 func bindDiffFlags(cmd *cobra.Command, d *diffFlags) {
-	cmd.Flags().StringArrayVar(&d.stripAttrs, "strip-attr", defaultStripAttrs,
+	cmd.Flags().StringArrayVar(&d.stripAttrs, "strip-attr", diff.DefaultStripAttrs,
 		"metadata annotation/label key to strip before diffing (repeatable; supplying any value replaces the default set)")
-	cmd.Flags().StringArrayVar(&d.stripFields, "strip-field", defaultStripFields,
+	cmd.Flags().StringArrayVar(&d.stripFields, "strip-field", diff.DefaultStripFields,
 		"dotted spec field-path to delete before diffing, e.g. spec.restic.unlock (repeatable; supplying any value replaces the default set)")
 }
 
@@ -356,7 +316,6 @@ func gatherAllArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, 
 // only to recover the producing object's spec.path (the diff header
 // shows it for KS parents).
 func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kind, name string, c *commonFlags) ([]diff.Doc, int) {
-	var out []diff.Doc
 	// Defensive re-drop of --skip-secrets / --skip-crds / --skip-kinds.
 	// Orchestrator.Render already applies the same set to Result.Manifests
 	// at the embed boundary; this still pulls weight for SDK consumers who
@@ -365,12 +324,13 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 	if c != nil {
 		skip = c.skipResourceKinds()
 	}
-	objs := o.Store().ListObjects(kind)
-	slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
-		return a.Named().Compare(b.Named())
-	})
+	// Filter the rendered manifests down to the in-scope parents
+	// (name + namespace), then hand the submap to diff.DocsFromManifests
+	// — the shared, store-free flattener SDK consumers use too — passing a
+	// store-backed pathOf so KS parents carry their spec.path.
+	sub := make(map[manifest.NamedResource][]map[string]any)
 	matched := 0
-	for _, obj := range objs {
+	for _, obj := range o.Store().ListObjects(kind) {
 		id := obj.Named()
 		if name != "" && id.Name != name {
 			continue
@@ -379,17 +339,15 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 			continue
 		}
 		matched++
-		docs, ok := res.Manifests[id]
-		if !ok {
-			continue
-		}
-		parent := diff.Parent{Kind: id.Kind, Namespace: id.Namespace, Name: id.Name}
-		if ks, ok := store.Get[*manifest.Kustomization](o.Store(), id); ok {
-			parent.Path = strings.TrimPrefix(ks.Path, "./")
-		}
-		for _, m := range manifest.DropKinds(docs, skip) {
-			out = append(out, diff.Doc{Manifest: m, Parent: parent})
+		if docs, ok := res.Manifests[id]; ok {
+			sub[id] = manifest.DropKinds(docs, skip)
 		}
 	}
-	return out, matched
+	docs := diff.DocsFromManifests(sub, func(id manifest.NamedResource) string {
+		if ks, ok := store.Get[*manifest.Kustomization](o.Store(), id); ok {
+			return strings.TrimPrefix(ks.Path, "./")
+		}
+		return ""
+	})
+	return docs, matched
 }

--- a/pkg/diff/bench_test.go
+++ b/pkg/diff/bench_test.go
@@ -80,7 +80,7 @@ func BenchmarkNormalizeDocs(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_ = normalizeDocs(docs, attrs, nil)
+		_ = normalizeDocs(docs, attrs, nil, nil)
 	}
 }
 

--- a/pkg/diff/changes.go
+++ b/pkg/diff/changes.go
@@ -1,0 +1,115 @@
+package diff
+
+import "reflect"
+
+// ChangeStatus classifies how a resource differs between two doc sets.
+type ChangeStatus string
+
+const (
+	// StatusAdded — present only on the right (New) side.
+	StatusAdded ChangeStatus = "added"
+	// StatusChanged — present on both sides with differing content.
+	StatusChanged ChangeStatus = "changed"
+	// StatusRemoved — present only on the left (Old) side.
+	StatusRemoved ChangeStatus = "removed"
+)
+
+// Change is one resource that differs between two rendered doc sets —
+// the structured form of what RenderDocs formats. SDK consumers build
+// their own output (an API payload, a web UI, an image report) from a
+// []Change instead of re-implementing the pairing + normalization that
+// RenderDocs does internally.
+type Change struct {
+	// Parent is the Flux Kustomization / HelmRelease that rendered this
+	// resource — the pairing discriminator (so a Deployment from HR A is
+	// never matched against the same-named Deployment from HR B).
+	Parent                Parent
+	Kind, Namespace, Name string
+	Status                ChangeStatus
+	// Old / New are the NORMALIZED manifests (Options strip + binaryData
+	// redaction + the optional Normalize hook applied). Old is nil for an
+	// add; New is nil for a remove.
+	Old, New map[string]any
+	// OldChart / NewChart are the resource's "helm.sh/chart" label
+	// ("<name>-<version>") captured BEFORE normalization stripped it —
+	// "" when absent. Surfaces a chart-version bump the stripped Old/New
+	// no longer carry.
+	OldChart, NewChart string
+}
+
+// Changes pairs left against right by (parent, apiVersion, kind,
+// namespace, name), drops byte-identical resources, and returns the
+// remaining differences as structured data. Each side is normalized
+// (opts.StripAttrs / opts.StripFields, ConfigMap binaryData redaction,
+// then the optional opts.Normalize hook) before the equality check, so
+// render-time noise — chart-bump annotations, volatile spec fields, a
+// consumer's secret/cert redaction — never reads as a spurious change.
+// opts.Format is ignored (Changes returns data, not formatted bytes).
+//
+// This is the data RenderDocs renders: exposed so SDK consumers stop
+// re-implementing the pairing. The result is sorted by parent then
+// resource identity for deterministic output.
+func Changes(left, right []Doc, opts Options) []Change {
+	// Pair the RAW docs so OldChart/NewChart can read helm.sh/chart
+	// before the strip removes it; normalize each side per-resource
+	// afterward. The pair key (apiVersion/kind/ns/name + parent) is
+	// untouched by normalization, so raw and normalized pair identically.
+	paired := pair(left, right)
+	out := make([]Change, 0, len(paired))
+	for _, p := range paired {
+		old := normalizeManifest(p.a, opts.StripAttrs, opts.StripFields, opts.Normalize)
+		nw := normalizeManifest(p.b, opts.StripAttrs, opts.StripFields, opts.Normalize)
+		status, differs := classify(old, nw)
+		if !differs {
+			continue
+		}
+		out = append(out, Change{
+			Parent:    p.parent,
+			Kind:      p.kind,
+			Namespace: p.namespace,
+			Name:      p.name,
+			Status:    status,
+			Old:       old,
+			New:       nw,
+			OldChart:  chartLabel(p.a),
+			NewChart:  chartLabel(p.b),
+		})
+	}
+	return out
+}
+
+// classify reports the change status of a paired resource and whether it
+// differs at all. old/new are the normalized sides (nil when the
+// resource is absent on that side). A both-present pair that is
+// DeepEqual after normalization is unchanged (differs=false) and dropped.
+func classify(old, nw map[string]any) (status ChangeStatus, differs bool) {
+	switch {
+	case old == nil:
+		return StatusAdded, true
+	case nw == nil:
+		return StatusRemoved, true
+	case reflect.DeepEqual(old, nw):
+		return "", false
+	default:
+		return StatusChanged, true
+	}
+}
+
+// chartLabel returns a manifest's "helm.sh/chart" label
+// ("<name>-<version>"), or "" when the manifest is nil or carries no such
+// label. Read before normalization strips it.
+func chartLabel(m map[string]any) string {
+	if m == nil {
+		return ""
+	}
+	meta, ok := m["metadata"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	labels, ok := meta["labels"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	s, _ := labels["helm.sh/chart"].(string)
+	return s
+}

--- a/pkg/diff/changes_test.go
+++ b/pkg/diff/changes_test.go
@@ -1,0 +1,132 @@
+package diff
+
+import (
+	"reflect"
+	"testing"
+)
+
+func cmDoc(parent Parent, name, ns, dataVal, chart string) Doc {
+	meta := map[string]any{"name": name}
+	if ns != "" {
+		meta["namespace"] = ns
+	}
+	if chart != "" {
+		meta["labels"] = map[string]any{"helm.sh/chart": chart}
+	}
+	return Doc{
+		Parent: parent,
+		Manifest: map[string]any{
+			"apiVersion": "v1", "kind": "ConfigMap",
+			"metadata": meta,
+			"data":     map[string]any{"k": dataVal},
+		},
+	}
+}
+
+// TestChanges_Classification locks added / changed / removed and the
+// drop of byte-identical resources.
+func TestChanges_Classification(t *testing.T) {
+	p := Parent{Kind: "Kustomization", Namespace: "flux-system", Name: "apps"}
+	left := []Doc{
+		cmDoc(p, "keep", "ns", "same", ""),
+		cmDoc(p, "edit", "ns", "old", ""),
+		cmDoc(p, "gone", "ns", "x", ""),
+	}
+	right := []Doc{
+		cmDoc(p, "keep", "ns", "same", ""),
+		cmDoc(p, "edit", "ns", "new", ""),
+		cmDoc(p, "fresh", "ns", "y", ""),
+	}
+
+	got := map[string]ChangeStatus{}
+	for _, c := range Changes(left, right, Options{}) {
+		got[c.Name] = c.Status
+	}
+	want := map[string]ChangeStatus{"edit": StatusChanged, "gone": StatusRemoved, "fresh": StatusAdded}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("statuses = %v; want %v (byte-identical 'keep' must be dropped)", got, want)
+	}
+}
+
+// TestChanges_StripDropsNoiseOnlyChange confirms a change confined to a
+// stripped attribute (a chart-label bump with identical content) is not
+// reported — the diff stays churn-free.
+func TestChanges_StripDropsNoiseOnlyChange(t *testing.T) {
+	p := Parent{Kind: "HelmRelease", Namespace: "ns", Name: "app"}
+	left := []Doc{cmDoc(p, "x", "ns", "same", "app-1.0.0")}
+	right := []Doc{cmDoc(p, "x", "ns", "same", "app-2.0.0")}
+	if got := Changes(left, right, Options{StripAttrs: DefaultStripAttrs}); len(got) != 0 {
+		t.Fatalf("a change only in a stripped attr should be dropped; got %+v", got)
+	}
+}
+
+// TestChanges_CapturesChartBeforeStrip locks that OldChart/NewChart read
+// helm.sh/chart from the pre-strip manifest while Old/New are stripped.
+func TestChanges_CapturesChartBeforeStrip(t *testing.T) {
+	p := Parent{Kind: "HelmRelease", Namespace: "ns", Name: "app"}
+	left := []Doc{cmDoc(p, "x", "ns", "old", "app-1.0.0")}
+	right := []Doc{cmDoc(p, "x", "ns", "new", "app-2.0.0")}
+
+	got := Changes(left, right, Options{StripAttrs: DefaultStripAttrs})
+	if len(got) != 1 {
+		t.Fatalf("want 1 change, got %d: %+v", len(got), got)
+	}
+	c := got[0]
+	if c.OldChart != "app-1.0.0" || c.NewChart != "app-2.0.0" {
+		t.Errorf("chart not captured pre-strip: Old=%q New=%q", c.OldChart, c.NewChart)
+	}
+	meta, _ := c.New["metadata"].(map[string]any)
+	if labels, ok := meta["labels"].(map[string]any); ok {
+		if _, present := labels["helm.sh/chart"]; present {
+			t.Errorf("helm.sh/chart must be stripped from New; labels=%v", labels)
+		}
+	}
+}
+
+// TestChanges_NormalizeHookSuppressesChange is the konflate use case: a
+// render-random Secret value reads as a change by default, but a redaction
+// hook constant-izes it so it no longer does.
+func TestChanges_NormalizeHookSuppressesChange(t *testing.T) {
+	p := Parent{Kind: "Kustomization", Namespace: "ns", Name: "apps"}
+	secret := func(val string) Doc {
+		return Doc{
+			Parent: p,
+			Manifest: map[string]any{
+				"apiVersion": "v1", "kind": "Secret",
+				"metadata": map[string]any{"name": "s", "namespace": "ns"},
+				"data":     map[string]any{"token": val},
+			},
+		}
+	}
+	left := []Doc{secret("AAAA")}
+	right := []Doc{secret("BBBB")}
+
+	if got := Changes(left, right, Options{}); len(got) != 1 {
+		t.Fatalf("without redaction the value change must show; got %d", len(got))
+	}
+	redact := func(m map[string]any) {
+		if m["kind"] != "Secret" {
+			return
+		}
+		if d, ok := m["data"].(map[string]any); ok {
+			for k := range d {
+				d[k] = "<redacted>"
+			}
+		}
+	}
+	if got := Changes(left, right, Options{Normalize: redact}); len(got) != 0 {
+		t.Fatalf("redaction hook should suppress the render-random change; got %+v", got)
+	}
+}
+
+// TestChanges_Sorted locks deterministic ordering by parent then identity.
+func TestChanges_Sorted(t *testing.T) {
+	pa := Parent{Kind: "Kustomization", Namespace: "ns", Name: "a"}
+	pb := Parent{Kind: "Kustomization", Namespace: "ns", Name: "b"}
+	left := []Doc{cmDoc(pb, "z", "ns", "1", ""), cmDoc(pa, "y", "ns", "1", "")}
+	right := []Doc{cmDoc(pb, "z", "ns", "2", ""), cmDoc(pa, "y", "ns", "2", "")}
+	got := Changes(left, right, Options{})
+	if len(got) != 2 || got[0].Parent.Name != "a" || got[1].Parent.Name != "b" {
+		t.Fatalf("changes not sorted by parent: %+v", got)
+	}
+}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -42,6 +42,14 @@ type Options struct {
 	// cannot be stabilized at render time (Helm exposes no funcMap
 	// hook). See manifest.StripResourceFields.
 	StripFields []string
+	// Normalize, when non-nil, is an extra per-manifest scrub applied to
+	// each (cloned) document AFTER StripAttrs/StripFields and binaryData
+	// redaction, before resources are paired and compared. Use it to
+	// suppress render-time noise the built-in strips don't cover —
+	// e.g. an SDK consumer redacting Secret values or chart-minted TLS
+	// certs so a per-render-random value doesn't read as a change.
+	// nil = no extra scrub (the CLI default).
+	Normalize func(map[string]any)
 	// Format selects the output style (see the Format constants). The
 	// zero value renders the human default.
 	Format Format

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -29,7 +29,33 @@
 // comparison runs — used to drop chart-bump noise (`helm.sh/chart`,
 // `checksum/config`, …) that rotates on every Helm upgrade but carries
 // no review-relevant signal. ConfigMap binaryData is summarized to a
-// content hash for the same reason.
+// content hash for the same reason. [DefaultStripAttrs] and
+// [DefaultStripFields] are the lists `flate diff` uses out of the box.
+//
+// # SDK usage
+//
+// [RenderDocs] returns formatted bytes. A consumer that needs the diff as
+// *data* — to build its own API payload, web UI, or image report —
+// instead calls [Changes], which returns the same paired, normalized,
+// noise-filtered set as a [][Change] (added / changed / removed, with the
+// per-side manifests and the captured helm.sh/chart label). The wiring
+// from two [orchestrator.Result]s is:
+//
+//	left  := diff.DocsFromManifests(baseRes.Manifests, nil)
+//	right := diff.DocsFromManifests(headRes.Manifests, nil)
+//	changes := diff.Changes(left, right, diff.Options{
+//		StripAttrs:  diff.DefaultStripAttrs,
+//		StripFields: diff.DefaultStripFields,
+//		Normalize:   redact, // optional extra per-manifest scrub
+//	})
+//
+// [DocsFromManifests] is the store-free adapter from a render Result's
+// per-parent manifests to the flat []Doc both [Changes] and [RenderDocs]
+// take. [Options].Normalize is an optional per-manifest hook (applied
+// after the built-in strips) for noise the defaults don't cover — e.g.
+// redacting Secret values or chart-minted TLS certs. See the package
+// Example.
 //
 // [dyff]: https://github.com/homeport/dyff
+// [orchestrator.Result]: https://pkg.go.dev/github.com/home-operations/flate/pkg/orchestrator#Result
 package diff

--- a/pkg/diff/docs.go
+++ b/pkg/diff/docs.go
@@ -1,0 +1,42 @@
+package diff
+
+import (
+	"slices"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// DocsFromManifests flattens an orchestrator render Result's per-parent
+// rendered manifests into the flat []Doc that RenderDocs and Changes
+// consume, tagging each document with the Flux Kustomization /
+// HelmRelease that produced it. The input is exactly
+// orchestrator.Result.Manifests (map[NamedResource][]map[string]any), so
+// an SDK consumer wires two renders straight into a diff without
+// re-implementing the walk.
+//
+// pathOf, when non-nil, supplies a parent's Flux Kustomization spec.path
+// — it disambiguates two same-named Kustomizations rendered from
+// different overlays (a real-world pairing collision); pass nil when the
+// path isn't available (HelmRelease parents and most consumers don't need
+// it). Documents are grouped and ordered by producing parent (each
+// parent's documents keep their render emission order) so the result is
+// deterministic across the input map's random iteration order.
+func DocsFromManifests(manifests map[manifest.NamedResource][]map[string]any, pathOf func(manifest.NamedResource) string) []Doc {
+	parents := make([]manifest.NamedResource, 0, len(manifests))
+	for id := range manifests {
+		parents = append(parents, id)
+	}
+	slices.SortFunc(parents, func(a, b manifest.NamedResource) int { return a.Compare(b) })
+
+	out := make([]Doc, 0, len(manifests))
+	for _, id := range parents {
+		p := Parent{Kind: id.Kind, Namespace: id.Namespace, Name: id.Name}
+		if pathOf != nil {
+			p.Path = pathOf(id)
+		}
+		for _, m := range manifests[id] {
+			out = append(out, Doc{Manifest: m, Parent: p})
+		}
+	}
+	return out
+}

--- a/pkg/diff/docs_test.go
+++ b/pkg/diff/docs_test.go
@@ -1,0 +1,61 @@
+package diff
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestDocsFromManifests_GroupsByParentDeterministically locks parent sort
+// order (so dyff/unified input is stable across the map's random
+// iteration), within-parent emission order, and the pathOf wiring.
+func TestDocsFromManifests_GroupsByParentDeterministically(t *testing.T) {
+	ksA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
+	ksB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
+	manifests := map[manifest.NamedResource][]map[string]any{
+		ksB: {{"kind": "ConfigMap", "metadata": map[string]any{"name": "b1"}}},
+		ksA: {
+			{"kind": "ConfigMap", "metadata": map[string]any{"name": "a1"}},
+			{"kind": "ConfigMap", "metadata": map[string]any{"name": "a2"}},
+		},
+	}
+	pathOf := func(id manifest.NamedResource) string {
+		if id.Name == "a" {
+			return "apps/a"
+		}
+		return ""
+	}
+
+	docs := DocsFromManifests(manifests, pathOf)
+	if len(docs) != 3 {
+		t.Fatalf("want 3 docs, got %d", len(docs))
+	}
+	// ksA sorts before ksB; a1 before a2 (slice order preserved).
+	if docs[0].Parent.Name != "a" || docs[0].Parent.Path != "apps/a" {
+		t.Errorf("doc[0] parent = %+v; want a / apps/a", docs[0].Parent)
+	}
+	if name, _ := docs[1].Manifest["metadata"].(map[string]any)["name"].(string); name != "a2" {
+		t.Errorf("within-parent order not preserved; doc[1] = %v", docs[1].Manifest)
+	}
+	if docs[2].Parent.Name != "b" || docs[2].Parent.Path != "" {
+		t.Errorf("doc[2] parent = %+v; want b / empty path", docs[2].Parent)
+	}
+
+	if docs2 := DocsFromManifests(manifests, pathOf); !reflect.DeepEqual(docs, docs2) {
+		t.Errorf("DocsFromManifests must be deterministic across map iteration")
+	}
+}
+
+// TestDocsFromManifests_NilPathOf confirms a nil pathOf leaves Path empty
+// (the common consumer case — HelmRelease parents, or callers that don't
+// need overlay disambiguation).
+func TestDocsFromManifests_NilPathOf(t *testing.T) {
+	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "hr"}
+	docs := DocsFromManifests(map[manifest.NamedResource][]map[string]any{
+		id: {{"kind": "Service"}},
+	}, nil)
+	if len(docs) != 1 || docs[0].Parent.Path != "" {
+		t.Errorf("nil pathOf should leave Path empty; got %+v", docs)
+	}
+}

--- a/pkg/diff/example_test.go
+++ b/pkg/diff/example_test.go
@@ -1,0 +1,45 @@
+package diff_test
+
+import (
+	"fmt"
+
+	"github.com/home-operations/flate/pkg/diff"
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// Example shows the SDK wiring an external consumer uses to turn two
+// renders into a structured diff: orchestrator.Result.Manifests →
+// DocsFromManifests → Changes. (Here the two manifest maps are hand-built
+// for a self-contained example; in practice they're baseRes.Manifests and
+// headRes.Manifests from two orchestrator.Render calls.)
+func Example() {
+	parent := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "media", Name: "sonarr"}
+	deployment := func(chartVer, image string) map[string]any {
+		return map[string]any{
+			"apiVersion": "apps/v1", "kind": "Deployment",
+			"metadata": map[string]any{
+				"name": "sonarr", "namespace": "media",
+				"labels": map[string]any{"helm.sh/chart": "app-template-" + chartVer},
+			},
+			"spec": map[string]any{
+				"template": map[string]any{"spec": map[string]any{
+					"containers": []any{map[string]any{"name": "main", "image": image}},
+				}},
+			},
+		}
+	}
+	base := map[manifest.NamedResource][]map[string]any{parent: {deployment("4.0.0", "ghcr.io/home-operations/sonarr:4.0.0")}}
+	head := map[manifest.NamedResource][]map[string]any{parent: {deployment("4.1.0", "ghcr.io/home-operations/sonarr:4.1.0")}}
+
+	changes := diff.Changes(
+		diff.DocsFromManifests(base, nil),
+		diff.DocsFromManifests(head, nil),
+		diff.Options{StripAttrs: diff.DefaultStripAttrs, StripFields: diff.DefaultStripFields},
+	)
+
+	for _, c := range changes {
+		fmt.Printf("%s %s %s/%s (chart %s -> %s)\n", c.Status, c.Kind, c.Namespace, c.Name, c.OldChart, c.NewChart)
+	}
+	// Output:
+	// changed Deployment media/sonarr (chart app-template-4.0.0 -> app-template-4.1.0)
+}

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -109,8 +109,8 @@ type sRow struct {
 // theme. Identical resources are dropped, matching renderUnified; an empty
 // diff produces no output at all, like the other formats.
 func renderHTML(left, right []Doc, opts Options) ([]byte, error) {
-	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields)
-	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields)
+	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields, opts.Normalize)
+	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields, opts.Normalize)
 
 	hl, css, err := newHighlighter()
 	if err != nil {

--- a/pkg/diff/native.go
+++ b/pkg/diff/native.go
@@ -19,11 +19,11 @@ import (
 // document-level "order changed" note. Both are rare in practice for
 // content diffs.
 func renderNative(left, right []Doc, opts Options) ([]byte, error) {
-	from, err := multiDocInput("from", normalizeDocs(left, opts.StripAttrs, opts.StripFields))
+	from, err := multiDocInput("from", normalizeDocs(left, opts.StripAttrs, opts.StripFields, opts.Normalize))
 	if err != nil {
 		return nil, err
 	}
-	to, err := multiDocInput("to", normalizeDocs(right, opts.StripAttrs, opts.StripFields))
+	to, err := multiDocInput("to", normalizeDocs(right, opts.StripAttrs, opts.StripFields, opts.Normalize))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -19,19 +19,34 @@ import (
 // like kube-prometheus-stack's CRD upgrade bundle). Deep-copies so
 // the original tree (shared with other consumers in the same
 // orchestrator run) is untouched.
-func normalizeDocs(docs []Doc, attrs, fields []string) []Doc {
-	if len(attrs) == 0 && len(fields) == 0 && !docsContainBinaryData(docs) {
+func normalizeDocs(docs []Doc, attrs, fields []string, hook func(map[string]any)) []Doc {
+	if len(attrs) == 0 && len(fields) == 0 && hook == nil && !docsContainBinaryData(docs) {
 		return docs
 	}
 	out := make([]Doc, len(docs))
 	for i, d := range docs {
-		copyDoc := manifest.DeepCopyMap(d.Manifest)
-		manifest.StripResourceAttributes(copyDoc, attrs)
-		manifest.StripResourceFields(copyDoc, fields)
-		redactBinaryData(copyDoc)
-		out[i] = Doc{Manifest: copyDoc, Parent: d.Parent}
+		out[i] = Doc{Manifest: normalizeManifest(d.Manifest, attrs, fields, hook), Parent: d.Parent}
 	}
 	return out
+}
+
+// normalizeManifest returns a normalized deep copy of m: strip the listed
+// annotation/label keys and spec field-paths, redact ConfigMap binaryData,
+// then apply the optional consumer hook. Returns nil for a nil input (an
+// added/removed side of a pair has no manifest). The original is never
+// mutated — it's shared with other consumers in the same orchestrator run.
+func normalizeManifest(m map[string]any, attrs, fields []string, hook func(map[string]any)) map[string]any {
+	if m == nil {
+		return nil
+	}
+	c := manifest.DeepCopyMap(m)
+	manifest.StripResourceAttributes(c, attrs)
+	manifest.StripResourceFields(c, fields)
+	redactBinaryData(c)
+	if hook != nil {
+		hook(c)
+	}
+	return c
 }
 
 // docsContainBinaryData reports whether any doc is a ConfigMap

--- a/pkg/diff/strip.go
+++ b/pkg/diff/strip.go
@@ -1,0 +1,42 @@
+package diff
+
+// DefaultStripAttrs is the default set of metadata annotation/label keys
+// dropped before diffing — the noise `flate diff` strips out of the box,
+// exported so SDK consumers normalize identically (and don't drift from a
+// hand-copied list). A trailing "/" is a prefix match (see
+// manifest.StripResourceAttributes): "checksum/" covers checksum/config,
+// checksum/secret, checksum/secrets, and every other checksum/<x> a chart
+// emits, in one entry.
+//
+// These rotate on every Helm chart bump and carry no review-relevant
+// signal, so leaving them in surfaces a spurious change on every resource
+// a touched chart renders. Some are genuinely per-render random — e.g.
+// matrix-synapse's `registration_shared_secret | default (randAlphaNum
+// 24)`, which sprig draws from crypto/rand (not seedable; Helm exposes no
+// funcMap hook to override it) — so flate cannot make them stable and
+// stripping is what keeps a diff churn-free.
+//
+// Treat as read-only; copy before mutating.
+var DefaultStripAttrs = []string{
+	"helm.sh/chart",
+	"checksum/",
+	"app.kubernetes.io/version",
+	"chart",
+}
+
+// DefaultStripFields is the default set of dotted spec field-paths
+// deleted before diffing — the same noise-suppression rationale as
+// DefaultStripAttrs, but for volatile values a chart templates into the
+// spec rather than metadata. The TrueCharts common library emits
+//
+//	spec.restic.unlock: {{ now | date "20060102150405" }}
+//
+// on every volsync ReplicationSource, so two diff sides rendered a second
+// apart (cold cache, or across machines) would otherwise show a spurious
+// `~ spec.restic.unlock` per backed-up app. Deleting the leaf keeps the
+// diff churn-free; raw `flate build` output still mirrors Helm.
+//
+// Treat as read-only; copy before mutating.
+var DefaultStripFields = []string{
+	"spec.restic.unlock",
+}

--- a/pkg/diff/unified.go
+++ b/pkg/diff/unified.go
@@ -20,8 +20,8 @@ func joinNS(ns, name string) string {
 // changed pair's YAML, and concatenates the bodies. Identical resources
 // are dropped. Not Kubernetes-aware — see unifiedBody.
 func renderUnified(left, right []Doc, opts Options) ([]byte, error) {
-	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields)
-	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields)
+	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields, opts.Normalize)
+	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields, opts.Normalize)
 	var b bytes.Buffer
 	first := true
 	for _, p := range pair(left, right) {


### PR DESCRIPTION
## Why

`pkg/diff` only exposed `RenderDocs` — *formatted bytes*. A consumer that needs the diff **as data** (to build its own UI / API / image report) had no choice but to re-implement flate's pairing + normalization. [`home-operations/konflate`](https://github.com/home-operations/konflate) does exactly that:

| konflate code | flate equivalent (was unexported / internal) |
|---|---|
| `pairChanges` + `indexChildren` + `unionKeys` + `coords` (~70 LOC) | `pkg/diff/pair.go:pair()` + `pairKey`/`pairedResource` (unexported) + `internal/cli/diff.go:gatherArtifacts` |
| `stripAttrs` / `stripFields` (verbatim copies, comment: *"Mirrors flate's diff defaults"*) | `internal/cli/diff.go:defaultStripAttrs`/`defaultStripFields` (unexported) |
| chart-label capture + binaryData summary | flate's `chartLabel` + `redactBinaryData` (it already does the latter) |

## What this exposes (additive; `RenderDocs` untouched)

- **`Changes(left, right []Doc, opts Options) []Change`** — the structured diff `RenderDocs` renders internally. Pairs by `(parent, apiVersion, kind, ns, name)`, normalizes each side, drops byte-identical resources, returns `added`/`changed`/`removed` with per-side manifests + the `helm.sh/chart` label captured **before** the strip (`OldChart`/`NewChart`).
- **`Options.Normalize func(map[string]any)`** — optional per-manifest scrub applied *after* the built-in strips, *before* pairing/equality. The konflate hook: redact Secret values / chart-minted TLS certs so a render-random value doesn't read as a change. Default `nil` = current behavior.
- **`DefaultStripAttrs` / `DefaultStripFields`** — the CLI's strip lists, moved out of `internal/cli` so consumers stop hand-copying them (and drifting).
- **`DocsFromManifests(manifests, pathOf) []Doc`** — store-free adapter from `orchestrator.Result.Manifests` to `[]Doc`; flate's own `gatherArtifacts` now uses it too.

## Guardrails

- **`RenderDocs` output byte-identical**: existing dyff/unified/html golden tests pass unchanged; `flate diff` (human + github) and `flate get images` byte-compared main-vs-branch across repos → identical.
- New `pkg/diff` tests: classification + identical-dropped, the `Normalize` hook suppressing a render-random change (the konflate case), `OldChart/NewChart` capture surviving the strip, `DocsFromManifests` determinism + `pathOf`.
- A runnable **package `Example`** (external `diff_test`) locks the public wiring — it compiles in CI as an outside consumer would.
- Full gate: `gofmt` / `go build` / `go vet` / `go test -race ./...` ✅ / `golangci-lint` → **0 issues**.

## Out of scope

A two-tree orchestration helper (too opinionated — konflate layers a git mirror + per-PR timeout on top); secret/cert redaction (stays in konflate via the `Normalize` hook); the `manifest.ContainerImages` helper (follow-up PR). konflate's adoption — deleting ~130 LOC of duplicated pairing/normalize/strip — is a follow-up PR in that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)