### PR TITLE
feat(orchestrator): RenderTrees — render two cluster dirs for comparison

### DIFF
--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -1,24 +1,18 @@
 package cli
 
 import (
-	"cmp"
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/diff"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
-	"github.com/home-operations/flate/pkg/source"
-	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -198,12 +192,12 @@ type diffSide struct {
 	Err error
 }
 
-// runDiffOrchestrators boots two orchestrators with each side's
-// --path-orig pointing at the other, so both resolve the same symmetric
-// change set and only render resources that differ between paths. Both
-// sides are independent (separate task service, helm client, staging
-// cache, store), so they run concurrently — wall time roughly halves
-// on changed-only diffs.
+// runDiffOrchestrators resolves the baseline, then hands the
+// two-orchestrator render to orchestrator.RenderTrees (swapped PathOrig
+// so each side renders changed-only against the other, one shared source
+// cache, concurrent) and maps its two sides into the diffSide pair the
+// diff/diff-images commands consume. base = --path-orig (left/old),
+// head = --path (right/new).
 func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (diffSide, diffSide, error) {
 	// diff REQUIRES a baseline — when neither --path-orig nor --base
 	// is set, auto-detect via the merge-base ladder. Cleanup is
@@ -214,54 +208,10 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 		return diffSide{}, diffSide{}, err
 	}
 	defer cleanup()
-	currentCfg := buildOrchCfg(*c, *h)
-	origCfg := currentCfg
-	origCfg.Path, origCfg.PathOrig = c.pathOrig, c.path
-
-	// One source.Cache shared across both orchestrators. They write into
-	// the same on-disk cache root; without a shared *Cache each side has
-	// its own mutex, and concurrent first-time clones of the same
-	// (url, ref) slot can race past the mkdir/Readdirnames check and
-	// step on each other.
-	cacheRoot := cmp.Or(currentCfg.CacheDir, filepath.Join(os.TempDir(), "flate-cache"))
-	shared := source.NewCache(cacheroot.New(cacheRoot))
-	currentCfg.SourceCache = shared
-	origCfg.SourceCache = shared
-
-	var (
-		orig, current    diffSide
-		origErr, currErr error
-	)
-	g, gctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		o, res, err := runOrchestratorCfg(gctx, currentCfg)
-		current = diffSide{O: o, Res: res, Err: err}
-		currErr = err
-		// Fatal Bootstrap errors return nil orchestrator — propagate
-		// those so the errgroup cancels its sibling. Per-resource Run
-		// failures keep the orchestrator non-nil; defer them so we
-		// still produce a diff before the caller flips the exit code.
-		if o == nil {
-			return err
-		}
-		return nil
-	})
-	g.Go(func() error {
-		o, res, err := runOrchestratorCfg(gctx, origCfg)
-		orig = diffSide{O: o, Res: res, Err: err}
-		origErr = err
-		if o == nil {
-			return err
-		}
-		return nil
-	})
-	if err := g.Wait(); err != nil {
-		return diffSide{}, diffSide{}, err
-	}
-	// Either side may have reconcile failures — return the combined
-	// run-error alongside the orchestrators so the diff caller can
-	// write its output, then flip the exit code.
-	return orig, current, joinRunErrors(origErr, currErr)
+	base, head, runErr := orchestrator.RenderTrees(ctx, c.pathOrig, c.path, buildOrchCfg(*c, *h))
+	orig := diffSide{O: base.Orchestrator, Res: base.Result, Err: base.Err}
+	current := diffSide{O: head.Orchestrator, Res: head.Result, Err: head.Err}
+	return orig, current, runErr
 }
 
 // joinRunErrors composes the orig/current Run errors into a single

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -38,16 +38,21 @@
 // *data* — to build its own API payload, web UI, or image report —
 // instead calls [Changes], which returns the same paired, normalized,
 // noise-filtered set as a [][Change] (added / changed / removed, with the
-// per-side manifests and the captured helm.sh/chart label). The wiring
-// from two [orchestrator.Result]s is:
+// per-side manifests and the captured helm.sh/chart label). Render two
+// cluster directories with [orchestrator.RenderTrees] (it owns the
+// two-orchestrator, shared-cache, changed-only dance), then feed the
+// Results to [Changes]:
 //
