### PR TITLE
refactor(controllers): fuse dep-wait re-read, route adapters via GetByName[T], fix RS attribution

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -379,6 +379,51 @@ func (c *Controller) Await(
 	return nil
 }
 
+// AwaitRefresh fuses Await with the load-bearing store re-read every
+// dependency wait performs on success. A structural parent may have
+// re-emitted this object with a mutated spec while it was parked, so the
+// caller MUST reconcile against the refreshed object, not the stale
+// snapshot it was dispatched with (see #102 and the dependsOn re-read
+// comments at the call sites). Wait and re-read were two statements joined
+// only by convention; fusing them means a future await site can't call
+// Await and silently forget the re-read.
+//
+// On a wait failure it returns (zero, false, err) — the caller returns the
+// error. On success it returns (fresh, true, nil) when the object is still
+// in the store, or (zero, false, nil) if it vanished, mirroring the prior
+// `if obj, ok := store.Get[T](...); ok { x = obj }` guard (the caller keeps
+// the object it already held).
+func AwaitRefresh[T manifest.BaseManifest](
+	ctx context.Context,
+	c *Controller,
+	id manifest.NamedResource,
+	w *depwait.Waiter,
+	deps []manifest.DependencyRef,
+	pendingMsg string,
+	onFail func(depwait.Summary) error,
+) (T, bool, error) {
+	if err := c.Await(ctx, id, w, deps, pendingMsg, onFail); err != nil {
+		var zero T
+		return zero, false, err
+	}
+	obj, ok := store.Get[T](c.Store, id)
+	return obj, ok, nil
+}
+
+// DepFailed returns the canonical onFail closure that reports a
+// dependency-wait failure as a *manifest.DependencyFailedError for id.
+// The identical literal was rebuilt at every dependsOn/pre-render wait;
+// single-sourcing it keeps the failure shape consistent across controllers.
+func DepFailed(id manifest.NamedResource) func(depwait.Summary) error {
+	return func(sum depwait.Summary) error {
+		return &manifest.DependencyFailedError{
+			Parent:  id,
+			Failed:  sum.Failed,
+			Reasons: sum.Messages,
+		}
+	}
+}
+
 // Recover catches a panic from the current goroutine and marks id
 // StatusFailed with a "panic: <r>" message so the orchestrator
 // surfaces it. Intended for use as `defer base.Recover(store, id, "kind")`

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -260,27 +260,21 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// Honor spec.dependsOn — HR-to-HR ordering. Flux gates rendering on
 	// each dependency reaching Ready before this HR reconciles.
 	if deps := c.collectHRDeps(hr); len(deps) > 0 {
-		err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout), deps,
-			"resolving dependencies",
-			func(sum depwait.Summary) error {
-				return &manifest.DependencyFailedError{
-					Parent:  id,
-					Failed:  sum.Failed,
-					Reasons: sum.Messages,
-				}
-			})
+		// AwaitRefresh fuses the dependsOn wait with the load-bearing
+		// re-read: the parent KS may have re-rendered (e.g. its own
+		// dependsOn cleared in the meantime, freeing up parent-render-time
+		// substitutions that mutate our spec). Without that refresh, an HR
+		// with explicit spec.dependsOn but no structural parent — or one
+		// whose parent re-emitted us after the parent-gate cleared — keeps
+		// the pre-mutation snapshot through chart resolution.
+		fresh, ok, err := base.AwaitRefresh[*manifest.HelmRelease](
+			ctx, c.Controller, id, c.NewWaiter(id, hr.Timeout), deps,
+			"resolving dependencies", base.DepFailed(id))
 		if err != nil {
 			return err
 		}
