### PR TITLE
fix(kustomize): apply Flux sourceignore defaults to working-tree sources

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -6,6 +6,7 @@
 package kustomization
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -189,7 +190,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "resolving source artifact")
-	sourceRoot, sourceFingerprint, err := c.resolveSourceRootAndFingerprint(ks)
+	src, err := c.resolveSourceRootAndFingerprint(ks)
 	if err != nil {
 		return err
 	}
@@ -213,7 +214,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	// kustomize.toolkit.fluxcd.io ownership labels). kustomize.RenderFlux
 	// is the hot path; skip it and reuse the prior artifact when the
 	// post-Prepare inputs are byte-identical. Same pattern as HR (#219).
-	fp := kustomizationFingerprint(ks, sourceRoot)
+	fp := kustomizationFingerprint(ks, src.root)
 	if existing, ok := c.Store.GetArtifact(id).(*store.KustomizationArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
 		if err := c.PreflightError(id); err != nil {
 			return err
@@ -236,7 +237,16 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	if err := c.PreflightError(id); err != nil {
 		return err
 	}
-	data, err := kustomize.RenderFlux(ctx, c.Staging, sourceRoot, sourceFingerprint, ks.Path, ks.Contents)
+	// A working-tree / self-referential source (src.local) is staged straight
+	// from the user's checkout, bypassing a Fetcher's ApplyIgnore — so filter
+	// its staged copy like Flux's source-controller artifact, else a
+	// default-ignored file (e.g. a root .sops.yaml) breaks the auto-generated
+	// kustomization for a `path: ./` Kustomization (the bo0tzz report).
+	var opts []kustomize.Option
+	if src.local {
+		opts = append(opts, kustomize.WithSourceIgnore())
+	}
+	data, err := kustomize.RenderFlux(ctx, c.Staging, src.root, src.fingerprint, ks.Path, ks.Contents, opts...)
 	if err != nil {
 		return err
 	}
@@ -274,7 +284,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	c.emitRenderedChildren(id, docs)
 
 	c.Store.SetArtifact(id, &store.KustomizationArtifact{
-		Path:        filepath.Join(sourceRoot, ks.Path),
+		Path:        filepath.Join(src.root, ks.Path),
 		Manifests:   docs,
 		Fingerprint: fp,
 	})
@@ -367,7 +377,7 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 // GitRepository overrides, sources soft-skipped via
 // --allow-missing-secrets) — the caller falls back to per-process
 // scratch staging and rebuilds from scratch each run.
-func (c *Controller) resolveSourceRootAndFingerprint(ks *manifest.Kustomization) (string, string, error) {
+func (c *Controller) resolveSourceRootAndFingerprint(ks *manifest.Kustomization) (resolvedSource, error) {
 	srcID := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
 	if ks.SourceKind == "" || ks.SourceName == "" {
 		// Child Kustomizations that inherit sourceRef from a parent's
@@ -376,7 +386,7 @@ func (c *Controller) resolveSourceRootAndFingerprint(ks *manifest.Kustomization)
 		// working tree) so the first reconcile resolves to the repo
 		// root instead of doubling ks.Path against itself (#105).
 		if ks.Path == "" {
-			return "", "", fmt.Errorf("%w: kustomization %s has no path and no source",
+			return resolvedSource{}, fmt.Errorf("%w: kustomization %s has no path and no source",
 				manifest.ErrInput, ks.Named().NamespacedName())
 		}
 		srcID = manifest.BootstrapSourceID
@@ -388,36 +398,43 @@ func (c *Controller) resolveSourceRootAndFingerprint(ks *manifest.Kustomization)
 		// that as a typed skip so the caller can mark the KS skipped too
 		// rather than reporting a generic "artifact not found" failure.
 		if info, ok := c.Store.GetStatus(srcID); ok && store.IsSkipped(info) {
-			return "", "", fmt.Errorf("%w: source %s %s", manifest.ErrSourceSkipped, srcID.String(), info.Message)
+			return resolvedSource{}, fmt.Errorf("%w: source %s %s", manifest.ErrSourceSkipped, srcID.String(), info.Message)
 		}
-		return "", "", fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())
+		return resolvedSource{}, fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())
 	}
-	if sa, ok := art.(*store.SourceArtifact); ok {
-		// Prefer the content-addressed Digest when the fetcher
-		// supplied one (OCI); fall back to Revision (the git commit
-		// SHA) so git-backed sources also key the persistent stage
-		// cache.
-		//
-		// The bootstrap source is the working-tree alias — fetchers
-		// don't run for it and Revision/Digest are empty. We walk the
-		// tree and hash (relpath, mtime, size) per regular file so
-		// repeated invocations against an untouched tree still hit
-		// the cache while any nested edit invalidates it. Same
-		// treatment applies to any other artifact that landed
-		// without a fetcher-supplied fingerprint
-		// (`overrideSelfReferentialGitRepositories`) — they too
-		// resolve to the user's working tree.
-		fp := sa.Digest
-		if fp == "" {
-			fp = sourceFingerprintFromRevision(sa.Revision)
-		}
-		if fp == "" {
-			fp = c.cachedWorkingTreeFingerprint(sa.LocalPath)
-		}
-		return sa.LocalPath, fp, nil
+	sa, ok := art.(*store.SourceArtifact)
+	if !ok {
+		return resolvedSource{}, fmt.Errorf("%w: unsupported source artifact type %T for %s",
+			manifest.ErrFlux, art, srcID.String())
 	}
-	return "", "", fmt.Errorf("%w: unsupported source artifact type %T for %s",
-		manifest.ErrFlux, art, srcID.String())
+	// Prefer the content-addressed Digest when the fetcher supplied one
+	// (OCI); fall back to Revision (the git commit SHA) so git-backed
+	// sources also key the persistent stage cache. Both imply a fetched
+	// artifact — already sourceignore-filtered by its Fetcher.
+	if fp := cmp.Or(sa.Digest, sourceFingerprintFromRevision(sa.Revision)); fp != "" {
+		return resolvedSource{root: sa.LocalPath, fingerprint: fp}, nil
+	}
+	// No fetcher-supplied identity ⇒ a working-tree alias (the bootstrap
+	// source or a self-referential / local GitRepository override): it
+	// resolves to the user's checkout, which no Fetcher filtered, so mark it
+	// local. We hash (relpath, mtime, size) per regular file so an untouched
+	// tree hits the cache while any nested edit invalidates it.
+	return resolvedSource{
+		root:        sa.LocalPath,
+		fingerprint: c.cachedWorkingTreeFingerprint(sa.LocalPath),
+		local:       true,
+	}, nil
+}
+
+// resolvedSource is where a Kustomization's render stages from.
+type resolvedSource struct {
+	root        string // on-disk source root the build stages from
+	fingerprint string // persistent stage-cache key ("" ⇒ per-process scratch)
+	// local marks a working-tree / self-referential source: one resolved to
+	// the user's checkout without a Fetcher, so its staged copy still needs
+	// the Flux default sourceignore filtering a fetched artifact gets. See
+	// kustomize.WithSourceIgnore.
+	local bool
 }
 
 // sourceFingerprintFromRevision normalizes a git-style Revision

--- a/pkg/controllers/kustomization/source_root_test.go
+++ b/pkg/controllers/kustomization/source_root_test.go
@@ -40,12 +40,12 @@ func TestResolveSourceRoot_FallsBackToBootstrapWhenSourceRefEmpty(t *testing.T) 
 			// render's `patches:` block.
 		},
 	}
-	got, _, err := c.resolveSourceRootAndFingerprint(ks)
+	src, err := c.resolveSourceRootAndFingerprint(ks)
 	if err != nil {
 		t.Fatalf("resolveSourceRoot: %v", err)
 	}
-	if got != "/repo" {
-		t.Errorf("resolveSourceRoot=%q, want %q (bootstrap LocalPath)", got, "/repo")
+	if src.root != "/repo" {
+		t.Errorf("resolveSourceRoot=%q, want %q (bootstrap LocalPath)", src.root, "/repo")
 	}
 }
 
@@ -79,12 +79,12 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 		SourceName:        "external",
 		SourceNamespace:   "flux-system",
 	}