-//	left  := diff.DocsFromManifests(baseRes.Manifests, nil)
-//	right := diff.DocsFromManifests(headRes.Manifests, nil)
-//	changes := diff.Changes(left, right, diff.Options{
-//		StripAttrs:  diff.DefaultStripAttrs,
-//		StripFields: diff.DefaultStripFields,
-//		Normalize:   redact, // optional extra per-manifest scrub
-//	})
+//	base, head, _ := orchestrator.RenderTrees(ctx, baseDir, headDir, cfg)
+//	changes := diff.Changes(
+//		diff.DocsFromManifests(base.Result.Manifests, nil),
+//		diff.DocsFromManifests(head.Result.Manifests, nil),
+//		diff.Options{
+//			StripAttrs:  diff.DefaultStripAttrs,
+//			StripFields: diff.DefaultStripFields,
+//			Normalize:   redact, // optional extra per-manifest scrub
+//		},
+//	)
 //
 // [DocsFromManifests] is the store-free adapter from a render Result's
 // per-parent manifests to the flat []Doc both [Changes] and [RenderDocs]
@@ -57,5 +62,7 @@
 // Example.
 //
 // [dyff]: https://github.com/homeport/dyff
+// [orchestrator.RenderTrees]: https://pkg.go.dev/github.com/home-operations/flate/pkg/orchestrator#RenderTrees
+//
 // [orchestrator.Result]: https://pkg.go.dev/github.com/home-operations/flate/pkg/orchestrator#Result
 package diff

