### PR TITLE
refactor(source): collapse cache-slot markers into one meta.json sidecar

### DIFF
--- a/pkg/source/git/bench_test.go
+++ b/pkg/source/git/bench_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/home-operations/flate/pkg/source"
 )
 
 // BenchmarkCachedRevision_HitMiss measures readCachedRevision against
@@ -56,7 +58,7 @@ func BenchmarkCachedRevision_HitMiss(b *testing.B) {
 	b.Run("FreshMiss_Stale", func(b *testing.B) {
 		// Backdate the marker so cachedRevisionFresh treats it as stale.
 		past := time.Now().Add(-2 * time.Hour)
-		if err := os.Chtimes(filepath.Join(hitSlot, cachedRevisionFile), past, past); err != nil {
+		if err := os.Chtimes(filepath.Join(hitSlot, source.SlotMetaFile), past, past); err != nil {
 			b.Fatalf("chtimes: %v", err)
 		}
 		b.ReportAllocs()
@@ -69,6 +71,6 @@ func BenchmarkCachedRevision_HitMiss(b *testing.B) {
 		}
 		// Restore for any later sub-benchmark; keep the slot useful.
 		now := time.Now()
-		_ = os.Chtimes(filepath.Join(hitSlot, cachedRevisionFile), now, now)
+		_ = os.Chtimes(filepath.Join(hitSlot, source.SlotMetaFile), now, now)
 	})
 }

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -439,10 +439,10 @@ func TestFetcher_CacheMarkerSurvivesIgnore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
-	marker := filepath.Join(art.LocalPath, cachedRevisionFile)
+	marker := filepath.Join(art.LocalPath, source.SlotMetaFile)
 	b, err := os.ReadFile(marker) //nolint:gosec // test path
 	if err != nil {
-		t.Fatalf("expected marker %s to exist after Fetch with restrictive ignore: %v", cachedRevisionFile, err)
+		t.Fatalf("expected marker %s to exist after Fetch with restrictive ignore: %v", source.SlotMetaFile, err)
 	}
 	if string(b) == "" {
 		t.Errorf("marker exists but is empty")
@@ -456,8 +456,8 @@ func TestFetcher_CacheMarkerSurvivesIgnore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Fetch second: %v", err)
 	}
-	if art2.Revision != string(b) {
-		t.Errorf("warm Fetch returned a different revision: %q vs %q", art2.Revision, string(b))
+	if art2.Revision != art.Revision {
+		t.Errorf("warm Fetch returned a different revision: %q vs %q", art2.Revision, art.Revision)
 	}
 }
 

--- a/pkg/source/git/marker.go
+++ b/pkg/source/git/marker.go
@@ -1,61 +1,42 @@
 package git
 
 import (
-	"io"
-	"os"
-	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
 
-	"github.com/home-operations/flate/pkg/source/atomic"
+	"github.com/home-operations/flate/pkg/source"
 )
 
-// cachedRevisionFile holds the resolved commit SHA of a fetched slot.
-// Written post-clone, BEFORE the caller's ApplyIgnore wipes .git/, so
-// future cache-hit checks can validate the slot without re-running
-// git.PlainOpen.
-const cachedRevisionFile = ".flate-git-revision"
+// The resolved commit SHA of a fetched slot is recorded in the slot's
+// source.SlotMeta sidecar (one .flate-meta.json per slot). It is written AFTER
+// the caller's ApplyIgnore wipes .git/, so a cache-hit check can validate the
+// slot without re-running git.PlainOpen on a tree whose .git/ is gone.
 
-// writeCachedRevision persists rev atomically — matches the OCI
-// marker's durability shape (atomic.WriteFile with syncDir). A crash
-// mid-write would otherwise leave a partial SHA that the next
-// reconcile reads back via TrimSpace, surfacing as a torn-but-non-
-// empty marker that the cache-hit gate treats as live.
+// writeCachedRevision records rev in the slot's meta sidecar (atomic).
 func writeCachedRevision(slot, rev string) error {
-	return atomic.WriteFile(filepath.Join(slot, cachedRevisionFile), []byte(rev), 0o600, true)
+	return source.WriteSlotMeta(slot, source.SlotMeta{Revision: rev})
 }
 
+// readCachedRevision returns the slot's recorded commit SHA, or "" when the
+// sidecar is absent/unreadable (a pre-meta.json slot — rebuilt on miss).
 func readCachedRevision(slot string) string {
-	b, err := os.ReadFile(filepath.Join(slot, cachedRevisionFile)) //nolint:gosec // slot is fetcher-owned cache path
-	if err != nil {
+	m, ok := source.ReadSlotMeta(slot)
+	if !ok {
 		return ""
 	}
-	return strings.TrimSpace(string(b))
+	return m.Revision
 }
 
+// cachedRevisionFresh returns the recorded SHA only when the sidecar was
+// written within maxAge — the freshness gate a mutable ref uses to skip a
+// network refetch within its reconcile interval.
 func cachedRevisionFresh(slot string, maxAge time.Duration) (string, bool) {
-	if maxAge <= 0 {
+	m, ok := source.ReadSlotMetaFresh(slot, maxAge)
+	if !ok || m.Revision == "" {
 		return "", false
 	}
-	// Single open: fstat for mtime, then read — avoids the TOCTOU window
-	// between a separate os.Stat and os.ReadFile on a fetcher-written file.
-	f, err := os.Open(filepath.Join(slot, cachedRevisionFile)) //nolint:gosec // slot is fetcher-owned cache path
-	if err != nil {
-		return "", false
-	}
-	defer f.Close() //nolint:errcheck
-	info, err := f.Stat()
-	if err != nil || time.Since(info.ModTime()) > maxAge {
-		return "", false
-	}
-	b, err := io.ReadAll(f)
-	if err != nil {
-		return "", false
-	}
-	rev := strings.TrimSpace(string(b))
-	return rev, rev != ""
+	return m.Revision, true
 }
 
 // readResolvedRevision returns the current commit SHA at the worktree.

--- a/pkg/source/git/remotebase_test.go
+++ b/pkg/source/git/remotebase_test.go
@@ -112,7 +112,7 @@ func TestFetchRemoteBase_CacheHit(t *testing.T) {
 		t.Fatalf("first FetchRemoteBase: %v", err)
 	}
 	// The committed slot carries the revision marker.
-	if _, err := os.Stat(filepath.Join(art1.LocalPath, cachedRevisionFile)); err != nil {
+	if _, err := os.Stat(filepath.Join(art1.LocalPath, source.SlotMetaFile)); err != nil {
 		t.Errorf("committed slot missing revision marker: %v", err)
 	}
 	art2, err := f.FetchRemoteBase(context.Background(), "file://"+src, "v1.0.0")

--- a/pkg/source/meta.go
+++ b/pkg/source/meta.go
@@ -1,0 +1,88 @@
+package source
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/home-operations/flate/pkg/source/atomic"
+)
+
+// SlotMetaFile is the single structured sidecar a fetched cache slot carries,
+// replacing the family of per-fact .flate-* marker files (the git revision, the
+// OCI digest, the verify-policy fingerprint). It is `.flate-`-prefixed so it
+// never collides with a user file in the materialized source tree, and JSON so
+// a new fact is a new field rather than a new file.
+const SlotMetaFile = ".flate-meta.json"
+
+// SlotMeta is the content of SlotMetaFile: the metadata a cache-hit needs to
+// validate a slot and decide whether work (a refetch, a re-verify) can be
+// skipped. Fields are populated by whichever fetcher owns the slot — git sets
+// Revision, OCI sets Digest (+ Verified when spec.verify is configured).
+type SlotMeta struct {
+	// Revision is the resolved git commit SHA (GitRepository slots).
+	Revision string `json:"revision,omitempty"`
+	// Digest is the resolved OCI content digest (OCIRepository slots).
+	Digest string `json:"digest,omitempty"`
+	// Verified is the verify-policy fingerprint the slot's content was last
+	// validated against; empty when verify is unconfigured. A mismatch on the
+	// next reconcile forces re-verify.
+	Verified string `json:"verified,omitempty"`
+}
+
+// WriteSlotMeta persists meta into slotDir atomically (temp file + fsync +
+// rename + dir sync), so a crash mid-write can never leave a torn sidecar that
+// a later run misreads as a live marker.
+func WriteSlotMeta(slotDir string, meta SlotMeta) error {
+	b, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return atomic.WriteFile(filepath.Join(slotDir, SlotMetaFile), b, 0o600, true)
+}
+
+// ReadSlotMeta returns the slot's sidecar. A missing, unreadable, or unparseable
+// sidecar yields ok=false — all three mean "no usable marker", so the caller
+// rebuilds. Atomic writes guarantee the file is either absent or complete, so a
+// parse failure indicates a pre-meta.json slot or external tampering, not a torn
+// write.
+func ReadSlotMeta(slotDir string) (meta SlotMeta, ok bool) {
+	b, err := os.ReadFile(filepath.Join(slotDir, SlotMetaFile)) //nolint:gosec // slotDir is fetcher-owned cache path
+	if err != nil {
+		return SlotMeta{}, false
+	}
+	if err := json.Unmarshal(b, &meta); err != nil {
+		return SlotMeta{}, false
+	}
+	return meta, true
+}
+
+// ReadSlotMetaFresh returns the sidecar only when it exists and was written
+// within maxAge — the freshness gate a mutable ref (branch/tag/semver/HEAD)
+// uses to skip a network refetch within its reconcile interval. A single open
+// (fstat for mtime, then read) avoids a stat/read TOCTOU on a fetcher-written
+// file. maxAge <= 0 disables the gate (always stale).
+func ReadSlotMetaFresh(slotDir string, maxAge time.Duration) (meta SlotMeta, ok bool) {
+	if maxAge <= 0 {
+		return SlotMeta{}, false
+	}
+	f, err := os.Open(filepath.Join(slotDir, SlotMetaFile)) //nolint:gosec // slotDir is fetcher-owned cache path
+	if err != nil {
+		return SlotMeta{}, false
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil || time.Since(info.ModTime()) > maxAge {
+		return SlotMeta{}, false
+	}
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return SlotMeta{}, false
+	}
+	if err := json.Unmarshal(b, &meta); err != nil {
+		return SlotMeta{}, false
+	}
+	return meta, true
+}

--- a/pkg/source/meta_test.go
+++ b/pkg/source/meta_test.go
@@ -1,0 +1,80 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSlotMeta_RoundTrip(t *testing.T) {
+	slot := t.TempDir()
+	want := SlotMeta{Revision: "abc123", Digest: "sha256:dead", Verified: "fp42"}
+	if err := WriteSlotMeta(slot, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, ok := ReadSlotMeta(slot)
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if got != want {
+		t.Errorf("round-trip mismatch: got %+v want %+v", got, want)
+	}
+}
+
+func TestSlotMeta_MissingIsNotOK(t *testing.T) {
+	if _, ok := ReadSlotMeta(t.TempDir()); ok {
+		t.Error("missing sidecar should read ok=false")
+	}
+}
+
+// TestSlotMeta_MalformedIsNotOK pins that a non-JSON sidecar (a legacy slot or
+// external tampering — atomic writes make a torn write impossible) reads as no
+// marker, so the caller rebuilds rather than trusting garbage.
+func TestSlotMeta_MalformedIsNotOK(t *testing.T) {
+	slot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(slot, SlotMetaFile), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadSlotMeta(slot); ok {
+		t.Error("malformed sidecar should read ok=false")
+	}
+}
+
+// TestSlotMeta_Fresh covers the freshness gate: a just-written sidecar is fresh
+// within maxAge; a backdated one is stale; maxAge<=0 is always stale.
+func TestSlotMeta_Fresh(t *testing.T) {
+	slot := t.TempDir()
+	if err := WriteSlotMeta(slot, SlotMeta{Revision: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadSlotMetaFresh(slot, time.Hour); !ok {
+		t.Error("just-written sidecar should be fresh")
+	}
+	if _, ok := ReadSlotMetaFresh(slot, 0); ok {
+		t.Error("maxAge<=0 should always be stale")
+	}
+	past := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(filepath.Join(slot, SlotMetaFile), past, past); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadSlotMetaFresh(slot, time.Hour); ok {
+		t.Error("backdated sidecar should be stale")
+	}
+}
+
+// TestSlotMeta_NoTempLeftover pins the atomic-write contract: a successful write
+// leaves only the sidecar, never a temp file.
+func TestSlotMeta_NoTempLeftover(t *testing.T) {
+	slot := t.TempDir()
+	if err := WriteSlotMeta(slot, SlotMeta{Revision: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != SlotMetaFile {
+		t.Errorf("expected only %s, got %v", SlotMetaFile, entries)
+	}
+}

--- a/pkg/source/oci/fetch_test.go
+++ b/pkg/source/oci/fetch_test.go
@@ -121,7 +121,7 @@ func TestFetcher_PartialSlotInvalidated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first Fetch: %v", err)
 	}
-	digestPath := filepath.Join(art.LocalPath, ".flate-digest")
+	digestPath := filepath.Join(art.LocalPath, source.SlotMetaFile)
 	if _, err := os.Stat(digestPath); err != nil {
 		t.Fatalf("first fetch did not produce .flate-digest: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestFetcher_PartialSlotInvalidated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second Fetch (after partial-slot reset): %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(art2.LocalPath, ".flate-digest")); err != nil {
+	if _, err := os.Stat(filepath.Join(art2.LocalPath, source.SlotMetaFile)); err != nil {
 		t.Errorf("second fetch did not re-populate .flate-digest after partial-slot reset: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(art2.LocalPath, "Chart.yaml")); err != nil {

--- a/pkg/source/oci/marker.go
+++ b/pkg/source/oci/marker.go
@@ -1,121 +1,84 @@
 package oci
 
 import (
-	"io"
-	"os"
-	"path/filepath"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
-	"github.com/home-operations/flate/pkg/source/atomic"
 )
 
-// cachedDigestFile is the slot-relative path where flate records the
-// resolved digest of an OCIRepository pull. Used to re-verify on cache
-// hit when spec.verify is configured.
-const cachedDigestFile = ".flate-digest"
+// An OCI slot records its resolved digest and verify-policy fingerprint in the
+// slot's source.SlotMeta sidecar (one .flate-meta.json per slot). The digest is
+// written as the final step of a successful pull; the verify fingerprint is
+// written (read-modify-write, preserving the digest) only after a successful
+// verification, so meta.Verified == want always implies the cached content was
+// validated under that exact policy — the cache-hit verify-skip can never skip
+// an unvalidated slot. Both writers run under the slot lock (cache.Slot
+// serializes per key), so the read-modify-write has a single writer.
 
-// verifyMarkerFile records the cosign verify-policy fingerprint that
-// the slot's cached digest was last validated against. When the
-// current spec.verify hashes to the same value, the cache-hit path
-// can skip the re-verify roundtrip — restoring flate's offline
-// promise for sources with verify configured. A missing or
-// mismatched marker forces re-verify (covering policy changes,
-// pre-marker slots, and tampered caches).
-const verifyMarkerFile = ".flate-verified"
-
-// digestRE matches a well-formed OCI content digest:
-// "<algorithm>:<hex>" where the hex side is at least 32 chars (sha256
-// truncated, the OCI spec minimum). Catches torn writes where the
-// previous run died mid-WriteFile and left a partial digest string —
-// rather than passing the partial to cosign and getting a misleading
-// "signature not found" error, treat it as a missing marker.
+// digestRE matches a well-formed OCI content digest ("<algorithm>:<hex>", hex
+// >= 32 chars). A digest that doesn't match is treated as a missing marker so
+// a hand-modified or legacy cache rebuilds rather than feeding a bad digest to
+// cosign.
 var digestRE = regexp.MustCompile(`^[a-z0-9]+:[a-fA-F0-9]{32,}$`)
 
-// writeCachedDigest persists digest atomically via atomic.WriteFile.
-// Without atomicity, a crash mid-write could leave a partial digest
-// string that would later mis-read on cache hit and trigger a
-// misleading cosign failure on the next reconcile.
+// writeCachedDigest records digest in the slot's meta sidecar, preserving any
+// existing verify fingerprint.
 func writeCachedDigest(slot, digest string) error {
-	return atomic.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(digest), 0o600, true)
+	m, _ := source.ReadSlotMeta(slot)
+	m.Digest = digest
+	return source.WriteSlotMeta(slot, m)
 }
 
-// readCachedDigest returns the cached digest only when it parses as a
-// well-formed OCI content digest. Empty + malformed both return "" so
-// the caller's "no marker" branch handles the recovery uniformly.
+// readCachedDigest returns the slot's recorded digest only when it is
+// well-formed; "" otherwise (missing sidecar, legacy slot, or malformed digest).
 func readCachedDigest(slot string) string {
-	b, err := os.ReadFile(filepath.Join(slot, cachedDigestFile)) //nolint:gosec // slot is fetcher-owned cache path
-	if err != nil {
+	m, ok := source.ReadSlotMeta(slot)
+	if !ok || !digestRE.MatchString(m.Digest) {
 		return ""
 	}
-	s := strings.TrimSpace(string(b))
-	if !digestRE.MatchString(s) {
-		return ""
-	}
-	return s
+	return m.Digest
 }
 
+// cachedDigestFresh returns the recorded digest only when the sidecar was
+// written within maxAge and the digest is well-formed.
 func cachedDigestFresh(slot string, maxAge time.Duration) (string, bool) {
-	if maxAge <= 0 {
+	m, ok := source.ReadSlotMetaFresh(slot, maxAge)
+	if !ok || !digestRE.MatchString(m.Digest) {
 		return "", false
 	}
-	f, err := os.Open(filepath.Join(slot, cachedDigestFile)) //nolint:gosec // slot is fetcher-owned cache path
-	if err != nil {
-		return "", false
-	}
-	defer func() { _ = f.Close() }()
-	info, err := f.Stat()
-	if err != nil || time.Since(info.ModTime()) > maxAge {
-		return "", false
-	}
-	b, err := io.ReadAll(f)
-	if err != nil {
-		return "", false
-	}
-	d := strings.TrimSpace(string(b))
-	if !digestRE.MatchString(d) {
-		return "", false
-	}
-	return d, true
+	return m.Digest, true
 }
 
-// verifyFingerprint hashes the verify spec into a short identifier
-// stored next to the cached digest. Any meaningful change to the
-// verify policy (provider, MatchOIDCIdentity, SecretRef) produces a
-// different fingerprint and forces re-verify. JSON-marshal the spec
-// for a deterministic representation — the upstream Verify struct
-// has stable JSON tags.
+// verifyFingerprint hashes the verify spec into a short identifier stored in
+// the sidecar. Any meaningful change to the verify policy (provider,
+// MatchOIDCIdentity, SecretRef) produces a different fingerprint and forces
+// re-verify. JSON-marshal the spec for a deterministic representation.
 func verifyFingerprint(v *manifest.OCIRepositoryVerify) string {
 	if v == nil {
 		return ""
 	}
 	h, err := source.CacheKeyHash(v, 16)
 	if err != nil {
-		// Marshal-of-typed-struct shouldn't fail; if it does we
-		// fingerprint as empty which forces re-verify (safe default).
+		// Marshal-of-typed-struct shouldn't fail; if it does we fingerprint as
+		// empty, which forces re-verify (the safe default).
 		return ""
 	}
 	return h
 }
 
-// writeVerifyMarker persists the verify-policy fingerprint to the
-// slot atomically. atomic.WriteFile handles the temp-file + fsync +
-// rename dance so a crash mid-write can't leave a partial fingerprint
-// that would falsely match.
+// writeVerifyMarker records the verify-policy fingerprint in the slot's meta
+// sidecar, preserving the digest. Called only after a successful verification.
 func writeVerifyMarker(slot, fingerprint string) error {
-	return atomic.WriteFile(filepath.Join(slot, verifyMarkerFile), []byte(fingerprint), 0o600, true)
+	m, _ := source.ReadSlotMeta(slot)
+	m.Verified = fingerprint
+	return source.WriteSlotMeta(slot, m)
 }
 
-// readVerifyMarker returns the cached fingerprint or "" when the
-// marker is missing / unreadable. Empty matches the fingerprint of a
-// nil Verify; a different non-empty value forces re-verify.
+// readVerifyMarker returns the slot's recorded verify fingerprint, or "" when
+// the sidecar is absent (forcing re-verify).
 func readVerifyMarker(slot string) string {
-	b, err := os.ReadFile(filepath.Join(slot, verifyMarkerFile)) //nolint:gosec // slot is fetcher-owned cache path
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(b))
+	m, _ := source.ReadSlotMeta(slot)
+	return m.Verified
 }

--- a/pkg/source/oci/oci_unit_test.go
+++ b/pkg/source/oci/oci_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 )
 
 // fullDigest is a sha256-shaped digest used across the cached-
@@ -38,24 +39,11 @@ func TestReadCachedDigest_MissingReturnsEmpty(t *testing.T) {
 	}
 }
 
-// TestReadCachedDigest_TrimsTrailingNewline covers the trim path —
-// an editor adding a trailing newline shouldn't break cache matching.
-func TestReadCachedDigest_TrimsTrailingNewline(t *testing.T) {
-	slot := t.TempDir()
-	if err := os.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(fullDigest+"\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if got := readCachedDigest(slot); got != fullDigest {
-		t.Errorf("got %q, want trimmed digest", got)
-	}
-}
-
 // TestReadCachedDigest_MalformedTreatedAsMissing pins the
-// format-validation contract: a torn write (partial digest, garbage,
-// or an old-shorter-than-spec value) must read as "" so the
-// fetcher's cache-hit path resets the slot instead of passing the
-// partial digest to cosign (which would produce a misleading
-// "signature not found" failure).
+// format-validation contract: a malformed digest in the sidecar (partial,
+// garbage, or shorter than the OCI spec minimum) must read as "" so the
+// fetcher's cache-hit path resets the slot instead of passing the bad digest
+// to cosign (which would produce a misleading "signature not found" failure).
 func TestReadCachedDigest_MalformedTreatedAsMissing(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -71,7 +59,7 @@ func TestReadCachedDigest_MalformedTreatedAsMissing(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			slot := t.TempDir()
-			if err := os.WriteFile(filepath.Join(slot, cachedDigestFile), []byte(tc.content), 0o600); err != nil {
+			if err := source.WriteSlotMeta(slot, source.SlotMeta{Digest: tc.content}); err != nil {
 				t.Fatal(err)
 			}
 			if got := readCachedDigest(slot); got != "" {
@@ -97,7 +85,7 @@ func TestWriteCachedDigest_AtomicNoPartial(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, e := range entries {
-		if e.Name() == cachedDigestFile {
+		if e.Name() == source.SlotMetaFile {
 			continue
 		}
 		t.Errorf("unexpected leftover entry in slot after writeCachedDigest: %q (atomic write should have cleaned up the temp)", e.Name())
@@ -198,7 +186,7 @@ func TestVerifyMarker_AtomicRoundtrip(t *testing.T) {
 	// No temp leftover.
 	entries, _ := os.ReadDir(slot)
 	for _, e := range entries {
-		if e.Name() == verifyMarkerFile {
+		if e.Name() == source.SlotMetaFile {
 			continue
 		}
 		t.Errorf("unexpected leftover entry %q in slot after writeVerifyMarker", e.Name())
@@ -218,5 +206,34 @@ func TestSignatureManifestRoundtrip(t *testing.T) {
 	}
 	if m.Layers[0].Annotations["dev.cosignproject.cosign/signature"] == "" {
 		t.Error("annotation roundtrip lost the signature key")
+	}
+}
+
+// TestSlotMeta_DigestAndVerifyCoexist pins the read-modify-write contract of
+// the unified sidecar: writing the digest, then the verify fingerprint (the
+// real fetch order), must leave BOTH readable — a writer must never clobber the
+// sibling field. A regression here surfaces as a cache hit re-verifying every
+// run (digest lost) or, worse, the digest rewrite dropping the fingerprint, so
+// it is the load-bearing invariant of the marker unification.
+func TestSlotMeta_DigestAndVerifyCoexist(t *testing.T) {
+	slot := t.TempDir()
+	if err := writeCachedDigest(slot, fullDigest); err != nil {
+		t.Fatalf("writeCachedDigest: %v", err)
+	}
+	if err := writeVerifyMarker(slot, "fp99"); err != nil {
+		t.Fatalf("writeVerifyMarker: %v", err)
+	}
+	if got := readCachedDigest(slot); got != fullDigest {
+		t.Errorf("digest lost after verify write: %q", got)
+	}
+	if got := readVerifyMarker(slot); got != "fp99" {
+		t.Errorf("verify lost: %q", got)
+	}
+	// A re-pull (digest rewrite) must preserve the verify fingerprint.
+	if err := writeCachedDigest(slot, fullDigest); err != nil {
+		t.Fatalf("rewrite digest: %v", err)
+	}
+	if got := readVerifyMarker(slot); got != "fp99" {
+		t.Errorf("verify clobbered by digest rewrite: %q", got)
 	}
 }


### PR DESCRIPTION
## What

Collapse the per-fact `.flate-*` cache-slot markers — `.flate-git-revision`,
`.flate-digest`, `.flate-verified` — into **one structured `.flate-meta.json`
sidecar** per fetched slot (`source.SlotMeta{revision, digest, verified}`,
atomically written). `.flate-`-prefixed so it never collides with a user file
in the materialized tree; JSON so a new fact is a new field, not a new file.

Phase 2 of the in-memory-rendering redesign (marker elimination).

## Why this shape

The redesign asked "why so many random file markers?". This answers it for the
source-cache layer. It does **not** drop the on-disk git worktree slot: Phase 1
pivoted the render to a memory-over-disk overlay that reads a git source from a
real on-disk path, so the worktree must stay. Dropping it (the original Phase 2
sketch, premised on the now-abandoned in-memory snapshot) would re-introduce a
full per-run tree materialization — the very per-run copying the redesign just
removed.

## Safety

- The OCI writers read-modify-write the sidecar so digest + verify coexist; the
  verify fingerprint is written **only after a successful verification**, so
  `meta.Verified == want` always implies the slot was validated under that
  policy. The cache-hit verify-skip cannot skip an unvalidated slot.
- Pre-`meta.json` slots read as "no marker" → rebuilt once (self-healing).

## Verification

- gofmt · `go build/vet ./...` · `go test -race ./...` · `golangci-lint` 0 issues.
- New tests: sidecar round-trip / missing / malformed-JSON / freshness, and the
  load-bearing **digest+verify coexistence** invariant (a writer must never
  clobber the sibling field).
- Cross-repo byte-equivalence vs the prior path across `~/repos` + `~/k8s-gitops`
  (render output is unchanged — the sidecar is cache metadata, not render input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
