### PR TITLE
refactor: redo flate's path model with an explicit source root

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -27,8 +27,17 @@ import (
 )
 
 type commonFlags struct {
-	path                string
-	pathOrig            string
+	path     string
+	pathOrig string
+	// pathOrigRoot / pathOrigSelfURLs are resolved by resolveBaseline for
+	// the --base flow: the materialized baseline tree carries no .git, so
+	// its repo root (the spec.path anchor + change-detect root) and the
+	// live tree's remote URLs (for self-referential aliasing on the
+	// baseline side) are threaded explicitly rather than re-derived from a
+	// .git. Empty for an explicit --path-orig (the CLI defaults the root
+	// via repoRootOf and lets the side read its own .git remotes).
+	pathOrigRoot        string
+	pathOrigSelfURLs    []string
 	base                string
 	namespace           string
 	skipCRDs            bool
@@ -337,11 +346,26 @@ func resolveBaseline(_ context.Context, c *commonFlags, autoFallback bool) (func
 		return noop, err
 	}
 	c.pathOrig = res.PathOrig
+	// The materialized baseline has no .git: pass its repo root + the live
+	// tree's remotes explicitly so the baseline side anchors spec.path and
+	// aliases self-referential sources without a synthetic marker.
+	c.pathOrigRoot = res.TempDir
+	c.pathOrigSelfURLs = res.SelfURLs
 	slog.Debug("baseline", "source", res.Source, "rev", res.Rev, "path_orig", res.PathOrig, "persistent", res.Persistent)
 	if res.Persistent {
 		return noop, nil
 	}
 	return func() { _ = os.RemoveAll(res.TempDir) }, nil
+}
+
+// baselineRoot is the baseline side's source root: the materialized
+// --base tree root when resolveBaseline set it, else the .git default of
+// an explicit --path-orig. Empty when there's no baseline (full-tree mode).
+func (c *commonFlags) baselineRoot() string {
+	if c.pathOrigRoot != "" {
+		return c.pathOrigRoot
+	}
+	return repoRootOf(c.pathOrig)
 }
 
 // repoRootOf resolves path to its source root the way discovery defaults
@@ -366,10 +390,10 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	return orchestrator.Config{
 		Path: c.path,
 		// PathOrig carries the baseline's REPO ROOT for change detection
-		// (change.Detect diffs root-to-root). A subdir --path-orig / a
-		// materialized --base tree is lifted to its root here, replacing
+		// (change.Detect diffs root-to-root): the materialized --base tree
+		// root, or the .git default of an explicit --path-orig. Replaces
 		// the core's old .git "widen" heuristic.
-		PathOrig:       repoRootOf(c.pathOrig),
+		PathOrig:       c.baselineRoot(),
 		HelmOptions:    c.helmOptions(h),
 		WipeSecrets:    true,
 		RegistryConfig: c.registryConfig,

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/home-operations/flate/internal/format"
 	"github.com/home-operations/flate/pkg/baseline"
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/discovery"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
@@ -343,10 +344,32 @@ func resolveBaseline(_ context.Context, c *commonFlags, autoFallback bool) (func
 	return func() { _ = os.RemoveAll(res.TempDir) }, nil
 }
 
+// repoRootOf resolves path to its source root the way discovery defaults
+// RepoRoot: the .git ancestor of the resolved path, or the path itself
+// when there's no .git. Empty in → empty out. This is the CLI's
+// .git-based default for the explicit RepoRoot / baseline PathOrig the
+// core now consumes — the changed-only core no longer infers a root or
+// "widens" to a .git ancestor itself; the CLI resolves it here and passes
+// it in.
+func repoRootOf(path string) string {
+	if path == "" {
+		return ""
+	}
+	abs, err := discovery.ResolveScanPath(path)
+	if err != nil {
+		return path
+	}
+	return discovery.FindRepoRoot(abs)
+}
+
 func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 	return orchestrator.Config{
-		Path:           c.path,
-		PathOrig:       c.pathOrig,
+		Path: c.path,
+		// PathOrig carries the baseline's REPO ROOT for change detection
+		// (change.Detect diffs root-to-root). A subdir --path-orig / a
+		// materialized --base tree is lifted to its root here, replacing
+		// the core's old .git "widen" heuristic.
+		PathOrig:       repoRootOf(c.pathOrig),
 		HelmOptions:    c.helmOptions(h),
 		WipeSecrets:    true,
 		RegistryConfig: c.registryConfig,

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -208,7 +208,14 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 		return diffSide{}, diffSide{}, err
 	}
 	defer cleanup()
-	base, head, runErr := orchestrator.RenderTrees(ctx, c.pathOrig, c.path, buildOrchCfg(*c, *h))
+	// Each side is a Tree: its scan entry point (Path) plus the source
+	// root (RepoRoot) that its spec.path values resolve against. The CLI
+	// resolves each root via the .git default (repoRootOf); RenderTrees
+	// reconciles each side changed-only against the other tree's root.
+	base, head, runErr := orchestrator.RenderTrees(ctx,
+		orchestrator.Tree{RepoRoot: repoRootOf(c.pathOrig), Path: c.pathOrig},
+		orchestrator.Tree{RepoRoot: repoRootOf(c.path), Path: c.path},
+		buildOrchCfg(*c, *h))
 	orig := diffSide{O: base.Orchestrator, Res: base.Result, Err: base.Err}
 	current := diffSide{O: head.Orchestrator, Res: head.Result, Err: head.Err}
 	return orig, current, runErr

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -213,7 +213,7 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 	// resolves each root via the .git default (repoRootOf); RenderTrees
 	// reconciles each side changed-only against the other tree's root.
 	base, head, runErr := orchestrator.RenderTrees(ctx,
-		orchestrator.Tree{RepoRoot: repoRootOf(c.pathOrig), Path: c.pathOrig},
+		orchestrator.Tree{RepoRoot: c.baselineRoot(), Path: c.pathOrig, SelfURLs: c.pathOrigSelfURLs},
 		orchestrator.Tree{RepoRoot: repoRootOf(c.path), Path: c.path},
 		buildOrchCfg(*c, *h))
 	orig := diffSide{O: base.Orchestrator, Res: base.Result, Err: base.Err}

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -43,6 +43,12 @@ type Result struct {
 	// picked (e.g. "merge-base with origin/HEAD", "explicit
 	// --base=main"), surfaced in the startup log line.
 	Source string
+	// SelfURLs are the working tree's git remote URLs (raw, unnormalized).
+	// The materialized baseline tree carries no .git, so the caller passes
+	// these to the baseline render as Config.SelfURLs — the source root
+	// represents the same repo, so a self-referential GitRepository aliases
+	// to the local tree on the baseline side too.
+	SelfURLs []string
 }
 
 // resolution carries the result of picking a baseline rev.
@@ -100,7 +106,24 @@ func AutoResolve(path, base string, layout cacheroot.Layout) (*Result, error) {
 		Persistent: persistent,
 		Rev:        shortRev(r.Hash),
 		Source:     r.Source,
+		SelfURLs:   repoRemoteURLs(repo),
 	}, nil
+}
+
+// repoRemoteURLs returns the working tree's configured remote URLs (raw).
+// Used to populate Result.SelfURLs so the caller can hand the baseline
+// render the same self-referential-source identity the live tree has —
+// the materialized baseline carries no .git to read them back from.
+func repoRemoteURLs(repo *git.Repository) []string {
+	cfg, err := repo.Config()
+	if err != nil {
+		return nil
+	}
+	var urls []string
+	for _, remote := range cfg.Remotes {
+		urls = append(urls, remote.URLs...)
+	}
+	return urls
 }
 
 // materializeAt produces the baseline tree on disk for hash and
