### PR TITLE
refactor: fifth behavior-preserving cleanliness pass

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -406,8 +406,5 @@ func isShallow(repo *git.Repository) bool {
 // log lines.
 func shortRev(h plumbing.Hash) string {
 	s := h.String()
-	if len(s) <= 7 {
-		return s
-	}
-	return s[:7]
+	return s[:min(len(s), 7)]
 }

--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -337,9 +337,9 @@ type fileMeta struct {
 	symlink bool
 }
 
-// scanTree walks root collecting per-file metadata. Mirrors the
-// directory pruning that hashTree previously did, and records symlinks
-// alongside regular files so the diff matches git's --no-index view.
+// scanTree walks root collecting per-file metadata. Prunes skip-dirs
+// (via shouldSkipDir) and records symlinks alongside regular files so
+// the diff matches git's --no-index view.
 func scanTree(root string) (map[string]fileMeta, error) {
 	out := map[string]fileMeta{}
 	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -34,10 +34,16 @@ func (f *fakeFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*store.
 
 func newController(t *testing.T, fetchers map[string]src.Fetcher) (*Controller, *store.Store) {
 	t.Helper()
+	return newConfiguredController(t, fetchers, FetchOptions{})
+}
+
+func newConfiguredController(t *testing.T, fetchers map[string]src.Fetcher, opts FetchOptions) (*Controller, *store.Store) {
+	t.Helper()
 	st := store.New()
 	ts := task.New()
 	c := New(st, ts)
 	maps.Copy(c.Fetchers, fetchers)
+	c.Configure(opts)
 	c.Start(context.Background())
 	t.Cleanup(func() {
 		c.Close()
@@ -131,17 +137,9 @@ func TestController_UnregisteredKindIgnored(t *testing.T) {
 func TestController_AllowMissingSecretsConvertsFailureToSkip(t *testing.T) {
 	f := &fakeFetcher{err: fmt.Errorf("%w: OCIRepository ns/r: secret ns/ghcr-creds not found",
 		manifest.ErrMissingSecret)}
-
-	st := store.New()
-	ts := task.New()
-	c := New(st, ts)
-	c.Fetchers[manifest.KindOCIRepository] = f
-	c.Configure(FetchOptions{AllowMissingSecrets: true})
-	c.Start(context.Background())
-	t.Cleanup(func() {
-		c.Close()
-		ts.BlockTillDone()
-	})
+	_, st := newConfiguredController(t,
+		map[string]src.Fetcher{manifest.KindOCIRepository: f},
+		FetchOptions{AllowMissingSecrets: true})
 
 	repo := &manifest.OCIRepository{
 		Name: "r", Namespace: "ns",
@@ -179,8 +177,6 @@ func TestController_AllowMissingSecretsOffStillFails(t *testing.T) {
 func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 	f := &fakeFetcher{artifact: &store.SourceArtifact{Kind: manifest.KindGitRepository}}
 
-	st := store.New()
-	ts := task.New()
 	// Filter that marks our repo as "no changes" — should short-circuit
 	// to Ready without fetching.
 	filter := change.NewFilter(
@@ -189,14 +185,9 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 		"",
 		testutil.MapLister{},
 	)
-	c := New(st, ts)
-	c.Fetchers[manifest.KindGitRepository] = f
-	c.Configure(FetchOptions{Filter: filter})
-	c.Start(context.Background())
-	t.Cleanup(func() {
-		c.Close()
-		ts.BlockTillDone()
-	})
+	_, st := newConfiguredController(t,
+		map[string]src.Fetcher{manifest.KindGitRepository: f},
+		FetchOptions{Filter: filter})
 
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -215,7 +215,7 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 			// the send never blocks. The previous select-on-ctx silently
 			// dropped events on cancellation, leaving the consumer with
 			// a Pending dep that would time out at the full budget.
-			out <- safeWatchOne(ctx, w, dep, timeout)
+			out <- w.safeWatchOne(ctx, dep, timeout)
 		})
 	}
 
@@ -271,7 +271,7 @@ func (w *Waiter) readyNow(dep manifest.DependencyRef) bool {
 // site (CEL projection panicking against a malformed Snapshot, a
 // nil-typed assertion in labelsAndAnnotations, etc.). Without the
 // stack the panic message alone is often opaque.
-func safeWatchOne(ctx context.Context, w *Waiter, dep manifest.DependencyRef, timeout time.Duration) (ev Event) {
+func (w *Waiter) safeWatchOne(ctx context.Context, dep manifest.DependencyRef, timeout time.Duration) (ev Event) {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("depwait: panic in watchOne",
@@ -366,7 +366,7 @@ func (w *Waiter) resolveMissing(ctx context.Context, id manifest.NamedResource) 
 		_, err := w.Store.WatchExists(graceCtx, id)
 		graceCancel()
 		if err != nil && !w.depExists(id) {
-			return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+			return notFound(id)
 		}
 		return nil
 	}
@@ -380,7 +380,7 @@ func (w *Waiter) resolveMissing(ctx context.Context, id manifest.NamedResource) 
 		// File was indexed at scan time but Promote failed — parse
 		// error, file mutated since record, etc. No amount of waiting
 		// will materialize this dep.
-		return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+		return notFound(id)
 	}
 
 	// No file record: dep can only arrive via a parent render's
@@ -401,11 +401,18 @@ func (w *Waiter) resolveMissing(ctx context.Context, id manifest.NamedResource) 
 		if errors.Is(err, errRenderCapExceeded) ||
 			errors.Is(err, context.DeadlineExceeded) ||
 			errors.Is(err, errRenderDrained) {
-			return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
+			return notFound(id)
 		}
 		return &Event{Dep: id, Status: DepFailed, Reason: err.Error()}
 	}
 	return nil
+}
+
+// notFound is the canonical terminal Event for a dependency that
+// never materialized — the same "dependency not found" reason callers
+// and tests grep for, single-sourced so the message can't drift.
+func notFound(id manifest.NamedResource) *Event {
+	return &Event{Dep: id, Status: DepFailed, Reason: "dependency not found"}
 }
 
 // watchReadyExpr evaluates expr against id's projected state and
@@ -433,16 +440,7 @@ func (w *Waiter) watchReadyExpr(ctx context.Context, id manifest.NamedResource, 
 	// One channel, two listeners — every wake re-evaluates against
 	// the latest store state. Coalesced via buffer-1 + default-send
 	// so a burst of events doesn't queue redundant evaluations.
-	ch := make(chan struct{}, 1)
-	wake := func(other manifest.NamedResource, _ any) {
-		if other != id {
-			return
-		}
-		select {
-		case ch <- struct{}{}:
-		default:
-		}
-	}
+	ch, wake := coalescingWake(id)
 	unsubStatus := w.Store.AddListener(store.EventStatusUpdated, wake, false)
 	defer unsubStatus()
 	unsubObject := w.Store.AddListener(store.EventObjectAdded, wake, false)
@@ -513,6 +511,24 @@ func (w *Waiter) depExists(dep manifest.NamedResource) bool {
 	return ok
 }
 
+// coalescingWake returns a buffer-1 signal channel and a store.Listener
+// that pulses it whenever an event fires for id. The buffer-1 +
+// non-blocking send coalesces a burst of events into a single wake, so
+// the waiter re-checks store state at most once per drain rather than
+// once per event.
+func coalescingWake(id manifest.NamedResource) (<-chan struct{}, store.Listener) {
+	ch := make(chan struct{}, 1)
+	return ch, func(other manifest.NamedResource, _ any) {
+		if other != id {
+			return
+		}
+		select {
+		case ch <- struct{}{}:
+		default:
+		}
+	}
+}
+
 // errRenderCapExceeded is returned by waitRenderEmission when the
 // inner RenderProducingTimeout fires (with or without parent ctx
 // also dying). Distinguishes "cap-fired no-show" from a genuine
@@ -546,16 +562,8 @@ func (w *Waiter) waitRenderEmission(ctx context.Context, id manifest.NamedResour
 
 	// Subscribe FIRST, then re-check the store, to close the race
 	// between subscribe and a concurrent AddObject.
-	arrived := make(chan struct{}, 1)
-	unsub := w.Store.AddListener(store.EventObjectAdded, func(other manifest.NamedResource, _ any) {
-		if other != id {
-			return
-		}
-		select {
-		case arrived <- struct{}{}:
-		default:
-		}
-	}, false)
+	arrived, wake := coalescingWake(id)
+	unsub := w.Store.AddListener(store.EventObjectAdded, wake, false)
 	defer unsub()
 	if w.depExists(id) {
 		return nil

--- a/pkg/diff/docs.go
+++ b/pkg/diff/docs.go
@@ -26,7 +26,7 @@ func DocsFromManifests(manifests map[manifest.NamedResource][]map[string]any, pa
 	for id := range manifests {
 		parents = append(parents, id)
 	}
-	slices.SortFunc(parents, func(a, b manifest.NamedResource) int { return a.Compare(b) })
+	slices.SortFunc(parents, manifest.NamedResource.Compare)
 
 	out := make([]Doc, 0, len(manifests))
 	for _, id := range parents {

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -241,7 +241,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	}
 	scanned := map[string]struct{}{}
 	total := 0
-	if err := d.loadAt(ctx, l, scanRoot, scanned, &total); err != nil {
+	if err := d.loadAt(ctx, scanRoot, scanned, &total); err != nil {
 		return err
 	}
 	// Apply namespaces once over the initially-scanned set so the
@@ -302,7 +302,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 			if !pathUnderRoot(target, repoRoot) {
 				continue
 			}
-			if err := d.loadAt(ctx, l, target, scanned, &total); err != nil {
+			if err := d.loadAt(ctx, target, scanned, &total); err != nil {
 				return err
 			}
 			added++
@@ -342,7 +342,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 
 // loadAt scans dir if not already scanned, marks it, and accumulates
 // the loaded object count.
-func (d *discoverer) loadAt(ctx context.Context, l *loader.Loader, dir string, scanned map[string]struct{}, total *int) error {
+func (d *discoverer) loadAt(ctx context.Context, dir string, scanned map[string]struct{}, total *int) error {
 	if _, seen := scanned[dir]; seen {
 		return nil
 	}
@@ -350,7 +350,7 @@ func (d *discoverer) loadAt(ctx context.Context, l *loader.Loader, dir string, s
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		return nil
 	}
-	n, err := l.Load(ctx, dir)
+	n, err := d.loader.Load(ctx, dir)
 	if err != nil {
 		return err
 	}

--- a/pkg/kustomize/generate.go
+++ b/pkg/kustomize/generate.go
@@ -14,11 +14,12 @@ package kustomize
 // here. A golden byte-equivalence test (generate_test.go) pins this to flux's
 // real Generator across the full field matrix.
 //
-// Scope: flate constructs the Generator via NewGenerator (no ignore, no filter),
-// so only the filter==false path is reproduced. Source-controller's file
-// exclusion (.sops.yaml, binaries, …) is applied earlier, when the tree is
-// materialized into the fs (see tree.go) — uniformly for every source — so the
-// Generator never sees an ignored file and needs no ignore logic of its own.
+// Scope: this mirrors flux's auto-generate (path: ./) case. When the caller
+// passes a non-nil ignore matcher — for working-tree / self-referential sources
+// that never passed through a fetcher — source-controller's file exclusion
+// (.sops.yaml, binaries, …) is applied here while scanning for resources,
+// reproducing flux's NewGeneratorWithIgnore behavior; fetched artifacts were
+// already filtered and pass nil.
 
 import (
 	"encoding/json"
@@ -201,16 +202,27 @@ func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]an
 	return manifest, kfile, nil
 }
 
+// kustomizationFileIn returns the path of the first recognized kustomization
+// file directly inside dir (a regular file, not a directory), or ok=false when
+// none is present. Mirrors the lookup flux performs in both findOrGenerate and
+// its manifest scan.
+func kustomizationFileIn(fsys filesys.FileSystem, dir string) (path string, ok bool) {
+	for _, name := range konfig.RecognizedKustomizationFileNames() {
+		kpath := filepath.Join(dir, name)
+		if fsys.Exists(kpath) && !fsys.IsDir(kpath) {
+			return kpath, true
+		}
+	}
+	return "", false
+}
+
 // findOrGenerateKustomization returns the existing kustomization file's bytes
 // (foundExisting=true) or, when none is present, synthesizes one from the YAML
 // manifests in dirPath via scanManifests. Mirrors the like-named flux function.
 func findOrGenerateKustomization(fsys filesys.FileSystem, dirPath string, ignore *sourceignore.Matcher) (data []byte, kfile string, foundExisting bool, err error) {
-	for _, name := range konfig.RecognizedKustomizationFileNames() {
-		kpath := filepath.Join(dirPath, name)
-		if fsys.Exists(kpath) && !fsys.IsDir(kpath) {
-			b, rerr := fsys.ReadFile(kpath)
-			return b, kpath, true, rerr
-		}
+	if kpath, ok := kustomizationFileIn(fsys, dirPath); ok {
+		b, rerr := fsys.ReadFile(kpath)
+		return b, kpath, true, rerr
 	}
 
 	// flux uses filepath.Abs(dirPath); under the memory-over-disk overlay
@@ -273,11 +285,9 @@ func scanManifests(fsys filesys.FileSystem, base string, ignore *sourceignore.Ma
 			return nil
 		}
 		if info.IsDir() {
-			for _, name := range konfig.RecognizedKustomizationFileNames() {
-				if kpath := filepath.Join(path, name); fsys.Exists(kpath) && !fsys.IsDir(kpath) {
-					paths = append(paths, path)
-					return filepath.SkipDir
-				}
+			if _, ok := kustomizationFileIn(fsys, path); ok {
+				paths = append(paths, path)
+				return filepath.SkipDir
 			}
 			return nil
 		}

--- a/pkg/manifest/envsubst.go
+++ b/pkg/manifest/envsubst.go
@@ -1,6 +1,9 @@
 package manifest
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // envsubstDefaultRE matches POSIX-style parameter expansion patterns
 // that carry an explicit default: `${VAR:=default}` and
@@ -33,14 +36,10 @@ func ResolveEnvsubstDefaults(s string) string {
 }
 
 // maybeHasEnvsubst is a cheap precheck — most strings have no `${`
-// at all, and ReplaceAllString allocates even when nothing matches.
+// at all, and ReplaceAllString / MatchString allocate even when nothing
+// matches.
 func maybeHasEnvsubst(s string) bool {
-	for i := range len(s) - 1 {
-		if s[i] == '$' && s[i+1] == '{' {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(s, "${")
 }
 
 // envsubstReferenceRE matches any unresolved envsubst reference —

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -137,22 +137,23 @@ func (k *Kustomization) UpdatePostBuildSubstitutions(subs map[string]any) {
 	if k.Contents == nil {
 		return
 	}
-	spec, _ := k.Contents["spec"].(map[string]any)
-	if spec == nil {
-		spec = make(map[string]any)
-		k.Contents["spec"] = spec
-	}
-	post, _ := spec["postBuild"].(map[string]any)
-	if post == nil {
-		post = make(map[string]any)
-		spec["postBuild"] = post
-	}
-	sub, _ := post["substitute"].(map[string]any)
-	if sub == nil {
-		sub = make(map[string]any)
-		post["substitute"] = sub
-	}
+	spec := childMap(k.Contents, "spec")
+	post := childMap(spec, "postBuild")
+	sub := childMap(post, "substitute")
 	maps.Copy(sub, subs)
+}
+
+// childMap returns parent[key] as a map[string]any, lazily creating one
+// when absent (or present as a non-map). Used by the Contents dual-write
+// helpers to walk into spec.postBuild.substitute without re-spelling the
+// type-assert-and-create dance at each level.
+func childMap(parent map[string]any, key string) map[string]any {
+	child, _ := parent[key].(map[string]any)
+	if child == nil {
+		child = make(map[string]any)
+		parent[key] = child
+	}
+	return child
 }
 
 // SetTargetNamespace sets spec.targetNamespace on both the typed field
@@ -164,12 +165,7 @@ func (k *Kustomization) SetTargetNamespace(ns string) {
 	if k.Contents == nil {
 		return
 	}
-	spec, _ := k.Contents["spec"].(map[string]any)
-	if spec == nil {
-		spec = make(map[string]any)
-		k.Contents["spec"] = spec
-	}
-	spec["targetNamespace"] = ns
+	childMap(k.Contents, "spec")["targetNamespace"] = ns
 }
 
 // parseKustomization decodes a Flux Kustomization CR via the

--- a/pkg/resourceset/template.go
+++ b/pkg/resourceset/template.go
@@ -60,7 +60,7 @@ func parseTemplate(tmplStr string) (*parsedTemplate, error) {
 }
 
 // executeTemplate runs pt with the given input set, reusing a pooled
-// buffer to reduce GC pressure. pt.cell is updated atomically before
+// buffer to reduce GC pressure. pt.cell is overwritten before each
 // execution; callers must not share a parsedTemplate across goroutines.
 func executeTemplate(pt *parsedTemplate, inputSet map[string]any) ([]byte, error) {
 	*pt.cell = inputSet

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -209,17 +209,13 @@ func (s *Slot) Commit() error {
 			// coordinates goroutines in this process, so adopt the
 			// existing non-empty slot instead of deleting it.
 			_ = os.RemoveAll(s.staging)
-			s.committed = true
-			s.staging = ""
-			s.Path = s.final
+			s.markCommitted()
 			s.Exists = true
 			return nil
 		}
 		return fmt.Errorf("cache commit: %w", err)
 	}
-	s.committed = true
-	s.staging = ""
-	s.Path = s.final
+	s.markCommitted()
 	return nil
 }
 
@@ -234,10 +230,16 @@ func (s *Slot) commitRefresh() error {
 		return fmt.Errorf("cache refresh commit: %w", err)
 	}
 	_ = os.RemoveAll(backup)
+	s.markCommitted()
+	return nil
+}
+
+// markCommitted records a finalized slot: the staging dir is gone and
+// Path now points at the populated final slot.
+func (s *Slot) markCommitted() {
 	s.committed = true
 	s.staging = ""
 	s.Path = s.final
-	return nil
 }
 
 // randomHex returns n random bytes encoded as a lowercase hex string (2n chars).
@@ -350,20 +352,19 @@ func (s *Slot) StageRefresh() error {
 func (s *Slot) lockFile(ctx context.Context) error {
 	s.fileLock = flock.New(s.final+".lock", flock.SetPermissions(0o600))
 	locked, err := s.fileLock.TryLockContext(ctx, 100*time.Millisecond)
-	if err != nil {
-		_ = s.fileLock.Close()
-		s.fileLock = nil
-		return fmt.Errorf("cache slot lock: %w", err)
+	if err == nil && locked {
+		return nil
 	}
-	if !locked {
-		_ = s.fileLock.Close()
-		s.fileLock = nil
-		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("cache slot lock: %w", err)
-		}
+	_ = s.fileLock.Close()
+	s.fileLock = nil
+	switch {
+	case err != nil:
+		return fmt.Errorf("cache slot lock: %w", err)
+	case ctx.Err() != nil:
+		return fmt.Errorf("cache slot lock: %w", ctx.Err())
+	default:
 		return errors.New("cache slot lock: not acquired")
 	}
-	return nil
 }
 
 func (s *Slot) unlock() {

--- a/pkg/source/git/tls.go
+++ b/pkg/source/git/tls.go
@@ -9,10 +9,6 @@ import (
 	"github.com/home-operations/flate/pkg/source"
 )
 
-// The shared HTTPS-transport install lock moved to
-// internal/gittransport so the bare-mirror subpackage can use the
-// same gate without a circular import.
-
 // resolveTLS builds a *tls.Config from spec.secretRef for HTTPS
 // GitRepositories. It reads both a custom CA ("ca.crt" preferred,
 // "caFile" legacy alias) AND a client certificate ("tls.crt" +

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strings"
 
 	"oras.land/oras-go/v2"
 	orasoci "oras.land/oras-go/v2/content/oci"
@@ -34,7 +33,8 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 		return nil, fmt.Errorf("%w: OCIRepository %s missing url", manifest.ErrInput, repo.RepoName())
 	}
 
-	reference, err := parseOCIRef("oci://" + strings.TrimPrefix(repo.URL, "oci://"))
+	// parseOCIRef strips any oci:// prefix itself, so pass repo.URL as-is.
+	reference, err := parseOCIRef(repo.URL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -307,8 +307,7 @@ func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 	s.rLockAll()
 	defer s.rUnlockAll()
 	out := make(map[manifest.NamedResource]StatusInfo)
-	for i := range s.shards {
-		sh := s.shards[i]
+	for _, sh := range s.shards {
 		for id, conds := range sh.conditions {
 			if _, inStore := sh.objects[id]; !inStore {
 				continue

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -126,9 +126,12 @@ func New() *Store {
 	for i := range s.shards {
 		s.shards[i] = newShard()
 	}
-	s.listeners[EventObjectAdded] = newListenerSet()
-	s.listeners[EventStatusUpdated] = newListenerSet()
-	s.listeners[EventArtifactUpdated] = newListenerSet()
+	// Index 0 is the reserved unused slot (EventKind is 1-based); init
+	// one listener set per real event kind so adding a kind can't drift
+	// out of sync with a forgotten assignment here.
+	for ev := EventObjectAdded; int(ev) <= numEventKinds; ev++ {
+		s.listeners[ev] = newListenerSet()
+	}
 	return s
 }
 
@@ -512,12 +515,12 @@ func (s *Store) ListObjects(kind string) []manifest.BaseManifest {
 
 	s.rLockAll()
 	total := 0
-	for i := range s.shards {
-		total += len(s.shards[i].objects)
+	for _, sh := range s.shards {
+		total += len(sh.objects)
 	}
 	out := make([]manifest.BaseManifest, 0, total)
-	for i := range s.shards {
-		for _, obj := range s.shards[i].objects {
+	for _, sh := range s.shards {
+		for _, obj := range sh.objects {
 			out = append(out, obj)
 		}
 	}

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -195,11 +195,9 @@ func (s *Service) QuiescenceCh(threshold int64) <-chan struct{} {
 //
 // On an unbounded Service (New or NewBounded(<=0)), fn runs unchanged.
 func (s *Service) YieldSlot(fn func()) {
-	if s.sem == nil {
-		fn()
-		return
+	if s.sem != nil {
+		defer s.releaseSlot()()
 	}
-	defer s.releaseSlot()()
 	fn()
 }
 

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -61,8 +61,7 @@ func (p *SliceProvider) Secret(namespace, name string) *manifest.Secret {
 	return nil
 }
 
-// NewStoreProvider returns a Provider backed by the central Store. It
-// replaces the per-controller storeProvider types.
+// NewStoreProvider returns a Provider backed by the central Store.
 func NewStoreProvider(s *store.Store) Provider { return &storeProvider{s: s} }
 
 type storeProvider struct{ s *store.Store }


### PR DESCRIPTION
Fifth autonomous code-cleanliness sweep — 15 packages, each verified behavior- and API-preserving.

## What changed
- **Extract shared helpers:** `notFound` (depwait, 4 sites) + `coalescingWake` (depwait, 2 sites); `childMap` (manifest — lazy `spec.postBuild.substitute` walk, 4 levels); `kustomizationFileIn` (kustomize — `findOrGenerate` + `scanManifests`); `markCommitted` (source cache, 3 sites); `newConfiguredController` (controllers/source test helper).
- **Simplify control flow:** source `lockFile` (success early-return + `switch`, all branches equivalent); `YieldSlot`; store `New` listener init via a `numEventKinds` loop so adding an event kind can't drift out of sync.
- **Modern idioms:** `min()` in `shortRev`; `strings.Contains` precheck; method values (`NamedResource.Compare`); `range`-over-value shard loops; drop a redundant `oci://` re-prefix and a dead `loader` param.
- **Doc accuracy:** kustomize generator ignore-matcher scope; remove stale breadcrumb/why-comments (git tls, change, resourceset, values).

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- Behavioral patches hand-verified: store `New` loop sets exactly indices 1–3 (matches the three explicit assignments; `EventObjectAdded = iota+1`, `numEventKinds = 3`); `parseOCIRef` strips `oci://` itself; `loadAt`'s `d.loader` is the same pointer the dropped param carried; `lockFile`'s switch reproduces every old branch.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set (Helm `genSignedCert` + infisical `updatedAt`), binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)