### PR TITLE
fix(preflight): implement git clone for kustomize remote base URLs

### DIFF
--- a/pkg/kustomize/gitfetch.go
+++ b/pkg/kustomize/gitfetch.go
@@ -1,0 +1,263 @@
+package kustomize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// gitCloneTimeout caps each preflight git clone (both ref attempts
+// combined). Wider than remoteFetchTimeout since a clone moves a full
+// tree, but a hung git server still fails in a minute, not never.
+const gitCloneTimeout = 60 * time.Second
+
+// gitRemoteSpec is a parsed kustomize git remote base URL.
+//
+//	https://github.com/org/repo?ref=v1.0         → {repoURL: "https://github.com/org/repo", subPath: ".", ref: "v1.0"}
+//	https://github.com/org/repo//config?ref=main → {repoURL: "https://github.com/org/repo", subPath: "config", ref: "main"}
+type gitRemoteSpec struct {
+	repoURL string
+	subPath string // "." when no // subpath present
+	ref     string // "" means the remote's default branch
+}
+
+func (s gitRemoteSpec) cloneKey() string {
+	return urlHash(s.repoURL + "\n" + s.ref)
+}
+
+// parseGitRemoteSpec returns (spec, true) if s is a kustomize git remote base
+// URL that should be resolved via git clone, (zero, false) for plain HTTP files.
+// Git remote bases carry one of kustomize's markers (?ref=, // subpath, .git
+// suffix) or are a bare org/repo path on a well-known git host; marker-less
+// deeper paths (releases/download/…, blob/…) are direct file downloads.
+func parseGitRemoteSpec(s string) (gitRemoteSpec, bool) {
+	if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		return gitRemoteSpec{}, false
+	}
+	u, err := url.Parse(s)
+	if err != nil {
+		return gitRemoteSpec{}, false
+	}
+
+	ref := u.Query().Get("ref")
+	subPath := "."
+
+	// Kustomize uses // in the URL path to separate the repo from a subdirectory.
+	if idx := strings.Index(u.Path, "//"); idx >= 0 {
+		if sub := strings.TrimLeft(u.Path[idx+2:], "/"); sub != "" {
+			subPath = sub
+		}
+		u.Path = u.Path[:idx]
+	}
+
+	if ref == "" && subPath == "." && !strings.HasSuffix(u.Path, ".git") {
+		// No marker; only a bare org/repo path on a known host qualifies.
+		switch u.Hostname() {
+		case "github.com", "gitlab.com", "bitbucket.org":
+			if strings.Count(strings.Trim(u.Path, "/"), "/") != 1 {
+				return gitRemoteSpec{}, false
+			}
+		default:
+			return gitRemoteSpec{}, false
+		}
+	}
+	u.RawQuery = ""
+	return gitRemoteSpec{repoURL: u.String(), subPath: subPath, ref: ref}, true
+}
+
+// gitClone carries the result of one clone, deduped via the same
+// sync.Once + done-channel discipline as remoteFetch (remotefetch.go).
+type gitClone struct {
+	start sync.Once
+	done  chan struct{}
+	dir   string
+	err   error
+}
+
+// fetchGitBase returns the path of a shallow clone of spec.repoURL at
+// spec.ref, cloning at most once per (repoURL, ref) within the
+// StagingCache lifetime. Same cache discipline as FetchRemote:
+// ref-not-found is definitive within a run and stays cached; transient
+// errors drop the entry so the next caller retries.
+//
+// Clones land in flate-stage-git-* tempdirs under c.root, inheriting
+// the per-process scratch lifecycle: removed by Close, swept by
+// sweepStaleStageDirs after a crash, skipped by the LRU and GC sweeps.
+// MkdirTemp keeps concurrent flate processes off each other's clones.
+func (c *StagingCache) fetchGitBase(ctx context.Context, spec gitRemoteSpec) (string, error) {
+	key := spec.cloneKey()
+	loaded, _ := c.gitClones.LoadOrStore(key, &gitClone{done: make(chan struct{})})
+	gc := loaded.(*gitClone)
+	gc.start.Do(func() {
+		go func() {
+			var dir string
+			dir, gc.err = os.MkdirTemp(c.root, "flate-stage-git-*")
+			if gc.err == nil {
+				gc.err = cloneAtRef(context.Background(), spec.repoURL, spec.ref, dir)
+				if gc.err == nil {
+					gc.err = rejectEscapingSymlinks(dir)
+				}
+				if gc.err == nil {
+					gc.dir = dir
+				} else {
+					_ = os.RemoveAll(dir)
+				}
+			}
+			// Evict transient failures before signaling done so no
+			// caller can observe the error and still load the dead entry.
+			if gc.err != nil && !isGitRefNotFound(gc.err) {
+				c.gitClones.CompareAndDelete(key, gc)
+			}
+			close(gc.done)
+		}()
+	})
+	select {
+	case <-gc.done:
+		return gc.dir, gc.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// fetchGitResource clones the remote git base, copies spec.subPath
+// into dir, and returns the directory name for use as a kustomization
+// resource entry. The copied tree is not re-walked, so nested remote
+// bases don't resolve — same depth-1 limit as the HTTP fetch path.
+func fetchGitResource(ctx context.Context, cache *StagingCache, dir, urlStr string, spec gitRemoteSpec) (string, error) {
+	cloneDir, err := cache.fetchGitBase(ctx, spec)
+	if err != nil {
+		return "", err
+	}
+	src := filepath.Join(cloneDir, filepath.FromSlash(spec.subPath))
+	// filepath.Join cleans ".." segments through the base — reject any
+	// subpath that escapes the clone, or a crafted //../../ URL would
+	// copy arbitrary host files into the render output.
+	if rel, relErr := filepath.Rel(cloneDir, src); relErr != nil ||
+		rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("subpath %q escapes the cloned repository", spec.subPath)
+	}
+	name := ".flate-remote-" + urlHash(urlStr)
+	dst := filepath.Join(dir, name)
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return "", err
+	}
+	if err := cache.copyTreeInto(src, dst); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+
+// gitRefNotFoundError is the typed sentinel for a definitive ref-
+// resolution failure — the git-path counterpart of httpStatusError,
+// classified via errors.As so it survives wrapping.
+type gitRefNotFoundError struct {
+	Ref  string
+	Repo string
+}
+
+func (e *gitRefNotFoundError) Error() string {
+	return fmt.Sprintf("ref %q not found as tag or branch in %s", e.Ref, e.Repo)
+}
+
+func isGitRefNotFound(err error) bool {
+	var rnf *gitRefNotFoundError
+	return errors.As(err, &rnf)
+}
+
+// refMissing reports whether a clone attempt failed because the named
+// ref doesn't exist, rather than a transport failure.
+func refMissing(err error) bool {
+	return errors.Is(err, plumbing.ErrReferenceNotFound) || errors.Is(err, git.NoMatchingRefSpecError{})
+}
+
+// cloneAtRef does a depth-1 clone of repoURL at ref, applying
+// gitCloneTimeout itself (like httpGetURL). Tries tag before branch
+// since semver refs are almost always tags; commit SHAs are not
+// resolvable this way and surface as gitRefNotFoundError. Removes the
+// dir on failure so a retry starts clean.
+func cloneAtRef(ctx context.Context, repoURL, ref, dir string) error {
+	cloneCtx, cancel := context.WithTimeout(ctx, gitCloneTimeout)
+	defer cancel()
+	if ref == "" {
+		_, err := git.PlainCloneContext(cloneCtx, dir, false, &git.CloneOptions{
+			URL:   repoURL,
+			Depth: 1,
+			Tags:  git.NoTags,
+		})
+		return err
+	}
+	tagErr := tryClone(cloneCtx, dir, repoURL, plumbing.NewTagReferenceName(ref))
+	if tagErr == nil {
+		return nil
+	}
+	_ = os.RemoveAll(dir)
+	if !refMissing(tagErr) {
+		// Transport failure or timeout — a branch attempt against the
+		// same server would fail the same way.
+		return fmt.Errorf("clone %s at ref %q: %w", repoURL, ref, tagErr)
+	}
+	branchErr := tryClone(cloneCtx, dir, repoURL, plumbing.NewBranchReferenceName(ref))
+	if branchErr == nil {
+		return nil
+	}
+	_ = os.RemoveAll(dir)
+	if refMissing(branchErr) {
+		return &gitRefNotFoundError{Ref: ref, Repo: repoURL}
+	}
+	return fmt.Errorf("clone %s at ref %q: %w", repoURL, ref, branchErr)
+}
+
+// rejectEscapingSymlinks errors on any symlink in a fresh clone that
+// resolves outside it. copyTreeInto dereferences symlinks, so a repo
+// carrying `link -> ../../home/user/.ssh` would otherwise copy host
+// files into the render output. Absolute targets arrive dangling
+// (go-git re-roots them at checkout) and are skipped, as are in-clone
+// symlinks, which shared-base layouts legitimately use.
+func rejectEscapingSymlinks(root string) error {
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() && path != root && SkipStageDir(d.Name()) {
+			return fs.SkipDir
+		}
+		if d.Type()&fs.ModeSymlink == 0 {
+			return nil
+		}
+		target, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return nil // dangling
+		}
+		rel, err := filepath.Rel(resolved, target)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+			name, _ := filepath.Rel(root, path)
+			return fmt.Errorf("symlink %s escapes the cloned repository", name)
+		}
+		return nil
+	})
+}
+
+func tryClone(ctx context.Context, dir, repoURL string, ref plumbing.ReferenceName) error {
+	_, err := git.PlainCloneContext(ctx, dir, false, &git.CloneOptions{
+		URL:           repoURL,
+		Depth:         1,
+		SingleBranch:  true,
+		ReferenceName: ref,
+		Tags:          git.NoTags,
+	})
+	return err
+}