-	got, _, err := c.resolveSourceRootAndFingerprint(ks)
+	src, err := c.resolveSourceRootAndFingerprint(ks)
 	if err != nil {
 		t.Fatalf("resolveSourceRoot: %v", err)
 	}
-	if got != "/external" {
-		t.Errorf("resolveSourceRoot=%q, want %q (explicit ref)", got, "/external")
+	if src.root != "/external" {
+		t.Errorf("resolveSourceRoot=%q, want %q (explicit ref)", src.root, "/external")
 	}
 }
 
@@ -97,7 +97,7 @@ func TestResolveSourceRoot_NoBootstrapNoSourceRefErrors(t *testing.T) {
 		Name: "foo", Namespace: "flux-system",
 		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
 	}
-	_, _, err := c.resolveSourceRootAndFingerprint(ks)
+	_, err := c.resolveSourceRootAndFingerprint(ks)
 	if err == nil {
 		t.Fatalf("expected error when bootstrap source is absent")
 	}

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -78,7 +78,7 @@ var BuildMutex sync.Mutex
 // back to per-process scratch staging (the right behavior for
 // local-path sources whose mtimes shift faster than a fingerprint
 // can keep up).
-func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, sourceFingerprint, subPath string, rawSpec map[string]any) ([]byte, error) {
+func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, sourceFingerprint, subPath string, rawSpec map[string]any, opts ...Option) ([]byte, error) {
 	if cache == nil {
 		return nil, errors.New("kustomize: nil staging cache")
 	}
@@ -99,7 +99,7 @@ func RenderFlux(ctx context.Context, cache *StagingCache, sourceRoot, sourceFing
 		return nil, err
 	}
 
-	staged, err := cache.Stage(ctx, sourceRoot, sourceFingerprint)
+	staged, err := cache.Stage(ctx, sourceRoot, sourceFingerprint, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kustomize/sourceignore_test.go
+++ b/pkg/kustomize/sourceignore_test.go
@@ -1,0 +1,134 @@
+package kustomize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+)
+
+// stripSops is a minimal stand-in for source.ApplyIgnore (which pkg/kustomize
+// can't import — cycle): it deletes a root .sops.yaml, the file flux's default
+// sourceignore strips that triggers the bo0tzz failure.
+func stripSops(root string) error {
+	err := os.Remove(filepath.Join(root, ".sops.yaml"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func TestStage_SourceIgnoreFilter(t *testing.T) {
+	src := t.TempDir()
+	testutil.WriteFileAt(t, filepath.Join(src, ".sops.yaml"), "creation_rules: []\n")
+	testutil.WriteFileAt(t, filepath.Join(src, "configmap.yaml"),
+		"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: keep}\n")
+
+	t.Run("applyIgnore=true strips the file", func(t *testing.T) {
+		cache := newPreflightCache(t)
+		var calls atomic.Int32
+		cache.SetSourceIgnoreFilter(func(root string) error { calls.Add(1); return stripSops(root) })
+
+		staged, err := cache.Stage(context.Background(), src, "fp-filtered", WithSourceIgnore())
+		if err != nil {
+			t.Fatalf("Stage: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(staged, ".sops.yaml")); !os.IsNotExist(err) {
+			t.Errorf(".sops.yaml should be filtered from the stage (stat err = %v)", err)
+		}
+		if _, err := os.Stat(filepath.Join(staged, "configmap.yaml")); err != nil {
+			t.Errorf("real resource must survive the filter: %v", err)
+		}
+		// Warm hit (same fingerprint) must not re-run the filter.
+		if _, err := cache.Stage(context.Background(), src, "fp-filtered", WithSourceIgnore()); err != nil {
+			t.Fatalf("Stage (warm): %v", err)
+		}
+		if n := calls.Load(); n != 1 {
+			t.Errorf("filter should run once per materialization, ran %d times", n)
+		}
+	})
+
+	t.Run("applyIgnore=false leaves the file", func(t *testing.T) {
+		cache := newPreflightCache(t)
+		cache.SetSourceIgnoreFilter(func(root string) error { return stripSops(root) })
+		staged, err := cache.Stage(context.Background(), src, "fp-unfiltered")
+		if err != nil {
+			t.Fatalf("Stage: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(staged, ".sops.yaml")); err != nil {
+			t.Errorf("filter must not run when applyIgnore=false: %v", err)
+		}
+	})
+
+	t.Run("nil filter is a no-op", func(t *testing.T) {
+		cache := newPreflightCache(t) // no SetSourceIgnoreFilter
+		staged, err := cache.Stage(context.Background(), src, "fp-nofilter", WithSourceIgnore())
+		if err != nil {
+			t.Fatalf("Stage: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(staged, ".sops.yaml")); err != nil {
+			t.Errorf("no filter wired ⇒ nothing stripped: %v", err)
+		}
+	})
+}
+
+// TestRenderFlux_SourceIgnoreStripsSopsConfig is the bo0tzz reproduction: a
+// working-tree source with path "." and NO kustomization.yaml, plus a root
+// .sops.yaml (a SOPS config, not a resource). flux's Generator auto-scans the
+// dir; without filtering it tries to decode .sops.yaml and fails with
+// "missing Resource metadata". WithSourceIgnore strips it first.
+func TestRenderFlux_SourceIgnoreStripsSopsConfig(t *testing.T) {
+	newSrc := func(t *testing.T) string {
+		src := t.TempDir()
+		testutil.WriteFileAt(t, filepath.Join(src, ".sops.yaml"),
+			"creation_rules:\n  - path_regex: .*.yaml\n    encrypted_regex: ^(data|stringData)$\n")
+		testutil.WriteFileAt(t, filepath.Join(src, "configmap.yaml"),
+			"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app\n")
+		return src
+	}
+	spec := map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "flux-system", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "."},
+	}
+
+	t.Run("with filter: builds, .sops.yaml ignored", func(t *testing.T) {
+		cache, err := NewStagingCache(t.TempDir(), 0)
+		if err != nil {
+			t.Fatalf("NewStagingCache: %v", err)
+		}
+		t.Cleanup(func() { _ = cache.Close() })
+		cache.SetSourceIgnoreFilter(func(root string) error { return stripSops(root) })
+
+		out, err := RenderFlux(context.Background(), cache, newSrc(t), "wt-fp", ".", spec, WithSourceIgnore())
+		if err != nil {
+			t.Fatalf("RenderFlux should succeed once .sops.yaml is filtered: %v", err)
+		}
+		if !strings.Contains(string(out), "name: app") {
+			t.Errorf("expected the ConfigMap in output:\n%s", out)
+		}
+	})
+
+	t.Run("without filter: reproduces the decode failure", func(t *testing.T) {
+		cache, err := NewStagingCache(t.TempDir(), 0)
+		if err != nil {
+			t.Fatalf("NewStagingCache: %v", err)
+		}
+		t.Cleanup(func() { _ = cache.Close() })
+		cache.SetSourceIgnoreFilter(func(root string) error { return stripSops(root) })
+
+		// No WithSourceIgnore ⇒ .sops.yaml reaches the Generator.
+		_, err = RenderFlux(context.Background(), cache, newSrc(t), "wt-fp-raw", ".", spec)
+		if err == nil {
+			t.Fatal("expected a kustomize decode failure on the unfiltered .sops.yaml")
+		}
+		if !strings.Contains(err.Error(), ".sops.yaml") {
+			t.Errorf("error should name .sops.yaml; got %q", err)
+		}
+	})
+}

--- a/pkg/kustomize/stage.go
+++ b/pkg/kustomize/stage.go
@@ -27,6 +27,12 @@ import (
 // the next Stage call rebuilds from scratch.
 const stageCompleteSentinel = ".flate-stage-complete"
 
+// filteredStageSuffix namespaces a sourceignore-filtered stage's directory
+// (and in-process key) so it stays distinct from the unfiltered stage of the
+// same source fingerprint — see WithSourceIgnore. Bump it if the filter's
+// effect ever changes, to invalidate stale filtered stages.
+const filteredStageSuffix = ".si"
+
 // StagingCache materializes one-or-more source roots into a stage
 // directory so Flux's kustomize Generator can safely write into the
 // staged copy without touching the user's working tree.
@@ -108,7 +114,31 @@ type StagingCache struct {
 	// library/test contexts; a git-base resource then fails with a clear
 	// error rather than silently HTTP-GETting its URL. See gitbase.go.
 	gitBase GitBaseFetcher
+
+	// sourceIgnore strips the files Flux's source-controller excludes from
+	// a GitRepository/OCIRepository artifact (default sourceignore
+	// patterns) from a staged working-tree copy. Injected via
+	// SetSourceIgnoreFilter — this package cannot import pkg/source (import
+	// cycle). Applied (when a Stage caller opts in) once per stage
+	// materialization, so working-tree-sourced stages mirror what Flux
+	// ships in an artifact tarball. Nil ⇒ no filtering; fetched sources are
+	// already filtered by their Fetcher.
+	sourceIgnore SourceIgnoreFilter
 }
+
+// SourceIgnoreFilter deletes the files Flux's source-controller would exclude
+// from an artifact (its default sourceignore patterns: .sops.yaml, .flux.yaml,
+// .goreleaser.yml, binary extensions, CI dirs, in-tree .sourceignore) from the
+// flate-owned staged copy at stagedRoot. The orchestrator supplies a closure
+// over source.ApplyIgnore; this package only sees the function value, keeping
+// it free of the pkg/source → pkg/kustomize import cycle.
+type SourceIgnoreFilter func(stagedRoot string) error
+
+// SetSourceIgnoreFilter wires the sourceignore filter applied to working-tree /
+// self-referential source stages (which don't pass through a source Fetcher's
+// ApplyIgnore). The orchestrator calls this once at construction; library/test
+// embedders may leave it unset (then Stage's applyIgnore opt-in is a no-op).
+func (c *StagingCache) SetSourceIgnoreFilter(fn SourceIgnoreFilter) { c.sourceIgnore = fn }
 
 // GitBaseFetcher materializes a remote kustomize git base — a repo URL at a
 // bare, undifferentiated ref (tag, branch, commit, or "" for the default
@@ -215,21 +245,62 @@ func sweepStaleStageDirs(parent string) {
 // per-process behavior: a `flate-stage-*` tempdir under root,
 // memoized by source path for the life of the cache, removed on
 // Close.
-func (c *StagingCache) Stage(ctx context.Context, source, fingerprint string) (string, error) {
+//
+// opts request optional materialization behavior — see WithSourceIgnore.
+func (c *StagingCache) Stage(ctx context.Context, source, fingerprint string, opts ...Option) (string, error) {
+	var cfg stageConfig
+	for _, o := range opts {
+		o(&cfg)
+	}
 	resolved, err := filepath.EvalSymlinks(source)
 	if err == nil {
 		source = resolved
 	}
 	if fingerprint == "" {
-		return c.stagePerProcess(source)
+		return c.stagePerProcess(source, cfg.applySourceIgnore)
 	}
-	return c.stagePersistent(ctx, source, fingerprint)
+	return c.stagePersistent(ctx, source, fingerprint, cfg.applySourceIgnore)
+}
+
+// Option tunes a Stage (or RenderFlux, which forwards them) call.
+type Option func(*stageConfig)
+
+type stageConfig struct {
+	// applySourceIgnore runs the injected SourceIgnoreFilter over the staged
+	// copy, so a working-tree / self-referential source's stage mirrors what
+	// Flux's source-controller ships in an artifact.
+	applySourceIgnore bool
+}
+
+// WithSourceIgnore strips the files Flux's source-controller excludes from an
+// artifact (.sops.yaml, .flux.yaml, .goreleaser.yml, binary files, CI dirs,
+// in-tree .sourceignore) from the staged copy before it is read. Use it for
+// working-tree / self-referential GitRepository sources, which flate stages
+// directly without a Fetcher's ApplyIgnore — otherwise e.g. a root .sops.yaml
+// breaks the auto-generated kustomization for a `path: ./` Kustomization. The
+// filtered stage is cached under a distinct key, so it never collides with (or
+// adopts) an unfiltered stage of the same tree. No-op when the cache has no
+// SourceIgnoreFilter wired.
+func WithSourceIgnore() Option { return func(c *stageConfig) { c.applySourceIgnore = true } }
+
+// materialize copies source into dst and, when applyIgnore is set and a filter
+// is wired, strips the source-controller-excluded files. Shared by both stage
+// modes so the sourceignore filtering happens inside the once/CAS build — once
+// per materialization, before any consumer reads the tree.
+func (c *StagingCache) materialize(source, dst string, applyIgnore bool) error {
+	if err := c.copyTreeInto(source, dst); err != nil {
+		return err
+	}
+	if applyIgnore && c.sourceIgnore != nil {
+		return c.sourceIgnore(dst)
+	}
+	return nil
 }
 
 // stagePerProcess implements the legacy fallback for sources that
 // don't carry a stable fingerprint: one tempdir per source, memoized
 // for the life of the cache via sync.OnceValues, removed on Close.
-func (c *StagingCache) stagePerProcess(source string) (string, error) {
+func (c *StagingCache) stagePerProcess(source string, applyIgnore bool) (string, error) {
 	c.mu.Lock()
 	s, ok := c.stages[source]
 	if !ok {
@@ -238,7 +309,7 @@ func (c *StagingCache) stagePerProcess(source string) (string, error) {
 			if err != nil {
 				return "", err
 			}
-			if err := c.copyTreeInto(source, dst); err != nil {
+			if err := c.materialize(source, dst, applyIgnore); err != nil {
 				_ = os.RemoveAll(dst)
 				return "", err
 			}
@@ -261,22 +332,31 @@ func (c *StagingCache) stagePerProcess(source string) (string, error) {
 // same fingerprint simultaneously) are tolerated: each writes into
 // its own tempdir; the loser's rename returns ENOTEMPTY and we
 // retry against the winner's sentinel.
-func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint string) (string, error) {
+func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint string, applyIgnore bool) (string, error) {
+	// key identifies the stage on disk and in the in-process record. A
+	// sourceignore-filtered stage gets a distinct key from the unfiltered
+	// stage of the same tree (its content differs), so the two never collide
+	// and a pre-fix unfiltered stage is never adopted for a filtered request.
+	key := fingerprint
+	if applyIgnore {
+		key += filteredStageSuffix
+	}
 	// Compose the on-disk slot. We reproduce the layout's prefix math
 	// here to keep this package free of an explicit Layout dep — the
 	// Stage constructor is given a parent dir, not a typed Layout, so
-	// downstream tests stay simple.
+	// downstream tests stay simple. The fan-out prefix is sliced from the
+	// bare fingerprint, so filtered and unfiltered variants share it.
 	prefix := fingerprint
 	if len(prefix) > 2 {
 		prefix = prefix[:2]
 	}
-	dir := filepath.Join(c.root, prefix, fingerprint)
+	dir := filepath.Join(c.root, prefix, key)
 	sentinel := filepath.Join(dir, stageCompleteSentinel)
 
 	// Cache an in-memory record so repeated lookups for the same
-	// fingerprint within one process skip even the sentinel stat.
+	// key within one process skip even the sentinel stat.
 	c.mu.Lock()
-	s, ok := c.stages[fingerprint]
+	s, ok := c.stages[key]
 	if ok && s.persistent {
 		c.mu.Unlock()
 		if dir, err := s.once(); err == nil {
@@ -293,11 +373,11 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 	// concurrent peer) run. Touch the dir's mtime so LRU eviction
 	// keeps recently-used stages alive.
 	if _, err := os.Stat(sentinel); err == nil {
-		return c.adoptCompletedStage(fingerprint, dir), nil
+		return c.adoptCompletedStage(key, dir), nil
 	}
 
 	// Slow path: serialize concurrent builds within the process.
-	release, err := c.fpLocks.Acquire(ctx, fingerprint)
+	release, err := c.fpLocks.Acquire(ctx, key)
 	if err != nil {
 		return "", err
 	}
@@ -306,7 +386,7 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 	// Recheck under the lock — another goroutine may have populated
 	// the sentinel while we were blocked.
 	if _, err := os.Stat(sentinel); err == nil {
-		return c.adoptCompletedStage(fingerprint, dir), nil
+		return c.adoptCompletedStage(key, dir), nil
 	}
 
 	if err := os.MkdirAll(filepath.Dir(dir), 0o750); err != nil {
@@ -330,14 +410,14 @@ func (c *StagingCache) stagePersistent(ctx context.Context, source, fingerprint 
 	// adopt the winner only when its sentinel is present — content
 	// addressing guarantees the trees are equivalent.
 	adopted, err := cas.Stage(filepath.Dir(dir), dir, "stage tmp", "stage finalize",
-		func(staging string) error { return c.copyTreeInto(source, staging) },
+		func(staging string) error { return c.materialize(source, staging, applyIgnore) },
 		func() bool { _, statErr := os.Stat(sentinel); return statErr == nil },
 	)
 	if err != nil {
 		return "", err
 	}
 	if adopted {
-		c.cacheStagePromise(fingerprint, dir)
+		c.cacheStagePromise(key, dir)
 		c.maybeKickSweep()
 		return dir, nil
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -317,6 +317,14 @@ func New(cfg Config) (*Orchestrator, error) {
 		// HelmChart fetcher's helm-tmp dir isn't created until later in New.
 		return nil, err
 	}
+	// Working-tree / self-referential sources (the bootstrap alias, in-tree
+	// GitRepository overrides) are staged directly from the user's checkout
+	// without a Fetcher's ApplyIgnore. Filter their staged copy the same way
+	// Flux's source-controller filters an artifact, so default-ignored files
+	// (.sops.yaml, .flux.yaml, binaries, …) don't leak into the kustomize build.
+	staging.SetSourceIgnoreFilter(func(stagedRoot string) error {
+		return source.ApplyIgnore(stagedRoot, nil)
+	})
 
 	st := store.New()
 	ts := task.NewBounded(cfg.Concurrency)


### PR DESCRIPTION
## Summary

`flate test all` / `flate build all` failed on a repo whose `flux-system` Kustomization has `spec.path: ./` (repo root, no root `kustomization.yaml`) sourced from a **self-referential GitRepository** (the cluster's own repo):

```
Kustomization/flux-system/flux-system: flux kustomize generator: failed to decode
Kubernetes YAML from .../stage/.../.sops.yaml: missing Resource metadata
```

**Root cause.** With no root `kustomization.yaml`, flux's Generator auto-scans the dir for `*.yaml` resources and tries to decode the repo-root `.sops.yaml` (a SOPS config, not a K8s resource). Real Flux's source-controller strips `.sops.yaml` (and other default-ignored files) from the GitRepository artifact via default sourceignore patterns; flate replicates that in `source.ApplyIgnore` — but **only for *fetched* sources** (the git Fetcher applies it). A self-referential GitRepository is aliased to the **local working tree**, bypassing the Fetcher, so the default-ignored files leaked into the staged tree.

## Fix

Filter working-tree / self-referential sourced staged copies through the same `source.ApplyIgnore` defaults Flux applies to an artifact — on the flate-owned stage, never the user's tree.

- The filter is an injected function value on `StagingCache` (`SetSourceIgnoreFilter`) — `pkg/kustomize` can't import `pkg/source` (import cycle), mirroring the existing `GitBaseFetcher` seam.
- Threaded via **one** variadic `kustomize.Option` (`WithSourceIgnore`) that `RenderFlux` forwards to `Stage` — no positional bool, no test churn.
- The filtered stage is cached under a **distinct key** (a `.si` leaf suffix owned by `stagePersistent`), so it never adopts a stale unfiltered stage of the same tree — the fix takes effect on a warm cache without a manual clear.
- The controller marks working-tree sources via a small `resolvedSource` struct (the ones that resolve to the checkout without a Fetcher).

Fetched sources (git Revision / OCI Digest) are unaffected — already filtered by their Fetcher. Bucket's no-defaults policy is untouched.

## Tests

- `pkg/kustomize/sourceignore_test.go` — the stage filter strips `.sops.yaml` and runs once per materialization (warm hits skip it); the `RenderFlux` `path: .` + root `.sops.yaml` reproduction builds *with* the option and reproduces the `missing Resource metadata` decode failure *without* it.

## Verification

- `gofmt` clean · `go build`/`vet` · `go test -race ./...` (37 pkgs) · `golangci-lint` 0 issues.
- `cd ~/repos/bo0tzz/kube && flate test all` → passes (was `exit 1`).
- Regression sweep `/tmp/flate` vs `/tmp/flate-base` (current main, incl. #624) across `~/repos/*/*` + `~/k8s-gitops`: identical except the fixed repo; the other diffs are confirmed pre-existing flakiness (Helm `genSignedCert` caBundle / `checksum/secrets`, infisical `updatedAt`), binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)