--- a/pkg/orchestrator/trees.go
+++ b/pkg/orchestrator/trees.go
@@ -1,0 +1,125 @@
+package orchestrator
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
+)
+
+// Rendered is one side of a RenderTrees comparison: the Orchestrator
+// (already Stopped — its background reconcile loops are released, but its
+// Store stays readable for diff doc gathering) paired with its render
+// Result and that side's render error. Result is nil only on a fatal
+// (Bootstrap) error; a per-resource render failure keeps Result non-nil
+// (the failures are in Result.Failed) and is reported in Err.
+type Rendered struct {
+	*Orchestrator
+	Result *Result
+	Err    error
+}
+
+// RenderTrees renders two cluster directories for comparison — the engine
+// behind `flate diff`, exposed so an SDK consumer (a PR-diff bot, a CI
+// gate) doesn't re-implement the two-orchestrator dance.
+//
+// Each side reconciles in CHANGED-ONLY mode against the other (its
+// PathOrig is set to the opposite tree), so only resources whose source
+// files differ between basePath and headPath — plus their dependency
+// closure — are rendered, not the whole cluster. Pairing the two scoped
+// outputs (e.g. via diff.Changes) yields the same diff a full render
+// would: an unchanged resource renders on neither side.
+//
+// Both sides share one source.Cache so a chart / OCI layer / git source
+// fetched for one side is reused by the other (and concurrent slot
+// allocation is serialized), and they run concurrently. cfg supplies the
+// render tuning; cfg.Path and cfg.PathOrig are set by RenderTrees and any
+// values there are ignored, and cfg.SourceCache, when nil, is created
+// from cfg.CacheDir (falling back to the OS tempdir). A consumer that
+// renders many comparisons (one per PR) should pass its own long-lived
+// cfg.SourceCache so artifacts persist across calls.
+//
+// Both orchestrators are Stopped before return; their Stores remain
+// readable. err is non-nil if either side had any failure; callers that
+// still want the partial diff check Rendered.Result != nil (nil only on a
+// fatal Bootstrap error) and treat err as advisory. base is the left/old
+// side and head the right/new — matching diff.Changes(left, right).
+func RenderTrees(ctx context.Context, basePath, headPath string, cfg Config) (base, head Rendered, err error) {
+	if cfg.SourceCache == nil {
+		root := cmp.Or(cfg.CacheDir, filepath.Join(os.TempDir(), "flate-cache"))
+		cfg.SourceCache = source.NewCache(cacheroot.New(root))
+	}
+	baseCfg := cfg
+	baseCfg.Path, baseCfg.PathOrig = basePath, headPath
+	headCfg := cfg
+	headCfg.Path, headCfg.PathOrig = headPath, basePath
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		o, res, e := renderOne(gctx, baseCfg)
+		base = Rendered{Orchestrator: o, Result: res, Err: e}
+		// A fatal Bootstrap error yields a nil orchestrator — propagate
+		// it so the errgroup cancels the sibling. Per-resource failures
+		// keep the orchestrator non-nil; defer them so the caller still
+		// gets a diff before flipping its exit code.
+		if o == nil {
+			return e
+		}
+		return nil
+	})
+	g.Go(func() error {
+		o, res, e := renderOne(gctx, headCfg)
+		head = Rendered{Orchestrator: o, Result: res, Err: e}
+		if o == nil {
+			return e
+		}
+		return nil
+	})
+	if e := g.Wait(); e != nil {
+		return base, head, e
+	}
+	return base, head, joinTreeErrors(base.Err, head.Err)
+}
+
+// renderOne runs one orchestrator end to end: New → Render → Stop. Stop
+// fires unconditionally so background loops are released even on the
+// failure paths; the Store stays readable afterward. A nil Result (fatal
+// Bootstrap error) drops the orchestrator so callers gate on it cleanly,
+// mirroring the CLI's single-tree runner.
+func renderOne(ctx context.Context, cfg Config) (*Orchestrator, *Result, error) {
+	o, err := New(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := o.Render(ctx)
+	o.Stop()
+	if res == nil {
+		return nil, nil, err
+	}
+	return o, res, err
+}
+
+// joinTreeErrors composes the per-side render errors into one non-nil
+// error when either side failed; both nil → nil.
+func joinTreeErrors(base, head error) error {
+	switch {
+	case base != nil && head != nil:
+		return errors.Join(
+			errors.New("both trees had reconcile failures"),
+			fmt.Errorf("base tree: %w", base),
+			fmt.Errorf("head tree: %w", head),
+		)
+	case base != nil:
+		return fmt.Errorf("base tree: %w", base)
+	case head != nil:
+		return fmt.Errorf("head tree: %w", head)
+	}
+	return nil
+}

--- a/pkg/orchestrator/trees_test.go
+++ b/pkg/orchestrator/trees_test.go
@@ -1,0 +1,129 @@
+package orchestrator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/diff"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/orchestrator"
+)
+
+// writeCluster lays out a two-app Flux cluster under dir: app-a renders
+// ConfigMap cfg-a (data k=aVal), app-b renders ConfigMap cfg-b (data
+// k=bVal). The two per-app Kustomizations are independent, so a change to
+// one's rendered output must not pull the other into changed-only scope.
+func writeCluster(t *testing.T, dir, aVal, bVal string) {
+	t.Helper()
+	ks := func(name string) string {
+		return "apiVersion: kustomize.toolkit.fluxcd.io/v1\nkind: Kustomization\n" +
+			"metadata: {name: " + name + ", namespace: flux-system}\n" +
+			"spec:\n  path: ./apps/" + name + "\n" +
+			"  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}\n"
+	}
+	cm := func(name, val string) string {
+		return "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: " + name + "}\ndata: {k: " + val + "}\n"
+	}
+	testutil.WriteFile(t, dir, "ks-a.yaml", ks("app-a"))
+	testutil.WriteFile(t, dir, "ks-b.yaml", ks("app-b"))
+	testutil.WriteFile(t, dir, "apps/app-a/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/app-a/cm.yaml", cm("cfg-a", aVal))
+	testutil.WriteFile(t, dir, "apps/app-b/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/app-b/cm.yaml", cm("cfg-b", bVal))
+}
+
+// configMapNames returns the set of ConfigMap names across every parent's
+// rendered manifests in a Result — what each side of the comparison
+// actually rendered.
+func configMapNames(res *orchestrator.Result) map[string]bool {
+	out := map[string]bool{}
+	for _, docs := range res.Manifests {
+		for _, m := range docs {
+			if m["kind"] == "ConfigMap" {
+				if meta, ok := m["metadata"].(map[string]any); ok {
+					if name, ok := meta["name"].(string); ok {
+						out[name] = true
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// TestRenderTrees_ChangedOnlyAndDiff renders two trees that differ in just
+// app-a's ConfigMap and asserts: both sides render (non-nil Results), the
+// unchanged app-b is scoped OUT of both (changed-only mode), and
+// diff.Changes over the two outputs reports exactly the cfg-a change.
+func TestRenderTrees_ChangedOnlyAndDiff(t *testing.T) {
+	baseDir := t.TempDir()
+	headDir := t.TempDir()
+	writeCluster(t, baseDir, "v1", "same")
+	writeCluster(t, headDir, "v2", "same") // only app-a's ConfigMap data differs
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	base, head, err := orchestrator.RenderTrees(ctx, baseDir, headDir, orchestrator.Config{
+		WipeSecrets: true,
+		Concurrency: 4,
+	})
+	if err != nil {
+		t.Fatalf("RenderTrees: %v", err)
+	}
+	if base.Result == nil || head.Result == nil {
+		t.Fatalf("both sides must render: base=%v head=%v", base.Result, head.Result)
+	}
+
+	// Changed-only scoping: cfg-a (changed) renders on both sides; cfg-b
+	// (unchanged) renders on neither.
+	for label, res := range map[string]*orchestrator.Result{"base": base.Result, "head": head.Result} {
+		names := configMapNames(res)
+		if !names["cfg-a"] {
+			t.Errorf("%s: expected cfg-a to render (it changed); got %v", label, names)
+		}
+		if names["cfg-b"] {
+			t.Errorf("%s: cfg-b is unchanged and must be scoped out of changed-only render; got %v", label, names)
+		}
+	}
+
+	// The structured diff: exactly cfg-a changed.
+	changes := diff.Changes(
+		diff.DocsFromManifests(base.Result.Manifests, nil),
+		diff.DocsFromManifests(head.Result.Manifests, nil),
+		diff.Options{},
+	)
+	if len(changes) != 1 {
+		t.Fatalf("want exactly 1 change (cfg-a), got %d: %+v", len(changes), changes)
+	}
+	c := changes[0]
+	if c.Name != "cfg-a" || c.Kind != "ConfigMap" || c.Status != diff.StatusChanged {
+		t.Errorf("change = %+v; want ConfigMap cfg-a changed", c)
+	}
+}
+
+// TestRenderTrees_StopsButStoreReadable confirms the contract the CLI and
+// SDK consumers rely on: both orchestrators are Stopped on return, yet
+// their Stores stay readable for post-render doc gathering.
+func TestRenderTrees_StopsButStoreReadable(t *testing.T) {
+	baseDir := t.TempDir()
+	headDir := t.TempDir()
+	writeCluster(t, baseDir, "v1", "same")
+	writeCluster(t, headDir, "v2", "same")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	base, head, err := orchestrator.RenderTrees(ctx, baseDir, headDir, orchestrator.Config{WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("RenderTrees: %v", err)
+	}
+	// Store still answers after the internal Stop.
+	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "app-a"}
+	if base.Store().GetObject(id) == nil {
+		t.Errorf("base Store unreadable after RenderTrees Stop: %s missing", id)
+	}
+	if head.Store().GetObject(id) == nil {
+		t.Errorf("head Store unreadable after RenderTrees Stop: %s missing", id)
+	}
+}


### PR DESCRIPTION
## Why

The two-orchestrator dance behind `flate diff` — boot two orchestrators over a base and head tree, each reconciling **changed-only against the other** (swapped `PathOrig`), sharing **one `source.Cache`**, concurrently — lived in `internal/cli` (`runDiffOrchestrators`), so an SDK consumer (a PR-diff bot like konflate) had to re-implement it. This holds that logic in flate as one public call, completing the SDK surface (#610 structured diff + #612 `image.Split`).

## What

`orchestrator.RenderTrees(ctx, basePath, headPath, cfg) (base, head Rendered, err error)`:

- derives the two swapped configs from `cfg`, wires a **shared source cache** (created from `cfg.CacheDir` when `cfg.SourceCache` is nil — a long-running consumer passes its own to persist artifacts across PRs), runs both **concurrently**, and **`Stop`s each** before returning (the Store stays readable for doc gathering);
- `Rendered{*Orchestrator, Result, Err}` — per-side error in `Err` + a combined return; a side's `Result` is nil only on a fatal Bootstrap error;
- `base` = left/old, `head` = right/new, matching `diff.Changes(left, right)`.

It stays **free of `pkg/diff`** (no dyff/chroma pulled into the core), so a consumer composes it with the public `diff.Changes`:

```go
base, head, _ := orchestrator.RenderTrees(ctx, baseDir, headDir, cfg)
changes := diff.Changes(
    diff.DocsFromManifests(base.Result.Manifests, nil),
    diff.DocsFromManifests(head.Result.Manifests, nil),
    diff.Options{StripAttrs: diff.DefaultStripAttrs, StripFields: diff.DefaultStripFields, Normalize: redact},
)
```

## Guardrails

- `internal/cli/diff.go:runDiffOrchestrators` now resolves the baseline (CLI/`--base` policy, unchanged) and delegates to `RenderTrees`, mapping its sides into the existing `diffSide` pair — the cache-wiring + errgroup are gone (the function sheds ~50 lines). The user-facing error still comes from `scopedDiffRunError` (per-side, CLI-worded), so messages are unchanged.
- **`flate diff` (human/github/unified) + `diff images` byte-identical** to `main` on `~/k8s-gitops --base main`.
- New external-package `trees_test.go`: changed-only scoping (an unchanged sibling renders on **neither** side), the structured diff is exactly the one change, and the Store is readable after the internal `Stop`. It imports `orchestrator` + `diff` as a real consumer would — the from-outside-`internal/` smoke test.
- Full gate: `gofmt` / `go build` / `go vet` / `go test -race ./...` ✅ / `golangci-lint` → **0 issues**.

## Net for konflate (follow-up PR in that repo)

Its `engine.Diff` + `render` collapse to one `RenderTrees` call + `diff.Changes` — dropping the render-pair boilerplate, the shared-cache wiring, and the manual concurrency on top of the pairing/normalize already removed by #610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)