### PR TITLE
refactor: sixth behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -575,14 +575,21 @@ func scopedRunError(o *orchestrator.Orchestrator, res *orchestrator.Result, c *c
 	return errors.Join(aggregateScopedFailures(failed), errors.Join(extras...))
 }
 
+// resourceAggregatePrefix is the leading text of the error
+// aggregateScopedFailures produces. nonResourceRunErrors uses it to tell
+// the per-resource failure aggregate apart from incidental run errors, so
+// both must reference this one constant or the classification silently
+// drifts.
+const resourceAggregatePrefix = "reconcile completed with "
+
 func aggregateScopedFailures(failed map[manifest.NamedResource]store.StatusInfo) error {
 	msgs := make([]string, 0, len(failed))
 	for id, info := range failed {
 		msgs = append(msgs, fmt.Sprintf("%s: %s", id, info.Message))
 	}
 	slices.Sort(msgs)
-	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",
-		len(msgs), strings.Join(msgs, "\n  "))
+	return fmt.Errorf("%s%d failure(s):\n  %s",
+		resourceAggregatePrefix, len(msgs), strings.Join(msgs, "\n  "))
 }
 
 func nonResourceRunErrors(err error) []error {
@@ -614,7 +621,7 @@ func flattenErrors(err error) []error {
 }
 
 func isResourceAggregateError(err error) bool {
-	return strings.HasPrefix(err.Error(), "reconcile completed with ")
+	return strings.HasPrefix(err.Error(), resourceAggregatePrefix)
 }
 
 func cmdContext(cmd *cobra.Command) context.Context {

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -215,6 +215,9 @@ func printResources[T manifest.BaseManifest](
 	}
 	pairs := make([]pair, 0, len(objs))
 	nameExists := sel.Name == ""
+	// Match on labels only; the name was already filtered above, so a
+	// label-only selector keeps the two passes from double-counting.
+	labelSel := selector.Metadata{Labels: sel.Labels}
 	for _, obj := range objs {
 		id := obj.Named()
 		if sel.Name != "" && id.Name != sel.Name {
@@ -224,7 +227,7 @@ func printResources[T manifest.BaseManifest](
 			continue
 		}
 		nameExists = true
-		if !(selector.Metadata{Labels: sel.Labels}).Matches(obj) {
+		if !labelSel.Matches(obj) {
 			continue
 		}
 		t, ok := obj.(T)

--- a/internal/cli/profile.go
+++ b/internal/cli/profile.go
@@ -50,26 +50,10 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 		}, nil
 	case "block":
 		runtime.SetBlockProfileRate(1)
-		return func() {
-			f, err := createProfileFile(path)
-			if err != nil {
-				return
-			}
-			_ = pprof.Lookup("block").WriteTo(f, 0)
-			runtime.SetBlockProfileRate(0)
-			_ = f.Close()
-		}, nil
+		return dumpProfileAt(path, "block", func() { runtime.SetBlockProfileRate(0) }), nil
 	case "mutex":
 		runtime.SetMutexProfileFraction(1)
-		return func() {
-			f, err := createProfileFile(path)
-			if err != nil {
-				return
-			}
-			_ = pprof.Lookup("mutex").WriteTo(f, 0)
-			runtime.SetMutexProfileFraction(0)
-			_ = f.Close()
-		}, nil
+		return dumpProfileAt(path, "mutex", func() { runtime.SetMutexProfileFraction(0) }), nil
 	case "trace":
 		f, err := createProfileFile(filepath.Join(outDir, "trace.out"))
 		if err != nil {
@@ -82,6 +66,22 @@ func startProfile(mode, outDir string) (stop func(), err error) {
 		return func() { trace.Stop(); _ = f.Close() }, nil
 	}
 	return nil, errors.New("--profile must be one of: cpu, mem, block, mutex, trace")
+}
+
+// dumpProfileAt returns a stop func that writes the named pprof profile
+// to path, then runs disable to turn sampling back off. Shared by the
+// block and mutex modes, which differ only in profile name and the
+// sampling toggle.
+func dumpProfileAt(path, name string, disable func()) func() {
+	return func() {
+		f, err := createProfileFile(path)
+		if err != nil {
+			return
+		}
+		_ = pprof.Lookup(name).WriteTo(f, 0)
+		disable()
+		_ = f.Close()
+	}
 }
 
 // createProfileFile opens path for writing a profile. The G304 nolint

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -503,6 +503,23 @@ func (f *Filter) resolve(objs ObjectLister) {
 	}
 
 	owners := buildOwnership(objs, f.repoRoot, f.componentCache)
+	// enqueueAncestorChain marks the structural parent that owns file
+	// (longest-prefix spec.path match) plus its meta-Kustomization
+	// ancestors as ancestor-only — they must render to inject patches /
+	// emit namespace-scoped sources, but their unrelated children must
+	// not cascade into keep (#58/#103). self is skipped so a KS walking
+	// its own source file doesn't re-enqueue itself; pass the zero id
+	// when there is nothing to exclude.
+	enqueueAncestorChain := func(file string, self manifest.NamedResource) {
+		for _, owner := range owners.ownersOf(file) {
+			if owner != self {
+				enqueueAncestor(owner)
+			}
+		}
+		for _, ancestor := range owners.ancestorsOf(file) {
+			enqueueAncestor(ancestor)
+		}
+	}
 	f.producersByID, f.producersByName = buildProducerIndex(f.sourceFiles, owners)
 	ownersHit := make(map[manifest.NamedResource]struct{})
 
@@ -566,12 +583,7 @@ func (f *Filter) resolve(objs ObjectLister) {
 			}
 			enqueuePrimary(consumer)
 			if cf, ok := f.sourceFiles[consumer]; ok {
-				for _, owner := range owners.ownersOf(cf) {
-					enqueueAncestor(owner)
-				}
-				for _, ancestor := range owners.ancestorsOf(cf) {
-					enqueueAncestor(ancestor)
-				}
+				enqueueAncestorChain(cf, manifest.NamedResource{})
 			}
 			break
 		}
@@ -644,15 +656,7 @@ func (f *Filter) resolve(objs ObjectLister) {
 		// file, so the parent never collides with the KS we're walking.
 		// Structural parents are ancestor-only (their unrelated children
 		// shouldn't cascade into keep — same rationale as ancestorsOf).
-		for _, owner := range owners.ownersOf(src) {
-			if owner == queue[head] {
-				continue
-			}
-			enqueueAncestor(owner)
-		}
-		for _, ancestor := range owners.ancestorsOf(src) {
-			enqueueAncestor(ancestor)
-		}
+		enqueueAncestorChain(src, queue[head])
 	}
 	f.keep = keep
 	f.primary = primary

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -99,7 +99,7 @@ type Controller struct {
 
 	// renderTracker receives every reconcilable/source child a render
 	// emits. Set via SetRenderTracker before Start; read-only after.
-	// nil is fine — markRenderedBatch no-ops.
+	// nil is fine — ReportRendered no-ops.
 	renderTracker RenderTracker
 }
 

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -101,22 +101,8 @@ func (c *Controller) omitValuesFrom(
 			filtered = append(filtered, ref)
 			continue
 		}
-		if failed != nil {
-			if _, wasFailed := failed[id]; !wasFailed {
-				filtered = append(filtered, ref)
-				continue
-			}
-		}
-		if c.valuesRefExists(id) {
-			filtered = append(filtered, ref)
-			continue
-		}
-		if c.IsFileIndexed(id) {
-			filtered = append(filtered, ref)
-			continue
-		}
-		producer, hasProducer := c.generatedValuesProducer(id)
-		if requireProducer && !hasProducer {
+		producer, hasProducer, omit := c.shouldOmitValuesRef(id, failed, requireProducer)
+		if !omit {
 			filtered = append(filtered, ref)
 			continue
 		}
@@ -127,6 +113,31 @@ func (c *Controller) omitValuesFrom(
 		slog.Debug("helmrelease: omitted unavailable valuesFrom ref", args...)
 	}
 	return cloneWithValuesFrom(hr, filtered)
+}
+
+// shouldOmitValuesRef decides whether the valuesFrom ref identified by id
+// should be dropped from the offline render. It also surfaces the indexed
+// producer (if any) for logging. A ref is kept (omit=false) when it is not in
+// the failed set, when it exists in the store, when it is file-indexed, or —
+// under requireProducer — when no generating producer is known for it.
+func (c *Controller) shouldOmitValuesRef(
+	id manifest.NamedResource,
+	failed map[manifest.NamedResource]struct{},
+	requireProducer bool,
+) (producer manifest.NamedResource, hasProducer, omit bool) {
+	if failed != nil {
+		if _, wasFailed := failed[id]; !wasFailed {
+			return manifest.NamedResource{}, false, false
+		}
+	}
+	if c.valuesRefExists(id) || c.IsFileIndexed(id) {
+		return manifest.NamedResource{}, false, false
+	}
+	producer, hasProducer = c.generatedValuesProducer(id)
+	if requireProducer && !hasProducer {
+		return producer, hasProducer, false
+	}
+	return producer, hasProducer, true
 }
 
 // cloneWithValuesFrom returns hr unchanged when filtered keeps every ref

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -57,16 +57,18 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	// (the prior per-child markRendered loop was the contention hot
 	// spot on KS-heavy fixtures).
 	rendered := make([]manifest.NamedResource, 0, len(objs))
+	keep := func(obj manifest.BaseManifest) {
+		c.KeepEmitted(id, obj)
+		rendered = append(rendered, obj.Named())
+	}
 	// Pass 1 — data first.
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
 			continue
 		}
 		if p.reconcilable {
-			childID := p.obj.Named()
-			c.KeepEmitted(id, p.obj)
+			keep(p.obj)
 			c.Store.AddObject(p.obj)
-			rendered = append(rendered, childID)
 		} else {
 			c.Store.AddRendered(p.obj)
 		}
@@ -75,9 +77,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	var leaves []manifest.BaseManifest
 	for _, p := range objs {
 		if p.reconcilable && isLeafReconcilable(p.obj) {
-			childID := p.obj.Named()
-			c.KeepEmitted(id, p.obj)
-			rendered = append(rendered, childID)
+			keep(p.obj)
 			leaves = append(leaves, p.obj)
 		}
 	}

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -227,10 +227,10 @@ func (c *diskRenderCache) sweep() {
 	// platform-dependent order.
 	diskcache.EvictOldest(entries, total, c.limit,
 		func(a, b diskcache.Entry) int {
-			if c := cmp.Compare(a.MTime, b.MTime); c != 0 {
-				return c
-			}
-			return cmp.Compare(a.Path, b.Path)
+			return cmp.Or(
+				cmp.Compare(a.MTime, b.MTime),
+				cmp.Compare(a.Path, b.Path),
+			)
 		},
 		func(e diskcache.Entry) error {
 			if err := os.Remove(e.Path); err != nil {

--- a/pkg/loader/existence.go
+++ b/pkg/loader/existence.go
@@ -82,7 +82,5 @@ func (i *ExistenceIndex) All() map[manifest.NamedResource]string {
 	}
 	i.mu.RLock()
 	defer i.mu.RUnlock()
-	out := make(map[manifest.NamedResource]string, len(i.entries))
-	maps.Copy(out, i.entries)
-	return out
+	return maps.Clone(i.entries)
 }

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -94,15 +94,14 @@ func logNewCycleMessages(prev, next map[manifest.NamedResource]string) {
 	if len(next) == 0 {
 		return
 	}
-	prevMsgs := make(map[string]struct{}, len(prev))
+	// Seed the seen-set with prev's messages so a cycle carried over
+	// from the previous snapshot is suppressed, then let it double as
+	// the within-next dedup so a multi-member cycle logs once.
+	seen := make(map[string]struct{}, len(prev)+len(next))
 	for _, msg := range prev {
-		prevMsgs[msg] = struct{}{}
+		seen[msg] = struct{}{}
 	}
-	seen := make(map[string]struct{}, len(next))
 	for _, msg := range next {
-		if _, old := prevMsgs[msg]; old {
-			continue
-		}
 		if _, dup := seen[msg]; dup {
 			continue
 		}

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -199,18 +199,13 @@ func splitMultiDoc(pt *parsedTemplate, inputSet map[string]any) ([]map[string]an
 	}
 	var out []map[string]any
 	for chunk := range bytes.SplitSeq(rendered, []byte("\n---")) {
-		chunk = bytes.TrimSpace(chunk)
-		if len(chunk) == 0 {
-			continue
+		doc, err := unmarshalDoc(bytes.TrimSpace(chunk))
+		if err != nil {
+			return nil, err
 		}
-		var doc map[string]any
-		if err := yaml.Unmarshal(chunk, &doc); err != nil {
-			return nil, fmt.Errorf("unmarshal rendered doc: %w", err)
+		if doc != nil {
+			out = append(out, doc)
 		}
-		if len(doc) == 0 {
-			continue
-		}
-		out = append(out, doc)
 	}
 	return out, nil
 }
@@ -220,8 +215,18 @@ func renderSingle(pt *parsedTemplate, inputSet map[string]any) (map[string]any, 
 	if err != nil {
 		return nil, err
 	}
+	return unmarshalDoc(rendered)
+}
+
+// unmarshalDoc decodes a single rendered YAML document, returning a nil
+// map (no error) when the chunk is empty or decodes to an empty object —
+// the caller treats that as "nothing to emit".
+func unmarshalDoc(chunk []byte) (map[string]any, error) {
+	if len(chunk) == 0 {
+		return nil, nil
+	}
 	var doc map[string]any
-	if err := yaml.Unmarshal(rendered, &doc); err != nil {
+	if err := yaml.Unmarshal(chunk, &doc); err != nil {
 		return nil, fmt.Errorf("unmarshal rendered doc: %w", err)
 	}
 	if len(doc) == 0 {

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -119,7 +119,6 @@ func (f *Fetcher) resolveTransport(repo *manifest.GitRepository) (transport.Auth
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
 func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
-	cache := f.Cache
 	if repo == nil {
 		return nil, errors.New("git repository is nil")
 	}
@@ -135,7 +134,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	mutableRef := !canUseCachedGitSlot(repo.Reference)
 
 	authID := authIdentity(repo)
-	slot, err := cache.Slot(ctx, repo.URL, slotRef, authID)
+	slot, err := f.Cache.Slot(ctx, repo.URL, slotRef, authID)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", repo.URL, err)
 	}

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -62,15 +62,11 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	if baseTransport != nil {
 		transport = baseTransport
 	}
-	httpClient := &http.Client{Transport: transport}
+	authClient := &auth.Client{Client: &http.Client{Transport: transport}}
 	if credStore != nil {
-		repoClient.Client = &auth.Client{
-			Credential: credentials.Credential(credStore),
-			Client:     httpClient,
-		}
-	} else {
-		repoClient.Client = &auth.Client{Client: httpClient}
+		authClient.Credential = credentials.Credential(credStore)
 	}
+	repoClient.Client = authClient
 
 	// Resolve spec.ref into a concrete (tag-or-digest) BEFORE choosing
 	// the cache slot, so different semver matches don't share a slot.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -32,9 +32,10 @@ const numEventKinds = 3
 const shardCount = 16
 
 // shard owns the per-Kind state for the Kinds that hash to its
-// index. The four maps are keyed by manifest.NamedResource, which
-// includes Kind — so within a shard each map is keyed by the same
-// set of ids, and a Snapshot for one id touches only this shard.
+// index. The objects/conditions/artifacts maps are keyed by
+// manifest.NamedResource, which includes Kind — so within a shard
+// each is keyed by the same set of ids, and a Snapshot for one id
+// touches only this shard.
 //
 // byName is the secondary index: kind → namespace/name → object.
 // Sharding by Kind means each shard's byName only sees the Kinds


### PR DESCRIPTION
Sixth autonomous code-cleanliness sweep — 12 packages, each verified behavior- and API-preserving.

## What changed
- **Extract shared helpers:** `enqueueAncestorChain` (change — two identical owners+ancestors loops); `shouldOmitValuesRef` (helmrelease — the keep/omit decision); `keep` closure (kustomization `emitRenderedChildren`, 2 sites); `dumpProfileAt` (cli — block + mutex stop funcs); `unmarshalDoc` (resourceset — `splitMultiDoc` + `renderSingle`).
- **Single-source magic strings:** `resourceAggregatePrefix` const, referenced by both the error producer and its classifier so they can't drift apart.
- **Modern idioms:** `maps.Clone`, `cmp.Or` eviction comparator, hoisted loop-invariant selector, folded oci `auth.Client` construction, dropped a redundant cache alias; collapsed `logNewCycleMessages` to one seeded seen-set.
- **Doc accuracy:** base/store/render comments.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- `shouldOmitValuesRef` and `unmarshalDoc` hand-verified to preserve their callers' exact keep/skip and nil-doc contracts.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set (Helm `genSignedCert` + infisical `updatedAt`), binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)