### PR TITLE
docs: scrub stale references to the deleted on-disk staging cache

### DIFF
--- a/internal/cas/stage.go
+++ b/internal/cas/stage.go
@@ -1,14 +1,11 @@
-// Package cas holds the atomic content-addressed staging dance shared
-// by baseline materialization and the kustomize stage cache: build into
-// a sibling temp dir, atomically rename it into the final slot, and —
-// when the rename loses a cross-process race — discard the temp and
-// adopt the winner's already-finalized directory.
+// Package cas holds the atomic content-addressed staging dance used by
+// baseline materialization: build into a sibling temp dir, atomically rename
+// it into the final slot, and — when the rename loses a cross-process race —
+// discard the temp and adopt the winner's already-finalized directory.
 //
-// What "build" does and how a race is detected differ between callers
-// (baseline writes a git tree + .git marker and adopts on a finalized
-// directory; the stage cache copies a file tree and adopts on a sentinel
-// file), so both are callbacks. The temp-dir lifecycle, the rename, and
-// the discard-on-failure cleanup are identical and live here.
+// What "build" does and how a race is detected are caller-supplied callbacks
+// (baseline writes a git tree and adopts on a finalized directory). The
+// temp-dir lifecycle, the rename, and the discard-on-failure cleanup live here.
 package cas
 
 import (

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -117,7 +117,7 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 	}
 	fs.StringVar(&f.registryConfig, "registry-config", "", "docker config.json for OCI authentication")
 	fs.StringVar(&f.cacheDir, "cache-dir", "",
-		"on-disk cache root for source artifacts, helm charts, kustomize stages, "+
+		"on-disk cache root for source artifacts, helm charts, "+
 			"and persistent render output. Defaults to $XDG_CACHE_HOME/flate "+
 			"(Linux), ~/Library/Caches/flate (macOS), %LocalAppData%/flate "+
 			"(Windows), falling back to $TMPDIR/flate-cache if those error.")

--- a/internal/diskcache/sweep.go
+++ b/internal/diskcache/sweep.go
@@ -1,8 +1,6 @@
 // Package diskcache holds the pieces of the single-flight, mtime-LRU
-// disk-cache sweep shared by the helm render cache and the kustomize
-// stage cache. The two consumers collect their entries very
-// differently (a recursive file walk vs. a two-level, sentinel-filtered
-// directory scan), so collection stays in each package; what's shared
+// disk-cache sweep used by the helm render cache (pkg/helm). Entry
+// collection (a recursive file walk) stays in the caller; what's shared
 // here is the single-flight gate that keeps a burst of writes from
 // forking one sweep per write, and the oldest-first eviction loop that
 // deletes entries until total bytes fall under a cap.
