### PR TITLE
feat(image): add Split for repo/version, the companion to Extract

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -32,6 +32,36 @@ func Extract(doc map[string]any) []string {
 	return slices.Sorted(maps.Keys(set))
 }
 
+// Split separates an OCI image reference into its repository name and
+// its version — the tag, or the digest when one is present (a digest is
+// more specific, so it wins when a reference carries both). The name is
+// returned verbatim, NOT normalized: "nginx:1" splits to ("nginx", "1"),
+// not ("docker.io/library/nginx", …). Intended for references Extract
+// returned; a value that doesn't parse as a reference yields (ref, "").
+//
+// Pairs with Extract for per-repository version diffing — detecting that
+// ghcr.io/home-operations/sonarr moved from v4.0.0 to v4.1.0 — so a
+// consumer doesn't hand-roll a string split that mishandles a registry
+// port (host:5000/img) or a tag+digest reference.
+func Split(ref string) (name, version string) {
+	parsed, err := reference.Parse(ref)
+	if err != nil {
+		return ref, ""
+	}
+	named, ok := parsed.(reference.Named)
+	if !ok {
+		return ref, ""
+	}
+	name = named.Name()
+	if d, ok := parsed.(reference.Digested); ok {
+		return name, d.Digest().String()
+	}
+	if t, ok := parsed.(reference.Tagged); ok {
+		return name, t.Tag()
+	}
+	return name, ""
+}
+
 func walk(v any, set map[string]struct{}) {
 	switch tv := v.(type) {
 	case map[string]any:

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -170,3 +170,51 @@ func Test_isImageRef(t *testing.T) {
 func sha256() string {
 	return "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
 }
+
+func TestSplit(t *testing.T) {
+	digest := "sha256:" + sha256()
+	cases := []struct {
+		ref          string
+		name, verstr string
+	}{
+		{"ghcr.io/home-operations/sonarr:v4.1.0", "ghcr.io/home-operations/sonarr", "v4.1.0"},
+		{"ghcr.io/foo/bar@" + digest, "ghcr.io/foo/bar", digest},
+		// tag + digest → digest wins (more specific).
+		{"ghcr.io/foo/bar:v1@" + digest, "ghcr.io/foo/bar", digest},
+		// a registry port must not be mistaken for the version.
+		{"localhost:5000/foo/bar:v1", "localhost:5000/foo/bar", "v1"},
+		// no tag or digest → empty version, name verbatim.
+		{"ghcr.io/foo/bar", "ghcr.io/foo/bar", ""},
+		// not normalized: a bare name keeps its verbatim form.
+		{"nginx:1.27", "nginx", "1.27"},
+		// unparseable → returned verbatim with no version.
+		{"not a ref", "not a ref", ""},
+	}
+	for _, c := range cases {
+		name, version := Split(c.ref)
+		if name != c.name || version != c.verstr {
+			t.Errorf("Split(%q) = (%q, %q); want (%q, %q)", c.ref, name, version, c.name, c.verstr)
+		}
+	}
+}
+
+// TestSplit_RoundTripsExtract confirms every ref Extract surfaces splits
+// into a non-empty (name, version) — the two are designed to compose for
+// per-repository version diffing.
+func TestSplit_RoundTripsExtract(t *testing.T) {
+	doc := map[string]any{
+		"kind": "Deployment",
+		"spec": map[string]any{"template": map[string]any{"spec": map[string]any{
+			"containers": []any{
+				map[string]any{"image": "ghcr.io/owner/app:v1.2.3"},
+				map[string]any{"image": "docker.io/library/redis@sha256:" + sha256()},
+			},
+		}}},
+	}
+	for _, ref := range Extract(doc) {
+		name, version := Split(ref)
+		if name == "" || version == "" {
+			t.Errorf("Split(%q) = (%q, %q); both should be non-empty for an Extract'd ref", ref, name, version)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Following #610 (structured diff SDK surface), the remaining duplication for an image-diff consumer (e.g. konflate's `walkContainers` + `splitImageRef`) is the image **split**. The walk itself is already public and *better* than a hand-rolled one: `image.Extract` finds references anywhere in a manifest, not just in `containers[]`/`initContainers[]` — so it catches CNPG `imageName`, sidecars under arbitrary CRD fields, etc.

The genuinely missing piece is turning an `Extract`'d reference into `(repository, version)` for per-repo version diffing.

## What

`image.Split(ref) (name, version string)` — parsed via `distribution/reference` (the same canonical parser `Extract` already uses), not a string split:

- a **digest wins** over a tag when a reference carries both (more specific);
- a **registry port** (`host:5000/img:v1`) is not mistaken for the version;
- the name is returned **verbatim** (not normalized — `nginx:1` → `("nginx", "1")`);
- an unparseable value yields `(ref, "")`.

`Extract` + `Split` compose, so a consumer drops both its `walkContainers` and `splitImageRef`.

## Tests / gate

Table test (tag, digest, tag+digest, registry-port, no-version, bare-name, garbage) + an `Extract`→`Split` round-trip. `gofmt` / `go build ./...` / `go vet` / `go test -race ./pkg/image/` ✅ / `golangci-lint` → **0 issues**. Purely additive — no existing behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)