-		// Re-read the HR after the dependsOn wait: the parent KS may
-		// have re-rendered (e.g. its own dependsOn cleared in the
-		// meantime, freeing up parent-render-time substitutions that
-		// mutate our spec). Without this refresh, an HR with explicit
-		// spec.dependsOn but no structural parent — or one whose
-		// parent re-emitted us after the parent-gate cleared — keeps
-		// the pre-mutation snapshot through chart resolution.
-		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
-			hr = obj
+		if ok {
+			hr = fresh
 		}
 	}
 	if err := c.PreflightError(id); err != nil {
@@ -310,9 +304,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			"awaiting pre-render references",
 			func(sum depwait.Summary) error {
 				preSum = sum
-				return &manifest.DependencyFailedError{
-					Parent: id, Failed: sum.Failed, Reasons: sum.Messages,
-				}
+				return base.DepFailed(id)(sum)
 			}); err != nil {
 			if c.allowMissingSecrets {
 				if next, ok := c.omitFailedValuesFrom(hr, preSum.Failed); ok {

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -167,25 +167,20 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 
 	deps := c.collectDeps(ks)
 	if len(deps) > 0 {
-		err := c.Await(ctx, id, c.NewWaiter(id, ks.Timeout), deps,
-			"", // status set above
-			func(sum depwait.Summary) error {
-				return &manifest.DependencyFailedError{
-					Parent:  id,
-					Failed:  sum.Failed,
-					Reasons: sum.Messages,
-				}
-			})
+		// AwaitRefresh fuses the wait with the load-bearing re-read: our
+		// structural parent may have re-emitted us with mutated spec (e.g.
+		// `replacements:` injecting spec.targetNamespace) while we were
+		// waiting. Without the refresh the first render would use the
+		// stale-spec snapshot captured by RunWithStatus, producing
+		// duplicate renders that linger in the store with the wrong
+		// namespace. See #102.
+		fresh, ok, err := base.AwaitRefresh[*manifest.Kustomization](
+			ctx, c.Controller, id, c.NewWaiter(id, ks.Timeout), deps,
+			"", base.DepFailed(id)) // status set above
 		if err != nil {
 			return err
 		}
-		// Refresh the KS — our structural parent may have re-emitted
-		// us with mutated spec (e.g. `replacements:` injecting
-		// spec.targetNamespace) while we were waiting. Without this
-		// re-read the first render would use the stale-spec snapshot
-		// captured by RunWithStatus, producing duplicate renders that
-		// linger in the store with the wrong namespace. See #102.
-		if fresh, ok := store.Get[*manifest.Kustomization](c.Store, id); ok {
+		if ok {
 			ks = fresh
 		}
 	}

--- a/pkg/helm/resolver.go
+++ b/pkg/helm/resolver.go
@@ -46,12 +46,12 @@ type storeResolver struct {
 }
 
 func (r *storeResolver) HelmRepository(namespace, name string) *manifest.HelmRepository {
-	obj, _ := r.store.GetByName(manifest.KindHelmRepository, namespace, name).(*manifest.HelmRepository)
+	obj, _ := store.GetByName[*manifest.HelmRepository](r.store, manifest.KindHelmRepository, namespace, name)
 	return obj
 }
 
 func (r *storeResolver) OCIRepository(namespace, name string) *manifest.OCIRepository {
-	obj, _ := r.store.GetByName(manifest.KindOCIRepository, namespace, name).(*manifest.OCIRepository)
+	obj, _ := store.GetByName[*manifest.OCIRepository](r.store, manifest.KindOCIRepository, namespace, name)
 	return obj
 }
 
@@ -62,6 +62,6 @@ func (r *storeResolver) LocalSourceArtifact(kind, namespace, name string) *store
 }
 
 func (r *storeResolver) HelmChart(namespace, name string) *manifest.HelmChartSource {
-	obj, _ := r.store.GetByName(manifest.KindHelmChart, namespace, name).(*manifest.HelmChartSource)
+	obj, _ := store.GetByName[*manifest.HelmChartSource](r.store, manifest.KindHelmChart, namespace, name)
 	return obj
 }

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -3,9 +3,6 @@ package orchestrator
 import (
 	"cmp"
 	"context"
-	"path/filepath"
-	"slices"
-	"strings"
 
 	"golang.org/x/sync/errgroup"
 
@@ -36,24 +33,16 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Owner index keyed by deepest spec.path prefix wins, mirroring
-	// loader.BuildParentIndex. The RS's source-file path lives below
-	// some KS's spec.path — that KS becomes its visibility parent.
-	type owner struct {
-		prefix string
-		id     manifest.NamedResource
-	}
-	ksList := store.ListAs[*manifest.Kustomization](o.store, manifest.KindKustomization)
-	owners := make([]owner, 0, len(ksList))
-	for _, ks := range ksList {
-		if ks.Path == "" {
-			continue
-		}
-		owners = append(owners, owner{prefix: loader.NormalizePrefix(ks.Path), id: ks.Named()})
-	}
-	slices.SortFunc(owners, func(a, b owner) int {
-		return cmp.Compare(len(b.prefix), len(a.prefix))
-	})
+	// Parent attribution: a RS's source-file path lives below some KS's
+	// claimed prefix — that KS is its visibility parent. Use the canonical
+	// claim index (spec.path + spec.components + on-disk components:, via
+	// the shared ComponentCache) and LongestParent — the SAME pair
+	// discovery's orphan promotion and the orchestrator's detectOrphans
+	// already use, so a RS inside a parent's component subtree attributes
+	// to the deeper component-owning KS instead of being dropped or pinned
+	// to a shallower one. (The previous inline index was a degraded third
+	// copy keyed on spec.path only.)
+	prefixes := loader.KSPathPrefixesWithCache(o.store, o.repoRoot, o.componentCache)
 
 	// A RS that arrived through file discovery has a sourceFile; a RS
 	// that arrived through KS-controller emission (kustomize bakes the
@@ -119,14 +108,12 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 				if file == "" {
 					return nil
 				}
-				slashFile := filepath.ToSlash(file)
-				idx := slices.IndexFunc(owners, func(w owner) bool {
-					return strings.HasPrefix(slashFile, w.prefix)
-				})
-				if idx < 0 {
+				// RS is never a KS, so LongestParent's self-exclusion is a no-op.
+				parent, ok := loader.LongestParent(prefixes, file, rs.Named())
+				if !ok {
 					return nil
 				}
-				parentKS = owners[idx].id
+				parentKS = parent
 			}
 			// Filter docs to RawObjects + collect dedup keys into this
 			// RS's own slot; the deterministic commit happens below.

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -180,9 +180,7 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource, quies
 				return info, ctx.Err()
 			}
 			if currentFailed != nil {
-				return *currentFailed, &manifest.ResourceFailedError{
-					Resource: id.String(), Reason: currentFailed.Message,
-				}
+				return failNow()
 			}
 			return StatusInfo{}, ctx.Err()
 		}
@@ -269,4 +267,3 @@ func (s *Store) subscribeWithStatus(fn Listener, id manifest.NamedResource) (Sta
 	s.rUnlockAll()
 	return info, ok, func() { set.remove(handle) }
 }
-

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // varsubRegex matches the upstream kustomize-controller var-name
@@ -60,25 +61,19 @@ func (p *SliceProvider) Secret(namespace, name string) *manifest.Secret {
 	return nil
 }
 
-// ObjectLister is the minimal Store surface needed for value lookups.
-// It is satisfied by *store.Store and by any test-only fake.
-type ObjectLister interface {
-	GetByName(kind, namespace, name string) manifest.BaseManifest
-}
+// NewStoreProvider returns a Provider backed by the central Store. It
+// replaces the per-controller storeProvider types.
+func NewStoreProvider(s *store.Store) Provider { return &storeProvider{s: s} }
 
-// NewStoreProvider returns a Provider backed by an ObjectLister (the
-// central Store). It replaces the per-controller storeProvider types.
-func NewStoreProvider(l ObjectLister) Provider { return &storeProvider{l: l} }
-
-type storeProvider struct{ l ObjectLister }
+type storeProvider struct{ s *store.Store }
 
 func (p *storeProvider) ConfigMap(namespace, name string) *manifest.ConfigMap {
-	c, _ := p.l.GetByName(manifest.KindConfigMap, namespace, name).(*manifest.ConfigMap)
+	c, _ := store.GetByName[*manifest.ConfigMap](p.s, manifest.KindConfigMap, namespace, name)
 	return c
 }
 
 func (p *storeProvider) Secret(namespace, name string) *manifest.Secret {
-	s, _ := p.l.GetByName(manifest.KindSecret, namespace, name).(*manifest.Secret)
+	s, _ := store.GetByName[*manifest.Secret](p.s, manifest.KindSecret, namespace, name)
 	return s
 }
 


### PR DESCRIPTION
**PR C of 3** in the deep structural refactor (stacks conceptually on PR A #620 — #9 reuses A's `BuildKSClaims`). Render-core control-flow + adapter cleanups, plus one latent-bug fix.

## Themes
- **#7 `base.AwaitRefresh` + `base.DepFailed`** — every dependency wait paired `c.Await` with a `store.Get[T]` re-read that is the **correctness-critical half** (a structural parent may re-emit a mutated spec while the object is parked — #102). Wait and re-read were two statements joined only by convention; `AwaitRefresh` fuses them so a future await site can't forget the re-read. `DepFailed(id)` single-sources the `DependencyFailedError` onFail literal. Migrated the KS + HR `dependsOn` sites; the HR parent-gate (different `ErrObjectNotFound` onFail) and the HR omit-loop structure stay intact (the latter adopts `DepFailed` for its error literal).
- **#8 route adapters through `store.GetByName[T]`** — replaced the hand-rolled `obj,_ := GetByName(...).(*T)` in `helm.storeResolver` and `values.storeProvider` with the generic helper written to kill exactly that shape; dropped the single-impl `values.ObjectLister` (callers already pass `*store.Store`), keeping the real `Provider`/`SliceProvider` seam; deduped the byte-identical `watch.go` `failNow` rebuild.
- **#9 RS-extension parent attribution** (BEHAVIOR-CHANGING, latent-bug fix) — `expandResourceSetsPostRun` hand-rolled a **degraded third copy** of the parent index keyed on `spec.path` ONLY. Routed it through the canonical `loader.KSPathPrefixesWithCache + LongestParent` (built on PR A's `BuildKSClaims`) — the same pair `discovery`/`detectOrphans` use — so a ResourceSet inside a parent's component subtree attributes to the deeper component-owning KS instead of being dropped/mis-pinned.

## Deferred from this group: #10 (valuesFrom-omission collapse)
On close reading, the consolidation isn't a clean behavior-preserving change:
- The audit's premise that the second `omitValuesFrom(hr,nil,true)` is "redundant" with the first **doesn't hold** — the first handles the `preDeps`-empty `break` path; the second handles the post-store-re-read path. They cover **different** code paths.
- `omitValuesFrom` (default-omit, gated) and `removeValuesRefs` (default-keep, id-set) have **opposite default dispositions** — the same obstacle that made me back out a related merge in the cleanliness sweep (#617).
Collapsing them on a flawed premise risks a subtle regression in a correctness-critical `--allow-missing-secrets` path for marginal payoff, so per the plan's own hedge ("do last and only if the test pins the behavior cleanly") it's deferred. Happy to pursue it as a focused, test-first effort if you want it.

## Verification
- Gate: gofmt ✓ · `go build`/`vet`/`test -race ./...` ✓ · `golangci-lint` **0 issues** (incl. the orchestrator RS-expansion golden + determinism tests).
- **Byte-equivalence vs `main`**: identical across buroa + 6 repos. #9's reattribution doesn't trigger in any of them (none have a ResourceSet inside a component subtree); the constructed case is covered by the orchestrator golden tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)