### PR TITLE
refactor: fourth behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -578,7 +578,7 @@ func scopedRunError(o *orchestrator.Orchestrator, res *orchestrator.Result, c *c
 func aggregateScopedFailures(failed map[manifest.NamedResource]store.StatusInfo) error {
 	msgs := make([]string, 0, len(failed))
 	for id, info := range failed {
-		msgs = append(msgs, fmt.Sprintf("%s: %s", id.String(), info.Message))
+		msgs = append(msgs, fmt.Sprintf("%s: %s", id, info.Message))
 	}
 	slices.Sort(msgs)
 	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",

--- a/internal/testutil/certs.go
+++ b/internal/testutil/certs.go
@@ -64,11 +64,12 @@ func pemKey(t *testing.T, priv *ecdsa.PrivateKey) string {
 func makeCertificate(t *testing.T, cn string, keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage, isCA bool) (cert, key string) {
 	t.Helper()
 	priv := ecKey(t)
+	now := time.Now()
 	tmpl := &x509.Certificate{
 		SerialNumber: randomSerial(t),
 		Subject:      pkix.Name{CommonName: cn},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(certValidity),
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(certValidity),
 		KeyUsage:     keyUsage,
 		ExtKeyUsage:  extKeyUsage,
 		IsCA:         isCA,

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -272,8 +272,8 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	// 1. @{u} via the branch config (go-git's ResolveRevision doesn't
 	//    accept @{u}; read branch.<name>.remote/.merge directly).
 	if up, ok := upstreamHash(repo, head); ok {
-		if base, err := mergeBase(repo, headCommit, up); err == nil {
-			return &resolution{Hash: base, Source: "merge-base with @{u}"}, nil
+		if mb, err := mergeBase(repo, headCommit, up); err == nil {
+			return &resolution{Hash: mb, Source: "merge-base with @{u}"}, nil
 		}
 	}
 
@@ -281,8 +281,8 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	//    pointing at e.g. refs/remotes/origin/main. Resolve through
 	//    the symref to the underlying branch tip.
 	if h, ok := resolveRef(repo, plumbing.NewRemoteHEADReferenceName("origin")); ok {
-		if base, err := mergeBase(repo, headCommit, h); err == nil {
-			return &resolution{Hash: base, Source: "merge-base with origin/HEAD"}, nil
+		if mb, err := mergeBase(repo, headCommit, h); err == nil {
+			return &resolution{Hash: mb, Source: "merge-base with origin/HEAD"}, nil
 		}
 	}
 
@@ -291,8 +291,8 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	for _, name := range []string{"main", "master"} {
 		ref := plumbing.NewRemoteReferenceName("origin", name)
 		if h, ok := resolveRef(repo, ref); ok {
-			if base, err := mergeBase(repo, headCommit, h); err == nil {
-				return &resolution{Hash: base, Source: "merge-base with origin/" + name}, nil
+			if mb, err := mergeBase(repo, headCommit, h); err == nil {
+				return &resolution{Hash: mb, Source: "merge-base with origin/" + name}, nil
 			}
 		}
 	}

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -468,7 +468,7 @@ func RunWithStatus[T manifest.BaseManifest](
 	fn func(context.Context, T) error,
 ) {
 	defer Recover(s, id, logKind)
-	obj, ok := s.GetObject(id).(T)
+	obj, ok := store.Get[T](s, id)
 	if !ok {
 		// Object deleted (or wrong type) between coalescer enqueue and
 		// run. A Refire-driven re-run that previously wrote

--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -1,6 +1,7 @@
 package depwait
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -63,7 +64,7 @@ func mustCELEnv() *cel.Env {
 //
 // Errors are split: a compile/program error is wrapped in *celCompileErr
 // (terminal — the expression itself is broken); an eval error against
-// the projected object is wrapped in *celEvalErr (transient — the dep's
+// the projected object is returned unwrapped (transient — the dep's
 // status may not yet be populated, so callers polling on store events
 // should keep waiting).
 func evaluateReadyExpr(expr string, s *store.Store, self, dep manifest.NamedResource) (bool, error) {
@@ -76,7 +77,7 @@ func evaluateReadyExpr(expr string, s *store.Store, self, dep manifest.NamedReso
 		"dep":  projectObject(s, dep),
 	})
 	if err != nil {
-		return false, &celEvalErr{fmt.Errorf("eval: %w", err)}
+		return false, fmt.Errorf("eval: %w", err)
 	}
 	// asBool errors are type-shape problems with the expression itself
 	// (e.g. `dep.metadata.name` returns a string). The user's expr is
@@ -95,15 +96,6 @@ type celCompileErr struct{ err error }
 
 func (e *celCompileErr) Error() string { return e.err.Error() }
 func (e *celCompileErr) Unwrap() error { return e.err }
-
-// celEvalErr signals a runtime evaluation failure against the current
-// projection — typically a "no such attribute" because the dep's
-// status hasn't landed yet. Polling callers should treat this as
-// transient and re-evaluate on the next store event.
-type celEvalErr struct{ err error }
-
-func (e *celEvalErr) Error() string { return e.err.Error() }
-func (e *celEvalErr) Unwrap() error { return e.err }
 
 func compileReadyExpr(expr string) (cel.Program, error) {
 	if v, ok := celCache.Load(expr); ok {
@@ -254,7 +246,7 @@ var kindAPIVersion = map[string]string{
 
 func asBool(v ref.Val) (bool, error) {
 	if v == nil {
-		return false, fmt.Errorf("readyExpr returned nil")
+		return false, errors.New("readyExpr returned nil")
 	}
 	if b, ok := v.Value().(bool); ok {
 		return b, nil

--- a/pkg/diff/doc.go
+++ b/pkg/diff/doc.go
@@ -64,6 +64,4 @@
 //
 // [dyff]: https://github.com/homeport/dyff
 // [orchestrator.RenderTrees]: https://pkg.go.dev/github.com/home-operations/flate/pkg/orchestrator#RenderTrees
-//
-// [orchestrator.Result]: https://pkg.go.dev/github.com/home-operations/flate/pkg/orchestrator#Result
 package diff

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -173,8 +173,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	// component reads); the shared ComponentCache deduped the file reads
 	// but not the iteration/sort/list construction.
 	prefixes := loader.KSPathPrefixesWithCache(d.cfg.Store, repoRoot, cfg.ComponentCache)
-	parentOf := map[manifest.NamedResource]manifest.NamedResource{}
-	maps.Copy(parentOf, loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindKustomization))
+	parentOf := loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindKustomization)
 	maps.Copy(parentOf, loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease))
 	// Orphan promotion: every Existence entry whose file path is NOT
 	// under any KS spec.path will never reach the Store through KS
@@ -313,7 +312,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 		// returned zero inputs.
 		currentRSIPCount := len(store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider))
 		if currentRSIPCount != prevRSIPCount {
-			rsConverged = map[manifest.NamedResource]struct{}{}
+			clear(rsConverged)
 			prevRSIPCount = currentRSIPCount
 		}
 		for _, rs := range store.ListAs[*manifest.ResourceSet](d.cfg.Store, manifest.KindResourceSet) {

--- a/pkg/loader/doc.go
+++ b/pkg/loader/doc.go
@@ -1,9 +1,0 @@
-// Package loader implements Loader — the entry point that scans a
-// local filesystem path, decodes every YAML document found, and adds
-// the recognized Flux objects to a Store.
-//
-// Loader honors a `.krmignore`-style ignore file at the scan root.
-// Unrecognized objects (Pods, Deployments, etc.) are silently skipped
-// to match flux-local's pre-filtering: flate derives them later from
-// the rendered output of Kustomizations and HelmReleases.
-package loader

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -450,7 +450,7 @@ func (w *walker) scanBootstrapFluxKS(dir string, k *kustomization, kpath string)
 				continue
 			}
 			id := obj.Named()
-			if w.loader.PreferExisting && w.loader.Store.GetObject(id) != nil {
+			if w.loader.skipExisting(id) {
 				continue
 			}
 			w.loader.Store.AddObject(obj)
@@ -632,6 +632,14 @@ func (w *walker) walkAdHoc(ctx context.Context, root string) (int, error) {
 	return count, err
 }
 
+// skipExisting reports whether id should be left untouched because
+// PreferExisting is set and the Store already holds it — the
+// orchestrator's recursive spec.path discovery wants the initial scan's
+// data to win over downstream paths that may point into a different tree.
+func (l *Loader) skipExisting(id manifest.NamedResource) bool {
+	return l.PreferExisting && l.Store.GetObject(id) != nil
+}
+
 func (l *Loader) loadFile(path string) (int, error) {
 	objs, err := parseFile(path, manifest.ParseDocOptions{WipeSecrets: l.Options.WipeSecrets})
 	if err != nil {
@@ -640,7 +648,7 @@ func (l *Loader) loadFile(path string) (int, error) {
 	count := 0
 	for _, obj := range objs {
 		id := obj.Named()
-		if l.PreferExisting && l.Store.GetObject(id) != nil {
+		if l.skipExisting(id) {
 			continue
 		}
 		if l.Options.DiscoveryOnly && !isDiscoveryKind(obj) {
@@ -685,7 +693,7 @@ func (l *Loader) recordDataFile(absPath string) error {
 			// producer-index use case is data-only.
 			continue
 		}
-		if l.PreferExisting && l.Store.GetObject(id) != nil {
+		if l.skipExisting(id) {
 			continue
 		}
 		if l.Existence != nil {

--- a/pkg/manifest/sops.go
+++ b/pkg/manifest/sops.go
@@ -35,13 +35,9 @@ func IsEncryptedSecret(doc map[string]any) bool {
 	if !ok {
 		return false
 	}
-	if _, ok := sops["mac"]; ok {
-		return true
-	}
-	if _, ok := sops["version"]; ok {
-		return true
-	}
-	return false
+	_, hasMac := sops["mac"]
+	_, hasVersion := sops["version"]
+	return hasMac || hasVersion
 }
 
 // SubstituteAnnotationKey is Flux kustomize-controller's per-resource

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -119,7 +119,7 @@ func logNewCycleMessages(prev, next map[manifest.NamedResource]string) {
 // code that calls failDependsOnCycles after a direct store mutation
 // still observes the latest cycle state.
 func (o *Orchestrator) rebuildDependencyGraphFromStore() {
-	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+	for _, kind := range reconcilableKinds {
 		for _, obj := range o.store.ListObjects(kind) {
 			id := obj.Named()
 			deps := sameKindDepTargets(obj, kind)
@@ -159,7 +159,7 @@ func sameKindDepTargets(obj manifest.BaseManifest, kind string) []manifest.Named
 func (o *Orchestrator) refireClearedPreflightFailures(ids []manifest.NamedResource) {
 	slices.SortFunc(ids, manifest.NamedResource.Compare)
 	for _, id := range ids {
-		if id.Kind == manifest.KindKustomization || id.Kind == manifest.KindHelmRelease {
+		if isReconcilableKind(id.Kind) {
 			o.store.Refire(id)
 		}
 	}

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -28,7 +28,7 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 	// reads are served from memory rather than re-stat'd here.
 	prefixes := loader.KSPathPrefixesWithCache(o.store, o.repoRoot, o.componentCache)
 	for id, info := range failed {
-		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
+		if !isReconcilableKind(id.Kind) {
 			continue
 		}
 		// A resource that any parent's render also emitted is by
@@ -130,7 +130,7 @@ func (o *Orchestrator) cascadeParentFailures(failed map[manifest.NamedResource]s
 	// doesn't re-scan the store for the same two counts. cascade only
 	// mutates status (never adds/removes objects), so these counts equal
 	// what a later ListObjects would report.
-	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+	for _, kind := range reconcilableKinds {
 		objs := o.store.ListObjects(kind)
 		switch kind {
 		case manifest.KindKustomization:

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -28,6 +28,19 @@ import (
 	"github.com/home-operations/flate/pkg/task"
 )
 
+// reconcilableKinds are the workload kinds the orchestrator drives
+// through the parent gate and dependsOn graph (Flux's spec.dependsOn is
+// kind-homogeneous to these two). Ranged over wherever a pass must visit
+// every Kustomization and HelmRelease in the store.
+var reconcilableKinds = []string{manifest.KindKustomization, manifest.KindHelmRelease}
+
+// isReconcilableKind reports whether kind is a Kustomization or
+// HelmRelease — the kinds that carry preflight failures, parent gates,
+// and dependsOn edges.
+func isReconcilableKind(kind string) bool {
+	return kind == manifest.KindKustomization || kind == manifest.KindHelmRelease
+}
+
 // Config carries everything the orchestrator needs.
 type Config struct {
 	// Path is the directory to scan for Flux objects (the scan entry

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -82,7 +82,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	// the ordering the controller goroutine could start waiting on a peer
 	// that's also waiting on it.
 	unsubCycles := o.store.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
-		if id.Kind != manifest.KindKustomization && id.Kind != manifest.KindHelmRelease {
+		if !isReconcilableKind(id.Kind) {
 			return
 		}
 		o.updateDependencyGraphFor(id)
@@ -357,7 +357,7 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 	// patched the CLI emit paths; this closes the same gap one layer
 	// down for SDK consumers.
 	skip := o.cfg.HelmOptions.SkipResourceKinds()
-	for _, kind := range []string{manifest.KindKustomization, manifest.KindHelmRelease} {
+	for _, kind := range reconcilableKinds {
 		for _, obj := range o.store.ListObjects(kind) {
 			id := obj.Named()
 			var mans []map[string]any

--- a/pkg/resourceset/output.go
+++ b/pkg/resourceset/output.go
@@ -35,13 +35,10 @@ func applyCommonMetadata(doc map[string]any, cm *fluxopv1.CommonMetadata) {
 
 func applyOwnerLabels(doc map[string]any, rs *manifest.ResourceSet) {
 	md := manifest.EnsureMetadata(doc)
-	labels, _ := md["labels"].(map[string]any)
-	if labels == nil {
-		labels = make(map[string]any, 2)
-	}
-	labels[fluxopv1.OwnerLabelResourceSetName] = rs.Name
-	labels[fluxopv1.OwnerLabelResourceSetNamespace] = rs.Namespace
-	md["labels"] = labels
+	manifest.MergeStringMap(md, "labels", map[string]string{
+		fluxopv1.OwnerLabelResourceSetName:      rs.Name,
+		fluxopv1.OwnerLabelResourceSetNamespace: rs.Namespace,
+	})
 }
 
 func disabledByReconcileAnnotation(doc map[string]any) bool {

--- a/pkg/resourceset/permute.go
+++ b/pkg/resourceset/permute.go
@@ -30,11 +30,9 @@ func permute(groups []providerInputs, includeEmpty bool) ([]map[string]any, erro
 	//
 	// Empty providers short-circuit the entire product: when
 	// includeEmpty=true and any provider has zero inputs, the
-	// Cartesian product is zero — return early so the size cap
-	// check stays meaningful (the previous second-pass at the end
-	// caught this but the size accumulator went through 0 in the
-	// process, making the cap check vacuous for any single empty
-	// provider). Mirrors upstream
+	// Cartesian product is zero — return early so the running size
+	// accumulator never passes through 0 and the cap check below
+	// stays meaningful. Mirrors upstream
 	// computePermutationsWithBacktracking's early-return.
 	scoped := make([]scopedProvider, 0, len(groups))
 	expected := uint64(1)

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -3,6 +3,7 @@
 // File map:
 //
 //	fetcher.go    — Fetcher type, Fetch entry, fetch + fetchViaMirror, authIdentity
+//	remotebase.go — FetchRemoteBase: anonymous kustomize remote git base
 //	auth.go       — SecretRef → transport.AuthMethod resolution
 //	tls.go        — spec.secretRef.ca.crt → *tls.Config
 //	ssh.go        — SSH URL / user extraction
@@ -23,6 +24,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -311,11 +313,7 @@ func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifa
 		if herr != nil {
 			return fmt.Errorf("verify: resolve HEAD: %w", herr)
 		}
-		tagName := ""
-		if repo.Reference != nil {
-			tagName = repo.Reference.Tag
-		}
-		if err := verify.Signatures(f.Secrets, repo.Namespace, repo.Name, repo.Verification.SecretRef.Name, repo.Verification.GetMode(), tagName, cloned, head.Hash()); err != nil {
+		if err := f.verifySignatures(repo, cloned, head.Hash()); err != nil {
 			return err
 		}
 	}
@@ -340,6 +338,22 @@ func applyIgnoreAndMark(repo *manifest.GitRepository, art *store.SourceArtifact)
 		_ = writeCachedRevision(art.LocalPath, art.Revision)
 	}
 	return nil
+}
+
+// verifySignatures runs PGP verification of the object at hash within
+// gitRepo (a local worktree or a bare mirror — both carry the object
+// store verify.Signatures walks). A no-op when repo.Verification is
+// unset, so callers can invoke it unconditionally.
+func (f *Fetcher) verifySignatures(repo *manifest.GitRepository, gitRepo *git.Repository, hash plumbing.Hash) error {
+	if repo.Verification == nil {
+		return nil
+	}
+	tagName := ""
+	if repo.Reference != nil {
+		tagName = repo.Reference.Tag
+	}
+	return verify.Signatures(f.Secrets, repo.Namespace, repo.Name,
+		repo.Verification.SecretRef.Name, repo.Verification.GetMode(), tagName, gitRepo, hash)
 }
 
 // canUseMirror reports whether this Fetcher can take the bare-mirror
@@ -434,14 +448,8 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 	}); err != nil {
 		return nil, fmt.Errorf("materialize %s at %s: %w", hash, refStr, err)
 	}
-	if repo.Verification != nil {
-		tagName := ""
-		if repo.Reference != nil {
-			tagName = repo.Reference.Tag
-		}
-		if err := verify.Signatures(f.Secrets, repo.Namespace, repo.Name, repo.Verification.SecretRef.Name, repo.Verification.GetMode(), tagName, mirrorRepo, hash); err != nil {
-			return nil, err
-		}
+	if err := f.verifySignatures(repo, mirrorRepo, hash); err != nil {
+		return nil, err
 	}
 	art := gitArtifact(repo.URL, slot.Path, hash.String())
 	if err := applyIgnoreAndMark(repo, art); err != nil {

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -35,7 +35,7 @@ type Options struct {
 	// fetcher and baseline contexts (the submodule's state rarely
 	// matches what flate is rendering); the callback exists so the
 	// caller can log at the right level / structured shape. Nil
-	// substitutes a slog.Warn with key "gittree.submodule".
+	// substitutes a slog.Warn carrying the submodule path.
 	OnSubmodule func(path string)
 }
 

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -68,28 +68,22 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 
 	// Scope the materialized PEM files under the fetcher's per-fetch
 	// tmpDir; helm's getter only reads them. cleanup removes every file
-	// a successful writeKey registered (see source.TempFiles).
+	// a successful write registered (see source.TempFiles).
 	tf := source.NewTempFiles(f.tmpDir)
 	cleanup := tf.Cleanup
-	writeKey := func(key string) (string, error) {
-		return tf.Write("helm-tls-*.pem", source.StringFromSecret(sec, key))
-	}
 
-	certPath, err := writeKey("tls.crt")
-	if err != nil {
-		cleanup()
-		return nil, noCleanup, err
+	// Materialize tls.crt / tls.key / ca.crt in the order WithTLSClientConfig
+	// takes them; a missing/empty key yields no file (path stays "").
+	var paths [3]string
+	for i, key := range [3]string{"tls.crt", "tls.key", "ca.crt"} {
+		p, err := tf.Write("helm-tls-*.pem", source.StringFromSecret(sec, key))
+		if err != nil {
+			cleanup()
+			return nil, noCleanup, err
+		}
+		paths[i] = p
 	}
-	keyPath, err := writeKey("tls.key")
-	if err != nil {
-		cleanup()
-		return nil, noCleanup, err
-	}
-	caPath, err := writeKey("ca.crt")
-	if err != nil {
-		cleanup()
-		return nil, noCleanup, err
-	}
+	certPath, keyPath, caPath := paths[0], paths[1], paths[2]
 	if certPath == "" && keyPath == "" && caPath == "" {
 		cleanup()
 		// A secret present but carrying none of the TLS keys is malformed

--- a/pkg/source/proxy.go
+++ b/pkg/source/proxy.go
@@ -41,13 +41,9 @@ func ResolveProxy(secrets SecretGetter, ns, ownerKind, ownerID string, ref *mani
 	if ref == nil {
 		return nil, nil
 	}
-	if secrets == nil {
-		return nil, fmt.Errorf("%s %s references proxySecretRef but no source.SecretGetter is wired",
-			ownerKind, ownerID)
-	}
-	sec := secrets(ns, ref.Name)
-	if sec == nil {
-		return nil, MissingSecretErr(ownerKind, ns, ownerID, ref.Name, "not found")
+	sec, err := resolveSecretRef(secrets, ns, ownerKind, ownerID, "proxySecretRef", ref)
+	if err != nil {
+		return nil, err
 	}
 	addr := StringFromSecret(sec, "address")
 	if addr == "" {

--- a/pkg/source/secret.go
+++ b/pkg/source/secret.go
@@ -14,6 +14,24 @@ func MissingSecretErr(kind, ns, name, secretRef, reason string) error {
 		manifest.ErrMissingSecret, kind, ns, name, ns, secretRef, reason)
 }
 
+// resolveSecretRef fetches the Secret a set *SecretRef points at, shared
+// by ResolveProxy and ResolveCertSecret. field names the spec field
+// (e.g. "proxySecretRef") for diagnostics. Callers handle the nil-ref
+// "not configured" case before calling; once ref is set, an unwired
+// SecretGetter or a missing Secret is a loud error matching
+// source-controller's fail-loud behavior.
+func resolveSecretRef(secrets SecretGetter, ns, ownerKind, ownerID, field string, ref *manifest.LocalObjectReference) (*manifest.Secret, error) {
+	if secrets == nil {
+		return nil, fmt.Errorf("%s %s references %s but no source.SecretGetter is wired",
+			ownerKind, ownerID, field)
+	}
+	sec := secrets(ns, ref.Name)
+	if sec == nil {
+		return nil, MissingSecretErr(ownerKind, ns, ownerID, ref.Name, "not found")
+	}
+	return sec, nil
+}
+
 // StringFromSecret reads a key from a Secret, preferring StringData
 // over Data. Data values are base64-decoded (per k8s Secret semantics)
 // before being returned, so the same string surface holds regardless

--- a/pkg/source/tls.go
+++ b/pkg/source/tls.go
@@ -20,13 +20,9 @@ func ResolveCertSecret(secrets SecretGetter, ns, ownerKind, ownerID string, ref 
 	if ref == nil {
 		return nil, nil
 	}
-	if secrets == nil {
-		return nil, fmt.Errorf("%s %s references certSecretRef but no source.SecretGetter is wired",
-			ownerKind, ownerID)
-	}
-	sec := secrets(ns, ref.Name)
-	if sec == nil {
-		return nil, MissingSecretErr(ownerKind, ns, ownerID, ref.Name, "not found")
+	sec, err := resolveSecretRef(secrets, ns, ownerKind, ownerID, "certSecretRef", ref)
+	if err != nil {
+		return nil, err
 	}
 	cfg, err := BuildTLSConfig(
 		StringFromSecret(sec, "tls.crt"),

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -477,20 +477,9 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 // "null" → nil). Strvals also handles list indices (foo.bar[0]) and
 // escaped dot keys (foo\\.bar).
 func replaceValueAtPath(values map[string]any, path, value string) (map[string]any, error) {
-	const (
-		singleQuote = "'"
-		doubleQuote = `"`
-	)
-	// The len >= 2 guard is load-bearing: a single-char "'" or `"`
-	// has prefix == suffix == the same byte, which would pass the
-	// boolean test below and then trip a `value[1:0]` slice — runtime
-	// panic. Untrusted Secret data shouldn't be able to crash the
-	// renderer, so reject the degenerate case explicitly.
 	var err error
-	if len(value) >= 2 &&
-		((strings.HasPrefix(value, singleQuote) && strings.HasSuffix(value, singleQuote)) ||
-			(strings.HasPrefix(value, doubleQuote) && strings.HasSuffix(value, doubleQuote))) {
-		err = strvals.ParseIntoString(path+"="+value[1:len(value)-1], values)
+	if unquoted, ok := stripMatchingQuotes(value); ok {
+		err = strvals.ParseIntoString(path+"="+unquoted, values)
 	} else {
 		err = strvals.ParseInto(path+"="+value, values)
 	}
@@ -498,6 +487,20 @@ func replaceValueAtPath(values map[string]any, path, value string) (map[string]a
 		return nil, fmt.Errorf("targetPath %q: %w", path, err)
 	}
 	return values, nil
+}
+
+// stripMatchingQuotes reports whether value is wrapped in a matching pair
+// of single or double quotes and, if so, returns the inner contents. The
+// len >= 2 guard is load-bearing: a single-char "'" or `"` has its first
+// byte equal to its last, which would otherwise pass the match and then
+// trip a value[1:0] slice — a runtime panic on untrusted Secret data.
+func stripMatchingQuotes(value string) (string, bool) {
+	if len(value) >= 2 {
+		if q := value[0]; (q == '\'' || q == '"') && value[len(value)-1] == q {
+			return value[1 : len(value)-1], true
+		}
+	}
+	return value, false
 }
 
 // ExpandPostBuildSubstituteReference resolves substituteFrom references

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -773,16 +773,16 @@ func mutateFile(t *testing.T, path, oldStr, newStr string) {
 func copyTree(t *testing.T, src string) string {
 	t.Helper()
 	dst := t.TempDir()
-	err := filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(src, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		rel, _ := filepath.Rel(src, p)
 		out := filepath.Join(dst, rel)
-		if info.IsDir() {
+		if d.IsDir() {
 			return os.MkdirAll(out, 0o750)
 		}
-		data, err := os.ReadFile(p) //nolint:gosec // p is supplied by filepath.Walk over a known root
+		data, err := os.ReadFile(p) //nolint:gosec // p is supplied by filepath.WalkDir over a known root
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fourth autonomous code-cleanliness sweep — 17 packages, each verified behavior- and API-preserving. (One agent-proposed patch was dropped: a trailing-blank trim in `pkg/kustomize/substitute.go`, a file kept as-is by maintainer preference.)

## What changed
- **Extract shared helpers:** `resolveSecretRef` (source — `ResolveProxy` + `ResolveCertSecret`); `verifySignatures` (git — `finalize` + `fetchViaMirror`); `skipExisting` (loader, 3 sites); `stripMatchingQuotes` (values); `reconcilableKinds`/`isReconcilableKind` (orchestrator, 6 sites); helmchart TLS-write loop. Reuse `manifest.MergeStringMap` (resourceset) and `store.Get[T]` (controllers/base).
- **Remove dead code:** `celEvalErr` (depwait — constructed but never type-matched; callers treat any eval error as transient); `loader/doc.go` (a stale package comment that *contradicted* loader.go's accurate one).
- **Modern idioms:** `clear()` over remap, `filepath.WalkDir`, `errors.New`, one `time.Now()` per cert, `%s` on a Stringer.
- **Doc fixes:** git file-map gains `remotebase.go`; diff drops a dead doc link; permute/gittree comment accuracy.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- Behavioral-claim patches hand-verified: `celEvalErr` is referenced only at its own def/construction (no `errors.As` matcher); `MergeStringMap` is byte-identical to the inlined label-merge (same `map[string]any`, preserves siblings); `BuildParentIndexFromPrefixes` returns a fresh map, safe to use as the merge accumulator.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set (Helm `genSignedCert` + infisical `updatedAt`), binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)