### PR TITLE
refactor: third behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -137,17 +137,14 @@ func collectRendered(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 		slices.SortStableFunc(docs, compareDocs)
 		if b.onlyCRDs {
 			docs = filterCRDsOnly(docs)
-			if len(docs) == 0 {
-				continue
-			}
 		} else {
 			// Defensive re-drop. Orchestrator.Render already filters
 			// Result.Manifests at the embed boundary using the same
 			// kind set, so this is a no-op for the normal CLI path.
 			docs = manifest.DropKinds(docs, skipKinds)
-			if len(docs) == 0 {
-				continue
-			}
+		}
+		if len(docs) == 0 {
+			continue
 		}
 		out = append(out, docs...)
 	}

--- a/internal/testutil/certs.go
+++ b/internal/testutil/certs.go
@@ -13,10 +13,9 @@ import (
 )
 
 // certValidity is the lifetime stamped on every test cert. 24h
-// generously covers any test run while still bounding the practical
+// generously covers any test run (including long-running integration
+// tests against frozen clocks) while still bounding the practical
 // window for a leaked fixture if someone pastes the cert somewhere.
-// Previously 1h, which flaked on slow CI runners — long-running
-// integration tests against frozen clocks could expire mid-run.
 const certValidity = 24 * time.Hour
 
 // randomSerial returns a 128-bit random serial — different on every

--- a/internal/testutil/manifest.go
+++ b/internal/testutil/manifest.go
@@ -1,8 +1,6 @@
 package testutil
 
-import (
-	"github.com/home-operations/flate/pkg/manifest"
-)
+import "github.com/home-operations/flate/pkg/manifest"
 
 // DepRefs wraps NamedResources as bare DependencyRefs (no ReadyExpr),
 // the shape dependency-ordering tests use to express dependsOn edges.

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -1,6 +1,7 @@
 package baseline
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -384,7 +385,7 @@ func mergeBase(repo *git.Repository, headCommit *object.Commit, other plumbing.H
 	// hash so two `flate diff` runs against the same repo pick the
 	// same baseline — reproducibility is a stated guarantee.
 	best := slices.MinFunc(bases, func(a, b *object.Commit) int {
-		return strings.Compare(a.Hash.String(), b.Hash.String())
+		return bytes.Compare(a.Hash[:], b.Hash[:])
 	})
 	return best.Hash, nil
 }

--- a/pkg/change/doc.go
+++ b/pkg/change/doc.go
@@ -10,8 +10,9 @@
 // The filter cascades through references: when a HelmRelease's file
 // changed, its chart source (OCIRepository / HelmRepository /
 // GitRepository) is also marked needed so the actual chart still gets
-// downloaded. Likewise, a Kustomization's sourceRef and dependsOn
-// ancestors are kept ready so downstream waits succeed.
+// downloaded. Likewise, a Kustomization's sourceRef is kept ready so
+// downstream waits succeed. dependsOn is intentionally excluded: it's a
+// reconcile-ordering signal, not a content dependency.
 //
 // The cascade also runs in reverse: when the changed file IS a source
 // resource, every HelmRelease/Kustomization that references it is kept

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -304,7 +304,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// dedup gate (a re-emit that finds the prior fingerprint cached must not
 	// replay stale docs over a source that has since failed or soft-skipped
 	// via --allow-missing-secrets).
