### PR TITLE
refactor(cli,source): retire the inert --stage-cache-mb flag and dead stage layout

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -60,9 +60,6 @@ type commonFlags struct {
 	// to an explicit commit always full-clone. Plumbed into
 	// orchestrator.Config.GitDepth → git.Fetcher.Depth.
 	gitDepth int
-	// stageCacheMB caps the persistent kustomize stage cache. 0
-	// disables LRU eviction so the GC subcommand owns cleanup.
-	stageCacheMB int
 	// cacheDir is resolved lazily via resolveCacheRoot and memoized so
 	// multiple lookups within one invocation return the same value.
 	cacheDir string
@@ -160,9 +157,6 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 	// CI runners where disk cost outweighs the rerun savings).
 	fs.IntVar(&f.helmRenderCacheMB, "helm-render-cache-mb", 1024,
 		"size of the persistent on-disk helm template-output cache in megabytes (0 disables)")
-	fs.IntVar(&f.stageCacheMB, "stage-cache-mb", 2048,
-		"cap (MiB) for the persistent kustomize stage cache; 0 disables LRU eviction "+
-			"(the cache subcommand still age-prunes)")
 }
 
 // skipResourceKinds delegates to helm.Options.SkipResourceKinds so
@@ -409,7 +403,6 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 		CacheDir:               c.resolveCacheRoot(),
 		HelmTemplateCacheBytes: int64(c.helmTemplateCacheMB) << 20,
 		HelmRenderCacheBytes:   int64(c.helmRenderCacheMB) << 20,
-		StageCacheBytes:        int64(c.stageCacheMB) << 20,
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -30,12 +30,6 @@ import (
 
 // Config carries everything the orchestrator needs.
 type Config struct {
-	// StageCacheBytes caps the persistent kustomize stage cache. 0
-	// disables eviction (unbounded growth — the GC subcommand still
-	// handles age-based cleanup). The flag's expected unit is mebibytes
-	// at the CLI layer; this field is bytes.
-	StageCacheBytes int64
-
 	// Path is the directory to scan for Flux objects (the scan entry
 	// point — a cluster's Flux entry, which may be a subdir of RepoRoot).
 	Path string

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -62,7 +62,6 @@ const (
 	RefsDir       = "refs"
 	GitMirrorsDir = "git-mirrors"
 	HelmTmpDir    = "helm-tmp"
-	StageDir      = "stage"
 	// RenderHelmCacheDir holds the persisted helm template-output
 	// cache. Entries are sharded `<root>/render/helm/<hex[:2]>/<hex>`
 	// where <hex> is the full sha256 of the template-cache key. Content
@@ -162,16 +161,6 @@ func (l Layout) GitMirror(urlHash string) string {
 // HelmTmp returns the scratch directory the HelmChart fetcher uses for
 // transient writes (index.yaml downloads, TLS cert materialization).
 func (l Layout) HelmTmp() string { return app2(l.Root, HelmTmpDir) }
-
-// Stage returns the kustomize staging root. Two consumers share it:
-//   - Per-process scratch stages land as flate-stage-<rand> children (legacy
-//     fallback for sources without a content-addressable fingerprint).
-//   - Persistent content-addressed stages land at <stage>/<digest[:2]>/<digest>/
-//     keyed by the source artifact's fingerprint (git SHA, OCI digest…).
-//
-// The two-char fan-out prefix keeps any one subdir below typical FS dirent
-// limits and never collides with the `flate-stage-` legacy prefix.
-func (l Layout) Stage() string { return app2(l.Root, StageDir) }
 
 // RenderHelmCache returns the parent directory of the persisted helm
 // template-output cache. Entries live under sharded subdirs keyed by

--- a/pkg/source/cacheroot/layout_test.go
+++ b/pkg/source/cacheroot/layout_test.go
@@ -27,7 +27,6 @@ func TestLayout_Paths(t *testing.T) {
 		{"GitMirrors", l.GitMirrors(), "/cache/git-mirrors"},
 		{"GitMirror", l.GitMirror("0123"), "/cache/git-mirrors/0123"},
 		{"HelmTmp", l.HelmTmp(), "/cache/helm-tmp"},
-		{"Stage", l.Stage(), "/cache/stage"},
 		{"RenderHelmCache", l.RenderHelmCache(), "/cache/render/helm"},
 	}
 	for _, c := range cases {


### PR DESCRIPTION
## What

Retire the now-inert persistent-stage-cache knobs left behind by the in-memory
render redesign (#626):

- the `--stage-cache-mb` CLI flag (+ its `stageCacheMB` field),
- `orchestrator.Config.StageCacheBytes` (no longer read),
- `cacheroot.Layout.Stage()` / `StageDir` (nothing writes a stage dir anymore).

Final cleanup phase of the redesign.

## Why

#626 made rendering fully in-memory and deleted the on-disk `StagingCache`, so
these were dead weight. `--stage-cache-mb` now errors as an unknown flag instead
of silently doing nothing.

## Verification

- gofmt · `go build/vet ./...` · `go test -race ./...` · `golangci-lint` 0 issues.
- Pure cleanup — render output is unchanged (the flag was already a no-op);
  confirmed by a `build all` smoke render (onedr0p, byte-identical line count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