@@ -122,7 +145,7 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		// through to their own stage (one wins the rename, the rest
 		// see ErrExist, discard the temp, and adopt the winner's slot).
 		if _, err := cas.Stage(filepath.Dir(slot), slot, "baseline staging", "baseline finalize",
-			func(staging string) error { return materializeAndMark(repo, hash, staging) },
+			func(staging string) error { return materialize(repo, hash, staging) },
 			func() bool { info, statErr := os.Stat(slot); return statErr == nil && info.IsDir() },
 		); err != nil {
 			return "", false, err
@@ -134,56 +157,11 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 	if err != nil {
 		return "", false, fmt.Errorf("baseline tempdir: %w", err)
 	}
-	if err := materializeAndMark(repo, hash, tmp); err != nil {
+	if err := materialize(repo, hash, tmp); err != nil {
 		_ = os.RemoveAll(tmp)
 		return "", false, err
 	}
 	return tmp, false, nil
-}
-
-// materializeAndMark extracts the commit tree into root and writes a
-// minimal, openable .git into it. The .git serves two ends:
-//
-//   - discovery.FindRepoRoot (used by orchestrator.buildChangeFilter's
-//     repo-root widening, PR #348) lifts the synthetic --path-orig to root,
-//     lining up with the current side's repoRoot. Without a .git the
-//     per-side roots match (both fall back to the passed path) and the
-//     widening short-circuits.
-//   - it carries the source repo's git remotes, so the baseline is
-//     self-describing: discovery's self-referential GitRepository alias —
-//     which URL-matches a GitRepository's spec.url against the working
-//     tree's remotes — fires on the baseline side too. A remotes-less
-//     marker leaves a private self-source unresolved, rendering the whole
-//     baseline empty (so every resource shows as a wholesale addition).
-//
-// It's a config + HEAD only — enough for go-git's PlainOpen and
-// repo.Config(); the dangling HEAD ref is never dereferenced.
-func materializeAndMark(repo *git.Repository, hash plumbing.Hash, root string) error {
-	if err := materialize(repo, hash, root); err != nil {
-		return err
-	}
-	dir := filepath.Join(root, ".git")
-	if err := os.Mkdir(dir, 0o700); err != nil {
-		return fmt.Errorf("baseline .git marker: %w", err)
-	}
-	cfg, err := repo.Config()
-	if err != nil {
-		return fmt.Errorf("baseline git config: %w", err)
-	}
-	var b strings.Builder
-	b.WriteString("[core]\n\trepositoryformatversion = 0\n")
-	for _, remote := range cfg.Remotes {
-		for _, url := range remote.URLs {
-			fmt.Fprintf(&b, "[remote %q]\n\turl = %s\n", remote.Name, url)
-		}
-	}
-	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(b.String()), 0o600); err != nil {
-		return fmt.Errorf("baseline .git/config: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o600); err != nil {
-		return fmt.Errorf("baseline .git/HEAD: %w", err)
-	}
-	return nil
 }
 
 // relToRepo returns path's location relative to repoRoot. Returns "."

--- a/pkg/baseline/baseline_test.go
+++ b/pkg/baseline/baseline_test.go
@@ -3,6 +3,7 @@ package baseline
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -42,12 +43,14 @@ func TestAutoResolve_ExplicitBase(t *testing.T) {
 	_ = commitB
 }
 
-// TestMaterializeAndMark_CarriesRemotes pins that the materialized baseline
-// tree's .git is openable and exposes the source repo's remotes — the
-// property discovery's self-referential GitRepository alias relies on.
-// Without it the baseline's private self-source goes unresolved and the
-// whole tree renders empty (every resource shown as a wholesale addition).
-func TestMaterializeAndMark_CarriesRemotes(t *testing.T) {
+// TestAutoResolve_SelfURLsCarryRemotes pins that Result.SelfURLs carries the
+// working tree's remote URLs — the property the self-referential
+// GitRepository alias relies on on the baseline side. The materialized tree
+// has no .git of its own, so the caller hands these to the baseline render
+// as Config.SelfURLs; without them the baseline's private self-source goes
+// unresolved and the whole tree renders empty (every resource a wholesale
+// addition).
+func TestAutoResolve_SelfURLsCarryRemotes(t *testing.T) {
 	dir := t.TempDir()
 	commit := initRepoWithFile(t, dir, "a.yaml", "x")
 	repo, err := git.PlainOpen(dir)
@@ -65,17 +68,12 @@ func TestMaterializeAndMark_CarriesRemotes(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(res.TempDir) }()
 
-	// The same open + Config() that discovery.readWorkingTreeRemotes performs.
-	got, err := git.PlainOpenWithOptions(res.TempDir, &git.PlainOpenOptions{DetectDotGit: true})
-	if err != nil {
-		t.Fatalf("materialized baseline .git not openable: %v", err)
+	if !slices.Contains(res.SelfURLs, url) {
+		t.Errorf("Result.SelfURLs = %v; want it to contain %q", res.SelfURLs, url)
 	}
-	cfg, err := got.Config()
-	if err != nil {
-		t.Fatalf("materialized baseline config: %v", err)
-	}
-	if origin, ok := cfg.Remotes["origin"]; !ok || len(origin.URLs) == 0 || origin.URLs[0] != url {
-		t.Errorf("materialized .git missing origin remote %q; got %+v", url, cfg.Remotes)
+	// The materialized tree must NOT carry a synthetic .git anymore.
+	if _, err := os.Stat(filepath.Join(res.TempDir, ".git")); !os.IsNotExist(err) {
+		t.Errorf("materialized baseline must have no .git marker; stat err = %v", err)
 	}
 }
 
@@ -339,10 +337,11 @@ func TestAutoResolve_PathOrigMappedToSubdir(t *testing.T) {
 	}
 }
 
-// TestAutoResolve_DropsGitMarker confirms the .git marker is present
-// in TempDir so discovery.FindRepoRoot (used by PR #348's repo-root
-// widening) lifts up correctly when --path-orig is a subdir.
-func TestAutoResolve_DropsGitMarker(t *testing.T) {
+// TestAutoResolve_NoGitMarker confirms the materialized baseline is pure
+// files — no synthetic .git. The repo root + remotes are surfaced via
+// Result (TempDir / SelfURLs) and threaded explicitly, so the marker the
+// old repo-root "widen" heuristic needed is gone.
+func TestAutoResolve_NoGitMarker(t *testing.T) {
 	dir := t.TempDir()
 	initRepoWithFile(t, dir, "a.yaml", "x")
 	commit := writeAndCommit(t, dir, "a.yaml", "y")
@@ -351,12 +350,13 @@ func TestAutoResolve_DropsGitMarker(t *testing.T) {
 		t.Fatalf("AutoResolve: %v", err)
 	}
 	defer func() { _ = os.RemoveAll(res.TempDir) }()
-	info, err := os.Stat(filepath.Join(res.TempDir, ".git"))
-	if err != nil {
-		t.Fatalf("expected .git marker in TempDir: %v", err)
+	// The materialized file is present...
+	if _, err := os.Stat(filepath.Join(res.TempDir, "a.yaml")); err != nil {
+		t.Errorf("expected materialized file in TempDir: %v", err)
 	}
-	if !info.IsDir() {
-		t.Errorf(".git marker should be a directory")
+	// ...but no synthetic .git marker.
+	if _, err := os.Stat(filepath.Join(res.TempDir, ".git")); !os.IsNotExist(err) {
+		t.Errorf("materialized baseline must have no .git marker; stat err = %v", err)
 	}
 }
 

--- a/pkg/change/integration_test.go
+++ b/pkg/change/integration_test.go
@@ -299,11 +299,16 @@ data:
 	// targets. The flux/cluster directory is byte-identical between
 	// the two checkouts; only kubernetes/apps/foo/cm.yaml differs.
 	currCluster := filepath.Join(currRoot, "kubernetes/flux")
-	origCluster := filepath.Join(origRoot, "kubernetes/flux")
 
+	// The CLI lifts a subdir --path / --path-orig to its repo root before
+	// reaching the orchestrator (repoRootOf); here we pass the explicit
+	// roots directly. change.Detect runs root-to-root, so an edit in
+	// kubernetes/apps/foo — outside the scanned flux/ subdir — still
+	// enters the keep set, without any .git-ancestor "widen" heuristic.
 	o, err := orchestrator.New(orchestrator.Config{
 		Path:        currCluster,
-		PathOrig:    origCluster,
+		RepoRoot:    currRoot,
+		PathOrig:    origRoot,
 		WipeSecrets: true,
 	})
 	if err != nil {

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -43,7 +43,8 @@
 // two-orchestrator, shared-cache, changed-only dance), then feed the
 // Results to [Changes]:
 //
-//	base, head, _ := orchestrator.RenderTrees(ctx, baseDir, headDir, cfg)
+//	base, head, _ := orchestrator.RenderTrees(ctx,
+//		orchestrator.Tree{RepoRoot: baseDir}, orchestrator.Tree{RepoRoot: headDir}, cfg)
 //	changes := diff.Changes(
 //		diff.DocsFromManifests(base.Result.Manifests, nil),
 //		diff.DocsFromManifests(head.Result.Manifests, nil),

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -130,7 +130,7 @@ func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifes
 // always rejects. A pass-1 alias can never URL-match a working-tree
 // remote, so the URL-match filter below is the natural guard.
 func (d *discoverer) overrideSelfReferentialGitRepositories(repoRoot string) []manifest.NamedResource {
-	remotes := readWorkingTreeRemotes(repoRoot)
+	remotes := d.selfRemotes(repoRoot)
 	debugLogRemotes(remotes)
 	if len(remotes) == 0 {
 		return nil

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -17,7 +17,17 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// RepoRoot is the spec.path anchor. When the caller supplies it
+	// explicitly (an SDK consumer rendering an extracted tree with no
+	// .git), use it verbatim; otherwise fall back to the .git-ancestor
+	// walk for a local working tree — byte-identical to prior behavior
+	// when RepoRoot is empty.
 	root := FindRepoRoot(abs)
+	if d.cfg.RepoRoot != "" {
+		if r, err := ResolveScanPath(d.cfg.RepoRoot); err == nil {
+			root = r
+		}
+	}
 	id := manifest.BootstrapSourceID
 	// Always seed the artifact + status: even if the user authored a
 	// GitRepository at this id (the `flux bootstrap` pattern), the

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -85,7 +85,15 @@ type Config struct {
 	// .git; the CLI defaults it to the .git ancestor of Path. Empty ⇒
 	// fall back to the .git walk (FindRepoRoot), preserving local
 	// behavior. Path must sit at or under RepoRoot.
-	RepoRoot    string
+	RepoRoot string
+	// SelfURLs are the remote URL(s) this tree represents. A user-authored
+	// GitRepository whose spec.url matches one of these is the cluster
+	// pulling itself; its artifact is aliased to the local tree
+	// (overrideSelfReferentialGitRepositories) so the offline render
+	// resolves it. Supplied explicitly by SDK consumers rendering
+	// extracted trees (no .git/config to read); empty ⇒ fall back to the
+	// working tree's .git remotes, preserving local behavior.
+	SelfURLs    []string
 	Store       *store.Store
 	WipeSecrets bool
 	// ComponentCache, when non-nil, memoizes

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -76,7 +76,16 @@ type Result struct {
 
 // Config is the input contract for Run. Store is mandatory.
 type Config struct {
-	Path        string
+	// Path is the scan entry point — the directory the file walker
+	// starts at (a Flux cluster's entry, e.g. kubernetes/flux/cluster).
+	Path string
+	// RepoRoot is the source root that Kustomization spec.path values
+	// resolve against (the GitRepository artifact root). Supplied
+	// explicitly by SDK consumers rendering extracted trees that have no
+	// .git; the CLI defaults it to the .git ancestor of Path. Empty ⇒
+	// fall back to the .git walk (FindRepoRoot), preserving local
+	// behavior. Path must sit at or under RepoRoot.
+	RepoRoot    string
 	Store       *store.Store
 	WipeSecrets bool
 	// ComponentCache, when non-nil, memoizes

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -10,6 +10,25 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 )
 
+// selfRemotes returns the normalized remote-URL set used to recognize a
+// self-referential GitRepository. When the caller supplied Config.SelfURLs
+// explicitly (an SDK consumer rendering an extracted tree with no
+// .git/config), those are used; otherwise it falls back to the working
+// tree's .git remotes — byte-identical to prior behavior when SelfURLs is
+// empty.
+func (d *discoverer) selfRemotes(repoRoot string) map[string]struct{} {
+	if len(d.cfg.SelfURLs) == 0 {
+		return readWorkingTreeRemotes(repoRoot)
+	}
+	out := make(map[string]struct{}, len(d.cfg.SelfURLs))
+	for _, u := range d.cfg.SelfURLs {
+		if n := normalizeGitURL(u); n != "" {
+			out[n] = struct{}{}
+		}
+	}
+	return out
+}
+
 // readWorkingTreeRemotes returns the set of remote URLs configured on
 // the git repository at repoRoot, normalized for comparison against
 // Flux GitRepository.spec.url. Returns nil if repoRoot is not a git

--- a/pkg/discovery/remotes_test.go
+++ b/pkg/discovery/remotes_test.go
@@ -2,6 +2,36 @@ package discovery
 
 import "testing"
 
+// TestSelfRemotes_ExplicitURLsOverrideGitConfig confirms an SDK consumer
+// rendering an extracted tree (no .git/config) can supply the repo's
+// remote URLs via Config.SelfURLs — they are normalized the same way the
+// .git fallback would be, so self-referential GitRepository aliasing fires
+// without a working tree.
+func TestSelfRemotes_ExplicitURLsOverrideGitConfig(t *testing.T) {
+	d := &discoverer{cfg: Config{SelfURLs: []string{
+		"git@github.com:Owner/Repo.git", // canonicalizes to github.com/owner/repo
+		"not-a-remote",                  // rejected by normalizeGitURL → dropped
+	}}}
+	// repoRoot points nowhere real; with SelfURLs set it must NOT be read.
+	got := d.selfRemotes("/nonexistent")
+	if _, ok := got["github.com/owner/repo"]; !ok {
+		t.Errorf("explicit SelfURL not normalized into the set: %v", got)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected exactly the one valid remote; got %v", got)
+	}
+}
+
+// TestSelfRemotes_EmptyFallsBackToGitConfig confirms the empty-SelfURLs
+// path is byte-identical to reading the working tree (here: a non-repo
+// path yields nil, the same as readWorkingTreeRemotes).
+func TestSelfRemotes_EmptyFallsBackToGitConfig(t *testing.T) {
+	d := &discoverer{cfg: Config{}}
+	if got := d.selfRemotes(t.TempDir()); got != nil {
+		t.Errorf("no SelfURLs + non-repo path should yield nil (git fallback); got %v", got)
+	}
+}
+
 // TestNormalizeGitURL_CanonicalForms exercises every URL shape the
 // bootstrap-alias URL-match heuristic needs to recognize as the same
 // remote. All four inputs below describe the same GitHub repository

--- a/pkg/orchestrator/changefilter.go
+++ b/pkg/orchestrator/changefilter.go
@@ -3,7 +3,6 @@ package orchestrator
 import (
 	"fmt"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/discovery"
@@ -67,63 +66,39 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	return nil
 }
 
-// computeChangeSet resolves --path / --path-orig, runs change.Detect,
-// and reroots the result into repoRoot's coordinate system. Returns
-// (nil, nil) when both paths resolve to the same directory (changed-
-// only mode would diff a tree against itself); the caller skips the
-// filter build in that case. Only reached when cfg.PathOrig != "".
+// computeChangeSet diffs the baseline source root (cfg.PathOrig) against
+// this side's source root (repoRoot) and returns the file-level change
+// set. Both are repo roots — the SAME coordinate system as repoRoot, so
+// the emitted paths line up with SourceFiles keys directly (no rerooting).
+// Returns (nil, nil) when the two roots resolve to the same directory
+// (changed-only mode would diff a tree against itself); the caller skips
+// the filter build then. Only reached when cfg.PathOrig != "".
+//
+// PathOrig carries the baseline's REPO ROOT (not a scan subdir): the CLI
+// resolves --base into a materialized tree root, and a subdir --path-orig
+// is lifted to its repo root before reaching here. That replaces the old
+// .git-ancestor "widen" heuristic — the policy of picking each side's root
+// now lives in the caller (internal/cli / RenderTrees), and this stays a
+// straight root-to-root diff.
 func (o *Orchestrator) computeChangeSet(repoRoot string) (*change.Set, error) {
-	origAbs, err := discovery.ResolveScanPath(o.cfg.PathOrig)
+	origRoot, err := discovery.ResolveScanPath(o.cfg.PathOrig)
 	if err != nil {
 		return nil, fmt.Errorf("--path-orig: %w", err)
 	}
-	currAbs, err := discovery.ResolveScanPath(o.cfg.Path)
-	if err != nil {
-		return nil, fmt.Errorf("--path: %w", err)
-	}
-	// Both paths resolved to the same directory (e.g. a symlink and
-	// its target, or literally the same arg twice). Changed-only mode
-	// would diff a tree against itself producing an empty change set.
-	// Skip filter build so the user's `--path-orig` typo doesn't
-	// silently render zero output.
-	if origAbs == currAbs {
-		slog.Warn("--path and --path-orig resolve to the same directory; ignoring --path-orig",
-			"resolved_path", currAbs)
+	// Both roots resolved to the same directory (e.g. a symlink and its
+	// target, or the same arg twice). Changed-only mode would diff a tree
+	// against itself producing an empty change set. Skip filter build so
+	// the user's `--path-orig` typo doesn't silently render zero output.
+	if origRoot == repoRoot {
+		slog.Warn("--path and --path-orig resolve to the same root; ignoring --path-orig",
+			"resolved_path", repoRoot)
 		return nil, nil
 	}
-	// Widen the diff scope to each side's .git root when the user
-	// pointed at sibling subdirs of separate checkouts — the
-	// canonical PR-vs-base-branch flow `flate diff ks --path
-	// pr/cluster --path-orig base/cluster` where the actual edits
-	// live in `apps/`, outside the cluster subdir. Diffing the
-	// literal subdirs would report zero changes even though the
-	// rendered output differs. We only widen when both sides resolve
-	// to .git roots that are (a) not the same root (one checkout,
-	// two subdirs is the deliberate subdir-vs-subdir case) and
-	// (b) actually distinct from the path the user passed (no .git
-	// ancestor → FindRepoRoot returns the path unchanged).
-	diffOrig, diffCurr := origAbs, currAbs
-	origRoot := discovery.FindRepoRoot(origAbs)
-	currRoot := discovery.FindRepoRoot(currAbs)
-	widened := origRoot != origAbs && currRoot != currAbs && origRoot != currRoot
-	if widened {
-		diffOrig, diffCurr = origRoot, currRoot
-	}
-	cs, err := change.Detect(diffOrig, diffCurr)
+	cs, err := change.Detect(origRoot, repoRoot)
 	if err != nil {
 		return nil, fmt.Errorf("change detect: %w", err)
 	}
-	// Detect emits paths relative to diffCurr. When we widened, that
-	// already equals repoRoot and SourceFiles keys line up. When we
-	// didn't, lift the subdir-relative paths into repoRoot's
-	// coordinate system so they match SourceFiles keys.
-	if !widened {
-		if rel, err := filepath.Rel(repoRoot, currAbs); err == nil && rel != "." {
-			cs = cs.Reroot(rel)
-		}
-	}
-	slog.Debug("changed-only mode",
-		"baseline", diffOrig, "current", diffCurr, "changed_files", cs.Len(), "widened_to_repo_root", widened)
+	slog.Debug("changed-only mode", "baseline", origRoot, "current", repoRoot, "changed_files", cs.Len())
 	if cs.Len() == 0 {
 		slog.Warn("no changes detected between --path and --path-orig — output will be empty; verify both paths reference distinct snapshots")
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -45,6 +45,11 @@ type Config struct {
 	// ancestor of Path. Empty ⇒ the .git walk (FindRepoRoot) runs,
 	// preserving local behavior.
 	RepoRoot string
+	// SelfURLs are the remote URL(s) this tree represents, for
+	// self-referential GitRepository aliasing (a cluster pulling itself).
+	// Supplied explicitly by SDK consumers rendering extracted trees with
+	// no .git/config; empty ⇒ the working tree's .git remotes are read.
+	SelfURLs []string
 	// PathOrig, when non-empty, switches every command into
 	// changed-only mode: only resources whose source files differ
 	// (plus the sources they reference) get reconciled.
@@ -450,7 +455,8 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 		return nil
 	}
 	res, err := discovery.Run(ctx, discovery.Config{
-		Path: o.cfg.Path, RepoRoot: o.cfg.RepoRoot, Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
+		Path: o.cfg.Path, RepoRoot: o.cfg.RepoRoot, SelfURLs: o.cfg.SelfURLs,
+		Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
 		ComponentCache: o.componentCache,
 	})
 	if err != nil {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -36,8 +36,15 @@ type Config struct {
 	// at the CLI layer; this field is bytes.
 	StageCacheBytes int64
 
-	// Path is the directory to scan for Flux objects.
+	// Path is the directory to scan for Flux objects (the scan entry
+	// point — a cluster's Flux entry, which may be a subdir of RepoRoot).
 	Path string
+	// RepoRoot is the source root that Kustomization spec.path values
+	// resolve against. Supplied explicitly by SDK consumers rendering
+	// extracted trees that have no .git; the CLI defaults it to the .git
+	// ancestor of Path. Empty ⇒ the .git walk (FindRepoRoot) runs,
+	// preserving local behavior.
+	RepoRoot string
 	// PathOrig, when non-empty, switches every command into
 	// changed-only mode: only resources whose source files differ
 	// (plus the sources they reference) get reconciled.
@@ -443,7 +450,7 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 		return nil
 	}
 	res, err := discovery.Run(ctx, discovery.Config{
-		Path: o.cfg.Path, Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
+		Path: o.cfg.Path, RepoRoot: o.cfg.RepoRoot, Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
 		ComponentCache: o.componentCache,
 	})
 	if err != nil {

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -418,6 +418,75 @@ spec:
 	}
 }
 
+// TestOrchestrator_ExplicitRepoRootNoGit proves Config.RepoRoot replaces the
+// .git-ancestor walk: an extracted tree with NO .git, the scan entry point at a
+// subdir (kubernetes/flux/cluster), and a repo-root-relative KS spec.path
+// (./kubernetes/apps) renders correctly when RepoRoot is set — the spec.path
+// resolves against RepoRoot, not the collapsed entry-point subdir. Without
+// RepoRoot and no .git, FindRepoRoot falls back to the subdir, ./kubernetes/apps
+// doubles into a nonexistent path, and nothing renders. This is konflate's
+// clusterPath bug; the explicit anchor is what fixes it.
+func TestOrchestrator_ExplicitRepoRootNoGit(t *testing.T) {
+	writeCluster := func(t *testing.T, dir string) {
+		testutil.WriteFile(t, dir, "kubernetes/flux/cluster/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./kubernetes/apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+		testutil.WriteFile(t, dir, "kubernetes/apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+		testutil.WriteFile(t, dir, "kubernetes/apps/cm.yaml",
+			"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: demo, namespace: default}\ndata: {k: v}\n")
+	}
+	clusterApps := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	rendersDemo := func(t *testing.T, cfg Config) bool {
+		t.Helper()
+		o, err := New(cfg)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		// A per-resource render failure (e.g. the doubled-path case below)
+		// is advisory — Result stays non-nil. Gate on the rendered docs, not
+		// on err.
+		res, err := o.Render(context.Background())
+		if res == nil {
+			t.Fatalf("Render returned nil Result: %v", err)
+		}
+		for _, m := range res.Manifests[clusterApps] {
+			if m["kind"] != "ConfigMap" {
+				continue
+			}
+			if meta, _ := m["metadata"].(map[string]any); meta != nil && meta["name"] == "demo" {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Explicit RepoRoot: spec.path ./kubernetes/apps resolves against the root,
+	// so the ConfigMap renders even though we scanned only the entry-point subdir
+	// and there is no .git to walk up to.
+	t.Run("explicit RepoRoot renders", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCluster(t, dir)
+		if !rendersDemo(t, Config{Path: dir + "/kubernetes/flux/cluster", RepoRoot: dir, WipeSecrets: true, Concurrency: 4}) {
+			t.Error("explicit RepoRoot: ConfigMap demo must render (spec.path resolves against RepoRoot)")
+		}
+	})
+
+	// No anchor (no RepoRoot, no .git): documents the failure mode the explicit
+	// anchor fixes — ./kubernetes/apps doubles under the entry-point subdir, so
+	// cluster-apps renders nothing.
+	t.Run("no anchor renders nothing", func(t *testing.T) {
+		dir := t.TempDir()
+		writeCluster(t, dir)
+		if rendersDemo(t, Config{Path: dir + "/kubernetes/flux/cluster", WipeSecrets: true, Concurrency: 4}) {
+			t.Error("no RepoRoot + no .git: spec.path doubles; cluster-apps should render nothing")
+		}
+	})
+}
+
 // The bjw-s/onedr0p self-substitute deadlock, in FULL mode: cluster-apps'
 // spec.path is a BARE dir whose flux-system group base pulls in a component
 // defining a namespace-less cluster-settings ConfigMap, which cluster-apps

--- a/pkg/orchestrator/trees.go
+++ b/pkg/orchestrator/trees.go
@@ -14,6 +14,20 @@ import (
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 )
 
+// Tree is one cluster directory to render for comparison. RepoRoot is the
+// source root that Kustomization spec.path values resolve against (the
+// GitRepository artifact root); Path is the scan entry point and defaults
+// to RepoRoot when empty (a cluster whose Flux entry is a subdir passes the
+// subdir as Path and the root as RepoRoot). SelfURLs are the remote URL(s)
+// the tree represents, for self-referential GitRepository aliasing. A
+// consumer rendering extracted trees with no .git supplies all three
+// explicitly; nothing here is inferred from a .git ancestor.
+type Tree struct {
+	RepoRoot string
+	Path     string
+	SelfURLs []string
+}
+
 // Rendered is one side of a RenderTrees comparison: the Orchestrator
 // (already Stopped — its background reconcile loops are released, but its
 // Store stays readable for diff doc gathering) paired with its render
@@ -31,8 +45,8 @@ type Rendered struct {
 // gate) doesn't re-implement the two-orchestrator dance.
 //
 // Each side reconciles in CHANGED-ONLY mode against the other (its
-// PathOrig is set to the opposite tree), so only resources whose source
-// files differ between basePath and headPath — plus their dependency
+// PathOrig is set to the opposite tree's RepoRoot), so only resources
+// whose source files differ between the two trees — plus their dependency
 // closure — are rendered, not the whole cluster. Pairing the two scoped
 // outputs (e.g. via diff.Changes) yields the same diff a full render
 // would: an unchanged resource renders on neither side.
@@ -40,26 +54,34 @@ type Rendered struct {
 // Both sides share one source.Cache so a chart / OCI layer / git source
 // fetched for one side is reused by the other (and concurrent slot
 // allocation is serialized), and they run concurrently. cfg supplies the
-// render tuning; cfg.Path and cfg.PathOrig are set by RenderTrees and any
-// values there are ignored, and cfg.SourceCache, when nil, is created
-// from cfg.CacheDir (falling back to the OS tempdir). A consumer that
-// renders many comparisons (one per PR) should pass its own long-lived
-// cfg.SourceCache so artifacts persist across calls.
+// render tuning; cfg.Path / RepoRoot / PathOrig / SelfURLs are set from
+// baseTree/headTree (any values on cfg are ignored), and cfg.SourceCache,
+// when nil, is created from cfg.CacheDir (falling back to the OS tempdir).
+// A consumer that renders many comparisons (one per PR) should pass its
+// own long-lived cfg.SourceCache so artifacts persist across calls.
 //
 // Both orchestrators are Stopped before return; their Stores remain
 // readable. err is non-nil if either side had any failure; callers that
 // still want the partial diff check Rendered.Result != nil (nil only on a
-// fatal Bootstrap error) and treat err as advisory. base is the left/old
-// side and head the right/new — matching diff.Changes(left, right).
-func RenderTrees(ctx context.Context, basePath, headPath string, cfg Config) (base, head Rendered, err error) {
+// fatal Bootstrap error) and treat err as advisory. baseTree is the
+// left/old side and headTree the right/new — matching diff.Changes(left,
+// right). Each side reconciles changed-only against the OTHER tree's
+// RepoRoot.
+func RenderTrees(ctx context.Context, baseTree, headTree Tree, cfg Config) (base, head Rendered, err error) {
 	if cfg.SourceCache == nil {
 		root := cmp.Or(cfg.CacheDir, filepath.Join(os.TempDir(), "flate-cache"))
 		cfg.SourceCache = source.NewCache(cacheroot.New(root))
 	}
 	baseCfg := cfg
-	baseCfg.Path, baseCfg.PathOrig = basePath, headPath
+	baseCfg.RepoRoot = baseTree.RepoRoot
+	baseCfg.Path = cmp.Or(baseTree.Path, baseTree.RepoRoot)
+	baseCfg.PathOrig = headTree.RepoRoot
+	baseCfg.SelfURLs = baseTree.SelfURLs
 	headCfg := cfg
-	headCfg.Path, headCfg.PathOrig = headPath, basePath
+	headCfg.RepoRoot = headTree.RepoRoot
+	headCfg.Path = cmp.Or(headTree.Path, headTree.RepoRoot)
+	headCfg.PathOrig = baseTree.RepoRoot
+	headCfg.SelfURLs = headTree.SelfURLs
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {

--- a/pkg/orchestrator/trees_test.go
+++ b/pkg/orchestrator/trees_test.go
@@ -65,10 +65,13 @@ func TestRenderTrees_ChangedOnlyAndDiff(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	base, head, err := orchestrator.RenderTrees(ctx, baseDir, headDir, orchestrator.Config{
-		WipeSecrets: true,
-		Concurrency: 4,
-	})
+	base, head, err := orchestrator.RenderTrees(ctx,
+		orchestrator.Tree{RepoRoot: baseDir},
+		orchestrator.Tree{RepoRoot: headDir},
+		orchestrator.Config{
+			WipeSecrets: true,
+			Concurrency: 4,
+		})
 	if err != nil {
 		t.Fatalf("RenderTrees: %v", err)
 	}
@@ -114,7 +117,10 @@ func TestRenderTrees_StopsButStoreReadable(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	base, head, err := orchestrator.RenderTrees(ctx, baseDir, headDir, orchestrator.Config{WipeSecrets: true, Concurrency: 4})
+	base, head, err := orchestrator.RenderTrees(ctx,
+		orchestrator.Tree{RepoRoot: baseDir},
+		orchestrator.Tree{RepoRoot: headDir},
+		orchestrator.Config{WipeSecrets: true, Concurrency: 4})
 	if err != nil {
 		t.Fatalf("RenderTrees: %v", err)
 	}
@@ -125,5 +131,62 @@ func TestRenderTrees_StopsButStoreReadable(t *testing.T) {
 	}
 	if head.Store().GetObject(id) == nil {
 		t.Errorf("head Store unreadable after RenderTrees Stop: %s missing", id)
+	}
+}
+
+// writeHomeOpsCluster lays out a cluster-template-style tree under dir
+// with NO .git: the Flux entry point is kubernetes/flux/cluster/ks.yaml
+// (cluster-apps → ./kubernetes/apps, repo-ROOT-relative), and the app's
+// ConfigMap carries val. This is konflate's extracted-tree shape — the
+// caller renders it via Tree{RepoRoot: dir, Path: dir/kubernetes/flux/cluster}.
+func writeHomeOpsCluster(t *testing.T, dir, val string) {
+	t.Helper()
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster/ks.yaml",
+		"apiVersion: kustomize.toolkit.fluxcd.io/v1\nkind: Kustomization\n"+
+			"metadata: {name: cluster-apps, namespace: flux-system}\n"+
+			"spec:\n  path: ./kubernetes/apps\n"+
+			"  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: demo, namespace: default}\ndata: {k: "+val+"}\n")
+}
+
+// TestRenderTrees_RepoRootRelativeNoGit is the konflate clusterPath
+// regression at the SDK level: two extracted trees with NO .git, the Flux
+// entry point a subdir (kubernetes/flux/cluster), and repo-root-relative
+// spec.path (./kubernetes/apps). With per-side Tree{RepoRoot, Path} the
+// change in kubernetes/apps/cm.yaml — outside the scanned entry-point dir —
+// is detected and rendered, and diff.Changes reports exactly it. (Before
+// the explicit-root model, the .git-less subdir collapsed the anchor and
+// the change detection both failed: empty diff / "no changes detected".)
+func TestRenderTrees_RepoRootRelativeNoGit(t *testing.T) {
+	baseDir := t.TempDir()
+	headDir := t.TempDir()
+	writeHomeOpsCluster(t, baseDir, "v1")
+	writeHomeOpsCluster(t, headDir, "v2") // only the ConfigMap data differs
+
+	entry := func(root string) string { return root + "/kubernetes/flux/cluster" }
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	base, head, err := orchestrator.RenderTrees(ctx,
+		orchestrator.Tree{RepoRoot: baseDir, Path: entry(baseDir)},
+		orchestrator.Tree{RepoRoot: headDir, Path: entry(headDir)},
+		orchestrator.Config{WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("RenderTrees: %v", err)
+	}
+	if base.Result == nil || head.Result == nil {
+		t.Fatalf("both sides must render: base=%v head=%v", base.Result, head.Result)
+	}
+	changes := diff.Changes(
+		diff.DocsFromManifests(base.Result.Manifests, nil),
+		diff.DocsFromManifests(head.Result.Manifests, nil),
+		diff.Options{},
+	)
+	if len(changes) != 1 {
+		t.Fatalf("want exactly 1 change (demo ConfigMap), got %d: %+v", len(changes), changes)
+	}
+	if c := changes[0]; c.Name != "demo" || c.Kind != "ConfigMap" || c.Status != diff.StatusChanged {
+		t.Errorf("change = %+v; want ConfigMap demo changed", c)
 	}
 }


### PR DESCRIPTION
## Context

flate inferred the repo root — the anchor that repo-root-relative Kustomization `spec.path` values (`./kubernetes/...`) resolve against — by walking up from `--path` to the nearest `.git` (`discovery.FindRepoRoot`), threaded that single inferred value into three load-bearing places, and **faked a `.git`** whenever it couldn't infer one. That fragility surfaced through the SDK: a consumer (the konflate PR-diff bot) rendering an **extracted tree with no `.git`** gets the root collapsed to the scan path, so repo-root-relative paths double into nonexistent dirs and changed-only detection misses edits outside the scanned subdir ("no changes detected").

This makes the source root an **explicit input**, with `.git`-walking demoted to a CLI default.

## What changed

- **`Config.RepoRoot`** (discovery + orchestrator) — the source root `spec.path` resolves against, decoupled from the scan entry point (`Path`). Empty ⇒ the `.git` walk still runs (local CLI unchanged).
- **`Config.SelfURLs`** — the tree's remote URL(s) for self-referential-GitRepository aliasing, so a `.git`-less tree can still alias a cluster that pulls itself. Empty ⇒ read the working tree's `.git` remotes.
- **`computeChangeSet`** collapses to a root-to-root `change.Detect` — the `.git`-inference **`widen` heuristic and reroot are gone**. The policy of picking each side's root moves to `internal/cli` (`repoRootOf`).
- **`RenderTrees`** takes per-side `Tree{RepoRoot, Path, SelfURLs}` and wires each side changed-only against the other tree's root. An SDK consumer passes the roots it already knows — no `.git`, no marker.
- **`baseline`** materializes pure files and **drops the synthetic `.git` marker**; `Result` carries the repo root + the live tree's remotes, which the CLI threads in explicitly.

## Verification

- Full gate green: `gofmt` / `build` / `vet` / `go test -race ./...` / `golangci-lint` (0 issues).
- **Byte-identical** `build all` across all 12 `~/repos` clusters (billimek 57k, joryirving 48k lines — 0 bytediff) and `diff --base HEAD~5/20/50` on `~/k8s-gitops` (incl. a 4.4k-line diff exercising the self-referential alias) with fresh markerless caches. The `.git` default reproduces the old behavior for local checkouts.
- New regressions: a no-`.git` + repo-root-relative `spec.path` + explicit `RepoRoot` orchestrator test, and the konflate-shape changed-only `RenderTrees` test (entry-point subdir, change outside it → detected + rendered + diffed).

## Follow-up

konflate adoption (pass the extracted roots + `clusterPath` as `Tree`/`RepoRoot`/`SelfURLs`; delete its `extractTree`) is a separate konflate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)