### PR TITLE
fix(kustomize): resolve git-repository references in kustomize resources

### DIFF
--- a/pkg/kustomize/gitbase.go
+++ b/pkg/kustomize/gitbase.go
@@ -1,0 +1,229 @@
+package kustomize
+
+// gitbase.go classifies and resolves remote GIT bases referenced from a
+// kustomization's resources:. kustomize itself resolves such a URL by trying
+// an HTTP file fetch first and, on failure, git-cloning it; flate's preflight
+// pre-resolves both so `kustomize build` only ever sees local files. The HTTP
+// half lives in preflight.go; this file owns the git half: recognize a git
+// base, fetch it via the injected GitBaseFetcher (which wraps the existing
+// pkg/source/git machinery), copy the worktree into the staged tree, and hand
+// back a local directory path for the resources: entry.
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// gitBaseSpec is a resources: entry classified as a remote git base,
+// decomposed into the parts FetchRemoteBase + the rewrite need.
+type gitBaseSpec struct {
+	repoURL string // clone URL: scheme + host + repoPath (no ?query, no //subPath)
+	subPath string // kustomization root within the repo ("" = repo root)
+	ref     string // ?ref= / ?version= value ("" = the repo's default branch)
+}
+
+// git URL markers, mirroring sigs.k8s.io/kustomize/api/internal/git/repospec.go
+// (tryExplicitMarkerSplit + ignoreForcedGitProtocol).
+const (
+	gitForcedProtocol = "git::" // legacy go-getter prefix; stripped, marks a git base
+	gitRootDelimiter  = "_git/" // Azure DevOps: repo root is the segment after _git/
+	gitSubPathSep     = "//"    // double-slash separates repo root from kust subpath
+	gitSuffix         = ".git"  // .git is part of the repo dir name
+)
+
+// isGitRemoteBase reports whether a resources: entry is a remote git base (vs
+// a plain HTTP file, an OCI ref, or a local path) and decomposes it into
+// (repoURL, subPath, ref).
+//
+// It mirrors kustomize's own classification (internal/git/repospec.go) but
+// WITHOUT a host allowlist — flate renders self-hosted Gitea / GitLab / Azure
+// too, and kustomize's git-vs-file decision is driven by URL markers, not the
+// host. To stay strictly additive over flate's existing HTTP-file preflight,
+// classification is limited to the http/https schemes preflight already
+// intercepts: a URL is a git base iff it carries an explicit marker (_git/,
+// //, .git, or a git:: prefix) OR a ?ref=/?version= query. A marker-less,
+// ref-less http(s) URL stays on the unchanged single-file fetch path; every
+// other scheme (file://, ssh://, oci://, …) and local path is left untouched
+// for kustomize to resolve as it does today.
+func isGitRemoteBase(raw string) (gitBaseSpec, bool) {
+	s, forced := trimPrefixFold(raw, gitForcedProtocol)
+	scheme, hostAndPath, ok := cutHTTPScheme(s)
+	if !ok {
+		return gitBaseSpec{}, false
+	}
+	// Cut the query (?ref=/?version=) before touching the path — per rfc3986
+	// "?" only appears in the query, so this split is unambiguous.
+	pathPart, query, _ := strings.Cut(hostAndPath, "?")
+	ref := refFromQuery(query)
+
+	// Host is everything up to the first "/", kept with its trailing slash to
+	// match kustomize's Host (e.g. "https://github.com/"); the rest is the path.
+	slash := strings.IndexByte(pathPart, '/')
+	if slash < 0 {
+		return gitBaseSpec{}, false // host only, no repo path
+	}
+	hostPrefix := scheme + pathPart[:slash+1]
+	repoSegs := pathPart[slash+1:]
+
+	repoPath, subPath, ok := markerSplit(repoSegs)
+	if !ok {
+		// No explicit marker: only a git:: prefix or a ?ref=/?version= query
+		// makes this a git base; otherwise it's a plain HTTP file left on the
+		// existing fetch path. With a ref/marker, apply kustomize's default
+		// org/repo (2-segment) split.
+		if !forced && ref == "" {
+			return gitBaseSpec{}, false
+		}
+		if repoPath, subPath, ok = defaultSplit(repoSegs); !ok {
+			return gitBaseSpec{}, false
+		}
+	}
+	if repoPath == "" || subPathEscapes(subPath) {
+		return gitBaseSpec{}, false
+	}
+	return gitBaseSpec{repoURL: hostPrefix + repoPath, subPath: subPath, ref: ref}, true
+}
+
+// markerSplit splits a repo path on the first explicit kustomize git marker
+// (_git/, then //, then .git), mirroring repospec.go's tryExplicitMarkerSplit
+// order. Returns ok=false when none is present.
+func markerSplit(p string) (repoPath, subPath string, ok bool) {
+	if i := strings.Index(p, gitRootDelimiter); i >= 0 {
+		// _git/: repo root is the FIRST segment after the delimiter.
+		seg, rest, _ := strings.Cut(p[i+len(gitRootDelimiter):], "/")
+		return p[:i+len(gitRootDelimiter)] + seg, rest, true
+	}
+	if before, after, found := strings.Cut(p, gitSubPathSep); found {
+		// //: a convention-only separator, dropped from the result.
+		return before, after, true
+	}
+	if i := gitSuffixIndex(p); i >= 0 {
+		// .git: part of the repo dir name; the subpath follows it.
+		end := i + len(gitSuffix)
+		return p[:end], strings.TrimPrefix(p[end:], "/"), true
+	}
+	return "", "", false
+}
+
+// gitSuffixIndex finds ".git" only as a path-segment suffix (followed by "/"
+// or end of string), so a ".gitignore"/".gitattributes" file resource is not
+// mistaken for a repo boundary. Returns -1 when absent.
+func gitSuffixIndex(p string) int {
+	for from := 0; ; {
+		i := strings.Index(p[from:], gitSuffix)
+		if i < 0 {
+			return -1
+		}
+		abs := from + i
+		end := abs + len(gitSuffix)
+		if end == len(p) || p[end] == '/' {
+			return abs
+		}
+		from = end
+	}
+}
+
+// defaultSplit takes the first two path segments as the repo (org/repo) and
+// the rest as the subpath, mirroring repospec.go's orgRepoSegments default.
+// Fewer than two non-empty segments is not a valid git base.
+func defaultSplit(p string) (repoPath, subPath string, ok bool) {
+	segs := strings.SplitN(p, "/", 3)
+	if len(segs) < 2 || segs[0] == "" || segs[1] == "" {
+		return "", "", false
+	}
+	repoPath = segs[0] + "/" + segs[1]
+	if len(segs) == 3 {
+		subPath = segs[2]
+	}
+	return repoPath, subPath, true
+}
+
+// refFromQuery returns the git ref from a URL query: ?ref= takes precedence
+// over ?version= (matching kustomize's parseQuery).
+func refFromQuery(query string) string {
+	if query == "" {
+		return ""
+	}
+	v, err := url.ParseQuery(query)
+	if err != nil {
+		return ""
+	}
+	if ref := v.Get("ref"); ref != "" {
+		return ref
+	}
+	return v.Get("version")
+}
+
+// subPathEscapes reports whether subPath climbs out of the repo root (e.g. a
+// crafted //../../etc). Mirrors repospec.go's kustRootPathExitsRepo: clean the
+// path and reject a leading "..".
+func subPathEscapes(subPath string) bool {
+	if subPath == "" {
+		return false
+	}
+	clean := path.Clean(strings.TrimPrefix(subPath, "/"))
+	first, _, _ := strings.Cut(clean, "/")
+	return first == ".."
+}
+
+// cutHTTPScheme splits an http:// or https:// scheme prefix from s. Other
+// schemes (file://, ssh://, oci://) and scheme-less paths return ok=false:
+// classification stays within the http(s) set flate's preflight already
+// intercepts, so no other resource kind changes behavior.
+func cutHTTPScheme(s string) (scheme, rest string, ok bool) {
+	for _, sc := range []string{"https://", "http://"} {
+		if r, found := trimPrefixFold(s, sc); found {
+			return sc, r, true
+		}
+	}
+	return "", "", false
+}
+
+// trimPrefixFold strips a case-insensitive prefix (kustomize lowercases
+// schemes and the git:: marker), returning the remainder and whether it matched.
+func trimPrefixFold(s, prefix string) (string, bool) {
+	if len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix) {
+		return s[len(prefix):], true
+	}
+	return s, false
+}
+
+// fetchGitBase resolves a classified git base via the injected GitBaseFetcher,
+// materializes the WHOLE repo worktree into a .flate-remote-<hash>/ directory
+// beside the referencing kustomization, and returns the relative resource path
+// (the directory joined with the in-repo subPath).
+//
+// Copying the whole repo — not just subPath — keeps any in-repo ../ references
+// the base itself relies on resolvable; the per-KS copy keeps each staged tree
+// self-contained (the expensive clone/materialize happens once in the cached
+// fetcher, this is a cheap same-filesystem hardlink fan-out via copyTreeInto).
+// The directory name keys on (repoURL, ref) only, so multiple subpaths of one
+// repo+ref share a single materialized copy.
+func fetchGitBase(ctx context.Context, cache *StagingCache, dir string, spec gitBaseSpec) (string, error) {
+	if cache.gitBase == nil {
+		return "", fmt.Errorf("kustomization references remote git base %q but no git fetcher is wired", spec.repoURL)
+	}
+	worktree, _, err := cache.gitBase(ctx, spec.repoURL, spec.ref)
+	if err != nil {
+		return "", err
+	}
+	name := ".flate-remote-" + urlHash(spec.repoURL+"@"+spec.ref)
+	dst := filepath.Join(dir, name)
+	// Idempotent across repeat reconciles: clear any prior materialization
+	// before re-copying so a changed upstream can't leave stale files behind.
+	if err := os.RemoveAll(dst); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dst, 0o750); err != nil {
+		return "", err
+	}
+	if err := cache.copyTreeInto(worktree, dst); err != nil {
+		return "", err
+	}
+	return "./" + path.Join(name, spec.subPath), nil
+}

