### PR TITLE
refactor: codebase-wide behavior-preserving cleanliness pass

### DIFF
--- a/cmd/flate/main.go
+++ b/cmd/flate/main.go
@@ -29,11 +29,7 @@ func versionString() string {
 	if commit == "unknown" {
 		return v
 	}
-	short := commit
-	if len(short) > 7 {
-		short = short[:7]
-	}
-	return v + " (" + short + ")"
+	return v + " (" + commit[:min(len(commit), 7)] + ")"
 }
 
 // tuneGC raises the GC target for flate's short-lived, allocation-heavy

--- a/internal/cas/stage.go
+++ b/internal/cas/stage.go
@@ -27,8 +27,8 @@ import (
 //     adopt it (no error); otherwise the rename error is wrapped with
 //     finalizePrefix ("<finalizePrefix>: %w").
 //
-// The two prefixes keep each call site's existing error strings intact
-// ("baseline staging"/"baseline finalize", "stage tmp"/"stage finalize").
+// The two prefixes let the caller keep its own error strings intact
+// (baseline passes "baseline staging"/"baseline finalize").
 //
 // adopted reports whether the returned slot came from adopting a peer's
 // finalized directory (false on the normal rename-wins path); callers

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -297,7 +297,7 @@ func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 
 // resolveBaseline runs baseline.AutoResolve when the user opted into
 // changed-only mode via --base, mutates c.pathOrig to the synthetic
-// materialized path, and schedules tempdir cleanup against ctx.
+// materialized path, and returns a tempdir-cleanup func.
 //
 // autoFallback toggles the "fire even when both flags are empty" case
 // — true for `flate diff` (which always needs a baseline; bare
@@ -320,7 +320,7 @@ func (c commonFlags) helmOptions(h helmFlags) helm.Options {
 //
 // Callers receive a no-op when no materialization happened (no
 // --base / no autoFallback / explicit --path-orig).
-func resolveBaseline(_ context.Context, c *commonFlags, autoFallback bool) (func(), error) {
+func resolveBaseline(c *commonFlags, autoFallback bool) (func(), error) {
 	noop := func() {}
 	if c.pathOrig != "" && c.base != "" {
 		return noop, errors.New("--path-orig and --base are mutually exclusive")
@@ -435,7 +435,7 @@ func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestr
 	// Cleanup is deferred (not bound to ctx) so the tempdir survives
 	// SIGINT until the orchestrator's read paths have actually
 	// unwound.
-	cleanup, err := resolveBaseline(ctx, &c, false)
+	cleanup, err := resolveBaseline(&c, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -203,7 +203,7 @@ func runDiffOrchestrators(ctx context.Context, c *commonFlags, h *helmFlags) (di
 	// is set, auto-detect via the merge-base ladder. Cleanup is
 	// deferred (not bound to ctx) so the tempdir survives SIGINT
 	// until both orchestrators' read paths have actually unwound.
-	cleanup, err := resolveBaseline(ctx, c, true)
+	cleanup, err := resolveBaseline(c, true)
 	if err != nil {
 		return diffSide{}, diffSide{}, err
 	}

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -216,10 +216,10 @@ func printResources[T manifest.BaseManifest](
 	pairs := make([]pair, 0, len(objs))
 	nameExists := sel.Name == ""
 	for _, obj := range objs {
-		if sel.Name != "" && obj.Named().Name != sel.Name {
+		id := obj.Named()
+		if sel.Name != "" && id.Name != sel.Name {
 			continue
 		}
-		id := obj.Named()
 		if !c.includeNamespace(o.Filter(), id.Namespace) {
 			continue
 		}

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -145,13 +145,7 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		// through to their own stage (one wins the rename, the rest
 		// see ErrExist, discard the temp, and adopt the winner's slot).
 		if _, err := cas.Stage(filepath.Dir(slot), slot, "baseline staging", "baseline finalize",
-			func(staging string) error {
-				return gittree.Materialize(context.Background(), repo, hash, staging, gittree.Options{
-					OnSubmodule: func(path string) {
-						slog.Warn("baseline: skipping submodule", "path", path)
-					},
-				})
-			},
+			func(staging string) error { return materialize(repo, hash, staging) },
 			func() bool { info, statErr := os.Stat(slot); return statErr == nil && info.IsDir() },
 		); err != nil {
 			return "", false, err
@@ -163,15 +157,21 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 	if err != nil {
 		return "", false, fmt.Errorf("baseline tempdir: %w", err)
 	}
-	if err := gittree.Materialize(context.Background(), repo, hash, tmp, gittree.Options{
-		OnSubmodule: func(path string) {
-			slog.Warn("baseline: skipping submodule", "path", path)
-		},
-	}); err != nil {
+	if err := materialize(repo, hash, tmp); err != nil {
 		_ = os.RemoveAll(tmp)
 		return "", false, err
 	}
 	return tmp, false, nil
+}
+
+// materialize extracts hash's tree into root, skipping (and warning on)
+// any submodules.
+func materialize(repo *git.Repository, hash plumbing.Hash, root string) error {
+	return gittree.Materialize(context.Background(), repo, hash, root, gittree.Options{
+		OnSubmodule: func(path string) {
+			slog.Warn("baseline: skipping submodule", "path", path)
+		},
+	})
 }
 
 // relToRepo returns path's location relative to repoRoot. Returns "."

--- a/pkg/baseline/doc.go
+++ b/pkg/baseline/doc.go
@@ -2,12 +2,12 @@
 // tempdir so `flate diff` can run without an explicit --path-orig.
 //
 // The user-facing flow: when --path-orig isn't supplied, the CLI
-// asks baseline.Resolve for the commit to diff against (either the
-// explicit --base=<rev>, or auto-detected via merge-base with the
-// branch's upstream / origin/HEAD / origin/{main,master}) and then
-// asks Materialize to extract that commit's tree into a fresh
-// tempdir. The CLI sets --path-orig to that tempdir for the
-// remainder of the diff run, then deletes it on exit.
+// calls AutoResolve, which picks the commit to diff against (either
+// the explicit --base=<rev>, or auto-detected via merge-base with the
+// branch's upstream / origin/HEAD / origin/{main,master}) and extracts
+// that commit's tree into a fresh tempdir. The CLI sets --path-orig to
+// that tempdir for the remainder of the diff run, then deletes it on
+// exit.
 //
 // This package treats the user's checkout as read-only — it opens
 // the existing repo via go-git's object store and does not mutate

--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -251,9 +251,11 @@ func detectViaWalker(before, after string) (*Set, error) {
 
 	paths := make(map[string]struct{}, len(afterFS)/8)
 	type hashJob struct {
-		rel                         string
-		beforeAbs, afterAbs         string
-		beforeSymlink, afterSymlink bool
+		rel                 string
+		beforeAbs, afterAbs string
+		// symlink applies to both sides: a job is only queued when the
+		// before/after entry kinds agree (a type swap is handled above).
+		symlink bool
 	}
 	var hashJobs []hashJob
 
@@ -278,7 +280,7 @@ func detectViaWalker(before, after string) (*Set, error) {
 		// on coarse-mtime filesystems; correctness over speed here.
 		hashJobs = append(hashJobs, hashJob{
 			rel: rel, beforeAbs: bef.abs, afterAbs: after.abs,
-			beforeSymlink: bef.symlink, afterSymlink: after.symlink,
+			symlink: after.symlink,
 		})
 	}
 	for rel := range beforeFS {
@@ -295,11 +297,11 @@ func detectViaWalker(before, after string) (*Set, error) {
 		for range hashWorkers {
 			hg.Go(func() error {
 				for j := range jobs {
-					b, err := hashEntry(j.beforeAbs, j.beforeSymlink)
+					b, err := hashEntry(j.beforeAbs, j.symlink)
 					if err != nil {
 						return err
 					}
-					a, err := hashEntry(j.afterAbs, j.afterSymlink)
+					a, err := hashEntry(j.afterAbs, j.symlink)
 					if err != nil {
 						return err
 					}

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -364,6 +364,16 @@ func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResourc
 	return f.addRecursiveLocked(id)
 }
 
+// markKept records id in the keep set, mirroring it into keepByName
+// only for empty-namespace ids (see ShouldReconcile for the asymmetry
+// rationale). Caller MUST hold f.mu.Lock().
+func (f *Filter) markKept(id manifest.NamedResource) {
+	f.keep[id] = struct{}{}
+	if id.Namespace == "" {
+		f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+	}
+}
+
 // addRecursiveLocked is the lock-free body of addRecursive — the
 // caller MUST hold f.mu.Lock(). Pulled out so AddEmitted can do its
 // gate-and-recurse atomically under a single lock acquisition.
@@ -379,10 +389,7 @@ func (f *Filter) addRecursiveLocked(id manifest.NamedResource) []manifest.NamedR
 			continue
 		}
 		if !alreadyKeep {
-			f.keep[cur] = struct{}{}
-			if cur.Namespace == "" {
-				f.keepByName[nameKey{cur.Kind, cur.Name}] = struct{}{}
-			}
+			f.markKept(cur)
 			added = append(added, cur)
 		}
 		// Promote ancestor-only entries to primary when a runtime
@@ -439,10 +446,7 @@ func (f *Filter) addDependencyOnlyRecursiveLocked(ids ...manifest.NamedResource)
 		if _, alreadyKeep := f.keep[cur]; alreadyKeep {
 			continue
 		}
-		f.keep[cur] = struct{}{}
-		if cur.Namespace == "" {
-			f.keepByName[nameKey{cur.Kind, cur.Name}] = struct{}{}
-		}
+		f.markKept(cur)
 		added = append(added, cur)
 		if f.objs == nil {
 			continue
@@ -473,9 +477,7 @@ func (f *Filter) resolve(objs ObjectLister) {
 			return
 		}
 		primary[id] = struct{}{}
-		if _, seen := keep[id]; !seen {
-			keep[id] = struct{}{}
-		}
+		keep[id] = struct{}{}
 		// Always re-queue when promoting an ancestor-only entry
 		// to primary: the BFS body uses the head's primacy at
 		// dequeue time to decide whether transitiveDeps propagate

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -162,8 +162,9 @@ func (c *Controller) onRawProducerAdded() store.Listener {
 
 // rawProducerTargetID returns the NamedResource of the Secret that raw
 // will produce, or (zero, false) when raw is not a recognised producer kind.
-// This mirrors the classification in rawProducerTargetID but returns the
-// target identity rather than a boolean, so the index can be keyed by it.
+// It is the single source of truth for producer classification; extending
+// coverage to a new kind means adding a case here (see the rawProducerIndex
+// field comment).
 func rawProducerTargetID(raw *manifest.RawObject) (manifest.NamedResource, bool) {
 	switch raw.Kind {
 	case "ExternalSecret":

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -95,7 +95,6 @@ func (c *Controller) omitValuesFrom(
 		return hr
 	}
 	filtered := make([]manifest.ValuesReference, 0, len(hr.ValuesFrom))
-	omitted := false
 	for _, ref := range hr.ValuesFrom {
 		id, ok := valuesRefID(hr, ref)
 		if !ok {
@@ -121,14 +120,21 @@ func (c *Controller) omitValuesFrom(
 			filtered = append(filtered, ref)
 			continue
 		}
-		omitted = true
 		args := []any{"id", hr.Named().String(), "ref", id.String()}
 		if hasProducer {
 			args = append(args, "producer", producer.String())
 		}
 		slog.Debug("helmrelease: omitted unavailable valuesFrom ref", args...)
 	}
-	if !omitted {
+	return cloneWithValuesFrom(hr, filtered)
+}
+
+// cloneWithValuesFrom returns hr unchanged when filtered keeps every ref
+// (the callers only ever drop, never add or reorder, so an equal length
+// means nothing was omitted), otherwise a clone carrying filtered. Keeping
+// the copy-on-write in one place lets the filtering loops stay declarative.
+func cloneWithValuesFrom(hr *manifest.HelmRelease, filtered []manifest.ValuesReference) *manifest.HelmRelease {
+	if len(filtered) == len(hr.ValuesFrom) {
 		return hr
 	}
 	out := hr.Clone()
@@ -192,21 +198,13 @@ func removeValuesRefs(hr *manifest.HelmRelease, ids map[manifest.NamedResource]s
 		return hr
 	}
 	filtered := make([]manifest.ValuesReference, 0, len(hr.ValuesFrom))
-	omitted := false
 	for _, ref := range hr.ValuesFrom {
-		id, ok := valuesRefID(hr, ref)
-		if ok {
+		if id, ok := valuesRefID(hr, ref); ok {
 			if _, drop := ids[id]; drop {
-				omitted = true
 				continue
 			}
 		}
 		filtered = append(filtered, ref)
 	}
-	if !omitted {
-		return hr
-	}
-	out := hr.Clone()
-	out.ValuesFrom = filtered
-	return out
+	return cloneWithValuesFrom(hr, filtered)
 }

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"slices"
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -280,7 +281,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 // continues); adding a hard edge here would regress every offline
 // render against a Flux repo that uses secret-substitute patterns.
 func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.DependencyRef {
-	deps := append([]manifest.DependencyRef(nil), ks.DependsOn...)
+	deps := slices.Clone(ks.DependsOn)
 	if ks.SourceKind != "" && ks.SourceName != "" {
 		deps = append(deps, manifest.DependencyRef{
 			NamedResource: manifest.NamedResource{

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -103,10 +103,8 @@ func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
 func (c *Controller) reconcile(ctx context.Context, obj manifest.BaseManifest) error {
 	id := obj.Named()
 	// The listener already filtered by registered Kind (see
-	// onObjectAdded), so this Fetchers lookup can't miss; lookup is
-	// cheap and lets us hold a typed reference for the rest of the
-	// function. Note: the second-redundant `c.Fetchers[id.Kind]`
-	// check that lived here was dropped — it was unreachable.
+	// onObjectAdded), so this Fetchers lookup can't miss; it's cheap and
+	// gives us a typed reference for the rest of the function.
 	fetcher := c.Fetchers[id.Kind]
 	// Existence short-circuit: a source we already fetched in this run
 	// stays fetched. Idempotent re-AddObject (e.g. a parent KS

--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -242,13 +242,13 @@ func conditionToMap(c metav1.Condition) map[string]any {
 // behave sensibly. Kinds absent from the map return "" — most ReadyExpr
 // formulations don't read it, so the empty value is a safe default.
 var kindAPIVersion = map[string]string{
-	manifest.KindKustomization:   manifest.FluxKustomizeDomain + "/v1",
-	manifest.KindHelmRelease:     manifest.HelmReleaseDomain + "/v2",
-	manifest.KindGitRepository:   manifest.SourceDomain + "/v1",
-	manifest.KindOCIRepository:   manifest.SourceDomain + "/v1",
-	manifest.KindHelmRepository:  manifest.SourceDomain + "/v1",
-	manifest.KindHelmChart:       manifest.SourceDomain + "/v1",
-	manifest.KindBucket:          manifest.SourceDomain + "/v1",
+	manifest.KindKustomization:    manifest.FluxKustomizeDomain + "/v1",
+	manifest.KindHelmRelease:      manifest.HelmReleaseDomain + "/v2",
+	manifest.KindGitRepository:    manifest.SourceDomain + "/v1",
+	manifest.KindOCIRepository:    manifest.SourceDomain + "/v1",
+	manifest.KindHelmRepository:   manifest.SourceDomain + "/v1",
+	manifest.KindHelmChart:        manifest.SourceDomain + "/v1",
+	manifest.KindBucket:           manifest.SourceDomain + "/v1",
 	manifest.KindExternalArtifact: manifest.SourceDomain + "/v1",
 }
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -211,9 +211,9 @@ type discoverer struct {
 	sourceRefs  map[manifest.NamedResource][]manifest.NamedResource
 	// repoRoot is the resolved .git ancestor of cfg.Path (or cfg.Path
 	// when no .git exists). Stored here because every consumer of
-	// loader.BuildParentIndexForKind / loader.KSPathPrefixes needs the
-	// repo-relative root used to resolve KS spec.path entries, and
-	// passing cfg.Path silently misreads `components:` lookups when
+	// loader.BuildParentIndexFromPrefixes / loader.KSPathPrefixesWithCache
+	// needs the repo-relative root used to resolve KS spec.path entries,
+	// and passing cfg.Path silently misreads `components:` lookups when
 	// the user pointed --path at a subdir.
 	repoRoot string
 }

--- a/pkg/discovery/orphans.go
+++ b/pkg/discovery/orphans.go
@@ -22,7 +22,7 @@ import (
 // substituteFrom edge fires before the producing KS reconciles).
 //
 // Shares the parent-path-prefix predicate with the orchestrator's
-// detectOrphans via loader.KSPathPrefixes — the two run in
+// detectOrphans via loader.LongestParent — the two run in
 // complementary phases (pre-reconcile materialization here,
 // post-reconcile failure demotion there) and must agree on the
 // same "under a KS path" predicate so an object can't be classified

--- a/pkg/helm/doc.go
+++ b/pkg/helm/doc.go
@@ -12,7 +12,7 @@
 //     ExternalArtifact lookups read straight from the canonical
 //     object store. Embedders rendering a single HR without an
 //     orchestrator can implement SourceResolver directly.
-//   - Prepare(hr, charts, provider) performs the pre-render dance
+//   - Prepare(hr, lookup, provider, cache) performs the pre-render dance
 //     (Clone → ResolveChartRef → ExpandValueReferences) — call this
 //     before TemplateDocs when rendering a HelmRelease in isolation.
 //   - Options exposes the helm CLI flags flate understands

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -36,7 +36,7 @@ import (
 // Concurrency: Get is unsynchronized — the filesystem already
 // serialises atomic-rename writes against partial reads. Put is
 // likewise unsynchronized; the only coordination is the single-flight
-// background sweep gated by sweepBusy so a burst of Puts triggers one
+// background sweep gated by sweepGate so a burst of Puts triggers one
 // eviction pass instead of N.
 type diskRenderCache struct {
 	root  string
@@ -121,7 +121,7 @@ func (c *diskRenderCache) Get(key string) ([]byte, bool) {
 // Put gzip-encodes payload and atomically writes it to the sharded
 // path. Subsequent reads either observe the previous complete file or
 // the new one — never a partial. After the write we kick a background
-// sweep (single-flight via sweepBusy) so the fast path doesn't block
+// sweep (single-flight via sweepGate) so the fast path doesn't block
 // on directory walks.
 //
 // nil-receiver no-ops so call sites can unconditionally Put without
@@ -181,7 +181,7 @@ func (c *diskRenderCache) Put(key string, payload []byte) {
 
 // sweep walks the cache root, totals byte usage, and (if over the
 // limit) deletes oldest-by-mtime entries until total ≤ limit. Runs
-// on a single goroutine — sweepBusy gates re-trigger so a sustained
+// on a single goroutine — sweepGate gates re-trigger so a sustained
 // write storm doesn't fork ~one sweep per Put. The flag clears at the
 // end so the *next* over-limit Put can re-trigger.
 //

--- a/pkg/helm/template_cache.go
+++ b/pkg/helm/template_cache.go
@@ -279,7 +279,7 @@ func computeTemplateKey(chartFP string, ch *chart.Chart, finalValues map[string]
 	writeOptionsBlob(h, opts)
 
 	// HR-level fields that drive action.Install but bypass opts. A
-	// dedicated tagged blob — same rationale as keyOpts above.
+	// dedicated tagged blob — same rationale as writeOptionsBlob above.
 	type keyHR struct {
 		ReleaseName              string                `json:"release_name"`
 		ReleaseNamespace         string                `json:"release_namespace"`

--- a/pkg/loader/generators.go
+++ b/pkg/loader/generators.go
@@ -81,23 +81,26 @@ func (r generatorRecord) materialize(parentNS string) manifest.BaseManifest {
 	// kustomize precedence: entry.namespace > kustomization.namespace > parent namespace.
 	ns := cmp.Or(r.entryNS, r.kustomizationNS, parentNS)
 	if r.isConfigMap {
-		data := make(map[string]any, len(r.literals))
-		for _, lit := range r.literals {
-			k, v, ok := strings.Cut(lit, "=")
-			if !ok {
-				continue
-			}
-			data[k] = v
-		}
-		return &manifest.ConfigMap{Name: r.name, Namespace: ns, Data: data}
+		// ConfigMap data keeps the literal value as-is.
+		return &manifest.ConfigMap{Name: r.name, Namespace: ns, Data: r.literalData(func(v string) any { return v })}
 	}
+	// Secret data is base64-encoded to match what a real k8s Secret carries.
+	return &manifest.Secret{Name: r.name, Namespace: ns, Data: r.literalData(func(v string) any {
+		return base64.StdEncoding.EncodeToString([]byte(v))
+	})}
+}
+
+// literalData splits each `key=value` literal into a data map, passing every
+// value through encode before it lands in the map. Literals without an `=`
+// are skipped, per kustomize's KvSources conventions.
+func (r generatorRecord) literalData(encode func(string) any) map[string]any {
 	data := make(map[string]any, len(r.literals))
 	for _, lit := range r.literals {
 		k, v, ok := strings.Cut(lit, "=")
 		if !ok {
 			continue
 		}
-		data[k] = base64.StdEncoding.EncodeToString([]byte(v))
+		data[k] = encode(v)
 	}
-	return &manifest.Secret{Name: r.name, Namespace: ns, Data: data}
+	return data
 }

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -140,11 +141,7 @@ func dataFilesFor(dir string, k *kustomization) map[string]struct{} {
 			data[abs] = struct{}{}
 		}
 	}
-	for _, g := range k.ConfigMapGenerator {
-		addEntries(g.Files, true)
-		addEntries(g.Envs, false)
-	}
-	for _, g := range k.SecretGenerator {
+	for _, g := range slices.Concat(k.ConfigMapGenerator, k.SecretGenerator) {
 		addEntries(g.Files, true)
 		addEntries(g.Envs, false)
 	}

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -2,7 +2,6 @@ package manifest
 
 import (
 	"cmp"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -235,13 +234,14 @@ func (h *HelmRelease) ReleaseName() string {
 // Inlined to keep pkg/manifest free of a helm-controller import (the
 // canonical impl lives in an internal/ tree we cannot reference).
 func shortenReleaseName(name string) string {
-	if len(name) <= 53 {
+	const (
+		maxLength       = 53
+		shortHashLength = 12
+	)
+	if len(name) <= maxLength {
 		return name
 	}
-	const maxLength = 53
-	const shortHashLength = 12
-	sum := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
-	return name[:maxLength-(shortHashLength+1)] + "-" + sum[:shortHashLength]
+	return name[:maxLength-(shortHashLength+1)] + "-" + SHA256Hex([]byte(name))[:shortHashLength]
 }
 
 // ReleaseNamespace returns TargetNamespace when set, otherwise Namespace.

--- a/pkg/orchestrator/depgraph.go
+++ b/pkg/orchestrator/depgraph.go
@@ -85,7 +85,7 @@ func (g *dependencyGraph) ReplaceEdges(id manifest.NamedResource, deps []manifes
 	}
 
 	oldSet := g.outEdges[id]
-	if edgesEqual(oldSet, newSet) {
+	if maps.Equal(oldSet, newSet) {
 		return
 	}
 
@@ -141,19 +141,6 @@ func (g *dependencyGraph) ReplaceEdges(id manifest.NamedResource, deps []manifes
 	if hasRemoved {
 		g.revalidateFailedLocked()
 	}
-}
-
-// edgesEqual reports whether two edge sets are identical.
-func edgesEqual(a, b map[manifest.NamedResource]struct{}) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for k := range a {
-		if _, ok := b[k]; !ok {
-			return false
-		}
-	}
-	return true
 }
 
 // findPathLocked runs an iterative forward DFS from start looking for

--- a/pkg/orchestrator/resourceset.go
+++ b/pkg/orchestrator/resourceset.go
@@ -61,11 +61,13 @@ func (o *Orchestrator) expandResourceSetsPostRun(ctx context.Context) error {
 	}
 
 	// Render each RS in parallel — they only read shared state (the
-	// store + owners index) which is safe under concurrent reads. The
-	// dedup + accumulation step runs under a mutex so the cross-RS
-	// "first-wins" invariant is preserved (a name-grouped RS may
-	// legitimately render the same child from each namespace variant
-	// and we don't want to double-emit it under the parent KS).
+	// store + owners index) which is safe under concurrent reads. Each
+	// goroutine writes only its own results[i] slot; the dedup +
+	// accumulation step runs serially after g.Wait (in rsList order) so
+	// the cross-RS "first-wins" invariant is preserved deterministically
+	// (a name-grouped RS may legitimately render the same child from each
+	// namespace variant and we don't want to double-emit it under the
+	// parent KS).
 	//
 	// Concurrency cap respects Config.Concurrency when set so operators
 	// who request serial/deterministic runs (Concurrency: 1) also get

--- a/pkg/resourceset/permute.go
+++ b/pkg/resourceset/permute.go
@@ -49,11 +49,9 @@ func permute(groups []providerInputs, includeEmpty bool) ([]map[string]any, erro
 		if norm == "" {
 			return nil, fmt.Errorf("permute: provider name %q normalizes to empty", g.name)
 		}
-		if len(scoped) == 0 {
-			expected = uint64(len(g.inputs))
-		} else {
-			expected *= uint64(len(g.inputs))
-		}
+		// expected starts at 1, so multiplying for the first non-empty
+		// provider yields its input count — no special-case needed.
+		expected *= uint64(len(g.inputs))
 		if expected > maxPermutations {
 			return nil, fmt.Errorf("permute: would exceed %d permutations (provider %q contributes %d inputs)",
 				maxPermutations, g.name, len(g.inputs))

--- a/pkg/source/authid.go
+++ b/pkg/source/authid.go
@@ -1,6 +1,11 @@
 package source
 
-import "github.com/home-operations/flate/pkg/manifest"
+import (
+	"slices"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
 
 // AuthIdentity returns a deterministic, opaque tag identifying the
 // auth context bound to a source fetch. It is appended to the cache
@@ -20,17 +25,8 @@ import "github.com/home-operations/flate/pkg/manifest"
 // lower-level entry point only when a non-secret-ref dimension (e.g.
 // a hashed cert thumbprint) needs to participate in the key.
 func AuthIdentity(parts ...string) string {
-	out := ""
-	for _, p := range parts {
-		if p == "" {
-			continue
-		}
-		if out != "" {
-			out += "\x00"
-		}
-		out += p
-	}
-	return out
+	nonEmpty := slices.DeleteFunc(slices.Clone(parts), func(p string) bool { return p == "" })
+	return strings.Join(nonEmpty, "\x00")
 }
 
 // AuthIdentityFromRefs is the typed entry point fetchers use to build

--- a/pkg/source/bucket/fetcher.go
+++ b/pkg/source/bucket/fetcher.go
@@ -5,6 +5,7 @@ package bucket
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/minio/minio-go/v7"
@@ -102,7 +103,7 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 		LocalPath: slot.Path,
 		Revision:  revHash,
 		Metadata: map[string]string{
-			"objectCount": fmt.Sprintf("%d", len(keys)),
+			"objectCount": strconv.Itoa(len(keys)),
 		},
 	}, nil
 }

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -86,21 +86,18 @@ func Sweep(layout cacheroot.Layout, opts SweepOpts) (SweepResult, error) {
 		// <root>/sources/<slug>/<hash>/ so age comparison is two levels
 		// in; blobs sit one level below the algo segment and are gated
 		// by mark.
-		ageRoots := []struct {
+		type ageRoot struct {
 			dir   string
 			depth int
 			gate  func(name string) bool // skip when gate returns true
-		}{
+		}
+		ageRoots := []ageRoot{
 			{layout.Sources(), 2, nil},
 			{layout.Baselines(), 1, nil},
 			{layout.Blobs(), 1, func(name string) bool { return live[name] }},
 		}
 		if opts.IncludeMirrors {
-			ageRoots = append(ageRoots, struct {
-				dir   string
-				depth int
-				gate  func(name string) bool
-			}{layout.GitMirrors(), 1, nil})
+			ageRoots = append(ageRoots, ageRoot{layout.GitMirrors(), 1, nil})
 		}
 		for _, ar := range ageRoots {
 			sweepDirByAge(ar.dir, ar.depth, cutoff, ar.gate, opts.DryRun, &res)

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -8,7 +8,7 @@
 //	ssh.go        — SSH URL / user extraction
 //	checkout.go   — checkoutRef + updateSubmodules
 //	resolve.go    — ref → commit hash (mirror path)
-//	marker.go     — .flate-git-revision slot marker + worktree HEAD lookup
+//	marker.go     — slot revision sidecar (.flate-meta.json) + worktree HEAD lookup
 package git
 
 import (
@@ -134,16 +134,10 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		// version or a hand-modified cache.
 		if rev := readCachedRevision(slot.Path); rev != "" {
 			if !mutableRef {
-				return &store.SourceArtifact{
-					Kind: manifest.KindGitRepository,
-					URL:  repo.URL, LocalPath: slot.Path, Revision: rev,
-				}, nil
+				return gitArtifact(repo.URL, slot.Path, rev), nil
 			}
 			if rev, ok := cachedRevisionFresh(slot.Path, repo.Interval.Duration); ok {
-				return &store.SourceArtifact{
-					Kind: manifest.KindGitRepository,
-					URL:  repo.URL, LocalPath: slot.Path, Revision: rev,
-				}, nil
+				return gitArtifact(repo.URL, slot.Path, rev), nil
 			}
 		}
 		if mutableRef {
@@ -170,11 +164,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
 	if proxy != nil {
-		cloneOpts.ProxyOptions = transport.ProxyOptions{
-			URL:      proxy.Address,
-			Username: proxy.Username,
-			Password: proxy.Password,
-		}
+		cloneOpts.ProxyOptions = proxyOptions(proxy)
 	}
 	if repo.RecurseSubmodules {
 		cloneOpts.RecurseSubmodules = git.DefaultSubmoduleRecursionDepth
@@ -211,10 +201,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	}
 
 	rev, _ := readResolvedRevision(slot.Path)
-	art := &store.SourceArtifact{
-		Kind: manifest.KindGitRepository,
-		URL:  repo.URL, LocalPath: slot.Path, Revision: rev,
-	}
+	art := gitArtifact(repo.URL, slot.Path, rev)
 	if err := f.finalize(repo, art); err != nil {
 		return nil, err
 	}
@@ -290,9 +277,7 @@ func fetchExplicitNamedRef(ctx context.Context, repo *git.Repository, auth trans
 		RefSpecs: []config.RefSpec{config.RefSpec("+" + name + ":" + name)},
 	}
 	if proxy != nil {
-		opts.ProxyOptions = transport.ProxyOptions{
-			URL: proxy.Address, Username: proxy.Username, Password: proxy.Password,
-		}
+		opts.ProxyOptions = proxyOptions(proxy)
 	}
 	if err := remote.FetchContext(ctx, opts); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return fmt.Errorf("fetch ref.name %s: %w", name, err)
@@ -463,10 +448,7 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 			return nil, err
 		}
 	}
-	art := &store.SourceArtifact{
-		Kind: manifest.KindGitRepository,
-		URL:  repo.URL, LocalPath: slot.Path, Revision: hash.String(),
-	}
+	art := gitArtifact(repo.URL, slot.Path, hash.String())
 	if err := applyIgnoreAndMark(repo, art); err != nil {
 		return nil, err
 	}
@@ -540,4 +522,25 @@ func mirrorRefSpecs(ref *manifest.GitRepositoryRef) mirror.FetchPlan {
 func authIdentity(repo *manifest.GitRepository) string {
 	return source.AuthIdentityFromRefs(repo.Namespace,
 		repo.SecretRef, repo.ProxySecretRef)
+}
+
+// proxyOptions maps a resolved ProxyConfig into go-git transport options,
+// shared by the clone and explicit-ref fetch paths.
+func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
+	return transport.ProxyOptions{
+		URL:      proxy.Address,
+		Username: proxy.Username,
+		Password: proxy.Password,
+	}
+}
+
+// gitArtifact builds the SourceArtifact every git fetch path returns: a
+// KindGitRepository pointing at the materialized slot directory.
+func gitArtifact(url, localPath, rev string) *store.SourceArtifact {
+	return &store.SourceArtifact{
+		Kind:      manifest.KindGitRepository,
+		URL:       url,
+		LocalPath: localPath,
+		Revision:  rev,
+	}
 }

--- a/pkg/source/git/mirror/mirror.go
+++ b/pkg/source/git/mirror/mirror.go
@@ -83,20 +83,21 @@ func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
 // subsequent calls incrementally Fetch. Holds the per-URL lock across
 // the network operation so two concurrent callers serialize.
 func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.AuthMethod, proxy *source.ProxyConfig, plan FetchPlan) (*git.Repository, error) {
-	release, err := m.locks.Acquire(ctx, urlHash(url))
+	hash := urlHash(url)
+	release, err := m.locks.Acquire(ctx, hash)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
 
-	path := m.layout.GitMirror(urlHash(url))
+	path := m.layout.GitMirror(hash)
 	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return nil, fmt.Errorf("mirror parent: %w", err)
 	}
 
 	repo, openErr := git.PlainOpen(path)
 	if openErr == nil {
-		if err := m.fetchInto(ctx, repo, auth, proxy, plan.RefSpecs, plan.Depth); err != nil {
+		if err := m.fetchInto(ctx, repo, auth, proxy, plan); err != nil {
 			return nil, err
 		}
 		return repo, nil
@@ -124,7 +125,7 @@ func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.Auth
 			// Broad clone pulls the server's default refs; the empty plan
 			// refspec falls back to +refs/*:refs/* so non-default refs are
 			// present too. Treat NoErrAlreadyUpToDate as success.
-			err = m.fetchInto(ctx, repo, auth, proxy, plan.RefSpecs, plan.Depth)
+			err = m.fetchInto(ctx, repo, auth, proxy, plan)
 		}
 	}
 	if err != nil {
@@ -149,7 +150,7 @@ func (m *Cache) initAndFetch(ctx context.Context, path, url string, auth transpo
 	if _, err := repo.CreateRemote(&config.RemoteConfig{Name: "origin", URLs: []string{url}}); err != nil {
 		return nil, fmt.Errorf("mirror remote: %w", err)
 	}
-	if err := m.fetchInto(ctx, repo, auth, proxy, plan.RefSpecs, plan.Depth); err != nil {
+	if err := m.fetchInto(ctx, repo, auth, proxy, plan); err != nil {
 		return nil, err
 	}
 	return repo, nil
@@ -159,7 +160,8 @@ func (m *Cache) initAndFetch(ctx context.Context, path, url string, auth transpo
 // the mirror refspec — every server ref updates in place, including
 // explicit spec.ref.name targets such as refs/pull/* and refs/merge-*.
 // Treats NoErrAlreadyUpToDate as a clean noop.
-func (m *Cache) fetchInto(ctx context.Context, repo *git.Repository, auth transport.AuthMethod, proxy *source.ProxyConfig, refSpecs []config.RefSpec, depth int) error {
+func (m *Cache) fetchInto(ctx context.Context, repo *git.Repository, auth transport.AuthMethod, proxy *source.ProxyConfig, plan FetchPlan) error {
+	refSpecs := plan.RefSpecs
 	if len(refSpecs) == 0 {
 		refSpecs = []config.RefSpec{"+refs/*:refs/*"}
 	}
@@ -167,7 +169,7 @@ func (m *Cache) fetchInto(ctx context.Context, repo *git.Repository, auth transp
 		Auth:         auth,
 		RefSpecs:     refSpecs,
 		ProxyOptions: proxyOptions(proxy),
-		Depth:        depth,
+		Depth:        plan.Depth,
 		// All refspecs above are explicit (named refs, +refs/tags/*, or the
 		// +refs/*:refs/* fallback), so suppress go-git's default tag auto-
 		// following — it would silently pull every tag back in.

--- a/pkg/source/git/remotebase.go
+++ b/pkg/source/git/remotebase.go
@@ -34,8 +34,8 @@ import (
 // a real GitRepository CR. Requires Mirrors and Cache. The materialized
 // worktree is cached per (repoURL, ref) in a slot whose ref label is
 // namespaced so it never collides with a real GitRepository CR's slot for
-// the same URL, and is reused on warm runs via the .flate-git-revision
-// marker.
+// the same URL, and is reused on warm runs via the revision recorded in
+// the slot's .flate-meta.json sidecar.
 func (f *Fetcher) FetchRemoteBase(ctx context.Context, repoURL, ref string) (*store.SourceArtifact, error) {
 	if f.Mirrors == nil || f.Cache == nil {
 		return nil, fmt.Errorf("%w: remote git base fetch requires mirror+cache", manifest.ErrInput)
@@ -61,10 +61,7 @@ func (f *Fetcher) FetchRemoteBase(ctx context.Context, repoURL, ref string) (*st
 	// so treat any marked slot as a hit and leave the mirror untouched.
 	if slot.Exists {
 		if rev := readCachedRevision(slot.Path); rev != "" {
-			return &store.SourceArtifact{
-				Kind: manifest.KindGitRepository,
-				URL:  repoURL, LocalPath: slot.Path, Revision: rev,
-			}, nil
+			return gitArtifact(repoURL, slot.Path, rev), nil
 		}
 		// Marker-less slot (legacy / hand-edited) — re-materialize cleanly.
 		if err := slot.Refresh(); err != nil {
@@ -110,8 +107,5 @@ func (f *Fetcher) FetchRemoteBase(ctx context.Context, repoURL, ref string) (*st
 	if err := slot.Commit(); err != nil {
 		return nil, fmt.Errorf("remote git base %s: commit slot: %w", repoURL, err)
 	}
-	return &store.SourceArtifact{
-		Kind: manifest.KindGitRepository,
-		URL:  repoURL, LocalPath: slot.Path, Revision: rev,
-	}, nil
+	return gitArtifact(repoURL, slot.Path, rev), nil
 }

--- a/pkg/source/git/verify/verify.go
+++ b/pkg/source/git/verify/verify.go
@@ -35,38 +35,36 @@ func Signatures(secrets source.SecretGetter, ns, name, secretRefName string, mod
 	if !matchesHEAD(mode) && !matchesTag(mode) {
 		return nil
 	}
+	// fail prefixes every error with the owning GitRepository for context.
+	fail := func(format string, args ...any) error {
+		return fmt.Errorf("GitRepository %s/%s: "+format, append([]any{ns, name}, args...)...)
+	}
 	if secretRefName == "" {
-		return fmt.Errorf("GitRepository %s/%s: spec.verify.secretRef is required",
-			ns, name)
+		return fail("spec.verify.secretRef is required")
 	}
 	if secrets == nil {
-		return fmt.Errorf("GitRepository %s/%s: spec.verify set but no source.SecretGetter is wired",
-			ns, name)
+		return fail("spec.verify set but no source.SecretGetter is wired")
 	}
 	sec := secrets(ns, secretRefName)
 	if sec == nil {
-		return fmt.Errorf("GitRepository %s/%s: verify secret %s/%s not found",
-			ns, name, ns, secretRefName)
+		return fail("verify secret %s/%s not found", ns, secretRefName)
 	}
 	keyring, err := buildPGPKeyring(sec)
 	if err != nil {
-		return fmt.Errorf("GitRepository %s/%s: %w", ns, name, err)
+		return fail("%w", err)
 	}
 
 	if matchesHEAD(mode) {
 		if err := verifyCommit(cloned, resolvedRef, keyring); err != nil {
-			return fmt.Errorf("GitRepository %s/%s: HEAD verify: %w",
-				ns, name, err)
+			return fail("HEAD verify: %w", err)
 		}
 	}
 	if matchesTag(mode) {
 		if tagName == "" {
-			return fmt.Errorf("GitRepository %s/%s: verify mode %q requires spec.ref.tag",
-				ns, name, mode)
+			return fail("verify mode %q requires spec.ref.tag", mode)
 		}
 		if err := verifyTagObject(cloned, tagName, keyring); err != nil {
-			return fmt.Errorf("GitRepository %s/%s: tag verify: %w",
-				ns, name, err)
+			return fail("tag verify: %w", err)
 		}
 	}
 	return nil

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -175,8 +175,11 @@ func (r *serializedObjectReader) blobBytes(hash plumbing.Hash, name string) ([]b
 }
 
 // writeEntry materializes one tree entry — a symlink or a blob — at
-// root/name. The walker pre-created the parent dir, so we don't
-// MkdirAll here.
+// root/name. Both kinds read their content under the object-read lock
+// (blobBytes) and write outside it, so concurrent workers write to disk
+// in parallel. The walker pre-created the parent dir, so we don't
+// MkdirAll here. The executable bit is preserved from
+// filemode.Executable.
 func writeEntry(objects *serializedObjectReader, entry object.TreeEntry, root, name string) error {
 	dst := filepath.Join(root, filepath.FromSlash(name))
 	if entry.Mode == filemode.Symlink {
@@ -189,20 +192,12 @@ func writeEntry(objects *serializedObjectReader, entry object.TreeEntry, root, n
 		}
 		return nil
 	}
-	return writeBlobTo(dst, objects, entry.Hash, entry.Mode, name)
-}
 
-// writeBlobTo writes blob's content to dst with mode-derived
-// permissions (executable bit preserved from filemode.Executable).
-// Caller (Materialize's walker) has already created the parent dir. The
-// blob is read under the object-read lock (blobBytes) and written here
-// outside it, so concurrent workers write to disk in parallel.
-func writeBlobTo(dst string, objects *serializedObjectReader, hash plumbing.Hash, mode filemode.FileMode, name string) error {
 	perm := os.FileMode(0o600)
-	if mode == filemode.Executable {
+	if entry.Mode == filemode.Executable {
 		perm = 0o700
 	}
-	data, err := objects.blobBytes(hash, name)
+	data, err := objects.blobBytes(entry.Hash, name)
 	if err != nil {
 		return fmt.Errorf("read blob %q: %w", name, err)
 	}

--- a/pkg/source/helmchart/fetcher.go
+++ b/pkg/source/helmchart/fetcher.go
@@ -114,14 +114,15 @@ func (f *Fetcher) Fetch(ctx context.Context, hc *manifest.HelmChartSource) (*sto
 // repo get distinct Store ids.
 func Synthesize(r *manifest.HelmRepository, chartName, version string) *manifest.HelmChartSource {
 	chartURL := normalizeChartURL(r.URL, chartName)
-	hc := &manifest.HelmChartSource{
+	return &manifest.HelmChartSource{
 		Name:      syntheticChartName(r.Name, chartName, chartURL, version),
 		Namespace: r.Namespace,
+		HelmChartSpec: sourcev1.HelmChartSpec{
+			Chart:     chartName,
+			Version:   version,
+			SourceRef: sourcev1.LocalHelmChartSourceReference{Kind: manifest.KindHelmRepository, Name: r.Name},
+		},
 	}
-	hc.Chart = chartName
-	hc.Version = version
-	hc.SourceRef = sourcev1.LocalHelmChartSourceReference{Kind: manifest.KindHelmRepository, Name: r.Name}
-	return hc
 }
 
 // normalizeChartURL joins a HelmRepository base URL and a chart name into the

--- a/pkg/source/mutable.go
+++ b/pkg/source/mutable.go
@@ -1,17 +1,8 @@
 package source
 
-import (
-	"crypto/rand"
-	"encoding/hex"
-)
-
 // MutableCacheKey returns a one-shot cache key for mutable source refs.
 // Mutable refs must refresh instead of serving a stale slot, but a failed
 // refresh must also leave any previously committed artifact intact.
 func MutableCacheKey(base string) string {
-	var nonce [16]byte
-	if _, err := rand.Read(nonce[:]); err != nil {
-		panic("crypto/rand unavailable: " + err.Error())
-	}
-	return base + "#mutable:" + hex.EncodeToString(nonce[:])
+	return base + "#mutable:" + randomHex(16)
 }

--- a/pkg/source/oci/cosign.go
+++ b/pkg/source/oci/cosign.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -157,7 +158,7 @@ func (f *Fetcher) verifyCosignSignature(
 		}
 	}
 	if lastErr == nil {
-		lastErr = fmt.Errorf("no signature layer matched any trusted key")
+		lastErr = errors.New("no signature layer matched any trusted key")
 	}
 	return fmt.Errorf("OCIRepository %s/%s: cosign verify failed: %w",
 		repo.Namespace, repo.Name, lastErr)
@@ -297,7 +298,7 @@ func verifyCosignSignatureBytes(key crypto.PublicKey, payload, sig []byte) error
 	case *ecdsa.PublicKey:
 		h := sha256.Sum256(payload)
 		if !ecdsa.VerifyASN1(k, h[:], sig) {
-			return fmt.Errorf("ecdsa verify failed")
+			return errors.New("ecdsa verify failed")
 		}
 		return nil
 	case *rsa.PublicKey:
@@ -305,7 +306,7 @@ func verifyCosignSignatureBytes(key crypto.PublicKey, payload, sig []byte) error
 		return rsa.VerifyPKCS1v15(k, crypto.SHA256, h[:], sig)
 	case ed25519.PublicKey:
 		if !ed25519.Verify(k, payload, sig) {
-			return fmt.Errorf("ed25519 verify failed")
+			return errors.New("ed25519 verify failed")
 		}
 		return nil
 	default:

--- a/pkg/source/safepath/safepath.go
+++ b/pkg/source/safepath/safepath.go
@@ -53,10 +53,10 @@ func SafeJoin(base, rel string, rejectAbsolute bool) (string, error) {
 	}
 
 	// rejectAbsolute = false: let filepath.Join handle leading slashes by
-	// treating them as component boundaries (not re-rooting at /).
+	// treating them as component boundaries (not re-rooting at /). filepath.Rel
+	// cleans its base argument internally, so base needs no pre-cleaning.
 	target := filepath.Join(base, rel)
-	cleanBase := filepath.Clean(base)
-	relInside, err := filepath.Rel(cleanBase, target)
+	relInside, err := filepath.Rel(base, target)
 	if err != nil {
 		return "", fmt.Errorf("path resolution: %w", err)
 	}

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -138,45 +138,42 @@ type idPayload struct {
 func (s *Store) snapshotForReplay(event EventKind) []idPayload {
 	switch event {
 	case EventObjectAdded:
-		total := 0
-		for i := range s.shards {
-			total += len(s.shards[i].objects)
-		}
-		out := make([]idPayload, 0, total)
-		for i := range s.shards {
-			for id, obj := range s.shards[i].objects {
-				out = append(out, idPayload{id, obj})
-			}
-		}
-		return out
+		return collectReplay(s.shards[:], func(sh *shard) map[manifest.NamedResource]manifest.BaseManifest {
+			return sh.objects
+		}, func(obj manifest.BaseManifest) (any, bool) { return obj, true })
 	case EventStatusUpdated:
-		total := 0
-		for i := range s.shards {
-			total += len(s.shards[i].conditions)
-		}
-		out := make([]idPayload, 0, total)
-		for i := range s.shards {
-			for id, conds := range s.shards[i].conditions {
-				if info, ok := statusInfoFromConditions(conds); ok {
-					out = append(out, idPayload{id, info})
-				}
-			}
-		}
-		return out
+		return collectReplay(s.shards[:], func(sh *shard) map[manifest.NamedResource][]Condition {
+			return sh.conditions
+		}, func(conds []Condition) (any, bool) { return statusInfoFromConditions(conds) })
 	case EventArtifactUpdated:
-		total := 0
-		for i := range s.shards {
-			total += len(s.shards[i].artifacts)
-		}
-		out := make([]idPayload, 0, total)
-		for i := range s.shards {
-			for id, art := range s.shards[i].artifacts {
-				out = append(out, idPayload{id, art})
-			}
-		}
-		return out
+		return collectReplay(s.shards[:], func(sh *shard) map[manifest.NamedResource]Artifact {
+			return sh.artifacts
+		}, func(art Artifact) (any, bool) { return art, true })
 	}
 	return nil
+}
+
+// collectReplay flattens one per-shard map (selected by pick) into a
+// replay slice, applying conv to each value. conv returns (payload, ok)
+// — entries for which ok is false are skipped (the EventStatusUpdated
+// case drops ids whose conditions carry no Ready rollup). The result is
+// pre-sized to the summed map lengths so the common all-keep case never
+// re-grows. Caller MUST hold every shard's write lock (see
+// snapshotForReplay).
+func collectReplay[V any](shards []*shard, pick func(*shard) map[manifest.NamedResource]V, conv func(V) (any, bool)) []idPayload {
+	total := 0
+	for _, sh := range shards {
+		total += len(pick(sh))
+	}
+	out := make([]idPayload, 0, total)
+	for _, sh := range shards {
+		for id, v := range pick(sh) {
+			if payload, ok := conv(v); ok {
+				out = append(out, idPayload{id, payload})
+			}
+		}
+	}
+	return out
 }
 
 // fireUnderLock is the race-safe dispatcher writers MUST use: it

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -403,29 +403,23 @@ func bagValueAsString(v any) (string, error) {
 	}
 }
 
-// updateHelmReleaseValues writes found into values using ref.TargetPath
-// when set; otherwise the found YAML is parsed and deep-merged.
+// updateHelmReleaseValues merges one valuesFrom ref into the values
+// accumulator and returns the (possibly new) accumulator.
 //
-// When targetPath is set, write through Helm's strvals parser
+// When ref.TargetPath is set, write through Helm's strvals parser
 // (path=value form). This matches upstream Flux's
 // chartutil.ChartValuesFromReferences (which calls strvals.ParseInto)
 // and gives the correct type coercion: "3" → int 3, "true" → bool,
 // "null" → nil. Single/double-quoted values force string-coercion
 // (strvals.ParseIntoString). A naive `inner[k] = found` left every
 // targetPath value as a literal string, which broke chart-schema
-// validation against `replicaCount: integer` and similar.
+// validation against `replicaCount: integer` and similar. The targetPath
+// path bypasses the cache — strvals parsing already mutates values in
+// place per-call and is comparatively cheap (no map allocation for the
+// parsed tree).
 //
-// Mutates values in place — ExpandValueReferences owns the accumulator
-// map; using DeepMergeInto avoids the O(N²) full-tree clone DeepMerge
-// would pay across N valuesFrom refs.
-//
-// The cache, when non-nil, memoizes parsed-YAML output by
-// (kind, namespace, name, valuesKey, content-hash). The targetPath
-// path bypasses the cache — strvals parsing already mutates values
-// in place per-call and is comparatively cheap (no map allocation
-// for the parsed tree).
-// updateHelmReleaseValues merges one valuesFrom ref into the values
-// accumulator and returns the (possibly new) accumulator.
+// Otherwise the found YAML is parsed (memoized in cache when non-nil, keyed
+// by kind, namespace, name, valuesKey, content-hash) and deep-merged.
 //
 // share selects the merge strategy, decided once per HR by the caller:
 //   - share=true (the HR has NO TargetPath ref): functional DeepMerge,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -22,15 +22,30 @@ import (
 	"github.com/home-operations/flate/internal/testutil"
 )
 
-func runCLI(t *testing.T, args ...string) string {
+// runCLIBuffers runs the CLI in-process and returns its captured stdout,
+// stderr, and exit code. All the runCLI* helpers build on it.
+func runCLIBuffers(args ...string) (stdout, stderr string, code int) {
+	var out, err bytes.Buffer
+	code = cli.Run(args, &out, &err)
+	return out.String(), err.String(), code
+}
+
+// requireCLIOK runs the CLI and fails the test on a non-zero exit code,
+// returning the captured stdout and stderr separately.
+func requireCLIOK(t *testing.T, args ...string) (stdout, stderr string) {
 	t.Helper()
-	var stdout, stderr bytes.Buffer
-	code := cli.Run(args, &stdout, &stderr)
+	stdout, stderr, code := runCLIBuffers(args...)
 	if code != 0 {
 		t.Fatalf("flate %s exited %d\nstdout:\n%s\nstderr:\n%s",
-			strings.Join(args, " "), code, stdout.String(), stderr.String())
+			strings.Join(args, " "), code, stdout, stderr)
 	}
-	return stdout.String() + stderr.String()
+	return stdout, stderr
+}
+
+func runCLI(t *testing.T, args ...string) string {
+	t.Helper()
+	stdout, stderr := requireCLIOK(t, args...)
+	return stdout + stderr
 }
 
 // runCLIOutputOnly captures stdout+stderr regardless of exit code.
@@ -42,37 +57,29 @@ func runCLI(t *testing.T, args ...string) string {
 // reconcile should keep using runCLI.
 func runCLIOutputOnly(t *testing.T, args ...string) string {
 	t.Helper()
-	var stdout, stderr bytes.Buffer
-	cli.Run(args, &stdout, &stderr)
-	return stdout.String() + stderr.String()
+	stdout, stderr, _ := runCLIBuffers(args...)
+	return stdout + stderr
 }
 
 // runCLIStdoutOnly is the stdout variant of runCLIOutputOnly.
 func runCLIStdoutOnly(t *testing.T, args ...string) string {
 	t.Helper()
-	var stdout, stderr bytes.Buffer
-	cli.Run(args, &stdout, &stderr)
-	return stdout.String()
+	stdout, _, _ := runCLIBuffers(args...)
+	return stdout
 }
 
 // runCLIStdout returns stdout only — log lines on stderr would
 // otherwise pollute payloads that tests parse.
 func runCLIStdout(t *testing.T, args ...string) string {
 	t.Helper()
-	var stdout, stderr bytes.Buffer
-	code := cli.Run(args, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("flate %s exited %d\nstdout:\n%s\nstderr:\n%s",
-			strings.Join(args, " "), code, stdout.String(), stderr.String())
-	}
-	return stdout.String()
+	stdout, _ := requireCLIOK(t, args...)
+	return stdout
 }
 
 func runCLIExpectErr(t *testing.T, args ...string) (string, int) {
 	t.Helper()
-	var stdout, stderr bytes.Buffer
-	code := cli.Run(args, &stdout, &stderr)
-	return stdout.String() + stderr.String(), code
+	stdout, stderr, code := runCLIBuffers(args...)
+	return stdout + stderr, code
 }
 
 func testdataPath(t *testing.T, sub string) string {
@@ -681,13 +688,9 @@ func TestE2E_ChangedOnlyHRDependsOnUnchangedDep(t *testing.T) {
 
 func mustExtractLine(t *testing.T, haystack, needle string) string {
 	t.Helper()
-	for line := range strings.SplitSeq(haystack, "\n") {
-		if strings.Contains(line, needle) && (strings.Contains(line, "PASSED") || strings.Contains(line, "FAILED")) {
-			return line
-		}
-	}
-	t.Fatalf("status line for %q not found in:\n%s", needle, haystack)
-	return ""
+	return mustFindLine(t, haystack, needle, "status", func(line string) bool {
+		return strings.Contains(line, "PASSED") || strings.Contains(line, "FAILED")
+	})
 }
 
 // mustExtractSkipLine returns the SKIPPED status line containing needle,
@@ -696,12 +699,21 @@ func mustExtractLine(t *testing.T, haystack, needle string) string {
 // wouldn't match a skipped resource.
 func mustExtractSkipLine(t *testing.T, haystack, needle string) string {
 	t.Helper()
+	return mustFindLine(t, haystack, needle, "SKIPPED", func(line string) bool {
+		return strings.Contains(line, "SKIPPED")
+	})
+}
+
+// mustFindLine returns the first line containing needle that also
+// satisfies match, failing the test with a kind-tagged message otherwise.
+func mustFindLine(t *testing.T, haystack, needle, kind string, match func(string) bool) string {
+	t.Helper()
 	for line := range strings.SplitSeq(haystack, "\n") {
-		if strings.Contains(line, needle) && strings.Contains(line, "SKIPPED") {
+		if strings.Contains(line, needle) && match(line) {
 			return line
 		}
 	}
-	t.Fatalf("SKIPPED line for %q not found in:\n%s", needle, haystack)
+	t.Fatalf("%s line for %q not found in:\n%s", kind, needle, haystack)
 	return ""
 }
 
@@ -731,25 +743,7 @@ func gitCommitAll(t *testing.T, repo *gogit.Repository) {
 // from a testdata fixture rather than inline bytes.
 func initGitFixtureFrom(t *testing.T, src string) (clusterPath, repoRoot string) {
 	t.Helper()
-	dir := t.TempDir()
-	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, _ := filepath.Rel(src, p)
-		out := filepath.Join(dir, rel)
-		if info.IsDir() {
-			return os.MkdirAll(out, 0o750)
-		}
-		data, err := os.ReadFile(p) //nolint:gosec // p is supplied by filepath.Walk over a known root
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(out, data, 0o600) //nolint:gosec // dir is t.TempDir()
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := copyTree(t, src)
 	repo, err := gogit.PlainInit(dir, false)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What

A codebase-wide, **behavior-preserving** cleanliness pass: de-duplication,
modern Go idioms, dead-code and stale-comment removal across 27 of 45
packages. No behavior or exported-API changes.

Produced by a parallel sweep — one agent per package, each self-verifying
(gofmt/build/test/lint) in an isolated git worktree, then the disjoint patches
applied together and re-gated centrally.

## Themes

- **De-dup** via small private helpers (source/git `gitArtifact`+`proxyOptions`,
  source/git/verify error-prefix closure, store generic `collectReplay`, loader
  `literalData`+`slices.Concat`, change `markKept`, helmrelease
  `cloneWithValuesFrom`, baseline `materialize`, test/e2e runner helpers).
- **Modern idioms**: `min` builtin, `slices.Clone`, `maps.Equal`,
  `slices.DeleteFunc`/`Join`, `strconv.Itoa`, `errors.New` over arg-less
  `fmt.Errorf`, `SHA256Hex` reuse (dropping a `crypto/sha256` import).
- **Simplify**: flattened if/else, dropped an unused `ctx` param, removed a
  redundant `filepath.Clean`, inlined a single-use helper.
- **Stale comment/doc fixes** across ~8 packages.

Net **-51 lines**.

## Verification

- gofmt · `go build/vet ./...` · `go test -race ./...` · `golangci-lint` 0 issues.
- Each package self-verified in isolation before its patch was collected.
- **Cross-repo byte-equivalence** vs main across `~/repos` + `~/k8s-gitops` —
  render output unchanged (the diffs are pure cleanliness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
