### PR TITLE
refactor: second behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -466,11 +466,17 @@ func validatePathFlag(flag, p string) error {
 // formats, listed in the order bindCommon received them (the first is the
 // default).
 func outputUsage(outputs []format.Output) string {
+	return "output format: " + joinOutputs(outputs)
+}
+
+// joinOutputs renders accepted -o formats as a comma-separated list, shared
+// by the help text and the parse-time rejection so the two can't drift.
+func joinOutputs(outputs []format.Output) string {
 	names := make([]string, len(outputs))
 	for i, o := range outputs {
 		names[i] = string(o)
 	}
-	return "output format: " + strings.Join(names, ", ")
+	return strings.Join(names, ", ")
 }
 
 // outputValue is the pflag.Value backing -o: a string constrained to a
@@ -490,11 +496,7 @@ func (o *outputValue) Set(v string) error {
 		*o.target = v
 		return nil
 	}
-	names := make([]string, len(o.allowed))
-	for i, a := range o.allowed {
-		names[i] = string(a)
-	}
-	return fmt.Errorf("must be one of: %s", strings.Join(names, ", "))
+	return fmt.Errorf("must be one of: %s", joinOutputs(o.allowed))
 }
 
 // profileModes are the runtime profiles --profile accepts. The empty

--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -23,8 +23,7 @@ func collectImages(o *orchestrator.Orchestrator, res *orchestrator.Result, c *co
 			continue
 		}
 		for _, doc := range docs {
-			imgs := image.Extract(doc)
-			for _, img := range imgs {
+			for _, img := range image.Extract(doc) {
 				set[img] = struct{}{}
 			}
 		}

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -77,7 +77,8 @@ func AutoResolve(path, base string, layout cacheroot.Layout) (*Result, error) {
 		return nil, err
 	}
 	// Validate path is inside the repo early, before any expensive work.
-	if _, err := relToRepo(repoRoot, path); err != nil {
+	rel, err := relToRepo(repoRoot, path)
+	if err != nil {
 		return nil, err
 	}
 	r, err := resolve(repo, base)
@@ -87,13 +88,6 @@ func AutoResolve(path, base string, layout cacheroot.Layout) (*Result, error) {
 
 	dir, persistent, err := materializeAt(repo, r.Hash, layout)
 	if err != nil {
-		return nil, err
-	}
-	rel, err := relToRepo(repoRoot, path)
-	if err != nil {
-		if !persistent {
-			_ = os.RemoveAll(dir)
-		}
 		return nil, err
 	}
 	pathOrig := dir

--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -236,13 +236,13 @@ func detectViaWalker(before, after string) (*Set, error) {
 		afterFS  map[string]fileMeta
 	)
 	eg.Go(func() error {
-		fs, err := scanTree(before)
-		beforeFS = fs
+		tree, err := scanTree(before)
+		beforeFS = tree
 		return err
 	})
 	eg.Go(func() error {
-		fs, err := scanTree(after)
-		afterFS = fs
+		tree, err := scanTree(after)
+		afterFS = tree
 		return err
 	})
 	if err := eg.Wait(); err != nil {
@@ -259,7 +259,7 @@ func detectViaWalker(before, after string) (*Set, error) {
 	}
 	var hashJobs []hashJob
 
-	for rel, after := range afterFS {
+	for rel, aft := range afterFS {
 		bef, ok := beforeFS[rel]
 		if !ok {
 			paths[rel] = struct{}{}
@@ -267,11 +267,11 @@ func detectViaWalker(before, after string) (*Set, error) {
 		}
 		// A type swap (regular ↔ symlink) is a content change in git's
 		// --no-index view; flag it without bothering to hash.
-		if bef.symlink != after.symlink {
+		if bef.symlink != aft.symlink {
 			paths[rel] = struct{}{}
 			continue
 		}
-		if bef.size != after.size {
+		if bef.size != aft.size {
 			paths[rel] = struct{}{}
 			continue
 		}
@@ -279,8 +279,8 @@ func detectViaWalker(before, after string) (*Set, error) {
 		// The pre-removal mtime fast-path silently dropped real edits
 		// on coarse-mtime filesystems; correctness over speed here.
 		hashJobs = append(hashJobs, hashJob{
-			rel: rel, beforeAbs: bef.abs, afterAbs: after.abs,
-			symlink: after.symlink,
+			rel: rel, beforeAbs: bef.abs, afterAbs: aft.abs,
+			symlink: aft.symlink,
 		})
 	}
 	for rel := range beforeFS {

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -765,7 +765,7 @@ func buildProducerIndex(sourceFiles map[manifest.NamedResource]string, owners ow
 // at producersFor merge time; the slices are short (typically a
 // single owner KS per data file) so the linear scan is cheaper than
 // a map intermediary.
-func appendUniqueProducers(dst []manifest.NamedResource, src []manifest.NamedResource) []manifest.NamedResource {
+func appendUniqueProducers(dst, src []manifest.NamedResource) []manifest.NamedResource {
 	for _, id := range src {
 		if !slices.Contains(dst, id) {
 			dst = append(dst, id)

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -109,13 +109,20 @@ func New(s *store.Store, t *task.Service) *Controller {
 	return &Controller{Store: s, Tasks: t}
 }
 
+// requireNotStarted panics if the started gate is set, enforcing the
+// invariant that reconcile-shaping config is frozen once dispatch
+// begins. method is the calling setter's name for the panic message.
+func (c *Controller) requireNotStarted(method string) {
+	if c.started.Load() {
+		panic("controller: " + method + " called after Start")
+	}
+}
+
 // SetFilter installs the change filter that gates reconciliation in
 // changed-only mode. Panics if called after Start — the invariant is
 // that reconcile-shaping config is frozen once dispatch begins.
 func (c *Controller) SetFilter(f *change.Filter) {
-	if c.started.Load() {
-		panic("controller: SetFilter called after Start")
-	}
+	c.requireNotStarted("SetFilter")
 	c.filter = f
 }
 
@@ -124,35 +131,27 @@ func (c *Controller) Filter() *change.Filter { return c.filter }
 
 // SetDepwait installs the depwait resolution wires. Panics after Start.
 func (c *Controller) SetDepwait(existence depwait.ExistenceLookup, renders depwait.RenderInflight) {
-	if c.started.Load() {
-		panic("controller: SetDepwait called after Start")
-	}
+	c.requireNotStarted("SetDepwait")
 	c.existence = existence
 	c.renders = renders
 }
 
 // SetPreflight installs the pre-reconcile failure reporter. Panics after Start.
 func (c *Controller) SetPreflight(f func(manifest.NamedResource) (string, bool)) {
-	if c.started.Load() {
-		panic("controller: SetPreflight called after Start")
-	}
+	c.requireNotStarted("SetPreflight")
 	c.preflight = f
 }
 
 // SetParentOf installs the structural parent resolver. Panics after Start.
 func (c *Controller) SetParentOf(f func(manifest.NamedResource) (manifest.NamedResource, bool)) {
-	if c.started.Load() {
-		panic("controller: SetParentOf called after Start")
-	}
+	c.requireNotStarted("SetParentOf")
 	c.parentOf = f
 }
 
 // SetRenderTracker installs the render-emission tracker. Panics after
 // Start — reconcile-shaping config is frozen once dispatch begins.
 func (c *Controller) SetRenderTracker(rt RenderTracker) {
-	if c.started.Load() {
-		panic("controller: SetRenderTracker called after Start")
-	}
+	c.requireNotStarted("SetRenderTracker")
 	c.renderTracker = rt
 }
 

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -526,7 +526,7 @@ func (c *Controller) collectHRDeps(hr *manifest.HelmRelease) []manifest.Dependen
 	if len(hr.DependsOn) == 0 {
 		return nil
 	}
-	deps := append([]manifest.DependencyRef(nil), hr.DependsOn...)
+	deps := slices.Clone(hr.DependsOn)
 	// Changed-only mode: a dependsOn target outside the keep-set is
 	// unchanged, so its producing Kustomization is skipped and the target
 	// HR is never render-emitted into the Store — depwait would report

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -212,4 +212,3 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 		t.Errorf("filtered-out source must not fetch; calls=%d", f.calls)
 	}
 }
-

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -324,11 +324,7 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 	// reconcile is in flight — a typo'd dependsOn won't be saved by a
 	// future re-emit, and burning the full grace adds visible wall time
 	// to errored runs (worst case: 3s × depth of chained parent gates).
-	var quiesce <-chan struct{}
-	if w.Renders != nil {
-		quiesce = w.Renders.QuiescenceCh()
-	}
-	info, err := w.Store.WatchReady(ctx, id, quiesce)
+	info, err := w.Store.WatchReady(ctx, id, w.quiesceCh())
 	if err != nil {
 		return classify(id, err, info.Message)
 	}
@@ -496,6 +492,17 @@ func (w *Waiter) tryReadyExpr(expr string, id manifest.NamedResource) (Event, bo
 	return Event{}, false
 }
 
+// quiesceCh returns the orchestrator's one-shot quiescence channel when
+// a Renders signal is wired, or nil otherwise. A nil channel selects
+// never, so legacy embedders without a task pool fall back to the
+// timeout-cap behavior.
+func (w *Waiter) quiesceCh() <-chan struct{} {
+	if w.Renders == nil {
+		return nil
+	}
+	return w.Renders.QuiescenceCh()
+}
+
 // depExists reports whether a dep is known to the store via either an
 // added object or a recorded status entry.
 func (w *Waiter) depExists(dep manifest.NamedResource) bool {
@@ -557,10 +564,7 @@ func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResour
 	// quiesce is a one-shot signal channel. A nil channel selects
 	// never, so embedders without a Renders wired (legacy callers)
 	// fall back to "wait for arrived or ctx" exactly as before.
-	var quiesce <-chan struct{}
-	if w.Renders != nil {
-		quiesce = w.Renders.QuiescenceCh()
-	}
+	quiesce := w.quiesceCh()
 
 	for {
 		select {

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -56,8 +56,8 @@ func readWorkingTreeRemotes(repoRoot string) map[string]struct{} {
 	}
 	out := map[string]struct{}{}
 	for _, remote := range cfg.Remotes {
-		for _, url := range remote.URLs {
-			if n := normalizeGitURL(url); n != "" {
+		for _, u := range remote.URLs {
+			if n := normalizeGitURL(u); n != "" {
 				out[n] = struct{}{}
 			}
 		}

--- a/pkg/helm/version.go
+++ b/pkg/helm/version.go
@@ -1,7 +1,6 @@
 package helm
 
 import (
-	"fmt"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -38,7 +37,7 @@ func detectBundledKubeVersion() string {
 		if i := strings.Index(v, "-"); i > 0 {
 			v = v[:i]
 		}
-		return fmt.Sprintf("1.%s", v)
+		return "1." + v
 	}
 	return fallbackKubeVersion
 }

--- a/pkg/kustomize/generate.go
+++ b/pkg/kustomize/generate.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	fluxapis "github.com/fluxcd/pkg/apis/kustomize"
@@ -174,8 +175,12 @@ func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]an
 			NewTag:  image.NewTag,
 			Digest:  image.Digest,
 		}
-		if exists, index := findImage(kus.Images, image.Name); exists {
-			kus.Images[index] = newImage
+		// Dedup spec.images by name, last write winning — flux's
+		// checkKustomizeImageExists.
+		if i := slices.IndexFunc(kus.Images, func(img kustypes.Image) bool {
+			return img.Name == image.Name
+		}); i >= 0 {
+			kus.Images[i] = newImage
 		} else {
 			kus.Images = append(kus.Images, newImage)
 		}
@@ -353,16 +358,4 @@ func adaptSelector(selector *fluxapis.Selector) *kustypes.Selector {
 	out.LabelSelector = selector.LabelSelector
 	out.AnnotationSelector = selector.AnnotationSelector
 	return out
-}
-
-// findImage returns whether an image with the given name is already present in
-// images, and its index. Mirrors flux's checkKustomizeImageExists (used to
-// dedup spec.images by name, last write winning).
-func findImage(images []kustypes.Image, name string) (bool, int) {
-	for i, image := range images {
-		if name == image.Name {
-			return true, i
-		}
-	}
-	return false, -1
 }

--- a/pkg/manifest/resourceset.go
+++ b/pkg/manifest/resourceset.go
@@ -1,8 +1,6 @@
 package manifest
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -150,6 +148,7 @@ func decodeResourceSetInputs(inputs []fluxopv1.ResourceSetInput) ([]map[string]a
 // derivedID is the placeholder for upstream's UID-derived id field —
 // stable across flate runs because flate has no UIDs.
 func (p *ResourceSetInputProvider) derivedID() string {
-	sum := sha256.Sum256([]byte(p.Namespace + "/" + p.Name))
-	return hex.EncodeToString(sum[:8])
+	// First 8 bytes (16 hex chars) of the full digest — enough to
+	// uniquely identify the input set within a render.
+	return SHA256Hex([]byte(p.Namespace + "/" + p.Name))[:16]
 }

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -23,12 +23,7 @@ import (
 // listeners do not overwrite each other's deltas. The graph itself
 // owns finer-grained synchronization for its in-memory state.
 func (o *Orchestrator) failDependsOnCycles() {
-	// Lazy-init for test harnesses that construct an Orchestrator
-	// literal (bypassing New). Production code goes through New
-	// which seeds depGraph.
-	if o.depGraph == nil {
-		o.depGraph = newDependencyGraph()
-	}
+	o.ensureDepGraph()
 	// Refresh the graph from the canonical store state. This walks
 	// every KS + HR and pushes their current dependsOn list through
 	// ReplaceEdges. After Bootstrap this is the only path that runs
@@ -36,6 +31,15 @@ func (o *Orchestrator) failDependsOnCycles() {
 	// re-Bootstrap (test harnesses) the graph picks up the new state.
 	o.rebuildDependencyGraphFromStore()
 	o.syncPreflightFailures()
+}
+
+// ensureDepGraph lazy-inits depGraph for test harnesses that construct
+// an Orchestrator literal (bypassing New). Production code goes through
+// New, which seeds depGraph, so this is a no-op there.
+func (o *Orchestrator) ensureDepGraph() {
+	if o.depGraph == nil {
+		o.depGraph = newDependencyGraph()
+	}
 }
 
 // updateDependencyGraphFor is the per-event incremental path the
@@ -49,9 +53,7 @@ func (o *Orchestrator) failDependsOnCycles() {
 // controllers read them via PreflightFailure on their next status
 // check.
 func (o *Orchestrator) updateDependencyGraphFor(id manifest.NamedResource) {
-	if o.depGraph == nil {
-		o.depGraph = newDependencyGraph()
-	}
+	o.ensureDepGraph()
 	obj := o.store.GetObject(id)
 	if obj == nil {
 		// Object went away between the event fire and our read.

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -379,7 +379,7 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 			}
 		}
 	}
-	// Same projection logRecourceFailures + aggregateFailures use —
+	// Same projection logResourceFailures + aggregateFailures use —
 	// see sanitizeFailed for the contract. Centralizing in one
 	// helper keeps the three readers in sync if the strip rule
 	// changes.

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -135,18 +135,8 @@ func renderResources(raw *apix.JSON, inputs []map[string]any) ([]map[string]any,
 		return nil, err
 	}
 
-	if len(inputs) == 0 {
-		doc, err := renderSingle(pt, nil)
-		if err != nil {
-			return nil, err
-		}
-		if doc == nil || disabledByReconcileAnnotation(doc) {
-			return nil, nil
-		}
-		return []map[string]any{doc}, nil
-	}
 	out := make([]map[string]any, 0, len(inputs))
-	for _, in := range inputs {
+	for _, in := range defaultNilInput(inputs) {
 		doc, err := renderSingle(pt, in)
 		if err != nil {
 			return nil, err
@@ -168,15 +158,8 @@ func renderResourcesTemplate(tmplStr string, inputs []map[string]any) ([]map[str
 	if err != nil {
 		return nil, err
 	}
-	if len(inputs) == 0 {
-		docs, err := splitMultiDoc(pt, nil)
-		if err != nil {
-			return nil, err
-		}
-		return filterDisabled(docs), nil
-	}
 	var out []map[string]any
-	for _, in := range inputs {
+	for _, in := range defaultNilInput(inputs) {
 		docs, err := splitMultiDoc(pt, in)
 		if err != nil {
 			return nil, err
@@ -184,6 +167,17 @@ func renderResourcesTemplate(tmplStr string, inputs []map[string]any) ([]map[str
 		out = append(out, filterDisabled(docs)...)
 	}
 	return out, nil
+}
+
+// defaultNilInput yields the input sets to template against: the given
+// slice, or a single nil set when it is empty. An empty matrix means
+// "render once with no inputs" (static resources), so both callers
+// would otherwise carry an identical len==0 special case.
+func defaultNilInput(inputs []map[string]any) []map[string]any {
+	if len(inputs) == 0 {
+		return []map[string]any{nil}
+	}
+	return inputs
 }
 
 // filterDisabled removes docs carrying the reconcile-disabled annotation

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -157,13 +157,10 @@ func (c *Cache) Slot(ctx context.Context, url, ref, authID string) (*Slot, error
 	case os.IsNotExist(statErr):
 		// Allocate a sibling staging dir on the same filesystem so
 		// the eventual rename is atomic.
-		staging, err := os.MkdirTemp(filepath.Dir(final), filepath.Base(final)+".tmp.*")
-		if err != nil {
+		if err := s.allocStaging("staging"); err != nil {
 			s.unlock()
-			return nil, fmt.Errorf("cache slot staging: %w", err)
+			return nil, err
 		}
-		s.Path = staging
-		s.staging = staging
 		return s, nil
 	default:
 		s.unlock()

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -72,25 +72,38 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*sto
 			repo.Namespace, repo.Name, repo.Provider, sourcev1.GitProviderGeneric,
 			"SecretRef-based credentials")
 	}
-	auth, err := f.resolveAuth(repo)
-	if err != nil {
-		return nil, err
-	}
-	tlsCfg, err := f.resolveTLS(repo)
-	if err != nil {
-		return nil, err
-	}
-	proxy, err := source.ResolveProxy(f.Secrets, repo.Namespace, "GitRepository",
-		repo.Namespace+"/"+repo.Name, repo.ProxySecretRef)
-	if err != nil {
-		return nil, err
-	}
-	restore, err := gittransport.InstallHTTPS(tlsCfg, proxy)
+	auth, proxy, restore, err := f.resolveTransport(repo)
 	if err != nil {
 		return nil, err
 	}
 	defer restore()
 	return f.fetch(ctx, repo, auth, proxy)
+}
+
+// resolveTransport resolves the auth, TLS, and proxy material for repo
+// and installs the process-wide HTTPS transport for the fetch. It
+// returns the auth method and proxy config the go-git call needs plus a
+// restore closure the caller MUST defer to tear the transport back down.
+// Shared by Fetch and Prewarm so both agree on credential resolution.
+func (f *Fetcher) resolveTransport(repo *manifest.GitRepository) (transport.AuthMethod, *source.ProxyConfig, func(), error) {
+	auth, err := f.resolveAuth(repo)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	tlsCfg, err := f.resolveTLS(repo)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	proxy, err := source.ResolveProxy(f.Secrets, repo.Namespace, "GitRepository",
+		repo.Namespace+"/"+repo.Name, repo.ProxySecretRef)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	restore, err := gittransport.InstallHTTPS(tlsCfg, proxy)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return auth, proxy, restore, nil
 }
 
 // fetch clones the GitRepository, then runs verification, ignore, and
@@ -200,8 +213,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		}
 	}
 
-	rev, _ := readResolvedRevision(slot.Path)
-	art := gitArtifact(repo.URL, slot.Path, rev)
+	art := gitArtifact(repo.URL, slot.Path, readResolvedRevision(slot.Path))
 	if err := f.finalize(repo, art); err != nil {
 		return nil, err
 	}
@@ -384,20 +396,7 @@ func (f *Fetcher) Prewarm(ctx context.Context, repo *manifest.GitRepository) err
 	if !f.canUseMirror(repo, url) {
 		return nil
 	}
-	auth, err := f.resolveAuth(repo)
-	if err != nil {
-		return err
-	}
-	tlsCfg, err := f.resolveTLS(repo)
-	if err != nil {
-		return err
-	}
-	proxy, err := source.ResolveProxy(f.Secrets, repo.Namespace, "GitRepository",
-		repo.Namespace+"/"+repo.Name, repo.ProxySecretRef)
-	if err != nil {
-		return err
-	}
-	restore, err := gittransport.InstallHTTPS(tlsCfg, proxy)
+	auth, proxy, restore, err := f.resolveTransport(repo)
 	if err != nil {
 		return err
 	}

--- a/pkg/source/git/marker.go
+++ b/pkg/source/git/marker.go
@@ -43,14 +43,14 @@ func cachedRevisionFresh(slot string, maxAge time.Duration) (string, bool) {
 // Best-effort: returns empty string on any failure. Used post-clone
 // (before .git/ is wiped by ApplyIgnore) to capture the resolved SHA
 // for the artifact + the cached-revision marker.
-func readResolvedRevision(slot string) (string, error) {
+func readResolvedRevision(slot string) string {
 	repo, err := git.PlainOpen(slot)
 	if err != nil {
-		return "", err
+		return ""
 	}
 	h, err := repo.Head()
 	if err != nil {
-		return "", err
+		return ""
 	}
-	return h.Hash().String(), nil
+	return h.Hash().String()
 }

--- a/pkg/source/git/verify/verify.go
+++ b/pkg/source/git/verify/verify.go
@@ -4,6 +4,7 @@
 package verify
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -111,7 +112,7 @@ func buildPGPKeyring(sec *manifest.Secret) (string, error) {
 		add(k)
 	}
 	if b.Len() == 0 {
-		return "", fmt.Errorf("verify secret carries no PGP public keys")
+		return "", errors.New("verify secret carries no PGP public keys")
 	}
 	return b.String(), nil
 }

--- a/pkg/source/gittree/materialize_test.go
+++ b/pkg/source/gittree/materialize_test.go
@@ -81,8 +81,7 @@ func TestMaterialize_SubmoduleCallbackWiredCorrectly(t *testing.T) {
 func TestMaterialize_RespectsCtxCancel(t *testing.T) {
 	src := t.TempDir()
 	repo := mustInit(t, src)
-	for i := range 50 {
-		_ = i
+	for range 50 {
 		_ = os.WriteFile(filepath.Join(src, "f"+filepath.Base(t.TempDir())), []byte("x"), 0o600)
 	}
 	hash := mustCommit(t, repo, src)

--- a/pkg/source/oci/layer.go
+++ b/pkg/source/oci/layer.go
@@ -320,7 +320,7 @@ func extractTarGz(src, dst string) error {
 			// for these and Flux's source-controller does the same.
 		}
 	}
-	if err := os.Remove(src); err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(src); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 	return nil

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -243,10 +243,6 @@ func (s *Store) AddObjects(objs []manifest.BaseManifest) {
 	if len(objs) == 0 {
 		return
 	}
-	type event struct {
-		id  manifest.NamedResource
-		obj manifest.BaseManifest
-	}
 	// Bucket inputs by shard index so each shard locks at most once.
 	var buckets [shardCount][]manifest.BaseManifest
 	for _, obj := range objs {
@@ -260,17 +256,13 @@ func (s *Store) AddObjects(objs []manifest.BaseManifest) {
 		}
 		sh := s.shards[i]
 		sh.mu.Lock()
-		events := make([]event, 0, len(buckets[i]))
 		for _, obj := range buckets[i] {
 			id := obj.Named()
 			if cur, ok := sh.objects[id]; ok && reflect.DeepEqual(cur, obj) {
 				continue
 			}
 			sh.setLocked(id, obj)
-			events = append(events, event{id: id, obj: obj})
-		}
-		for _, e := range events {
-			dispatches = append(dispatches, s.fireUnderLock(EventObjectAdded, e.id, e.obj))
+			dispatches = append(dispatches, s.fireUnderLock(EventObjectAdded, id, obj))
 		}
 		sh.mu.Unlock()
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -199,9 +199,19 @@ func (s *Service) YieldSlot(fn func()) {
 		fn()
 		return
 	}
-	<-s.sem
-	defer func() { s.sem <- struct{}{} }()
+	defer s.releaseSlot()()
 	fn()
+}
+
+// releaseSlot drops the calling goroutine's worker slot and returns a
+// closure that re-acquires one. Callers defer the returned closure so a
+// panic in the released gap still restores the slot count; otherwise
+// Service.Go's outer `defer <-s.sem` drains a phantom slot on unwind,
+// eventually hanging a goroutine that legitimately owns a slot. Only
+// valid on a bounded Service (s.sem != nil).
+func (s *Service) releaseSlot() func() {
+	<-s.sem
+	return func() { s.sem <- struct{}{} }
 }
 
 // YieldQuiescent releases the worker slot AND decrements the active
@@ -227,8 +237,7 @@ func (s *Service) YieldSlot(fn func()) {
 // unwind.
 func (s *Service) YieldQuiescent(fn func()) {
 	if s.sem != nil {
-		<-s.sem
-		defer func() { s.sem <- struct{}{} }()
+		defer s.releaseSlot()()
 	}
 	now := s.active.Add(-1)
 	s.notifyQuiescence(now)

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -239,13 +239,9 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider, cache *C
 	// the cached canonicals by reference (cheap, the common platform-CM
 	// pattern); if ANY ref has one, keep the eager fully-owned copy so the
 	// in-place write can't reach the cache. See updateHelmReleaseValues.
-	share := true
-	for _, ref := range hr.ValuesFrom {
-		if ref.TargetPath != "" {
-			share = false
-			break
-		}
-	}
+	share := !slices.ContainsFunc(hr.ValuesFrom, func(ref manifest.ValuesReference) bool {
+		return ref.TargetPath != ""
+	})
 	values := map[string]any{}
 	for _, ref := range hr.ValuesFrom {
 		found, err := lookupValueRef(ref, hr.Namespace, provider)
@@ -255,8 +251,7 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider, cache *C
 			}
 			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
-		values, err = updateHelmReleaseValues(ref, found, values, hr.Namespace, cache, share)
-		if err != nil {
+		if values, err = updateHelmReleaseValues(ref, found, values, hr.Namespace, cache, share); err != nil {
 			return fmt.Errorf("building HelmRelease %s: %w", hr.Named().NamespacedName(), err)
 		}
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -239,18 +239,7 @@ func TestE2E_DiffImagesNoChange(t *testing.T) {
 func TestE2E_DiffAutoBaseline_Base(t *testing.T) {
 	clusterPath, repoRoot := initGitFixture(t)
 	// Edit cm.yaml in the working tree; HEAD still has the original.
-	cm := filepath.Join(repoRoot, "kubernetes", "apps", "cm.yaml")
-	body, err := os.ReadFile(cm) //nolint:gosec // dir is t.TempDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mutated := strings.Replace(string(body), "value: original", "value: changed", 1)
-	if mutated == string(body) {
-		t.Fatal("sentinel 'value: original' not found in fixture")
-	}
-	if err := os.WriteFile(cm, []byte(mutated), 0o600); err != nil { //nolint:gosec // dir is t.TempDir()
-		t.Fatal(err)
-	}
+	mutateFile(t, filepath.Join(repoRoot, "kubernetes", "apps", "cm.yaml"), "value: original", "value: changed")
 	out := runCLI(t, "diff", "ks", "--path", clusterPath, "--base", "HEAD")
 	if !strings.Contains(out, "changed") {
 		t.Errorf("expected 'changed' to surface in diff body:\n%s", out)
@@ -430,18 +419,7 @@ func TestE2E_ComponentChangePropagatesToAllConsumers(t *testing.T) {
 	current := copyTree(t, src)
 
 	// Mutate the shared component in only the "current" tree.
-	target := filepath.Join(current, "components", "shared", "shared-cm.yaml")
-	data, err := os.ReadFile(target) //nolint:gosec // target is inside a t.TempDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mutated := strings.Replace(string(data), "value: original", "value: changed", 1)
-	if mutated == string(data) {
-		t.Fatal("fixture sentinel not found; check shared-cm.yaml")
-	}
-	if err := os.WriteFile(target, []byte(mutated), 0o600); err != nil { //nolint:gosec // target is inside a t.TempDir()
-		t.Fatal(err)
-	}
+	mutateFile(t, filepath.Join(current, "components", "shared", "shared-cm.yaml"), "value: original", "value: changed")
 
 	// -o github explicitly: this test asserts github diff-syntax markers,
 	// independent of the default style.
@@ -465,18 +443,7 @@ func TestE2E_NonSharedChangeDoesNotPropagate(t *testing.T) {
 	orig := copyTree(t, src)
 	current := copyTree(t, src)
 
-	target := filepath.Join(current, "apps", "app-a", "cm.yaml")
-	data, err := os.ReadFile(target) //nolint:gosec // target is inside a t.TempDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mutated := strings.Replace(string(data), "app: app-a", "app: app-a-edited", 1)
-	if mutated == string(data) {
-		t.Fatal("fixture sentinel not found")
-	}
-	if err := os.WriteFile(target, []byte(mutated), 0o600); err != nil { //nolint:gosec // target is inside a t.TempDir()
-		t.Fatal(err)
-	}
+	mutateFile(t, filepath.Join(current, "apps", "app-a", "cm.yaml"), "app: app-a", "app: app-a-edited")
 
 	out := runCLI(t, "diff", "ks", "--path", current, "--path-orig", orig)
 
@@ -658,17 +625,7 @@ func TestE2E_ChangedOnlyHRDependsOnUnchangedDep(t *testing.T) {
 	// scope; qbittorrent (its dependsOn target) stays unchanged, so its
 	// Kustomization is skipped and the qbittorrent HR is never emitted.
 	hr := filepath.Join(repoRoot, "apps", "downloads", "lidarr", "app", "helmrelease.yaml")
-	body, err := os.ReadFile(hr) //nolint:gosec // repoRoot is t.TempDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mutated := strings.Replace(string(body), "hello-from-lidarr", "hello-from-lidarr-edited", 1)
-	if mutated == string(body) {
-		t.Fatal("sentinel 'hello-from-lidarr' not found in lidarr helmrelease.yaml")
-	}
-	if err := os.WriteFile(hr, []byte(mutated), 0o600); err != nil { //nolint:gosec // repoRoot is t.TempDir()
-		t.Fatal(err)
-	}
+	mutateFile(t, hr, "hello-from-lidarr", "hello-from-lidarr-edited")
 
 	out := runCLIOutputOnly(t, "test", "all", "--path", clusterPath, "--base", "HEAD")
 
@@ -789,6 +746,25 @@ data:
 `)
 	gitCommitAll(t, repo)
 	return filepath.Join(dir, "kubernetes", "flux"), dir
+}
+
+// mutateFile rewrites the file at path, replacing the first occurrence of
+// oldStr with newStr. It fails the test if oldStr is absent (a stale fixture
+// sentinel would otherwise let the test pass without exercising the change it
+// asserts). path is always inside a t.TempDir() in callers.
+func mutateFile(t *testing.T, path, oldStr, newStr string) {
+	t.Helper()
+	body, err := os.ReadFile(path) //nolint:gosec // path is inside a t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated := strings.Replace(string(body), oldStr, newStr, 1)
+	if mutated == string(body) {
+		t.Fatalf("sentinel %q not found in %s", oldStr, path)
+	}
+	if err := os.WriteFile(path, []byte(mutated), 0o600); err != nil { //nolint:gosec // path is inside a t.TempDir()
+		t.Fatal(err)
+	}
 }
 
 // copyTree shallow-copies src into a fresh tempdir, preserving the


### PR DESCRIPTION
Second autonomous code-cleanliness sweep — 22 packages, each refactored by an isolated agent and verified behavior- and API-preserving. Net **−48 lines**.

## What changed
- **Extract shared helpers** collapsing repeated blocks: `joinOutputs` (internal/cli), `requireNotStarted` (controllers/base, 5 call sites), `quiesceCh` (depwait), `ensureDepGraph` (orchestrator), `defaultNilInput` (resourceset), `resolveTransport` (source/git — shared by Fetch + Prewarm), `releaseSlot` (task), `mutateFile` (test/e2e, 4 call sites).
- **Reuse existing primitives:** `slices.Clone`, `slices.IndexFunc`, `slices.ContainsFunc`, `manifest.SHA256Hex`, `Slot.allocStaging` (third inline copy).
- **Modern idioms:** `errors.New` over arg-less `fmt.Errorf`, string concat over `fmt.Sprintf`, `errors.Is(err, os.ErrNotExist)`, range-over-int.
- **Drop dead imports** (`crypto/sha256`, `encoding/hex`, `fmt`) and redundant local bindings; fix two comment typos.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` all pass · `golangci-lint` **0 issues**.
- **Cross-repo byte-equivalence** (`build all`, disk render cache off, shared source cache) across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set (Helm `genSignedCert` cert regeneration + infisical `updatedAt` timestamps) — confirmed binary-independent (base-vs-base reproduces the same diffs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)