### PR TITLE
refactor(manifest): single-source the cross-package KS/substitute invariants

### DIFF
--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -812,11 +812,11 @@ func transitiveDepsOf(obj manifest.BaseManifest) []manifest.NamedResource {
 			})
 		}
 		for _, ref := range o.PostBuildSubstituteFrom {
-			// Mirrors collectDeps in pkg/controllers/kustomization:
-			// Optional refs are best-effort; Secrets are SOPS/ExternalSecret-
-			// managed and can't be materialized offline; empty Name is
-			// malformed. See #418.
-			if ref.Optional || ref.Kind != manifest.KindConfigMap || ref.Name == "" {
+			// Shared with collectDeps in pkg/controllers/kustomization via
+			// manifest.IsHardConfigMapEdge — keep-set membership and reconcile
+			// ordering MUST agree on which substituteFrom refs are hard edges
+			// (see the predicate's doc + #418).
+			if !manifest.IsHardConfigMapEdge(ref) {
 				continue
 			}
 			out = append(out, manifest.NamedResource{

--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -1,9 +1,6 @@
 package change
 
 import (
-	"path"
-	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -46,52 +43,23 @@ type ownershipIndex struct {
 // here. nil cache falls back to a per-call local map; behavior is
 // identical, just without cross-call sharing.
 func buildOwnership(objs ObjectLister, repoRoot string, cache *manifest.ComponentCache) ownershipIndex {
-	ksList := objs.ListObjects(manifest.KindKustomization)
-	// Each KS contributes at least one claim (its own spec.path) plus a
-	// variable number of component paths. Pre-allocate for the base case
-	// to avoid repeated backing-array copies during the append loop.
-	claims := make([]ksClaim, 0, len(ksList))
-	add := func(id manifest.NamedResource, base, ref string) {
-		if ref == "" || strings.Contains(ref, "://") || filepath.IsAbs(ref) {
-			return
-		}
-		resolved := path.Clean(path.Join(base, ref))
-		if resolved == "." || strings.HasPrefix(resolved, "..") {
-			return
-		}
-		claims = append(claims, ksClaim{id: id, path: resolved + "/"})
-	}
-	// Local cache backs the nil-shared-cache path so multi-KS calls
-	// that share a spec.path still dedup. When the caller supplies a
-	// shared cache, ComponentCache.Get already handles dedup.
-	localCache := make(map[string][]string)
-	for _, obj := range ksList {
-		ks, ok := obj.(*manifest.Kustomization)
-		if !ok || ks.Path == "" {
-			continue
-		}
-		id := ks.Named()
-		base := normalizeKSPath(ks.Path)
-		claims = append(claims, ksClaim{id: id, path: base + "/"})
-		for _, comp := range ks.Components {
-			add(id, base, comp)
-		}
-		var comps []string
-		if cache != nil {
-			comps = cache.Get(repoRoot, base)
-		} else {
-			var ok bool
-			comps, ok = localCache[base]
-			if !ok {
-				comps = manifest.ReadKustomizeComponents(repoRoot, base)
-				localCache[base] = comps
-			}
-		}
-		for _, comp := range comps {
-			add(id, base, comp)
+	objList := objs.ListObjects(manifest.KindKustomization)
+	kss := make([]*manifest.Kustomization, 0, len(objList))
+	for _, obj := range objList {
+		if ks, ok := obj.(*manifest.Kustomization); ok {
+			kss = append(kss, ks)
 		}
 	}
-	slices.SortStableFunc(claims, func(a, b ksClaim) int { return len(b.path) - len(a.path) })
+	// Construction is single-sourced in manifest.BuildKSClaims so it can't
+	// drift from loader's parent index (the two are documented must-agree
+	// invariants). This side keeps only the multi-owner ownersOf/ancestorsOf
+	// lookup semantics below. (BuildKSClaims gates on-disk component reads on
+	// repoRoot != "" — a no-op here since resolve always passes a real root.)
+	mclaims := manifest.BuildKSClaims(kss, repoRoot, cache)
+	claims := make([]ksClaim, len(mclaims))
+	for i, c := range mclaims {
+		claims[i] = ksClaim{id: c.ID, path: c.Prefix}
+	}
 	return ownershipIndex{
 		claims:         claims,
 		ownersCache:    make(map[string][]manifest.NamedResource),
@@ -161,11 +129,4 @@ func (idx ownershipIndex) ancestorsOf(file string) []manifest.NamedResource {
 	}
 	idx.ancestorsCache[file] = ancestors
 	return ancestors
-}
-
-// normalizeKSPath strips the conventional `./` prefix and any trailing
-// slash so KS paths can be compared as plain string prefixes.
-func normalizeKSPath(p string) string {
-	p = strings.TrimPrefix(p, "./")
-	return strings.TrimSuffix(p, "/")
 }

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -322,16 +322,11 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 		deps = append(deps, manifest.DependencyRef{NamedResource: parent})
 	}
 	for _, ref := range ks.PostBuildSubstituteFrom {
-		if ref.Optional {
-			// Optional refs are best-effort — their absence shouldn't
-			// gate reconcile. Matches Flux's own substituteFrom
-			// semantics for Optional=true.
-			continue
-		}
-		if ref.Kind != manifest.KindConfigMap {
-			continue
-		}
-		if ref.Name == "" {
+		// Shared with change.transitiveDepsOf via manifest.IsHardConfigMapEdge:
+		// only a non-Optional, named ConfigMap is a hard offline edge (Optional
+		// is best-effort, Secrets are SOPS/ExternalSecret-managed). Keep-set and
+		// reconcile ordering MUST agree on this — see the predicate's doc + #418.
+		if !manifest.IsHardConfigMapEdge(ref) {
 			continue
 		}
 		depID := manifest.NamedResource{Kind: ref.Kind, Namespace: ks.Namespace, Name: ref.Name}

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -1,10 +1,7 @@
 package loader
 
 import (
-	"cmp"
-	"path"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -68,53 +65,16 @@ type KSPathPrefix struct {
 // cache so a single call doesn't re-read the same kustomization.yaml
 // across KSes that share a spec.path.
 func KSPathPrefixesWithCache(s *store.Store, repoRoot string, cache *manifest.ComponentCache) []KSPathPrefix {
-	var out []KSPathPrefix
-	// Local cache backs the nil-shared-cache path so multi-KS calls
-	// that share a spec.path still dedup. When the caller supplies a
-	// shared cache, ComponentCache.Get already handles dedup and the
-	// local map is unused.
-	localCache := make(map[string][]string)
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
-		if ks.Path == "" {
-			continue
-		}
-		id := ks.Named()
-		base := NormalizePrefix(ks.Path)
-		out = append(out, KSPathPrefix{ID: id, Prefix: base})
-		addComponent := func(ref string) {
-			if ref == "" || strings.Contains(ref, "://") || filepath.IsAbs(ref) {
-				return
-			}
-			resolved := path.Clean(path.Join(strings.TrimSuffix(base, "/"), ref))
-			if resolved == "." || strings.HasPrefix(resolved, "..") {
-				return
-			}
-			out = append(out, KSPathPrefix{ID: id, Prefix: resolved + "/"})
-		}
-		for _, comp := range ks.Components {
-			addComponent(comp)
-		}
-		if repoRoot != "" {
-			baseTrimmed := strings.TrimSuffix(base, "/")
-			var comps []string
-			if cache != nil {
-				comps = cache.Get(repoRoot, baseTrimmed)
-			} else {
-				var ok bool
-				comps, ok = localCache[baseTrimmed]
-				if !ok {
-					comps = manifest.ReadKustomizeComponents(repoRoot, baseTrimmed)
-					localCache[baseTrimmed] = comps
-				}
-			}
-			for _, comp := range comps {
-				addComponent(comp)
-			}
-		}
+	// Thin adapter over the canonical builder in pkg/manifest — the claim
+	// construction (spec.path + spec.components + on-disk components:, the
+	// reject/clean resolver, longest-first sort) is single-sourced there so
+	// it can't drift from change.buildOwnership. This side keeps only the
+	// KSPathPrefix shape and the LongestParent lookup semantics.
+	claims := manifest.BuildKSClaims(store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization), repoRoot, cache)
+	out := make([]KSPathPrefix, len(claims))
+	for i, c := range claims {
+		out[i] = KSPathPrefix{ID: c.ID, Prefix: c.Prefix}
 	}
-	slices.SortFunc(out, func(a, b KSPathPrefix) int {
-		return cmp.Compare(len(b.Prefix), len(a.Prefix))
-	})
 	return out
 }
 

--- a/pkg/manifest/bucket.go
+++ b/pkg/manifest/bucket.go
@@ -35,15 +35,9 @@ func (b *Bucket) Suspended() bool { return b.Suspend }
 // parseBucket decodes a Bucket CR via the source-controller typed
 // schema.
 func parseBucket(doc map[string]any) (*Bucket, error) {
-	if err := checkAPIVersion(doc, SourceDomain); err != nil {
-		return nil, err
-	}
 	var cr sourcev1.Bucket
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("Bucket decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("Bucket missing metadata.name")
+	if err := decodeCR(doc, &cr, "Bucket", SourceDomain); err != nil {
+		return nil, err
 	}
 	if cr.Spec.BucketName == "" {
 		return nil, inputf("Bucket %s/%s missing spec.bucketName", cr.Namespace, cr.Name)

--- a/pkg/manifest/helmchartsource.go
+++ b/pkg/manifest/helmchartsource.go
@@ -25,15 +25,9 @@ func (h *HelmChartSource) Named() NamedResource {
 // parseHelmChartSource decodes a standalone HelmChart CRD via the
 // source-controller typed schema.
 func parseHelmChartSource(doc map[string]any) (*HelmChartSource, error) {
-	if err := checkAPIVersion(doc, SourceDomain); err != nil {
-		return nil, err
-	}
 	var cr sourcev1.HelmChart
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("HelmChart decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("HelmChart missing metadata.name")
+	if err := decodeCR(doc, &cr, "HelmChart", SourceDomain); err != nil {
+		return nil, err
 	}
 	if cr.Spec.Chart == "" {
 		return nil, inputf("HelmChart missing spec.chart")

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -288,15 +288,9 @@ func (h *HelmRelease) ResolveChartRef(lookup HelmChartLookup) error {
 // typed schema (helm-controller/api/v2). The chart vs chartRef
 // normalization is preserved by chartFromHelmRelease.
 func parseHelmRelease(doc map[string]any) (*HelmRelease, error) {
-	if err := checkAPIVersion(doc, HelmReleaseDomain); err != nil {
-		return nil, err
-	}
 	var cr helmv2.HelmRelease
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("HelmRelease decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("HelmRelease missing metadata.name")
+	if err := decodeCR(doc, &cr, "HelmRelease", HelmReleaseDomain); err != nil {
+		return nil, err
 	}
 	// Resolve ${VAR:=default} / ${VAR:-default} on valuesFrom refs,
 	// mirroring the Kustomization spec.path / dependsOn precedent

--- a/pkg/manifest/helmrepository.go
+++ b/pkg/manifest/helmrepository.go
@@ -27,15 +27,9 @@ func (h *HelmRepository) RepoName() string { return h.Named().FluxResourceName()
 // parseHelmRepository decodes a HelmRepository CR via the
 // source-controller typed schema.
 func parseHelmRepository(doc map[string]any) (*HelmRepository, error) {
-	if err := checkAPIVersion(doc, SourceDomain); err != nil {
-		return nil, err
-	}
 	var cr sourcev1.HelmRepository
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("HelmRepository decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("HelmRepository missing metadata.name")
+	if err := decodeCR(doc, &cr, "HelmRepository", SourceDomain); err != nil {
+		return nil, err
 	}
 	if cr.Spec.URL == "" {
 		return nil, inputf("HelmRepository missing spec.url")

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -177,15 +177,9 @@ func (k *Kustomization) SetTargetNamespace(ns string) {
 // Contents because RenderFlux still feeds it to fluxcd/pkg/kustomize
 // as an unstructured.Unstructured.
 func parseKustomization(doc map[string]any) (*Kustomization, error) {
-	if err := checkAPIVersion(doc, FluxKustomizeDomain); err != nil {
-		return nil, err
-	}
 	var cr kustomizev1.Kustomization
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("Kustomization decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("Kustomization missing metadata.name")
+	if err := decodeCR(doc, &cr, "Kustomization", FluxKustomizeDomain); err != nil {
+		return nil, err
 	}
 	// Pre-resolve envsubst defaults so flate's path / dep resolution
 	// matches what real Flux's postBuild.substitute would produce.

--- a/pkg/manifest/kustomize_fs.go
+++ b/pkg/manifest/kustomize_fs.go
@@ -2,7 +2,10 @@ package manifest
 
 import (
 	"os"
+	"path"
 	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 
 	yaml "go.yaml.in/yaml/v4"
@@ -108,4 +111,71 @@ func (c *ComponentCache) Get(repoRoot, base string) []string {
 	c.cache[key] = v
 	c.mu.Unlock()
 	return v
+}
+
+// KSClaim pairs a Flux Kustomization id with one of its slash-terminated,
+// repo-relative claimed-path prefixes. A KS claims its spec.path plus one
+// prefix per spec.components entry and per on-disk `components:` entry; the
+// same ID across multiple prefixes is intentional (the deepest claim wins
+// in a longest-prefix lookup).
+type KSClaim struct {
+	ID     NamedResource
+	Prefix string
+}
+
+// BuildKSClaims constructs the canonical longest-prefix-first KS claim
+// index shared by loader's parent index (loader.KSPathPrefixesWithCache)
+// and change's ownership index (change.buildOwnership). Both previously
+// hand-rolled this identical construction — spec.path + spec.components +
+// on-disk `components:` (via ReadKustomizeComponents/ComponentCache), with
+// the same reject/clean resolver — guarded only by "must agree" comments,
+// and had drifted (ToSlash vs not; SortFunc vs SortStableFunc). This is the
+// one source of truth; callers map KSClaim onto their own claim type and
+// keep their divergent LOOKUP semantics (loader's single-strict-parent vs
+// change's multi-owner+ancestors).
+//
+// repoRoot is the filesystem root on-disk component reads resolve against;
+// "" skips them (spec.path + spec.components only) — preserving loader's
+// guard against cwd-relative reads. cache may be nil (Get falls through to
+// an uncached read). Output sorted by prefix length descending, stably.
+func BuildKSClaims(kss []*Kustomization, repoRoot string, cache *ComponentCache) []KSClaim {
+	claims := make([]KSClaim, 0, len(kss))
+	add := func(id NamedResource, base, ref string) {
+		if ref == "" || strings.Contains(ref, "://") || filepath.IsAbs(ref) {
+			return
+		}
+		resolved := path.Clean(path.Join(base, ref))
+		if resolved == "." || strings.HasPrefix(resolved, "..") {
+			return
+		}
+		claims = append(claims, KSClaim{ID: id, Prefix: resolved + "/"})
+	}
+	for _, ks := range kss {
+		if ks.Path == "" {
+			continue
+		}
+		id := ks.Named()
+		base := normalizeClaimBase(ks.Path)
+		claims = append(claims, KSClaim{ID: id, Prefix: base + "/"})
+		for _, comp := range ks.Components {
+			add(id, base, comp)
+		}
+		if repoRoot != "" {
+			for _, comp := range cache.Get(repoRoot, base) {
+				add(id, base, comp)
+			}
+		}
+	}
+	slices.SortStableFunc(claims, func(a, b KSClaim) int { return len(b.Prefix) - len(a.Prefix) })
+	return claims
+}
+
+// normalizeClaimBase turns a Kustomization spec.path into a clean,
+// slash-separated, repo-relative base with no trailing slash. ToSlash is
+// applied so Windows-style spec.path values (rare, but unconstrained by the
+// Flux CRD) normalize to the same shape as SourceFiles keys.
+func normalizeClaimBase(p string) string {
+	p = filepath.ToSlash(p)
+	p = strings.TrimPrefix(p, "./")
+	return strings.TrimSuffix(p, "/")
 }

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -3,9 +3,11 @@ package manifest
 import (
 	"encoding/json"
 	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// decodeTyped re-marshals a parsed YAML document into a typed Flux CR
+// decodeInto re-marshals a parsed YAML document into a typed Flux CR
 // via a JSON round-trip. The Flux API types use the same JSON tags
 // k8s uses to serialize their CRDs, so this matches `kubectl apply`'s
 // decoding fidelity without keeping the raw YAML bytes around.
@@ -13,12 +15,30 @@ import (
 // Per-document cost is ~one marshal + one unmarshal; documents are
 // small (a single CR) and this only runs during the load phase, not on
 // the render hot path.
-func decodeTyped[T any](doc map[string]any, out *T) error {
+func decodeInto(doc map[string]any, out any) error {
 	raw, err := json.Marshal(doc)
 	if err != nil {
 		return err
 	}
 	return json.Unmarshal(raw, out)
+}
+
+// decodeCR runs the shared typed-CR decode preamble: API-version
+// check, JSON round-trip into cr, and a non-empty metadata.name
+// check. cr must be a pointer to a Flux CR type (all embed
+// metav1.ObjectMeta, so GetName() is available). Centralizes the
+// identical opening previously hand-copied across the typed parsers.
+func decodeCR(doc map[string]any, cr metav1.Object, kind, domain string) error {
+	if err := checkAPIVersion(doc, domain); err != nil {
+		return err
+	}
+	if err := decodeInto(doc, cr); err != nil {
+		return inputf("%s decode: %w", kind, err)
+	}
+	if cr.GetName() == "" {
+		return inputf("%s missing metadata.name", kind)
+	}
+	return nil
 }
 
 // DocKind returns the "kind" field of a manifest document, or "" if absent.

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -43,15 +43,9 @@ func (r *ResourceSet) GetLabels() map[string]string { return r.Labels }
 // parseResourceSet decodes a ResourceSet CR via the flux-operator
 // typed schema (controlplane.io/v1).
 func parseResourceSet(doc map[string]any) (*ResourceSet, error) {
-	if err := checkAPIVersion(doc, FluxOperatorDomain); err != nil {
-		return nil, err
-	}
 	var cr fluxopv1.ResourceSet
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("ResourceSet decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("ResourceSet missing metadata.name")
+	if err := decodeCR(doc, &cr, "ResourceSet", FluxOperatorDomain); err != nil {
+		return nil, err
 	}
 	return &ResourceSet{
 		Name:            cr.Name,
@@ -91,15 +85,9 @@ func (p *ResourceSetInputProvider) GetLabels() map[string]string { return p.Labe
 
 // parseResourceSetInputProvider decodes a ResourceSetInputProvider CR.
 func parseResourceSetInputProvider(doc map[string]any) (*ResourceSetInputProvider, error) {
-	if err := checkAPIVersion(doc, FluxOperatorDomain); err != nil {
-		return nil, err
-	}
 	var cr fluxopv1.ResourceSetInputProvider
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("ResourceSetInputProvider decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("ResourceSetInputProvider missing metadata.name")
+	if err := decodeCR(doc, &cr, "ResourceSetInputProvider", FluxOperatorDomain); err != nil {
+		return nil, err
 	}
 	return &ResourceSetInputProvider{
 		Name:                         cr.Name,

--- a/pkg/manifest/source.go
+++ b/pkg/manifest/source.go
@@ -110,15 +110,9 @@ func validateOptionalRefs(kind, owner string, checks ...secretRefCheck) error {
 // schema (source-controller/api/v1), then projects the fields flate
 // uses into the local struct.
 func parseGitRepository(doc map[string]any) (*GitRepository, error) {
-	if err := checkAPIVersion(doc, SourceDomain); err != nil {
-		return nil, err
-	}
 	var cr sourcev1.GitRepository
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("GitRepository decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("GitRepository missing metadata.name")
+	if err := decodeCR(doc, &cr, "GitRepository", SourceDomain); err != nil {
+		return nil, err
 	}
 	if cr.Spec.URL == "" {
 		return nil, inputf("GitRepository missing spec.url")
@@ -213,15 +207,9 @@ func (o *OCIRepository) Version() string {
 
 // ParseOCIRepository decodes an OCIRepository CR.
 func ParseOCIRepository(doc map[string]any) (*OCIRepository, error) {
-	if err := checkAPIVersion(doc, SourceDomain); err != nil {
-		return nil, err
-	}
 	var cr sourcev1.OCIRepository
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("OCIRepository decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("OCIRepository missing metadata.name")
+	if err := decodeCR(doc, &cr, "OCIRepository", SourceDomain); err != nil {
+		return nil, err
 	}
 	if cr.Spec.URL == "" {
 		return nil, inputf("OCIRepository missing spec.url")
@@ -296,15 +284,9 @@ func (e *ExternalArtifact) Suspended() bool { return false }
 // parseExternalArtifact decodes an ExternalArtifact CR via the
 // source-controller typed schema.
 func parseExternalArtifact(doc map[string]any) (*ExternalArtifact, error) {
-	if err := checkAPIVersion(doc, SourceDomain); err != nil {
-		return nil, err
-	}
 	var cr sourcev1.ExternalArtifact
-	if err := decodeTyped(doc, &cr); err != nil {
-		return nil, inputf("ExternalArtifact decode: %w", err)
-	}
-	if cr.Name == "" {
-		return nil, inputf("ExternalArtifact missing metadata.name")
+	if err := decodeCR(doc, &cr, "ExternalArtifact", SourceDomain); err != nil {
+		return nil, err
 	}
 	out := &ExternalArtifact{
 		Name:                 cr.Name,

--- a/pkg/manifest/types.go
+++ b/pkg/manifest/types.go
@@ -22,6 +22,21 @@ type ValuesReference = meta.ValuesReference
 // the same three fields (Kind, Name, Optional) into a local twin.
 type SubstituteReference = kustomizev1.SubstituteReference
 
+// IsHardConfigMapEdge reports whether a substituteFrom ref forms a hard
+// dependency edge that must be resolvable offline: a non-Optional,
+// non-empty-Name ConfigMap. Optional refs are best-effort; Secrets are
+// SOPS/ExternalSecret-managed and can't be materialized offline; an
+// empty Name is malformed. The changed-only keep set (change.transitiveDepsOf)
+// and the reconcile dependency ordering (kustomization.collectDeps) MUST
+// agree on this predicate or changed-only mode keeps a CM the controller
+// never waits on (or vice-versa), yielding an undefined-${VAR} render that
+// only reproduces in changed-only mode. Single-sourced here so they can't
+// drift. See #418. (A free function, not a method: SubstituteReference is
+// an alias to an external type.)
+func IsHardConfigMapEdge(r SubstituteReference) bool {
+	return !r.Optional && r.Kind == KindConfigMap && r.Name != ""
+}
+
 // NamedResource uniquely identifies a Kubernetes resource by kind +
 // namespace + name. Values are comparable and safe to use as map keys.
 type NamedResource struct {


### PR DESCRIPTION
**PR A of 3** in the deep structural refactor (audit → ranked roadmap, grouped by domain). Collapses three cross-package "must-agree" invariants — single-sourced today only by hand-copied comments, and already drifting — into one home in `pkg/manifest`, with consumers rewired as thin adapters.

## Themes
- **#1 `manifest.IsHardConfigMapEdge`** — the substituteFrom hard-edge predicate (`!Optional && Kind==ConfigMap && Name!=""`) was written verbatim in `change.transitiveDepsOf` (filter.go) and `kustomization.collectDeps` (controller.go), with a "Mirrors collectDeps … #418" comment. Now one free function both call. (Free function, not a method — `SubstituteReference` is a type alias to an external type.)
- **#2 `manifest.BuildKSClaims`** (keystone) — `loader.KSPathPrefixesWithCache` and `change.buildOwnership` hand-rolled the *identical* longest-first KS claim index (spec.path + spec.components + on-disk `components:`, same reject/clean resolver), guarded only by "MUST agree" comments and **already drifted** (`ToSlash` vs not; `SortFunc` vs `SortStableFunc`). Single-sourced with one canonical normalize (`ToSlash` — the more-correct) and a stable sort. Both callers are now thin adapters keeping only their divergent **lookup** semantics (loader single-strict-parent vs change multi-owner+ancestors).
- **#5 `manifest.decodeCR`** — 10 typed parsers opened with the identical 4-statement preamble (`checkAPIVersion` / decode / empty-`metadata.name` check). Centralized into one helper, **preserving the `inputf`/`ErrInput` sentinel chain** (a generic `fmt.Errorf` version would have silently broken `errors.Is(err, ErrInput)` and every parse error string). Each parser keeps its bespoke spec validation.

## Verification
- Gate: gofmt ✓ · `go build`/`vet`/`test -race ./...` ✓ · `golangci-lint` **0 issues**.
- **Byte-equivalence vs `main`**: identical rendered output across **8 repos + buroa/k8s-gitops** in both `build all` and `build all --base HEAD~15` (the claim-index + git-materialization path — the most #2-sensitive). The 2 non-matching repos were proven pre-existing non-determinism: the unchanged `main` binary differs against *itself* there, and the deltas are Helm-generated TLS certs (`genSignedCert`) / secret checksums — same resource set, chart-level crypto randomness, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)