@@ -42,11 +40,10 @@ type Entry struct {
 // EvictOldest removes entries oldest-first until the running total is at
 // or below limit. total is the caller's pre-summed byte usage of
 // entries; when it's already within limit nothing is removed. less
-// defines the eviction order (callers pin their own tie-break — helm
-// sorts by mtime then path, the stage cache by mtime alone). remove
-// deletes one entry's path and returns an error on failure; a failed
-// remove is skipped (its bytes stay counted) and the sweep continues,
-// matching both call sites' best-effort semantics.
+// defines the eviction order (the helm render cache pins mtime then
+// path). remove deletes one entry's path and returns an error on
+// failure; a failed remove is skipped (its bytes stay counted) and the
+// sweep continues, matching the caller's best-effort semantics.
 func EvictOldest(entries []Entry, total, limit int64, less func(a, b Entry) int, remove func(e Entry) error) {
 	if total <= limit {
 		return

--- a/pkg/helm/postrender.go
+++ b/pkg/helm/postrender.go
@@ -89,7 +89,7 @@ func runKustomizePostRender(in *bytes.Buffer, k *helmv2.Kustomize) (*bytes.Buffe
 	// kustomize's krusty pipeline mutates package-global state that is
 	// not goroutine-safe. Hold the shared build mutex so this HR
 	// post-render never runs concurrently with a Kustomization's
-	// SecureBuild (or another HR's post-render) — see kustomize.BuildMutex.
+	// build (or another HR's post-render) — see kustomize.BuildMutex.
 	rm, err := func() (resmap.ResMap, error) {
 		flatekustomize.BuildMutex.Lock()
 		defer flatekustomize.BuildMutex.Unlock()

--- a/pkg/kustomize/doc.go
+++ b/pkg/kustomize/doc.go
@@ -1,10 +1,13 @@
 // Package kustomize wraps sigs.k8s.io/kustomize/api so the rest of
 // flate never invokes the `kustomize` CLI. It provides:
 //
-//   - Build / RenderFlux: render a kustomization directory to YAML
-//     documents. Build is the plain krusty surface; RenderFlux adds
-//     the Flux generator that handles spec.components and embedded
-//     inline Contents.
+//   - RenderFlux: render a Flux Kustomization to YAML documents entirely
+//     in memory. It reproduces the kustomize-controller's spec merge
+//     (generate.go) and builds against a memory-over-disk overlay
+//     (overlayfs.go) rooted at the source — source files are read from a
+//     secure on-disk FS, the merged kustomization.yaml + any pre-fetched
+//     remote resources are written to an in-memory layer, and the source
+//     tree is never copied or mutated.
 //   - Prepare: the standard pre-render dance (Clone + expand
 //     postBuild.substituteFrom) for embedders rendering a single
 //     Kustomization. Symmetric to helm.Prepare for HelmReleases, minus
@@ -13,24 +16,19 @@
 //   - Substitute: envsubst-style "${VAR}" / "${VAR:=default}" used
 //     for Flux post-build substitutions.
 //
-// Concurrency. Two locks guard krusty's non-thread-safety:
+// Concurrency. Each RenderFlux call builds against its own private overlay,
+// so no two renders share mutable state and there is no per-tree build lock.
+// krusty's package-global state (the openapi schema registry, builtin
+// plugin/transformer factories) is still not goroutine-safe, so the
+// process-wide BuildMutex (flux.go) serializes EVERY krusty invocation flate
+// runs — including the helm post-renderer's krusty.Run in pkg/helm.
+// fluxcd/pkg/kustomize guards its own Build for the same reason; every
+// flate-owned krusty entrypoint MUST hold BuildMutex.
 //
-//   - A per-path lock (stageLocks) serializes builds against the SAME
-//     staged directory, which krusty mutates in place.
-//   - The process-wide BuildMutex (flux.go) serializes EVERY krusty
-//     invocation flate runs — including the helm post-renderer's
-//     krusty.Run in pkg/helm — because kustomize's package-global state
-//     (the openapi schema registry, builtin plugin/transformer
-//     factories) is not goroutine-safe. fluxcd/pkg/kustomize guards its
-//     own SecureBuild for the same reason; every flate-owned krusty
-//     entrypoint MUST hold BuildMutex.
-//
-// Caching boundary. kustomize output caching is deferred to the
-// controller layer (the Kustomization controller's spec+source
-// fingerprint dedup), NOT memoized inside this package the way
-// helm.Client caches template output. RenderFlux mutates the staged
-// workspace and krusty plugins/generators are not guaranteed
-// deterministic, so the stable point to memoize is the coarse
-// spec+source hash the controller already computes — not the render
-// engine's fluid internals.
+// Caching boundary. kustomize output caching is deferred to the controller
+// layer (the Kustomization controller's spec+source fingerprint dedup), NOT
+// memoized inside this package the way helm.Client caches template output.
+// krusty plugins/generators are not guaranteed deterministic, so the stable
+// point to memoize is the coarse spec+source hash the controller already
+// computes — not the render engine's fluid internals.
 package kustomize

--- a/pkg/kustomize/gitbase.go
+++ b/pkg/kustomize/gitbase.go
@@ -6,8 +6,8 @@ package kustomize
 // pre-resolves both so `kustomize build` only ever sees local files. The HTTP
 // half lives in preflight.go; this file owns the git half: recognize a git
 // base, fetch it via the injected GitBaseFetcher (which wraps the existing
-// pkg/source/git machinery), copy the worktree into the staged tree, and hand
-// back a local directory path for the resources: entry.
+// pkg/source/git machinery), copy the worktree into the render's in-memory fs,
+// and hand back a local directory path for the resources: entry.
 
 import (
 	"context"

--- a/pkg/kustomize/remotefetch.go
+++ b/pkg/kustomize/remotefetch.go
@@ -23,7 +23,7 @@ type remoteFetch struct {
 
 // FetchRemote returns the body of urlStr, fetched at most once per
 // (url, success) cache entry. Successful bodies are cached for the
-// StagingCache lifetime; transient errors (DNS, connection reset,
+// TreeCache lifetime; transient errors (DNS, connection reset,
 // timeout, 5xx) are NOT cached — the next caller retries. Only
 // definitive HTTP 4xx responses are cached as negative entries
 // (they won't change between retries within a run).


### PR DESCRIPTION
Comment + CLI-help-string cleanup closing out the in-memory render redesign (#626/#627/#628): doc comments that still described `StagingCache` / `stageLocks` / the staged workspace / the kustomize stage cache now describe the in-memory overlay reality (private per-render overlay, `TreeCache`, `Build`, single-consumer `cas`/`diskcache`). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)