--- a/pkg/kustomize/gitbase_test.go
+++ b/pkg/kustomize/gitbase_test.go
@@ -1,0 +1,300 @@
+package kustomize
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+)
+
+func TestIsGitRemoteBase(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		ok      bool
+		repoURL string
+		subPath string
+		ref     string
+	}{
+		// --- git bases ---
+		{name: "ref query", url: "https://github.com/o/r?ref=v0.2.2",
+			ok: true, repoURL: "https://github.com/o/r", ref: "v0.2.2"},
+		{name: "version query", url: "https://github.com/o/r?version=v0.2.2",
+			ok: true, repoURL: "https://github.com/o/r", ref: "v0.2.2"},
+		{name: "ref beats version", url: "https://github.com/o/r?version=v1&ref=v2",
+			ok: true, repoURL: "https://github.com/o/r", ref: "v2"},
+		{name: "double-slash subpath", url: "https://github.com/o/r//sub/dir?ref=main",
+			ok: true, repoURL: "https://github.com/o/r", subPath: "sub/dir", ref: "main"},
+		{name: "double-slash no ref", url: "https://github.com/o/r//sub",
+			ok: true, repoURL: "https://github.com/o/r", subPath: "sub"},
+		{name: "git suffix with subpath", url: "https://github.com/o/r.git/sub?ref=abc",
+			ok: true, repoURL: "https://github.com/o/r.git", subPath: "sub", ref: "abc"},
+		{name: "git suffix root", url: "https://github.com/o/r.git?ref=v1",
+			ok: true, repoURL: "https://github.com/o/r.git", ref: "v1"},
+		{name: "azure _git", url: "https://dev.azure.com/org/proj/_git/repo/sub?ref=v1",
+			ok: true, repoURL: "https://dev.azure.com/org/proj/_git/repo", subPath: "sub", ref: "v1"},
+		{name: "git:: forced no ref", url: "git::https://x.example/o/r",
+			ok: true, repoURL: "https://x.example/o/r"},
+		{name: "git:: forced with ref", url: "git::https://x.example/o/r?ref=v1",
+			ok: true, repoURL: "https://x.example/o/r", ref: "v1"},
+		{name: "self-hosted gitea, no allowlist", url: "https://gitea.internal/o/r?ref=v1",
+			ok: true, repoURL: "https://gitea.internal/o/r", ref: "v1"},
+		{name: "http scheme", url: "http://h.example/o/r?ref=v1",
+			ok: true, repoURL: "http://h.example/o/r", ref: "v1"},
+
+		// --- not git bases ---
+		{name: "plain http file", url: "https://raw.githubusercontent.com/o/r/main/cm.yaml"},
+		{name: "plain http file short", url: "https://example.com/foo.yaml"},
+		{name: "marker-less ref-less repo (documented limit)", url: "https://github.com/o/r"},
+		{name: "oci ref", url: "oci://ghcr.io/o/r"},
+		{name: "ssh left to kustomize", url: "ssh://git@github.com/o/r?ref=v1"},
+		{name: "local relative", url: "./local"},
+		{name: "parent relative", url: "../shared"},
+		{name: "host only with ref", url: "https://github.com?ref=v1"},
+		{name: "single segment with ref", url: "https://github.com/onlyorg?ref=v1"},
+		{name: "subpath escapes repo", url: "https://github.com/o/r//../escape?ref=v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec, ok := isGitRemoteBase(tc.url)
+			if ok != tc.ok {
+				t.Fatalf("isGitRemoteBase(%q) ok = %v, want %v (spec %+v)", tc.url, ok, tc.ok, spec)
+			}
+			if !ok {
+				return
+			}
+			if spec.repoURL != tc.repoURL || spec.subPath != tc.subPath || spec.ref != tc.ref {
+				t.Errorf("isGitRemoteBase(%q) = {repoURL:%q subPath:%q ref:%q}, want {repoURL:%q subPath:%q ref:%q}",
+					tc.url, spec.repoURL, spec.subPath, spec.ref, tc.repoURL, tc.subPath, tc.ref)
+			}
+		})
+	}
+}
+
+// fakeWorktree writes files into a fresh dir and returns its path,
+// standing in for a materialized git worktree.
+func fakeWorktree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for rel, content := range files {
+		testutil.WriteFileAt(t, filepath.Join(dir, rel), content)
+	}
+	return dir
+}
+
+// withFakeGitBase installs a GitBaseFetcher returning worktree for every
+// call and counting invocations.
+func withFakeGitBase(c *StagingCache, worktree string, calls *atomic.Int32) {
+	c.SetGitBaseFetcher(func(_ context.Context, _, _ string) (string, string, error) {
+		if calls != nil {
+			calls.Add(1)
+		}
+		return worktree, "deadbeef", nil
+	})
+}
+
+func TestPreflightGitBase_RewritesToDirectory(t *testing.T) {
+	worktree := fakeWorktree(t, map[string]string{
+		"kustomization.yaml":               "resources:\n  - ./cm.yaml\n",
+		"cm.yaml":                          "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: base}\n",
+		"overlays/prod/kustomization.yaml": "resources:\n  - ../../\n",
+	})
+
+	stage := t.TempDir()
+	ks := filepath.Join(stage, "kustomization.yaml")
+	const gitURL = "https://github.com/o/r//overlays/prod?ref=v1"
+	testutil.WriteFileAt(t, ks, "resources:\n  - "+gitURL+"\n")
+
+	cache := newPreflightCache(t)
+	withFakeGitBase(cache, worktree, nil)
+	if err := preflightRemoteResources(context.Background(), cache, stage); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+
+	body, err := os.ReadFile(ks) //nolint:gosec // ks is t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDir := remoteResourcePrefix + urlHash("https://github.com/o/r"+"@"+"v1")
+	wantEntry := "./" + wantDir + "/overlays/prod"
+	if !strings.Contains(string(body), wantEntry) {
+		t.Errorf("entry not rewritten to base subdir %q:\n%s", wantEntry, body)
+	}
+	if strings.Contains(string(body), gitURL) {
+		t.Errorf("git URL still present after preflight:\n%s", body)
+	}
+	// The whole repo is materialized as a DIRECTORY, not a single .yaml file.
+	if matches, _ := filepath.Glob(filepath.Join(stage, remoteResourcePrefix+"*.yaml")); len(matches) != 0 {
+		t.Fatalf("git base must not write a .yaml file (that's the #616 bug): %v", matches)
+	}
+	for _, rel := range []string{"kustomization.yaml", "cm.yaml", "overlays/prod/kustomization.yaml"} {
+		if _, err := os.Stat(filepath.Join(stage, wantDir, rel)); err != nil {
+			t.Errorf("whole repo not copied, missing %s: %v", rel, err)
+		}
+	}
+}
+
+// TestPreflightGitBase_DoesNotHTTPGetGitURL is the #616 regression guard:
+// a git-base URL must take the clone path, never an HTTP GET that returns
+// the host's HTML page and gets written as malformed YAML.
+func TestPreflightGitBase_DoesNotHTTPGetGitURL(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte("<!DOCTYPE html><html><body>not yaml</body></html>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	worktree := fakeWorktree(t, map[string]string{
+		"kustomization.yaml": "resources:\n  - ./cm.yaml\n",
+		"cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: base}\n",
+	})
+
+	stage := t.TempDir()
+	ks := filepath.Join(stage, "kustomization.yaml")
+	// A git URL (carries ?ref=) pointing at the HTML server.
+	testutil.WriteFileAt(t, ks, "resources:\n  - "+srv.URL+"/o/r?ref=v1\n")
+
+	cache := newPreflightCache(t)
+	withFakeGitBase(cache, worktree, nil)
+	if err := preflightRemoteResources(context.Background(), cache, stage); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+
+	if n := hits.Load(); n != 0 {
+		t.Errorf("git URL was HTTP-GETted %d time(s); it must be cloned instead (#616)", n)
+	}
+	if matches, _ := filepath.Glob(filepath.Join(stage, remoteResourcePrefix+"*.yaml")); len(matches) != 0 {
+		t.Fatalf("HTML was written as a .yaml resource (#616): %v", matches)
+	}
+}
+
+// TestPreflightGitBase_WholeRepoPreservesParentRefs renders end-to-end and
+// proves the whole repo is materialized: a subPath kustomization's in-repo
+// ../ reference still resolves (copy-only-subPath would break this).
+func TestPreflightGitBase_WholeRepoPreservesParentRefs(t *testing.T) {
+	worktree := fakeWorktree(t, map[string]string{
+		"apps/foo/kustomization.yaml": "resources:\n  - ../../shared\n",
+		"shared/kustomization.yaml":   "resources:\n  - ./cm.yaml\n",
+		"shared/cm.yaml":              "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: from-parent-ref\n",
+	})
+
+	src := t.TempDir()
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"),
+		"resources:\n  - https://example.com/o/r//apps/foo?ref=v1\n")
+
+	cache, err := NewStagingCache(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+	withFakeGitBase(cache, worktree, nil)
+
+	out, err := RenderFlux(context.Background(), cache, src, "", ".", map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "apps", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "."},
+	})
+	if err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+	if !strings.Contains(string(out), "from-parent-ref") {
+		t.Fatalf("in-repo ../ reference inside the base did not resolve:\n%s", out)
+	}
+}
+
+// TestPreflightGitBase_SourceTreeImmutable confirms a git base referenced
+// from a SOURCE kustomization mutates only the staged copy.
+func TestPreflightGitBase_SourceTreeImmutable(t *testing.T) {
+	worktree := fakeWorktree(t, map[string]string{
+		"kustomization.yaml": "resources:\n  - ./cm.yaml\n",
+		"cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: base}\n",
+	})
+
+	src := t.TempDir()
+	original := "resources:\n  - https://example.com/o/r?ref=v1\n"
+	testutil.WriteFileAt(t, filepath.Join(src, "kustomization.yaml"), original)
+
+	cache, err := NewStagingCache(t.TempDir(), 0)
+	if err != nil {
+		t.Fatalf("NewStagingCache: %v", err)
+	}
+	t.Cleanup(func() { _ = cache.Close() })
+	withFakeGitBase(cache, worktree, nil)
+
+	if _, err := RenderFlux(context.Background(), cache, src, "", ".", map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "apps", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "."},
+	}); err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(src, "kustomization.yaml")) //nolint:gosec // src is t.TempDir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Errorf("source kustomization mutated:\nwant %q\ngot  %q", original, got)
+	}
+	if matches, _ := filepath.Glob(filepath.Join(src, remoteResourcePrefix+"*")); len(matches) != 0 {
+		t.Errorf("git base materialized into source tree: %v", matches)
+	}
+}
+
+// TestPreflightGitBase_NilFetcherErrors: with no GitBaseFetcher wired, a git
+// base surfaces a clear error rather than silently HTTP-GETting the URL.
+func TestPreflightGitBase_NilFetcherErrors(t *testing.T) {
+	stage := t.TempDir()
+	testutil.WriteFileAt(t, filepath.Join(stage, "kustomization.yaml"),
+		"resources:\n  - https://github.com/o/r?ref=v1\n")
+
+	err := preflightRemoteResources(context.Background(), newPreflightCache(t), stage)
+	if err == nil {
+		t.Fatal("expected error when no git fetcher is wired")
+	}
+	if !strings.Contains(err.Error(), "no git fetcher is wired") {
+		t.Errorf("error should explain the missing fetcher; got %q", err)
+	}
+}
+
+// TestPreflightGitBase_EachKSGetsOwnCopy: multiple kustomizations referencing
+// the same base each get their own self-contained .flate-remote-<hash>/ dir.
+func TestPreflightGitBase_EachKSGetsOwnCopy(t *testing.T) {
+	worktree := fakeWorktree(t, map[string]string{
+		"kustomization.yaml": "resources:\n  - ./cm.yaml\n",
+		"cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: base}\n",
+	})
+
+	stage := t.TempDir()
+	for _, sub := range []string{"a", "b", "c"} {
+		dir := filepath.Join(stage, sub)
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		testutil.WriteFileAt(t, filepath.Join(dir, "kustomization.yaml"),
+			"resources:\n  - https://example.com/o/r?ref=v1\n")
+	}
+
+	var calls atomic.Int32
+	cache := newPreflightCache(t)
+	withFakeGitBase(cache, worktree, &calls)
+	if err := preflightRemoteResources(context.Background(), cache, stage); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+
+	wantDir := remoteResourcePrefix + urlHash("https://example.com/o/r@v1")
+	for _, sub := range []string{"a", "b", "c"} {
+		if _, err := os.Stat(filepath.Join(stage, sub, wantDir, "cm.yaml")); err != nil {
+			t.Errorf("%s: base not copied into its own dir: %v", sub, err)
+		}
+	}
+}

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -37,12 +37,21 @@ const remoteFetchMaxBytes = 64 << 20 // 64 MiB
 // fetch latency stays observable.
 var remoteFetchClient = &http.Client{Timeout: remoteFetchTimeout}
 