-	if err := c.awaitChartSource(ctx, id, hr, chartSourceID(hr)); err != nil {
+	if err := c.awaitChartSource(ctx, id, hr); err != nil {
 		return err
 	}
 	// A HelmRepository is just a registry/index base — its chart has no
@@ -317,7 +317,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// dance.
 	hr, repointed := c.materializeHelmChartSource(id, hr)
 	if repointed {
-		if err := c.awaitChartSource(ctx, id, hr, chartSourceID(hr)); err != nil {
+		if err := c.awaitChartSource(ctx, id, hr); err != nil {
 			return err
 		}
 	}
@@ -391,11 +391,12 @@ func chartSourceID(hr *manifest.HelmRelease) manifest.NamedResource {
 	}
 }
 
-// awaitChartSource blocks until srcID reaches Ready, then propagates a
-// soft-skip (--allow-missing-secrets on the source's auth marks it Ready but
-// writes no artifact, so fail here rather than letting the render fail later
-// with a confusing chart-not-found).
-func (c *Controller) awaitChartSource(ctx context.Context, id manifest.NamedResource, hr *manifest.HelmRelease, srcID manifest.NamedResource) error {
+// awaitChartSource blocks until hr's current chart source reaches Ready, then
+// propagates a soft-skip (--allow-missing-secrets on the source's auth marks it
+// Ready but writes no artifact, so fail here rather than letting the render fail
+// later with a confusing chart-not-found).
+func (c *Controller) awaitChartSource(ctx context.Context, id manifest.NamedResource, hr *manifest.HelmRelease) error {
+	srcID := chartSourceID(hr)
 	if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout),
 		[]manifest.DependencyRef{{NamedResource: srcID}},
 		"", // status already set by the caller

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -373,8 +373,7 @@ func (c *Controller) resolveSource(ks *manifest.Kustomization) (sourceRoot strin
 		return "", false, fmt.Errorf("%w: source %s artifact not found", manifest.ErrObjectNotFound, srcID.String())
 	}
 	if sa, ok := art.(*store.SourceArtifact); ok {
-		applyIgnore := sa.Digest == "" && sa.Revision == ""
-		return sa.LocalPath, applyIgnore, nil
+		return sa.LocalPath, sa.Digest == "" && sa.Revision == "", nil
 	}
 	return "", false, fmt.Errorf("%w: unsupported source artifact type %T for %s",
 		manifest.ErrFlux, art, srcID.String())

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -129,14 +129,13 @@ func parseGitURL(raw string) (host, path string, ok bool) {
 	// when no `@`) separates host from path. Anything that doesn't
 	// match this shape is treated as a local path and rejected.
 	rest := raw
-	if at := strings.Index(rest, "@"); at >= 0 {
-		rest = rest[at+1:]
+	if _, after, ok := strings.Cut(rest, "@"); ok {
+		rest = after
 	}
-	colon := strings.Index(rest, ":")
-	if colon <= 0 {
+	host, path, ok = strings.Cut(rest, ":")
+	if !ok || host == "" {
 		return "", "", false
 	}
-	host, path = rest[:colon], rest[colon+1:]
 	if strings.ContainsAny(host, "/\\") {
 		// Looks like a relative path containing a colon, not
 		// host:path. Reject.

--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -433,7 +433,7 @@ func chartCacheFingerprint(path string) (mtime, size int64, ok bool) {
 	if !info.IsDir() {
 		return info.ModTime().UnixNano(), info.Size(), true
 	}
-	cy, err := os.Stat(filepath.Join(path, "Chart.yaml"))
+	cy, err := os.Stat(filepath.Join(path, chartYamlFilename))
 	if err != nil {
 		return 0, 0, false
 	}

--- a/pkg/helm/repo.go
+++ b/pkg/helm/repo.go
@@ -37,7 +37,7 @@ func (c *Client) locateLocalChart(hr *manifest.HelmRelease) (string, error) {
 			manifest.ErrObjectNotFound, hr.Chart.RepoKind, hr.Chart.RepoFullName(), hr.Named().NamespacedName())
 	}
 	path := filepath.Join(art.LocalPath, hr.Chart.Name)
-	if _, err := os.Stat(filepath.Join(path, "Chart.yaml")); err != nil {
+	if _, err := os.Stat(filepath.Join(path, chartYamlFilename)); err != nil {
 		return "", fmt.Errorf("chart not found at %s: %w", path, err)
 	}
 	return path, nil

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -124,9 +124,7 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 			if fetchErr != nil {
 				return fmt.Errorf("remote git base %s: %w", entry.Value, fetchErr)
 			}
-			entry.Value = localDir
-			entry.Tag = "!!str"
-			entry.Style = 0
+			setPlainScalar(entry, localDir)
 			changed = true
 			continue
 		}
@@ -137,9 +135,7 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 		if fetchErr != nil {
 			return fmt.Errorf("remote resource %s: %w", entry.Value, fetchErr)
 		}
-		entry.Value = "./" + localFile
-		entry.Tag = "!!str"
-		entry.Style = 0 // plain scalar; preserve other entries' styles
+		setPlainScalar(entry, "./"+localFile)
 		changed = true
 	}
 	if !changed {
@@ -150,6 +146,14 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 		return err
 	}
 	return memFS.WriteFile(ksFile, out)
+}
+
+// setPlainScalar rewrites node to a plain (unquoted, untagged) string scalar
+// holding value, leaving sibling sequence entries' styles untouched.
+func setPlainScalar(node *yaml.Node, value string) {
+	node.Value = value
+	node.Tag = "!!str"
+	node.Style = 0
 }
 
 // findMappingValue returns the value node for the first mapping entry with the

--- a/pkg/loader/generators.go
+++ b/pkg/loader/generators.go
@@ -46,24 +46,19 @@ func collectGeneratorRecords(k *kustomization, file string) []generatorRecord {
 		return nil
 	}
 	out := make([]generatorRecord, 0, len(k.ConfigMapGenerator)+len(k.SecretGenerator))
-	for _, g := range k.ConfigMapGenerator {
-		if g.Name == "" {
-			continue
+	collect := func(entries []kvPairGenerator, isConfigMap bool) {
+		for _, g := range entries {
+			if g.Name == "" {
+				continue
+			}
+			out = append(out, generatorRecord{
+				file: file, kustomizationNS: k.Namespace, entryNS: g.Namespace,
+				isConfigMap: isConfigMap, name: g.Name, literals: g.Literals,
+			})
 		}
-		out = append(out, generatorRecord{
-			file: file, kustomizationNS: k.Namespace, entryNS: g.Namespace,
-			isConfigMap: true, name: g.Name, literals: g.Literals,
-		})
 	}
-	for _, g := range k.SecretGenerator {
-		if g.Name == "" {
-			continue
-		}
-		out = append(out, generatorRecord{
-			file: file, kustomizationNS: k.Namespace, entryNS: g.Namespace,
-			isConfigMap: false, name: g.Name, literals: g.Literals,
-		})
-	}
+	collect(k.ConfigMapGenerator, true)
+	collect(k.SecretGenerator, false)
 	return out
 }
 

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -2,12 +2,9 @@ package loader
 
 import (
 	"cmp"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
-
-	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -232,21 +229,8 @@ func indexKustomizeNamespaces(sourceFiles map[manifest.NamedResource]string, rep
 // a kustomization.yaml in dir (resolved relative to repoRoot), or ""
 // if no kustomize file exists or the namespace key is absent.
 func readKustomizeNamespace(repoRoot, dir string) string {
-	for _, name := range manifest.KustomizeBuilderFilenames {
-		path := filepath.Join(repoRoot, dir, name)
-		data, err := os.ReadFile(path) //nolint:gosec // path composed from known cluster layout
-		if err != nil {
-			continue
-		}
-		var doc struct {
-			Namespace string `yaml:"namespace"`
-		}
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			continue
-		}
-		return doc.Namespace
-	}
-	return ""
+	d, _ := readKustomizeDirectives(repoRoot, dir)
+	return d.Namespace
 }
 
 // cloneWithNamespace returns a shallow copy of obj with metadata.namespace

--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -81,11 +81,7 @@ var kustomizationFileNames = [3]string{
 // the real error later with better context than the loader can.
 //
 // The caller hands the returned path forward to walkKustomize /
-// walkComponentData so they don't open the same file again. Before
-// the dedup, descend opened the kustomization.yaml once here, then
-// kustomizationFilePath stat'd it for the generator harvest, then
-// walkKustomize re-stat'd it to load the file itself — three opens
-// of the same path per package directory.
+// walkComponentData so they don't open the same file again.
 func readKustomizationAt(dir string) (*kustomization, string) {
 	for _, name := range kustomizationFileNames {
 		path := filepath.Join(dir, name)

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -105,7 +105,7 @@ type Loader struct {
 	// finalize detectOrphans, and change.buildOwnership all read each
 	// kustomization.yaml's `components:` field at most once per
 	// Bootstrap. nil falls back to per-call caches with no cross-call
-	// sharing (the pre-1.A behavior).
+	// sharing.
 	ComponentCache *manifest.ComponentCache
 
 	// generators accumulates configMapGenerator/secretGenerator
@@ -233,11 +233,7 @@ func (w *walker) descend(ctx context.Context, dir string) (int, error) {
 
 	// readKustomizationAt returns the resolved file path alongside the
 	// parsed body so descend can hand both forward to walkKustomize /
-	// walkComponentData without a second kustomizationFilePath stat.
-	// Before this dedup, every package directory cost three opens of
-	// the same kustomization.yaml: readKustomization here,
-	// kustomizationFilePath for the generator harvest, then
-	// kustomizationFilePath again inside walkKustomize.
+	// walkComponentData without re-opening the same kustomization.yaml.
 	k, kpath := readKustomizationAt(dir)
 	if k != nil {
 		// Harvest configMapGenerator/secretGenerator entries

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -47,9 +47,8 @@ type KSPathPrefix struct {
 // Entries are sorted by prefix length descending so the first
 // HasPrefix match on a given file is the deepest claimant — a child
 // file under a parent's component dir wins over the parent's
-// spec.path. Previously this function only emitted (1); the new
-// (2)+(3) bring loader's parent index in line with change/ownership's
-// already-richer attribution, eliminating the false-orphan class
+// spec.path. Emitting (2)+(3) keeps loader's parent index in line with
+// change/ownership's attribution, eliminating the false-orphan class
 // where a child KS lives inside a parent's component subtree.
 //
 // repoRoot is the filesystem root the kustomization-file reads

--- a/pkg/orchestrator/depgraph.go
+++ b/pkg/orchestrator/depgraph.go
@@ -203,18 +203,10 @@ func (g *dependencyGraph) findPathLocked(
 }
 
 // sortedNeighbors returns the keys of edges in deterministic order
-// (NamedResource.Compare). Empty input returns nil so callers can
-// range over the result safely.
+// (NamedResource.Compare). Callers range over the result, so an empty
+// edge set yielding an empty slice is safe.
 func sortedNeighbors(edges map[manifest.NamedResource]struct{}) []manifest.NamedResource {
-	if len(edges) == 0 {
-		return nil
-	}
-	out := make([]manifest.NamedResource, 0, len(edges))
-	for k := range edges {
-		out = append(out, k)
-	}
-	slices.SortFunc(out, manifest.NamedResource.Compare)
-	return out
+	return slices.SortedFunc(maps.Keys(edges), manifest.NamedResource.Compare)
 }
 
 // revalidateFailedLocked walks every currently-failed node and checks
@@ -230,11 +222,7 @@ func (g *dependencyGraph) revalidateFailedLocked() {
 		return
 	}
 	// Snapshot keys so we can delete while iterating.
-	ids := make([]manifest.NamedResource, 0, len(g.failed))
-	for id := range g.failed {
-		ids = append(ids, id)
-	}
-	for _, id := range ids {
+	for _, id := range slices.Collect(maps.Keys(g.failed)) {
 		if _, ok := g.findPathLocked(id, id); !ok {
 			delete(g.failed, id)
 		}

--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -75,12 +75,7 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 	groups := make([]providerInputs, 0, 1+len(rs.InputsFrom))
 
 	// Provider 0: the ResourceSet itself with its inline spec.inputs.
-	inlineProv := map[string]any{
-		"apiVersion": fluxopv1.GroupVersion.String(),
-		"kind":       manifest.KindResourceSet,
-		"name":       rs.Name,
-		"namespace":  rs.Namespace,
-	}
+	inlineProv := providerBlock(manifest.KindResourceSet, rs.Name, rs.Namespace)
 	inline := make([]map[string]any, 0, len(rs.Inputs))
 	for _, in := range rs.Inputs {
 		decoded := decodeInputSet(in)
@@ -131,12 +126,7 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 				"provider", p.Named().NamespacedName(),
 				"type", p.Type)
 		}
-		provBlock := map[string]any{
-			"apiVersion": fluxopv1.GroupVersion.String(),
-			"kind":       manifest.KindResourceSetInputProvider,
-			"name":       p.Name,
-			"namespace":  p.Namespace,
-		}
+		provBlock := providerBlock(manifest.KindResourceSetInputProvider, p.Name, p.Namespace)
 		pInputs := make([]map[string]any, 0, len(exported))
 		for _, set := range exported {
 			set["provider"] = provBlock
@@ -145,6 +135,17 @@ func collectProviderInputs(rs *manifest.ResourceSet, resolve ProviderResolver) (
 		groups = append(groups, providerInputs{name: p.Name, inputs: pInputs})
 	}
 	return groups, nil
+}
+
+// providerBlock builds the `provider` block stamped onto each input set
+// so templates can recover which CR sourced the values.
+func providerBlock(kind, name, namespace string) map[string]any {
+	return map[string]any{
+		"apiVersion": fluxopv1.GroupVersion.String(),
+		"kind":       kind,
+		"name":       name,
+		"namespace":  namespace,
+	}
 }
 
 func decodeInputSet(in fluxopv1.ResourceSetInput) map[string]any {

--- a/pkg/resourceset/template.go
+++ b/pkg/resourceset/template.go
@@ -91,8 +91,5 @@ func toYaml(v any) string {
 // this when the template is willing to fail loudly on malformed inputs.
 func mustToYaml(v any) (string, error) {
 	out, err := yaml.Marshal(v)
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
+	return string(out), err
 }

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -70,100 +70,89 @@ const (
 	RenderHelmCacheDir = "render/helm"
 )
 
-// pathSep is the platform separator as a string, used by the join
-// helpers so each can stay allocation-free for the separator itself.
+// pathSep is the platform separator as a string, used by join so it can
+// stay allocation-free for the separator itself.
 var pathSep = string(filepath.Separator)
 
-// app2 appends one path segment to a clean base without a filepath.Clean
-// pass. New guarantees Root is clean; all callers pass string constants
-// as the second argument.
-func app2(base, seg string) string { return base + pathSep + seg }
-
-// app3 appends two path segments to a clean base; see app2.
-func app3(base, seg1, seg2 string) string {
+// join appends segs to a clean base separated by pathSep, without a
+// filepath.Clean pass. New guarantees Root is clean; all callers pass
+// string constants (or already-validated keys) as the segments. It
+// pre-sizes the builder to the exact final length so each path is a
+// single allocation.
+func join(base string, segs ...string) string {
+	n := len(base)
+	for _, s := range segs {
+		n += 1 + len(s)
+	}
 	var b strings.Builder
-	b.Grow(len(base) + 1 + len(seg1) + 1 + len(seg2))
+	b.Grow(n)
 	b.WriteString(base)
-	b.WriteString(pathSep)
-	b.WriteString(seg1)
-	b.WriteString(pathSep)
-	b.WriteString(seg2)
-	return b.String()
-}
-
-// app4 appends three path segments to a clean base; see app2.
-func app4(base, seg1, seg2, seg3 string) string {
-	var b strings.Builder
-	b.Grow(len(base) + 1 + len(seg1) + 1 + len(seg2) + 1 + len(seg3))
-	b.WriteString(base)
-	b.WriteString(pathSep)
-	b.WriteString(seg1)
-	b.WriteString(pathSep)
-	b.WriteString(seg2)
-	b.WriteString(pathSep)
-	b.WriteString(seg3)
+	for _, s := range segs {
+		b.WriteString(pathSep)
+		b.WriteString(s)
+	}
 	return b.String()
 }
 
 // Sources returns the parent directory of every source slot. Used by
 // GC's age sweep and listing tools.
-func (l Layout) Sources() string { return app2(l.Root, SourcesDir) }
+func (l Layout) Sources() string { return join(l.Root, SourcesDir) }
 
 // SourceSlot returns the on-disk slot for a given (slug, hash) pair.
 // slug is a human-readable repo name; hash is the content-keyed
 // identifier source.Cache computes from (url, ref, authID).
 func (l Layout) SourceSlot(slug, hash string) string {
-	return app4(l.Root, SourcesDir, slug, hash)
+	return join(l.Root, SourcesDir, slug, hash)
 }
 
 // Baselines returns the parent directory of every materialized
 // baseline tree.
-func (l Layout) Baselines() string { return app2(l.Root, BaselinesDir) }
+func (l Layout) Baselines() string { return join(l.Root, BaselinesDir) }
 
 // Baseline returns the on-disk path for a baseline tree keyed by its
 // commit sha.
 func (l Layout) Baseline(commitSHA string) string {
-	return app3(l.Root, BaselinesDir, commitSHA)
+	return join(l.Root, BaselinesDir, commitSHA)
 }
 
 // Blobs returns the parent of every content-addressed blob.
 // Always includes the algorithm segment so blobs/sha512/ etc. can land
 // here later without rewriting the GC's walk.
-func (l Layout) Blobs() string { return app3(l.Root, BlobsDir, BlobsAlgo) }
+func (l Layout) Blobs() string { return join(l.Root, BlobsDir, BlobsAlgo) }
 
 // Blob returns the on-disk directory for a single blob keyed by its
 // hex sha256 digest.
 func (l Layout) Blob(digest string) string {
-	return app4(l.Root, BlobsDir, BlobsAlgo, digest)
+	return join(l.Root, BlobsDir, BlobsAlgo, digest)
 }
 
 // RefsRoot returns the parent of every refs table. Walked by GC to
 // clean dangling pointers.
-func (l Layout) RefsRoot() string { return app2(l.Root, RefsDir) }
+func (l Layout) RefsRoot() string { return join(l.Root, RefsDir) }
 
 // RefsCategory carves out a subdirectory under refs/ for one
 // caller's identity→digest mapping. The first arg is a stable name
 // (e.g. "chart-tarballs", "git-revisions") shared between the writer
 // and any introspection tooling.
 func (l Layout) RefsCategory(name string) string {
-	return app3(l.Root, RefsDir, name)
+	return join(l.Root, RefsDir, name)
 }
 
 // GitMirrors returns the parent of every bare git mirror.
-func (l Layout) GitMirrors() string { return app2(l.Root, GitMirrorsDir) }
+func (l Layout) GitMirrors() string { return join(l.Root, GitMirrorsDir) }
 
 // GitMirror returns the on-disk path for a bare mirror keyed by the
 // stable hash of an upstream URL.
 func (l Layout) GitMirror(urlHash string) string {
-	return app3(l.Root, GitMirrorsDir, urlHash)
+	return join(l.Root, GitMirrorsDir, urlHash)
 }
 
 // HelmTmp returns the scratch directory the HelmChart fetcher uses for
 // transient writes (index.yaml downloads, TLS cert materialization).
-func (l Layout) HelmTmp() string { return app2(l.Root, HelmTmpDir) }
+func (l Layout) HelmTmp() string { return join(l.Root, HelmTmpDir) }
 
 // RenderHelmCache returns the parent directory of the persisted helm
 // template-output cache. Entries live under sharded subdirs keyed by
 // the first two hex chars of the cache key; the disk layer in
 // pkg/helm owns the layout below this root.
-func (l Layout) RenderHelmCache() string { return app2(l.Root, RenderHelmCacheDir) }
+func (l Layout) RenderHelmCache() string { return join(l.Root, RenderHelmCacheDir) }

--- a/pkg/source/cacheroot/layout_test.go
+++ b/pkg/source/cacheroot/layout_test.go
@@ -39,7 +39,7 @@ func TestLayout_Paths(t *testing.T) {
 }
 
 // TestNew_CleansRoot confirms that New normalises dirty roots so that
-// the app3/app4 hot-path helpers can skip a second filepath.Clean pass.
+// the join hot-path helper can skip a second filepath.Clean pass.
 func TestNew_CleansRoot(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"/cache/", "/cache"},

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -171,7 +171,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		url = rest
 	}
 
-	if f.canUseMirror(repo, url) {
+	if f.canUseMirror(repo) {
 		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy)
 	}
 
@@ -346,7 +346,7 @@ func applyIgnoreAndMark(repo *manifest.GitRepository, art *store.SourceArtifact)
 // path for repo. The mirror path doesn't support submodule recursion
 // or sparse checkout — both require a real worktree go-git can act on.
 // Everything else (https, ssh, file://) is mirror-eligible.
-func (f *Fetcher) canUseMirror(repo *manifest.GitRepository, _ string) bool {
+func (f *Fetcher) canUseMirror(repo *manifest.GitRepository) bool {
 	if f.Mirrors == nil {
 		return false
 	}
@@ -389,11 +389,7 @@ func (f *Fetcher) Prewarm(ctx context.Context, repo *manifest.GitRepository) err
 		// the source controller's reconcile is the canonical reporter.
 		return nil
 	}
-	url := repo.URL
-	if rest, ok := strings.CutPrefix(url, "file://"); ok {
-		url = rest
-	}
-	if !f.canUseMirror(repo, url) {
+	if !f.canUseMirror(repo) {
 		return nil
 	}
 	auth, proxy, restore, err := f.resolveTransport(repo)

--- a/pkg/source/git/mirror/mirror.go
+++ b/pkg/source/git/mirror/mirror.go
@@ -64,7 +64,7 @@ func New(layout cacheroot.Layout) *Cache {
 // via the cache slot's authID (see source.Cache.Slot).
 func urlHash(url string) string {
 	h := sha256.Sum256([]byte(url))
-	return hex.EncodeToString(h[:])[:16]
+	return hex.EncodeToString(h[:8])
 }
 
 // proxyOptions converts a nullable ProxyConfig into go-git's inline

--- a/pkg/source/git/mirror_test.go
+++ b/pkg/source/git/mirror_test.go
@@ -82,22 +82,22 @@ func TestMirror_FallsBackForSubmodules(t *testing.T) {
 			URL: "https://example.com/x", RecurseSubmodules: true,
 		},
 	}
-	if f.canUseMirror(repo, "https://example.com/x") {
+	if f.canUseMirror(repo) {
 		t.Error("RecurseSubmodules should disable the mirror path")
 	}
 	repo.RecurseSubmodules = false
 	repo.SparseCheckout = []string{"sub/"}
-	if f.canUseMirror(repo, "https://example.com/x") {
+	if f.canUseMirror(repo) {
 		t.Error("SparseCheckout should disable the mirror path")
 	}
 	repo.SparseCheckout = nil
-	if !f.canUseMirror(repo, "https://example.com/x") {
+	if !f.canUseMirror(repo) {
 		t.Error("vanilla fetch should be mirror-eligible")
 	}
 
 	// Nil Mirrors → legacy.
 	f2 := &Fetcher{}
-	if f2.canUseMirror(repo, "https://example.com/x") {
+	if f2.canUseMirror(repo) {
 		t.Error("nil Mirrors should disable the mirror path")
 	}
 }

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -199,7 +199,7 @@ func writeEntry(objects *serializedObjectReader, entry object.TreeEntry, root, n
 	}
 	data, err := objects.blobBytes(entry.Hash, name)
 	if err != nil {
-		return fmt.Errorf("read blob %q: %w", name, err)
+		return err
 	}
 	if err := os.WriteFile(dst, data, perm); err != nil { //nolint:gosec // dst is built from the tree's commit object under the caller's root
 		return fmt.Errorf("write %s: %w", dst, err)

--- a/pkg/source/oci/auth.go
+++ b/pkg/source/oci/auth.go
@@ -82,7 +82,6 @@ func (f *Fetcher) resolveRegistryConfig(repo *manifest.OCIRepository) (string, f
 // loadCredentials returns a credentials.Store backed by the given config
 // path. An empty configPath uses the docker default lookup.
 func loadCredentials(configPath string) (credentials.Store, error) {
-	opts := credentials.StoreOptions{AllowPlaintextPut: false}
 	if configPath != "" {
 		s, err := credentials.NewFileStore(configPath)
 		if err != nil {
@@ -90,7 +89,7 @@ func loadCredentials(configPath string) (credentials.Store, error) {
 		}
 		return s, nil
 	}
-	s, err := credentials.NewStoreFromDocker(opts)
+	s, err := credentials.NewStoreFromDocker(credentials.StoreOptions{AllowPlaintextPut: false})
 	if err != nil {
 		// Missing docker config is not fatal — anonymous pulls work.
 		// Distinguish os.ErrNotExist (the common case: no docker login

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -168,7 +168,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 			return nil, err
 		}
 	}
-	if err := applyLayerSelector(slot.Path, desc.Digest.String(), repo.LayerSelector); err != nil {
+	if err := applyLayerSelector(slot.Path, digest, repo.LayerSelector); err != nil {
 		return nil, fmt.Errorf("OCIRepository %s/%s: layer select: %w", repo.Namespace, repo.Name, err)
 	}
 	// Source-controller's default ignore set includes `*.tar.gz`. For

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -489,31 +489,15 @@ func (s *Store) GetByName(kind, namespace, name string) manifest.BaseManifest {
 // so without sorting the same file can be attributed to different
 // KS owners on different runs.
 func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
-	var out []manifest.BaseManifest
 	if kind != "" {
 		sh := s.shardForKind(kind)
 		sh.mu.RLock()
 		inner := sh.byName[kind]
-		out = make([]manifest.BaseManifest, 0, len(inner))
+		out := make([]manifest.BaseManifest, 0, len(inner))
 		for _, obj := range inner {
 			out = append(out, obj)
 		}
 		sh.mu.RUnlock()
-	} else {
-		s.rLockAll()
-		total := 0
-		for i := range s.shards {
-			total += len(s.shards[i].objects)
-		}
-		out = make([]manifest.BaseManifest, 0, total)
-		for i := range s.shards {
-			for _, obj := range s.shards[i].objects {
-				out = append(out, obj)
-			}
-		}
-		s.rUnlockAll()
-	}
-	if kind != "" {
 		// All results share the queried Kind (byName[kind] index), so
 		// NamedResource.Compare's leading Kind comparison is always 0 here.
 		// Sort by (Namespace, Name) directly — identical order, one fewer
@@ -523,10 +507,23 @@ func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 			an, bn := a.Named(), b.Named()
 			return cmp.Or(cmp.Compare(an.Namespace, bn.Namespace), cmp.Compare(an.Name, bn.Name))
 		})
-	} else {
-		slices.SortFunc(out, func(a, b manifest.BaseManifest) int {
-			return a.Named().Compare(b.Named())
-		})
+		return out
 	}
+
+	s.rLockAll()
+	total := 0
+	for i := range s.shards {
+		total += len(s.shards[i].objects)
+	}
+	out := make([]manifest.BaseManifest, 0, total)
+	for i := range s.shards {
+		for _, obj := range s.shards[i].objects {
+			out = append(out, obj)
+		}
+	}
+	s.rUnlockAll()
+	slices.SortFunc(out, func(a, b manifest.BaseManifest) int {
+		return a.Named().Compare(b.Named())
+	})
 	return out
 }

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -193,14 +193,16 @@ func valuesRefCacheKey(kind, namespace, name, valuesKey, content string) uint64 
 	// _, _ = drains the (int, error) tuple so gosec G104 doesn't flag
 	// every byte fed into the digest.
 	h := fnv.New64a()
-	_, _ = h.Write([]byte(kind))
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(namespace))
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(name))
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(valuesKey))
-	_, _ = h.Write([]byte{0})
+	// Each field is followed by a NUL so adjacent fields can't run
+	// together (e.g. name="ab"+key="c" vs name="a"+key="bc").
+	writeField := func(s string) {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	writeField(kind)
+	writeField(namespace)
+	writeField(name)
+	writeField(valuesKey)
 	// Mix the content length into the hash explicitly so two refs that
 	// happen to FNV-collide on the same prefix don't end up sharing
 	// a cache entry; binary.LittleEndian.PutUint64 produces 8 stable

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -288,10 +288,7 @@ data:
 func initSelfRefGitFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	repo, err := gogit.PlainInit(dir, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	repo := gitInit(t, dir)
 	if _, err := repo.CreateRemote(&config.RemoteConfig{
 		Name: "origin", URLs: []string{"https://github.com/example/cluster.git"},
 	}); err != nil {
@@ -674,6 +671,16 @@ func mustFindLine(t *testing.T, haystack, needle, kind string, match func(string
 	return ""
 }
 
+// gitInit inits a git repo at dir, failing the test on error.
+func gitInit(t *testing.T, dir string) *gogit.Repository {
+	t.Helper()
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
 // gitCommitAll stages and commits the whole worktree with a fixed author,
 // so every fixture lands one deterministic "init" commit.
 func gitCommitAll(t *testing.T, repo *gogit.Repository) {
@@ -701,10 +708,7 @@ func gitCommitAll(t *testing.T, repo *gogit.Repository) {
 func initGitFixtureFrom(t *testing.T, src string) (clusterPath, repoRoot string) {
 	t.Helper()
 	dir := copyTree(t, src)
-	repo, err := gogit.PlainInit(dir, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	repo := gitInit(t, dir)
 	gitCommitAll(t, repo)
 	return filepath.Join(dir, "flux"), dir
 }
@@ -717,10 +721,7 @@ func initGitFixtureFrom(t *testing.T, src string) (clusterPath, repoRoot string)
 func initGitFixture(t *testing.T) (clusterPath, repoRoot string) {
 	t.Helper()
 	dir := t.TempDir()
-	repo, err := gogit.PlainInit(dir, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	repo := gitInit(t, dir)
 	writeFile := func(rel, body string) { testutil.WriteFile(t, dir, rel, body) }
 	writeFile("kubernetes/flux/cluster.yaml", `---
 apiVersion: source.toolkit.fluxcd.io/v1


### PR DESCRIPTION
Third autonomous code-cleanliness sweep — 20 packages, each refactored by an isolated agent and verified behavior- and API-preserving.

## What changed
- **Collapse near-duplicate helpers:** cacheroot `app2`/`app3`/`app4` → one variadic `join`; loader configMap/secretGenerator harvest → shared closure; `readKustomizeNamespace` → `readKustomizeDirectives` (drops a parallel inline YAML parser); `providerBlock` (resourceset); `setPlainScalar` (kustomize); `writeField` (values); `gitInit` (test/e2e); `chartYamlFilename` constant (helm).
- **Drop redundant work/context:** `awaitChartSource` self-derives `srcID`; gittree/oci drop double-wrapped error context and a re-derived digest; `store.ListObjects` early-return; orchestrator `slices.SortedFunc`/`slices.Collect`.
- **Modern idioms:** `strings.Cut` URL parse, `bytes.Compare` over hashed strings, single-line guards.
- **Doc correction:** the change-filter package doc claimed `dependsOn` ancestors are kept ready; `filter.go`'s own contract comment says `dependsOn` is intentionally excluded (a reconcile-ordering signal, not a content dependency). Fixed the stale doc to match the code.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` all pass · `golangci-lint` **0 issues**.
- Three behavioral-claim patches verified by hand before merge: the `dependsOn` doc matches `filter.go`; the dropped gittree wrap was identical double-context (`blobBytes` already names the blob); the oci `digest` swap is the same `desc.Digest.String()` value.
- **Cross-repo byte-equivalence** (`build all`, disk render cache off, shared source cache) across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set (Helm `genSignedCert` + infisical `updatedAt`), confirmed binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)