### PR TITLE
refactor(helmrelease): extract resolvePreRenderValuesFrom from reconcile

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -281,52 +281,9 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return err
 	}
 
-	if c.allowMissingSecrets {
-		hr = c.omitValuesFrom(hr, nil, true)
-	}
-
-	// Pre-Prepare existence waits: helm.Prepare reads from the live
-	// Store synchronously, returning ErrObjectNotFound for missing
-	// chartRef-HelmChart CRDs and non-optional valuesFrom refs. A
-	// legitimate load order — HR observed before the HelmChart CR
-	// it references, or before a sibling KS emits its valuesFrom CM —
-	// would hard-fail here without waiting. Collect the existence-
-	// only deps (no Ready semantics needed; they just have to be in
-	// the store before Prepare reads through them) and Await them.
-	omittedValuesRefs := map[manifest.NamedResource]struct{}{}
-	for {
-		preDeps := preparePrereqs(hr)
-		if len(preDeps) == 0 {
-			break
-		}
-		var preSum depwait.Summary
-		if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout), preDeps,
-			"awaiting pre-render references",
-			func(sum depwait.Summary) error {
-				preSum = sum
-				return base.DepFailed(id)(sum)
-			}); err != nil {
-			if c.allowMissingSecrets {
-				if next, ok := c.omitFailedValuesFrom(hr, preSum.Failed); ok {
-					for _, omitted := range omittedValuesRefIDs(hr, next) {
-						omittedValuesRefs[omitted] = struct{}{}
-					}
-					hr = next
-					continue
-				}
-			}
-			return err
-		}
-		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
-			hr = obj
-		}
-		if len(omittedValuesRefs) > 0 {
-			hr = removeValuesRefs(hr, omittedValuesRefs)
-		}
-		if c.allowMissingSecrets {
-			hr = c.omitValuesFrom(hr, nil, true)
-		}
-		break
+	hr, err := c.resolvePreRenderValuesFrom(ctx, id, hr)
+	if err != nil {
+		return err
 	}
 	if err := c.PreflightError(id); err != nil {
 		return err
@@ -337,7 +294,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// the same pre-render dance an embedder calling TemplateDocs
 	// directly performs. Keeping one canonical implementation here
 	// means changes to the contract only land in one place.
-	hr, err := helm.Prepare(hr, c.Helm.Resolver().HelmChart, values.NewStoreProvider(c.Store), c.Helm.ValuesCache())
+	hr, err = helm.Prepare(hr, c.Helm.Resolver().HelmChart, values.NewStoreProvider(c.Store), c.Helm.ValuesCache())
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -7,10 +7,75 @@ package helmrelease
 // mirroring the kustomization package's dispatch.go / substitute.go split.
 
 import (
+	"context"
 	"log/slog"
 
+	"github.com/home-operations/flate/pkg/controllers/base"
+	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
+
+// resolvePreRenderValuesFrom reduces hr's valuesFrom to the set helm.Prepare
+// can resolve offline, isolating the one non-linear stretch of reconcile (a
+// retry loop + a load-bearing store re-read) so reconcile itself reads as a
+// linear gate/resolve/render sequence.
+//
+// Two phases. (1) When allowMissingSecrets, proactively omit refs whose
+// producer can't materialize offline so they don't become pre-render waits.
+// (2) Wait for the remaining pre-render references — helm.Prepare reads the
+// live Store synchronously and hard-fails on a missing chartRef HelmChart or
+// non-optional valuesFrom CM/Secret, so a legitimate load order (HR observed
+// before its HelmChart CR, or before a sibling KS emits its valuesFrom CM)
+// must wait rather than fail. On a wait failure under allowMissingSecrets the
+// failed refs are dropped and the wait retried; otherwise the reconcile fails.
+//
+// On success the canonical HR is re-read from the store (a structural parent
+// may have re-emitted it with the full valuesFrom list while we waited), then
+// the accumulated failed-ref drops and the proactive omission are re-applied —
+// the re-applied proactive pass re-evaluates against the now-current store, so
+// a ref that materialized during the wait is correctly kept.
+func (c *Controller) resolvePreRenderValuesFrom(ctx context.Context, id manifest.NamedResource, hr *manifest.HelmRelease) (*manifest.HelmRelease, error) {
+	if c.allowMissingSecrets {
+		hr = c.omitValuesFrom(hr, nil, true)
+	}
+	omittedValuesRefs := map[manifest.NamedResource]struct{}{}
+	for {
+		preDeps := preparePrereqs(hr)
+		if len(preDeps) == 0 {
+			break
+		}
+		var preSum depwait.Summary
+		if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout), preDeps,
+			"awaiting pre-render references",
+			func(sum depwait.Summary) error {
+				preSum = sum
+				return base.DepFailed(id)(sum)
+			}); err != nil {
+			if c.allowMissingSecrets {
+				if next, ok := c.omitFailedValuesFrom(hr, preSum.Failed); ok {
+					for _, omitted := range omittedValuesRefIDs(hr, next) {
+						omittedValuesRefs[omitted] = struct{}{}
+					}
+					hr = next
+					continue
+				}
+			}
+			return nil, err
+		}
+		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
+			hr = obj
+		}
+		if len(omittedValuesRefs) > 0 {
+			hr = removeValuesRefs(hr, omittedValuesRefs)
+		}
+		if c.allowMissingSecrets {
+			hr = c.omitValuesFrom(hr, nil, true)
+		}
+		break
+	}
+	return hr, nil
+}
 
 func (c *Controller) omitFailedValuesFrom(hr *manifest.HelmRelease, failed []manifest.NamedResource) (*manifest.HelmRelease, bool) {
 	failedSet := make(map[manifest.NamedResource]struct{}, len(failed))


### PR DESCRIPTION
The final roadmap item (#10). `reconcile` is the largest function in the repo — a deep-audit complexity hotspot. Its one genuinely non-linear stretch is lifted **verbatim** into a named, documented method.

## Change
`resolvePreRenderValuesFrom(ctx, id, hr)` now owns: the proactive valuesFrom omit, the pre-render existence-wait retry loop, the load-bearing store re-read that resurrects the canonical HR, and the re-applied omissions. `reconcile` becomes a linear `gate → resolve → render` sequence, and the omit machinery is independently comprehensible (and now unit-testable in isolation).

## Verification
- **Pure code motion** — byte-identical rendered output across 7 repos (`build all --allow-missing-secrets`). The existing `TestController_AllowMissingSecretsOmitsUnavailableValuesFrom` exercises the moved loop end-to-end (its `present-values`/`app-values`/`runtime-values` refs hit the kept / proactive-omit / failed-accumulate-then-resurrect paths). Gate: gofmt/build/vet/test -race + golangci-lint **0 issues**.

## What I did NOT do (and why)
The original roadmap also proposed collapsing the three omit primitives (`omitValuesFrom` / `omitFailedValuesFrom` / `removeValuesRefs`) into one id-set model. **On inspection that consolidation is unsound:**
- The proactive omit runs **twice by design** — once before the loop (so `preparePrereqs` doesn't wait on producer-backed refs) and once **after the store re-read** — and the second pass **re-evaluates against the now-current store**, so a ref that materialized during the wait is correctly kept. Freezing the first pass into an id-set would drop it.
- The three primitives have **opposite default dispositions** (omit-unless-available vs keep-unless-listed) — the same obstacle that made me back out a related merge in the cleanliness sweep (#617).

So I shipped the behavior-preserving extraction (the real clarity win — it tames the repo's biggest function) and left the omit primitives intact. The audit's "redundant second pass" premise didn't survive close reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)