--- a/pkg/kustomize/gitfetch_test.go
+++ b/pkg/kustomize/gitfetch_test.go
@@ -1,0 +1,430 @@
+package kustomize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func makeTestRepo(t *testing.T, files map[string]string, tag string) string {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		fpath := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(fpath), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(fpath, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := wt.Add(name); err != nil {
+			t.Fatalf("git add %s: %v", name, err)
+		}
+	}
+	hash, err := wt.Commit("init", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test", When: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if tag != "" {
+		if _, err := repo.CreateTag(tag, hash, nil); err != nil {
+			t.Fatalf("git tag %s: %v", tag, err)
+		}
+	}
+	return dir
+}
+
+func addSymlink(t *testing.T, repoDir, name, target, tag string) {
+	t.Helper()
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		t.Fatalf("PlainOpen: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(repoDir, name)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wt.Add(name); err != nil {
+		t.Fatalf("git add %s: %v", name, err)
+	}
+	hash, err := wt.Commit("symlink", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test", When: time.Unix(0, 0)},
+	})
+	if err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := repo.CreateTag(tag, hash, nil); err != nil {
+		t.Fatalf("git tag %s: %v", tag, err)
+	}
+}
+
+func TestParseGitRemoteSpec(t *testing.T) {
+	cases := []struct {
+		url     string
+		wantGit bool
+		repo    string
+		subPath string
+		ref     string
+	}{
+		{
+			url:     "https://github.com/kubernetes-sigs/repo?ref=v0.2.2",
+			wantGit: true, repo: "https://github.com/kubernetes-sigs/repo",
+			subPath: ".", ref: "v0.2.2",
+		},
+		{
+			url:     "https://gitlab.com/org/repo?ref=main",
+			wantGit: true, repo: "https://gitlab.com/org/repo",
+			subPath: ".", ref: "main",
+		},
+		{
+			url:     "https://bitbucket.org/org/repo?ref=v1.0",
+			wantGit: true, repo: "https://bitbucket.org/org/repo",
+			subPath: ".", ref: "v1.0",
+		},
+		{
+			url:     "https://github.com/org/repo//config/default?ref=main",
+			wantGit: true, repo: "https://github.com/org/repo",
+			subPath: "config/default", ref: "main",
+		},
+		{
+			url:     "https://gitea.internal/org/repo?ref=v1.0",
+			wantGit: true, repo: "https://gitea.internal/org/repo",
+			subPath: ".", ref: "v1.0",
+		},
+		{
+			url:     "https://gitea.internal/org/repo//subdir",
+			wantGit: true, repo: "https://gitea.internal/org/repo",
+			subPath: "subdir", ref: "",
+		},
+		{
+			url:     "https://gitea.internal/org/repo.git",
+			wantGit: true, repo: "https://gitea.internal/org/repo.git",
+			subPath: ".", ref: "",
+		},
+		{
+			url:     "https://github.com/org/repo",
+			wantGit: true, repo: "https://github.com/org/repo",
+			subPath: ".", ref: "",
+		},
+		// Marker-less deeper paths are file downloads, even on git hosts.
+		{url: "https://github.com/org/repo/releases/download/v1.0/manifest.yaml", wantGit: false},
+		{url: "https://github.com/org", wantGit: false},
+		{url: "https://example.com/org/repo", wantGit: false},
+		{url: "https://raw.githubusercontent.com/org/repo/main/file.yaml", wantGit: false},
+		{url: "https://example.com/manifests.yaml", wantGit: false},
+		{url: "./local.yaml", wantGit: false},
+		{url: "../shared/cm.yaml", wantGit: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			spec, ok := parseGitRemoteSpec(tc.url)
+			if ok != tc.wantGit {
+				t.Fatalf("parseGitRemoteSpec(%q) git=%v, want %v", tc.url, ok, tc.wantGit)
+			}
+			if !ok {
+				return
+			}
+			if spec.repoURL != tc.repo {
+				t.Errorf("repoURL: got %q, want %q", spec.repoURL, tc.repo)
+			}
+			if spec.subPath != tc.subPath {
+				t.Errorf("subPath: got %q, want %q", spec.subPath, tc.subPath)
+			}
+			if spec.ref != tc.ref {
+				t.Errorf("ref: got %q, want %q", spec.ref, tc.ref)
+			}
+		})
+	}
+}
+
+func TestCloneAtRef_Tag(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"app/cm.yaml": "apiVersion: v1\nkind: ConfigMap\n",
+	}, "v1.0")
+
+	dst := t.TempDir()
+	if err := cloneAtRef(context.Background(), src, "v1.0", dst); err != nil {
+		t.Fatalf("cloneAtRef: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "app/cm.yaml")); err != nil {
+		t.Errorf("expected app/cm.yaml in clone: %v", err)
+	}
+}
+
+func TestCloneAtRef_Branch(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"deploy.yaml": "kind: Deployment\n",
+	}, "")
+
+	dst := t.TempDir()
+	// go-git PlainInit defaults to "master"; clone by that branch name.
+	if err := cloneAtRef(context.Background(), src, "master", dst); err != nil {
+		t.Fatalf("cloneAtRef: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "deploy.yaml")); err != nil {
+		t.Errorf("expected deploy.yaml in clone: %v", err)
+	}
+}
+
+func TestCloneAtRef_RefNotFound(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "v1.0")
+
+	dst := filepath.Join(t.TempDir(), "clone")
+	err := cloneAtRef(context.Background(), src, "does-not-exist", dst)
+	if err == nil {
+		t.Fatal("expected error for missing ref, got nil")
+	}
+	if !isGitRefNotFound(err) {
+		t.Errorf("expected gitRefNotFoundError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "not found as tag or branch") {
+		t.Errorf("error should name the failure mode; got %q", err)
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("partial clone dir left behind after failure")
+	}
+}
+
+func TestFetchGitResource_Root(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml":  "apiVersion: v1\nkind: ConfigMap\n",
+		"svc.yaml": "apiVersion: v1\nkind: Service\n",
+	}, "v2.0")
+
+	cache := newPreflightCache(t)
+	dir := t.TempDir()
+
+	spec := gitRemoteSpec{repoURL: src, subPath: ".", ref: "v2.0"}
+	name, err := fetchGitResource(context.Background(), cache, dir, src+"?ref=v2.0", spec)
+	if err != nil {
+		t.Fatalf("fetchGitResource: %v", err)
+	}
+
+	for _, f := range []string{"cm.yaml", "svc.yaml"} {
+		if _, err := os.Stat(filepath.Join(dir, name, f)); err != nil {
+			t.Errorf("expected %s in fetched dir: %v", f, err)
+		}
+	}
+	// SkipStageDir excludes dot-dirs, so .git must not be copied.
+	if _, err := os.Stat(filepath.Join(dir, name, ".git")); err == nil {
+		t.Error(".git directory should not be present in fetched output")
+	}
+}
+
+func TestFetchGitResource_SubPath(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"app/cm.yaml":    "apiVersion: v1\nkind: ConfigMap\n",
+		"other/svc.yaml": "apiVersion: v1\nkind: Service\n",
+	}, "v1.0")
+
+	cache := newPreflightCache(t)
+	dir := t.TempDir()
+
+	spec := gitRemoteSpec{repoURL: src, subPath: "app", ref: "v1.0"}
+	name, err := fetchGitResource(context.Background(), cache, dir, src+"//app?ref=v1.0", spec)
+	if err != nil {
+		t.Fatalf("fetchGitResource: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, name, "cm.yaml")); err != nil {
+		t.Errorf("expected cm.yaml in app subpath: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, name, "other")); err == nil {
+		t.Error("other/ should not be present when subPath=app")
+	}
+}
+
+func TestFetchGitResource_RejectsTraversal(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "v1.0")
+
+	cache := newPreflightCache(t)
+	dir := t.TempDir()
+
+	for _, sub := range []string{"..", "../..", "../../../etc", "app/../.."} {
+		spec := gitRemoteSpec{repoURL: src, subPath: sub, ref: "v1.0"}
+		_, err := fetchGitResource(context.Background(), cache, dir, src+"//"+sub+"?ref=v1.0", spec)
+		if err == nil {
+			t.Errorf("subPath %q: expected escape error, got nil", sub)
+			continue
+		}
+		if !strings.Contains(err.Error(), "escapes the cloned repository") {
+			t.Errorf("subPath %q: expected escape error, got %q", sub, err)
+		}
+	}
+}
+
+// Destroying the source repo after the first fetch proves the second
+// fetch is served from the cached clone.
+func TestFetchGitResource_ClonesOnce(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "v1.0")
+
+	cache := newPreflightCache(t)
+	spec := gitRemoteSpec{repoURL: src, subPath: ".", ref: "v1.0"}
+	urlStr := src + "?ref=v1.0"
+
+	dir1, dir2 := t.TempDir(), t.TempDir()
+	if _, err := fetchGitResource(context.Background(), cache, dir1, urlStr, spec); err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+
+	if err := os.RemoveAll(src); err != nil {
+		t.Fatal(err)
+	}
+	name, err := fetchGitResource(context.Background(), cache, dir2, urlStr, spec)
+	if err != nil {
+		t.Fatalf("second fetch should reuse the cached clone: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir2, name, "cm.yaml")); err != nil {
+		t.Errorf("second copy missing cm.yaml: %v", err)
+	}
+}
+
+// Ref-not-found is definitive and stays cached: after destroying the
+// source repo, a retry must return the cached error rather than a
+// repository-missing transport error.
+func TestFetchGitBase_NegativeCachesRefNotFound(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "v1.0")
+
+	cache := newPreflightCache(t)
+	spec := gitRemoteSpec{repoURL: src, subPath: ".", ref: "nope"}
+
+	_, err := cache.fetchGitBase(context.Background(), spec)
+	if !isGitRefNotFound(err) {
+		t.Fatalf("expected gitRefNotFoundError, got %v", err)
+	}
+
+	if err := os.RemoveAll(src); err != nil {
+		t.Fatal(err)
+	}
+	_, err2 := cache.fetchGitBase(context.Background(), spec)
+	if !isGitRefNotFound(err2) {
+		t.Errorf("negative cache miss: second call re-cloned (got %v)", err2)
+	}
+}
+
+func TestFetchGitBase_EvictsTransientFailure(t *testing.T) {
+	cache := newPreflightCache(t)
+	spec := gitRemoteSpec{repoURL: filepath.Join(t.TempDir(), "no-such-repo"), subPath: ".", ref: "v1.0"}
+
+	_, err := cache.fetchGitBase(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected error cloning a nonexistent repo")
+	}
+	if isGitRefNotFound(err) {
+		t.Fatalf("transport failure misclassified as ref-not-found: %v", err)
+	}
+	if _, loaded := cache.gitClones.Load(spec.cloneKey()); loaded {
+		t.Error("transient failure left a cached entry; next caller would inherit it")
+	}
+}
+
+// A relative ../ symlink escaping the clone must fail the fetch.
+// Absolute targets aren't tested: go-git re-roots them at checkout,
+// so they arrive dangling.
+func TestFetchGitBase_RejectsEscapingSymlink(t *testing.T) {
+	secret := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(secret, []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "")
+
+	cacheRoot := t.TempDir()
+	cache, err := NewStagingCache(cacheRoot, 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+
+	// The clone lands at <cacheRoot>/flate-stage-git-*, one level deep;
+	// "clone-level" stands in for that dir to get the ../ count right.
+	relTarget, err := filepath.Rel(filepath.Join(cacheRoot, "clone-level"), secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addSymlink(t, src, "esc", relTarget, "v1.0")
+
+	_, err = cache.fetchGitBase(context.Background(), gitRemoteSpec{repoURL: src, subPath: ".", ref: "v1.0"})
+	if err == nil {
+		t.Fatal("expected escaping-symlink error, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes the cloned repository") {
+		t.Errorf("expected escape error, got %q", err)
+	}
+}
+
+func TestFetchGitBase_AllowsInternalSymlink(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "")
+	addSymlink(t, src, "alias.yaml", "cm.yaml", "v1.0")
+
+	cache := newPreflightCache(t)
+	dir, err := cache.fetchGitBase(context.Background(), gitRemoteSpec{repoURL: src, subPath: ".", ref: "v1.0"})
+	if err != nil {
+		t.Fatalf("internal symlink should be allowed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "alias.yaml")); err != nil {
+		t.Errorf("alias.yaml missing from clone: %v", err)
+	}
+}
+
+func TestStagingCacheClose_RemovesGitClones(t *testing.T) {
+	src := makeTestRepo(t, map[string]string{
+		"cm.yaml": "kind: ConfigMap\n",
+	}, "v1.0")
+
+	root := t.TempDir()
+	cache, err := NewStagingCache(root, 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+
+	spec := gitRemoteSpec{repoURL: src, subPath: ".", ref: "v1.0"}
+	cloneDir, err := cache.fetchGitBase(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("fetchGitBase: %v", err)
+	}
+	if _, err := os.Stat(cloneDir); err != nil {
+		t.Fatalf("clone dir missing before Close: %v", err)
+	}
+
+	if err := cache.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(cloneDir); err == nil {
+		t.Error("clone dir survived Close")
+	}
+	matches, _ := filepath.Glob(filepath.Join(root, "flate-stage-git-*"))
+	if len(matches) != 0 {
+		t.Errorf("clone dirs left under cache root after Close: %v", matches)
+	}
+}

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -116,14 +116,24 @@ func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string
 		if entry.Kind != yaml.ScalarNode {
 			continue
 		}
-		if !isHTTPURL(entry.Value) {
+		var (
+			localRef string
+			fetchErr error
+		)
+		if spec, ok := parseGitRemoteSpec(entry.Value); ok {
+			localRef, fetchErr = fetchGitResource(ctx, cache, dir, entry.Value, spec)
+			if fetchErr != nil {
+				return fmt.Errorf("remote git base %s: %w", entry.Value, fetchErr)
+			}
+		} else if isHTTPURL(entry.Value) {
+			localRef, fetchErr = fetchRemoteResource(ctx, cache, dir, entry.Value)
+			if fetchErr != nil {
+				return fmt.Errorf("remote resource %s: %w", entry.Value, fetchErr)
+			}
+		} else {
 			continue
 		}
-		localFile, fetchErr := fetchRemoteResource(ctx, cache, dir, entry.Value)
-		if fetchErr != nil {
-			return fmt.Errorf("remote resource %s: %w", entry.Value, fetchErr)
-		}
-		entry.Value = "./" + localFile
+		entry.Value = "./" + localRef
 		entry.Tag = "!!str"
 		entry.Style = 0 // plain scalar; preserve other entries' styles
 		changed = true

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -84,6 +84,9 @@ type StagingCache struct {
 	// re-fetches the same URL and re-emits the same WARN line.
 	remoteFetches sync.Map // url string -> *remoteFetch
 
+	// gitClones dedupes git remote base clones across preflight passes.
+	gitClones sync.Map // cloneKey string -> *gitClone
+
 	// sizes memoizes each completed stage's byte size by directory path
 	// for the LRU sweep, which needs the per-stage size to enforce the
 	// cap. A completed stage is content-addressed and effectively
@@ -388,6 +391,17 @@ func (c *StagingCache) Close() error {
 		}
 		delete(c.stages, key)
 	}
+	// Wait for in-flight clones the same way the stage loop above
+	// blocks on s.once() — the clone goroutine is bounded by
+	// gitCloneTimeout, so this can't hang.
+	c.gitClones.Range(func(_, v any) bool {
+		gc := v.(*gitClone)
+		<-gc.done
+		if gc.err == nil && gc.dir != "" {
+			errs = append(errs, os.RemoveAll(gc.dir))
+		}
+		return true
+	})
 	return errors.Join(errs...)
 }
 


### PR DESCRIPTION
## Summary

- Kustomize remote base URLs like `https://github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2` were being HTTP GET'd by flate's preflight pass, which received GitHub's HTML page, wrote it as `.flate-remote-*.yaml`, and caused `MalformedYAMLError: yaml: line 35: mapping values are not allowed in this context`
- These URLs are **kustomize remote bases** — kustomize resolves them via `git clone`, not HTTP GET
- Fix: preflight now clones git remote bases via `go-git` (no `git` subprocess) and rewrites the entry to the local `.flate-remote-*/` directory, same as it already does for plain HTTP file URLs

## Classification logic (`parseGitRemoteSpec`)

A URL is treated as a git remote base when:
- the host is a known git domain (`github.com`, `gitlab.com`, `bitbucket.org`)
- **or** the URL carries kustomize's structural markers (`?ref=` query param or `//` subpath separator) — covers self-hosted GitLab/Gitea instances too

Everything else remains an HTTP file fetch.

## Implementation

- `gitfetch.go` — `parseGitRemoteSpec`, `FetchGitBase` (deduped per run via `StagingCache`, mirrors the existing `remoteFetch` pattern), `fetchGitResource` (clone + copy subpath), `cloneAtRef` (tries tag then branch for semver-style refs)
- `stage.go` — `gitClones sync.Map` field + cleanup in `Close()`
- `preflight.go` — `rewriteURLResources` now calls git path first, falls through to HTTP; `isHTTPURL` restored to simple form

## Test plan

- [ ] `TestParseGitRemoteSpec` — classification matrix: known hosts, `?ref=`, `//` subpath, plain HTTP, local paths
- [ ] `TestCloneAtRef_Tag` / `TestCloneAtRef_Branch` — tag and branch resolution against a local repo
- [ ] `TestFetchGitResource_Root` / `TestFetchGitResource_SubPath` — full clone + copy pipeline; `.git/` excluded from output
- [ ] `TestFetchGitResource_ClonesOnce` — dedup: same `(repoURL, ref)` shares one clone
- [ ] All existing preflight and kustomize tests pass