+// remoteResourcePrefix names the staged artifacts preflight writes beside a
+// kustomization for a pre-fetched remote resource: a `<prefix><hash>.yaml`
+// file for an HTTP single-file resource, or a `<prefix><hash>/` directory for
+// a cloned git base. The walk below skips these so a cloned base's own nested
+// kustomizations aren't re-rewritten.
+const remoteResourcePrefix = ".flate-remote-"
+
 // preflightRemoteResources walks every kustomization file under root
-// and pre-fetches HTTP/HTTPS `resources:` entries via flate's own
-// HTTP client so kustomize.Build sees only local files — never
-// invoking its built-in `exec.Command("git", "fetch", ...)` fallback
-// (which silently adds a git-binary dependency and a 10s+ timeout
-// on broken URLs).
+// and pre-resolves remote `resources:` entries so kustomize.Build sees
+// only local files — never invoking its built-in
+// `exec.Command("git", "fetch", ...)` fallback (which silently adds a
+// git-binary dependency and a 10s+ timeout on broken URLs). HTTP/HTTPS
+// single-file entries are fetched via flate's own HTTP client; git
+// bases (URLs carrying kustomize's git markers / ?ref=) are cloned via
+// the injected GitBaseFetcher and materialized locally. See gitbase.go.
 //
 // root is the **subPath dir**, not the whole stage. Scoping the walk
 // makes URL-fetch failures localized: a broken URL in one
@@ -66,6 +75,13 @@ func preflightRemoteResources(ctx context.Context, cache *StagingCache, root str
 			return err
 		}
 		if d.IsDir() {
+			// Skip a git base materialized by a prior resources: entry — its
+			// own nested kustomization.yaml files must NOT be re-rewritten
+			// here (depth-1 limit, like the ../-outside-subPath blind spot
+			// noted above). The kustomize build of that base resolves its URLs.
+			if strings.HasPrefix(d.Name(), remoteResourcePrefix) {
+				return fs.SkipDir
+			}
 			return nil
 		}
 		if !slices.Contains(manifest.KustomizeBuilderFilenames, d.Name()) {
@@ -114,6 +130,21 @@ func rewriteURLResources(ctx context.Context, cache *StagingCache, ksFile string
 	dir := filepath.Dir(ksFile)
 	for _, entry := range resourcesNode.Content {
 		if entry.Kind != yaml.ScalarNode {
+			continue
+		}
+		// Classify git bases BEFORE the HTTP-file check: a git base is also an
+		// https:// URL, but kustomize resolves it by cloning, not by GETting a
+		// single file. GETting a git URL returns the host's HTML page, which
+		// then fails to parse as YAML (#616) — so it must take the git path.
+		if spec, ok := isGitRemoteBase(entry.Value); ok {
+			localDir, fetchErr := fetchGitBase(ctx, cache, dir, spec)
+			if fetchErr != nil {
+				return fmt.Errorf("remote git base %s: %w", entry.Value, fetchErr)
+			}
+			entry.Value = localDir
+			entry.Tag = "!!str"
+			entry.Style = 0
+			changed = true
 			continue
 		}
 		if !isHTTPURL(entry.Value) {
@@ -175,7 +206,7 @@ func fetchRemoteResource(ctx context.Context, cache *StagingCache, dir, urlStr s
 	if err != nil {
 		return "", err
 	}
-	name := ".flate-remote-" + urlHash(urlStr) + ".yaml"
+	name := remoteResourcePrefix + urlHash(urlStr) + ".yaml"
 	if err := os.WriteFile(filepath.Join(dir, name), body, 0o600); err != nil {
 		return "", err
 	}

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -101,7 +101,29 @@ type StagingCache struct {
 	// cache — so a warm run's count stays flat. Lightweight observability;
 	// asserted by TestStagePersistent_HitDoesNotKickSweep.
 	sweepKicks atomic.Int64
+
+	// gitBase resolves a remote kustomize git base (a repo URL at a bare
+	// ref) to an on-disk worktree. Injected via SetGitBaseFetcher because
+	// this package cannot import pkg/source/git (import cycle). Nil in
+	// library/test contexts; a git-base resource then fails with a clear
+	// error rather than silently HTTP-GETting its URL. See gitbase.go.
+	gitBase GitBaseFetcher
 }
+
+// GitBaseFetcher materializes a remote kustomize git base — a repo URL at a
+// bare, undifferentiated ref (tag, branch, commit, or "" for the default
+// branch) — into an on-disk worktree, returning its absolute path and the
+// resolved revision. The orchestrator supplies a closure over its
+// *git.Fetcher (which owns the clone/mirror/ref-resolution machinery); this
+// package only ever sees the function value, keeping it free of the
+// pkg/source → pkg/kustomize import cycle.
+type GitBaseFetcher func(ctx context.Context, repoURL, ref string) (localPath, revision string, err error)
+
+// SetGitBaseFetcher wires the git-clone capability used to resolve remote git
+// bases referenced from a kustomization's resources:. The orchestrator calls
+// this once at construction; library/test embedders may leave it unset, in
+// which case a git-base resource surfaces a clear "not wired" error.
+func (c *StagingCache) SetGitBaseFetcher(fn GitBaseFetcher) { c.gitBase = fn }
 
 // stage holds the per-source materialization promise. The OnceValues
 // pattern keeps copyTree work to one execution per key within the

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -343,6 +343,17 @@ func New(cfg Config) (*Orchestrator, error) {
 		Mirrors: mirror.New(layout),
 		Depth:   cfg.GitDepth,
 	}
+	// Resolve kustomize remote git bases (resources: URLs carrying ?ref= or a
+	// git marker) through the same clone/mirror/ref-resolution machinery as
+	// Flux GitRepository sources. The seam is a function value because
+	// pkg/kustomize cannot import pkg/source/git (import cycle via pkg/source).
+	staging.SetGitBaseFetcher(func(ctx context.Context, repoURL, ref string) (string, string, error) {
+		art, err := gitFetcher.FetchRemoteBase(ctx, repoURL, ref)
+		if err != nil {
+			return "", "", err
+		}
+		return art.LocalPath, art.Revision, nil
+	})
 	srcCtrl.Fetchers[manifest.KindGitRepository] = source.Wrap(
 		manifest.KindGitRepository, gitFetcher)
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap(

--- a/pkg/source/git/remotebase.go
+++ b/pkg/source/git/remotebase.go
@@ -1,0 +1,117 @@
+package git
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/git/mirror"
+	"github.com/home-operations/flate/pkg/source/gittree"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// FetchRemoteBase fetches a public kustomize remote git base: repoURL at a
+// bare, undifferentiated ref (tag, branch, commit, or "" for the default
+// branch), anonymously, returning a SourceArtifact whose LocalPath is a
+// materialized worktree directory (no .git). It is a lean sibling of
+// fetchViaMirror for the one job kustomize remote bases need.
+//
+// Unlike Fetch — which takes a Flux GitRepository CR with EXCLUSIVE ref
+// fields (Tag XOR Branch XOR Commit XOR …) and a NARROW per-field mirror
+// fetch — kustomize's ?ref= is a single opaque string with `git checkout
+// <ref>` semantics: it may be a tag, branch, or commit SHA and the caller
+// cannot know which. So FetchRemoteBase fetches the mirror BROADLY (empty
+// FetchPlan → +refs/*:refs/*, all heads+tags+HEAD) and resolves the string
+// through resolveRefHash's Name branch, which delegates to go-git
+// ResolveRevision — git rev-parse order over refs/tags then refs/heads then
+// a hash prefix, peeling annotated tags. One call covers every ref kind with
+// no field-guessing; an empty ref resolves to the mirror's HEAD.
+//
+// Anonymous only (no SecretRef/proxy/TLS/verification/submodules/sparse):
+// kustomize remote bases are public bases; an authenticated base belongs in
+// a real GitRepository CR. Requires Mirrors and Cache. The materialized
+// worktree is cached per (repoURL, ref) in a slot whose ref label is
+// namespaced so it never collides with a real GitRepository CR's slot for
+// the same URL, and is reused on warm runs via the .flate-git-revision
+// marker.
+func (f *Fetcher) FetchRemoteBase(ctx context.Context, repoURL, ref string) (*store.SourceArtifact, error) {
+	if f.Mirrors == nil || f.Cache == nil {
+		return nil, fmt.Errorf("%w: remote git base fetch requires mirror+cache", manifest.ErrInput)
+	}
+	if repoURL == "" {
+		return nil, fmt.Errorf("%w: remote git base missing url", manifest.ErrInput)
+	}
+	refLabel := cmp.Or(ref, "HEAD")
+
+	// Per-(url, ref) slot, anonymous (authID ""). The ref label is
+	// namespaced ("kustomize-base#…") so a remote base never shares a slot
+	// with a real GitRepository CR pinned at the same URL+ref — the two have
+	// different materialization disciplines (this one is .git-free + marked).
+	slot, err := f.Cache.Slot(ctx, repoURL, "kustomize-base#"+refLabel, "")
+	if err != nil {
+		return nil, fmt.Errorf("cache slot for %s: %w", repoURL, err)
+	}
+	defer slot.Release()
+
+	// Warm-run hit: a committed slot always carries the revision marker
+	// (written below, before Commit). A bare ref may name a mutable branch,
+	// but kustomize bases are pinned in practice and re-resolution is cheap,
+	// so treat any marked slot as a hit and leave the mirror untouched.
+	if slot.Exists {
+		if rev := readCachedRevision(slot.Path); rev != "" {
+			return &store.SourceArtifact{
+				Kind: manifest.KindGitRepository,
+				URL:  repoURL, LocalPath: slot.Path, Revision: rev,
+			}, nil
+		}
+		// Marker-less slot (legacy / hand-edited) — re-materialize cleanly.
+		if err := slot.Refresh(); err != nil {
+			return nil, err
+		}
+	}
+
+	// Broad fetch: empty FetchPlan → mirror falls back to +refs/*:refs/* so
+	// refs/tags/*, refs/heads/*, and HEAD are all present for ResolveRevision.
+	// go-git accepts file:// URLs directly (same as fetchViaMirror), so no
+	// scheme stripping is needed here.
+	mirrorRepo, err := f.Mirrors.OpenOrFetch(ctx, repoURL, nil, nil, mirror.FetchPlan{})
+	if err != nil {
+		return nil, err
+	}
+
+	var refPtr *manifest.GitRepositoryRef
+	if ref != "" {
+		refPtr = &manifest.GitRepositoryRef{Name: ref} // Name → ResolveRevision (rev-parse order)
+	}
+	hash, err := resolveRefHash(mirrorRepo, refPtr)
+	if err != nil {
+		return nil, fmt.Errorf("remote git base %s ref %q: %w", repoURL, refLabel, err)
+	}
+
+	// Walk the tree at hash into the slot's staging dir. Symlinks materialize
+	// as real OS symlinks so a base that follows symlinked components renders
+	// like a git checkout; submodules are warn-and-skipped (the bare mirror
+	// has no nested object stores).
+	if err := gittree.Materialize(ctx, mirrorRepo, hash, slot.Path, gittree.Options{
+		OnSubmodule: func(path string) {
+			slog.Warn("kustomize remote base: skipping submodule (mirror path does not recurse)",
+				"url", repoURL, "path", path)
+		},
+	}); err != nil {
+		return nil, fmt.Errorf("materialize %s at %s: %w", hash, refLabel, err)
+	}
+
+	rev := hash.String()
+	if err := writeCachedRevision(slot.Path, rev); err != nil {
+		return nil, fmt.Errorf("remote git base %s: write revision marker: %w", repoURL, err)
+	}
+	if err := slot.Commit(); err != nil {
+		return nil, fmt.Errorf("remote git base %s: commit slot: %w", repoURL, err)
+	}
+	return &store.SourceArtifact{
+		Kind: manifest.KindGitRepository,
+		URL:  repoURL, LocalPath: slot.Path, Revision: rev,
+	}, nil
+}

--- a/pkg/source/git/remotebase_test.go
+++ b/pkg/source/git/remotebase_test.go
@@ -1,0 +1,144 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/source/git/mirror"
+)
+
+func newRemoteBaseFetcher(t *testing.T) *Fetcher {
+	t.Helper()
+	layout := cacheroot.New(t.TempDir())
+	return &Fetcher{Cache: source.NewCache(layout), Mirrors: mirror.New(layout)}
+}
+
+func assertWorktree(t *testing.T, dir, file, wantContent string) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(dir, file)) //nolint:gosec // dir is the test cache slot
+	if err != nil {
+		t.Fatalf("read materialized %s: %v", file, err)
+	}
+	if string(got) != wantContent {
+		t.Errorf("%s = %q, want %q", file, got, wantContent)
+	}
+	// gittree.Materialize produces a clean worktree — no .git.
+	if _, err := os.Stat(filepath.Join(dir, ".git")); !os.IsNotExist(err) {
+		t.Errorf("materialized base must not contain .git (stat err = %v)", err)
+	}
+}
+
+func TestFetchRemoteBase_Tag(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{"kustomization.yaml": "tag-content"})
+	tagged := mustTagHEAD(t, src, "v0.2.2")
+
+	f := newRemoteBaseFetcher(t)
+	art, err := f.FetchRemoteBase(context.Background(), "file://"+src, "v0.2.2")
+	if err != nil {
+		t.Fatalf("FetchRemoteBase tag: %v", err)
+	}
+	if art.Revision != tagged {
+		t.Errorf("revision = %q, want tagged %q", art.Revision, tagged)
+	}
+	assertWorktree(t, art.LocalPath, "kustomization.yaml", "tag-content")
+}
+
+func TestFetchRemoteBase_Branch(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{"kustomization.yaml": "v1"})
+	initial := mustHead(t, src)
+	mustCommitFile(t, src, "kustomization.yaml", "v2") // advance the default branch
+	mustSetRefToHash(t, src, "refs/heads/feature", initial)
+
+	f := newRemoteBaseFetcher(t)
+	art, err := f.FetchRemoteBase(context.Background(), "file://"+src, "feature")
+	if err != nil {
+		t.Fatalf("FetchRemoteBase branch: %v", err)
+	}
+	if art.Revision != initial {
+		t.Errorf("branch revision = %q, want %q (the branch tip, not HEAD)", art.Revision, initial)
+	}
+	assertWorktree(t, art.LocalPath, "kustomization.yaml", "v1")
+}
+
+func TestFetchRemoteBase_Commit(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{"kustomization.yaml": "c1"})
+	first := mustHead(t, src)
+	mustCommitFile(t, src, "kustomization.yaml", "c2")
+
+	f := newRemoteBaseFetcher(t)
+	art, err := f.FetchRemoteBase(context.Background(), "file://"+src, first)
+	if err != nil {
+		t.Fatalf("FetchRemoteBase commit: %v", err)
+	}
+	if art.Revision != first {
+		t.Errorf("commit revision = %q, want %q", art.Revision, first)
+	}
+	assertWorktree(t, art.LocalPath, "kustomization.yaml", "c1")
+}
+
+func TestFetchRemoteBase_HEAD(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{"kustomization.yaml": "head-content"})
+	head := mustHead(t, src)
+
+	f := newRemoteBaseFetcher(t)
+	art, err := f.FetchRemoteBase(context.Background(), "file://"+src, "")
+	if err != nil {
+		t.Fatalf("FetchRemoteBase HEAD: %v", err)
+	}
+	if art.Revision != head {
+		t.Errorf("HEAD revision = %q, want %q", art.Revision, head)
+	}
+	assertWorktree(t, art.LocalPath, "kustomization.yaml", "head-content")
+}
+
+func TestFetchRemoteBase_CacheHit(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepoWithFiles(t, src, map[string]string{"kustomization.yaml": "x"})
+	mustTagHEAD(t, src, "v1.0.0")
+
+	f := newRemoteBaseFetcher(t)
+	art1, err := f.FetchRemoteBase(context.Background(), "file://"+src, "v1.0.0")
+	if err != nil {
+		t.Fatalf("first FetchRemoteBase: %v", err)
+	}
+	// The committed slot carries the revision marker.
+	if _, err := os.Stat(filepath.Join(art1.LocalPath, cachedRevisionFile)); err != nil {
+		t.Errorf("committed slot missing revision marker: %v", err)
+	}
+	art2, err := f.FetchRemoteBase(context.Background(), "file://"+src, "v1.0.0")
+	if err != nil {
+		t.Fatalf("second FetchRemoteBase: %v", err)
+	}
+	if art1.LocalPath != art2.LocalPath {
+		t.Errorf("cache hit should reuse slot: %q vs %q", art1.LocalPath, art2.LocalPath)
+	}
+	if art1.Revision != art2.Revision {
+		t.Errorf("revision mismatch across cache hit: %q vs %q", art1.Revision, art2.Revision)
+	}
+}
+
+func TestFetchRemoteBase_RequiresMirrorAndCache(t *testing.T) {
+	f := &Fetcher{} // no Mirrors, no Cache
+	_, err := f.FetchRemoteBase(context.Background(), "file:///nope", "v1")
+	if !errors.Is(err, manifest.ErrInput) {
+		t.Fatalf("want ErrInput without mirror+cache, got %v", err)
+	}
+}
+
+func TestFetchRemoteBase_MissingURL(t *testing.T) {
+	f := newRemoteBaseFetcher(t)
+	_, err := f.FetchRemoteBase(context.Background(), "", "v1")
+	if !errors.Is(err, manifest.ErrInput) {
+		t.Fatalf("want ErrInput for empty url, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`flate build` failed when a kustomization's `resources:` referenced a remote **git repository** (#616):

```yaml
resources:
  - https://github.com/kubernetes-sigs/container-object-storage-interface?ref=v0.2.2
```

```
MalformedYAMLError: yaml: line 35: mapping values are not allowed in this context
in File: ./.flate-remote-07eb79a386efc6d0.yaml
```

**Root cause.** The preflight pass classified *any* `http(s)://` `resources:` entry as a plain file, HTTP-GETted it, and wrote the body to `.flate-remote-<hash>.yaml`. A git-base URL also starts with `https://`, so flate fetched the host's **HTML** page and kustomize choked. kustomize itself resolves these URLs by **git-cloning** (it tries an HTTP file first, then clones); flate never reached the git path.

## Fix

- **Classify** git bases in preflight (`pkg/kustomize/gitbase.go`), mirroring kustomize's `repospec.go` markers — `?ref=`/`?version=`, `//`, `.git`, `_git/`, `git::` — with **no host allowlist** (so self-hosted Gitea/GitLab/Azure work). Classification stays within the http(s) scheme set preflight already intercepts, and only fires on an explicit marker or `?ref=`, so marker-less HTTP-file resources keep the exact existing behavior.
- **Resolve** them through the existing `pkg/source/git` mirror/clone/ref-resolution machinery via a new `Fetcher.FetchRemoteBase` — a lean sibling of `fetchViaMirror`. A kustomize `?ref=` is an undifferentiated tag/branch/commit, so it fetches the mirror broadly and resolves via `resolveRefHash`→go-git `ResolveRevision` (git rev-parse order), with no ref-kind guessing.
- **Inject** the capability into `StagingCache` as a function value (`SetGitBaseFetcher`), wired by the orchestrator — `pkg/kustomize` cannot import `pkg/source/git` (import cycle via `pkg/source`).
- **Materialize the whole repo** into `.flate-remote-<hash>/` and rewrite the entry to its `subPath`, so in-repo `../` references the base relies on still resolve.

No fresh `go-git` in `pkg/kustomize` — the rejected approach in #619 duplicated the source machinery and broke in-repo `../` refs; this reuses it.

## Tests

- `pkg/source/git/remotebase_test.go` — real `Fetcher` over `file://` fixtures: resolves by **tag**, **branch**, **commit**, **HEAD**; slot cache-hit; `.git`-free worktree.
- `pkg/kustomize/gitbase_test.go` — classification matrix (markers, `?ref=`, escape rejection, self-hosted hosts, non-git URLs); rewrite-to-directory; **#616 regression guard** (a git URL is never HTTP-GETted / written as malformed YAML); whole-repo `../`-fidelity end-to-end; source-tree immutability; nil-fetcher error.

## Verification

- `gofmt` clean · `go build`/`vet` · `go test -race ./...` (all pass) · `golangci-lint` 0 issues.
- **Byte-equivalence** across `~/repos` + `~/k8s-gitops`: strictly additive — every already-working render is byte-identical (the only differing repos are confirmed pre-existing flakiness: Helm `checksum/secrets` hashes and a wall-clock `updatedAt` annotation, binary-independent).
- **Repro**: the issue's `cosi-repro` fixture fails on `main` with the exact `MalformedYAMLError`, and builds cleanly on this branch (renders the COSI Deployment/RBAC/Namespace).

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)