### PR TITLE
refactor: seventh behavior-preserving cleanliness pass

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -184,10 +184,10 @@ func relToRepo(repoRoot, path string) (string, error) {
 	// otherwise, handled above), so no IsAbs check is needed — reject
 	// only the repo-escaping ".." and "../…" forms. A dir literally named
 	// "..foo" is in-repo and stays accepted.
-	if rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return rel, nil
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("--path %q is outside the git repo at %q; pass --path-orig explicitly", path, repoRoot)
 	}
-	return "", fmt.Errorf("--path %q is outside the git repo at %q; pass --path-orig explicitly", path, repoRoot)
+	return rel, nil
 }
 
 // GitRepoRoot returns the .git ancestor of path, or "" when none
@@ -269,11 +269,20 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 		return nil, fmt.Errorf("could not resolve --base=%q: not found locally or as origin/%s", base, base)
 	}
 
+	// Each rung names a candidate ref tip and tries the merge-base
+	// against HEAD; the first that resolves wins.
+	mergeBaseWith := func(candidate plumbing.Hash, source string) (*resolution, bool) {
+		if mb, err := mergeBase(repo, headCommit, candidate); err == nil {
+			return &resolution{Hash: mb, Source: source}, true
+		}
+		return nil, false
+	}
+
 	// 1. @{u} via the branch config (go-git's ResolveRevision doesn't
 	//    accept @{u}; read branch.<name>.remote/.merge directly).
 	if up, ok := upstreamHash(repo, head); ok {
-		if mb, err := mergeBase(repo, headCommit, up); err == nil {
-			return &resolution{Hash: mb, Source: "merge-base with @{u}"}, nil
+		if r, ok := mergeBaseWith(up, "merge-base with @{u}"); ok {
+			return r, nil
 		}
 	}
 
@@ -281,18 +290,17 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	//    pointing at e.g. refs/remotes/origin/main. Resolve through
 	//    the symref to the underlying branch tip.
 	if h, ok := resolveRef(repo, plumbing.NewRemoteHEADReferenceName("origin")); ok {
-		if mb, err := mergeBase(repo, headCommit, h); err == nil {
-			return &resolution{Hash: mb, Source: "merge-base with origin/HEAD"}, nil
+		if r, ok := mergeBaseWith(h, "merge-base with origin/HEAD"); ok {
+			return r, nil
 		}
 	}
 
 	// 3. Common defaults when origin/HEAD isn't set (older clones,
 	//    some self-hosted setups).
 	for _, name := range []string{"main", "master"} {
-		ref := plumbing.NewRemoteReferenceName("origin", name)
-		if h, ok := resolveRef(repo, ref); ok {
-			if mb, err := mergeBase(repo, headCommit, h); err == nil {
-				return &resolution{Hash: mb, Source: "merge-base with origin/" + name}, nil
+		if h, ok := resolveRef(repo, plumbing.NewRemoteReferenceName("origin", name)); ok {
+			if r, ok := mergeBaseWith(h, "merge-base with origin/"+name); ok {
+				return r, nil
 			}
 		}
 	}

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -162,7 +162,7 @@ func NewFilterWithCache(changes *Set, sourceFiles map[manifest.NamedResource]str
 	if changes == nil {
 		return f
 	}
-	f.resolve(objs)
+	f.resolve()
 	return f
 }
 
@@ -464,7 +464,8 @@ func (f *Filter) addDependencyOnlyRecursiveLocked(ids ...manifest.NamedResource)
 	return added
 }
 
-func (f *Filter) resolve(objs ObjectLister) {
+func (f *Filter) resolve() {
+	objs := f.objs
 	// Capacity hint: the final keep set is roughly proportional to the
 	// source-files map; prime both maps and the BFS queue at that size
 	// to avoid repeated rehash/realloc on the initial resolve scan.

--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -102,25 +102,26 @@ func compileReadyExpr(expr string) (cel.Program, error) {
 		e := v.(celCacheEntry)
 		return e.prog, e.err
 	}
-	entry := celCacheEntry{}
-	ast, issues := celEnv.Compile(expr)
-	if issues != nil && issues.Err() != nil {
-		entry.err = fmt.Errorf("compile: %w", issues.Err())
-	} else {
-		prog, err := celEnv.Program(ast)
-		if err != nil {
-			entry.err = fmt.Errorf("program: %w", err)
-		} else {
-			entry.prog = prog
-		}
-	}
-	// LoadOrStore: a concurrent compile of the same expr both lose
-	// races; the loser's prog/err is discarded and we return the
-	// winner's. cel-go's compilation is deterministic so the two
-	// results are equivalent.
-	actual, _ := celCache.LoadOrStore(expr, entry)
+	// LoadOrStore: concurrent compiles of the same expr both race; the
+	// loser's entry is discarded and we return the winner's. cel-go's
+	// compilation is deterministic so the two results are equivalent.
+	actual, _ := celCache.LoadOrStore(expr, buildCacheEntry(expr))
 	e := actual.(celCacheEntry)
 	return e.prog, e.err
+}
+
+// buildCacheEntry compiles expr into the program (or terminal error)
+// that compileReadyExpr memoizes.
+func buildCacheEntry(expr string) celCacheEntry {
+	ast, issues := celEnv.Compile(expr)
+	if issues != nil && issues.Err() != nil {
+		return celCacheEntry{err: fmt.Errorf("compile: %w", issues.Err())}
+	}
+	prog, err := celEnv.Program(ast)
+	if err != nil {
+		return celCacheEntry{err: fmt.Errorf("program: %w", err)}
+	}
+	return celCacheEntry{prog: prog}
 }
 
 // projectObject builds the unstructured-shaped value the CEL

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -273,7 +273,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	l.PreferExisting = true
 	ksExpanded := map[manifest.NamedResource]struct{}{}
 	rsConverged := map[manifest.NamedResource]struct{}{}
-	prevRSIPCount := len(store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider))
+	prevRSIPCount := d.rsipCount()
 	for {
 		added := 0
 		for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
@@ -310,7 +310,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 		// Re-evaluate the convergence cache when new RSIPs arrived
 		// between passes — they may match selectors that previously
 		// returned zero inputs.
-		currentRSIPCount := len(store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider))
+		currentRSIPCount := d.rsipCount()
 		if currentRSIPCount != prevRSIPCount {
 			clear(rsConverged)
 			prevRSIPCount = currentRSIPCount
@@ -356,4 +356,11 @@ func (d *discoverer) loadAt(ctx context.Context, dir string, scanned map[string]
 	}
 	*total += n
 	return nil
+}
+
+// rsipCount reports how many ResourceSetInputProviders are currently in
+// the store. The expansion loop compares this between passes to decide
+// when to invalidate the ResourceSet convergence cache.
+func (d *discoverer) rsipCount() int {
+	return len(store.ListAs[*manifest.ResourceSetInputProvider](d.cfg.Store, manifest.KindResourceSetInputProvider))
 }

--- a/pkg/discovery/remotes.go
+++ b/pkg/discovery/remotes.go
@@ -21,12 +21,18 @@ func (d *discoverer) selfRemotes(repoRoot string) map[string]struct{} {
 		return readWorkingTreeRemotes(repoRoot)
 	}
 	out := make(map[string]struct{}, len(d.cfg.SelfURLs))
-	for _, u := range d.cfg.SelfURLs {
+	addNormalizedRemotes(out, d.cfg.SelfURLs...)
+	return out
+}
+
+// addNormalizedRemotes normalizes each URL and inserts the non-empty
+// results into out, skipping URLs that don't describe a remote.
+func addNormalizedRemotes(out map[string]struct{}, urls ...string) {
+	for _, u := range urls {
 		if n := normalizeGitURL(u); n != "" {
 			out[n] = struct{}{}
 		}
 	}
-	return out
 }
 
 // readWorkingTreeRemotes returns the set of remote URLs configured on
@@ -56,11 +62,7 @@ func readWorkingTreeRemotes(repoRoot string) map[string]struct{} {
 	}
 	out := map[string]struct{}{}
 	for _, remote := range cfg.Remotes {
-		for _, u := range remote.URLs {
-			if n := normalizeGitURL(u); n != "" {
-				out[n] = struct{}{}
-			}
-		}
+		addNormalizedRemotes(out, remote.URLs...)
 	}
 	return out
 }

--- a/pkg/helm/render_cache_disk.go
+++ b/pkg/helm/render_cache_disk.go
@@ -18,8 +18,8 @@ import (
 )
 
 // diskRenderCache persists helm template-output across `flate`
-// invocations. It sits behind the in-process templateCache (Phase 2.2):
-// the in-process LRU has zero hit rate across processes, and profile
+// invocations. It sits behind the in-process templateCache: the
+// in-process LRU has zero hit rate across processes, and profile
 // evidence from `buroa/k8s-gitops` puts helm.TemplateDocs at ~64% of
 // warm allocations and ~13% of warm CPU — most of that re-runs across
 // CLI invocations.

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -196,9 +196,9 @@ func newInstallAction(cfg *action.Configuration, hr *manifest.HelmRelease, opts 
 
 // mergeChartValuesFiles is the cache-aware entry point: it consults
 // Client.chartValuesCache before re-parsing and stores the canonical
-// merged map on miss. Callers receive a deep clone (defensive-copy
-// convention matching indexCache) — downstream layering DeepMerges
-// the result, which may mutate intermediate sub-maps.
+// merged map on miss. Callers receive a deep clone — downstream
+// layering DeepMerges the result, which may mutate intermediate
+// sub-maps.
 //
 // Cache key = sha256(chart.Name || chart.Version || joined valuesFiles
 // list || ignoreMissing bit). Distinct chart identities (different

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -218,11 +218,7 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	if err := f.finalize(repo, art); err != nil {
 		return nil, err
 	}
-	if err := slot.Commit(); err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
-	}
-	art.LocalPath = slot.Path
-	return art, nil
+	return commitArtifact(repo, slot, art)
 }
 
 func effectiveNamedRef(ref manifest.GitRepositoryRef) string {
@@ -454,11 +450,7 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 	if err := applyIgnoreAndMark(repo, art); err != nil {
 		return nil, err
 	}
-	if err := slot.Commit(); err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
-	}
-	art.LocalPath = slot.Path
-	return art, nil
+	return commitArtifact(repo, slot, art)
 }
 
 // mirrorFetchPlan builds the per-GitRepository mirror update plan: the
@@ -534,6 +526,18 @@ func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
 		Username: proxy.Username,
 		Password: proxy.Password,
 	}
+}
+
+// commitArtifact atomically commits the staged slot and stamps the
+// artifact's LocalPath with the committed slot path. Shared by the
+// legacy clone path (fetch) and the bare-mirror path (fetchViaMirror),
+// which finalize the slot identically once materialization is done.
+func commitArtifact(repo *manifest.GitRepository, slot *source.Slot, art *store.SourceArtifact) (*store.SourceArtifact, error) {
+	if err := slot.Commit(); err != nil {
+		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
+	}
+	art.LocalPath = slot.Path
+	return art, nil
 }
 
 // gitArtifact builds the SourceArtifact every git fetch path returns: a

--- a/pkg/source/git/verify/verify.go
+++ b/pkg/source/git/verify/verify.go
@@ -71,11 +71,11 @@ func Signatures(secrets source.SecretGetter, ns, name, secretRefName string, mod
 	return nil
 }
 
-func matchesHEAD(mode sourcev1.GitVerificationMode) bool {
+func matchesHEAD(mode GitVerificationMode) bool {
 	return mode == sourcev1.ModeGitHEAD || mode == sourcev1.ModeGitTagAndHEAD
 }
 
-func matchesTag(mode sourcev1.GitVerificationMode) bool {
+func matchesTag(mode GitVerificationMode) bool {
 	return mode == sourcev1.ModeGitTag || mode == sourcev1.ModeGitTagAndHEAD
 }
 

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -84,7 +84,7 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		paths[i] = p
 	}
 	certPath, keyPath, caPath := paths[0], paths[1], paths[2]
-	if certPath == "" && keyPath == "" && caPath == "" {
+	if paths == [3]string{} {
 		cleanup()
 		// A secret present but carrying none of the TLS keys is malformed
 		// config — fail loud (no ErrMissingSecret wrap), like BuildTLSConfig.

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -308,15 +308,15 @@ func ociCacheKey(repo *manifest.OCIRepository, ref manifest.OCIRepositoryRef, re
 func (f *Fetcher) checkCacheHit(ctx context.Context, repoClient *remote.Repository, repo *manifest.OCIRepository, slotPath string, ref manifest.OCIRepositoryRef, versioned, expectedDigest string) (*store.SourceArtifact, bool, error) {
 	cachedDigest := readCachedDigest(slotPath)
 	if cachedDigest == "" {
-		// `.flate-digest` is written as the FINAL step of a successful
-		// fetch (and the slot is committed via atomic rename only after
-		// that write), so its absence on a final slot means the slot
-		// was committed from a pre-marker flate version or someone
-		// hand-modified the cache.
+		// The cached digest is recorded in the meta sidecar as the FINAL
+		// step of a successful fetch (and the slot is committed via atomic
+		// rename only after that write), so its absence on a final slot
+		// means the slot was committed from a pre-marker flate version or
+		// someone hand-modified the cache.
 		return nil, false, nil
 	}
 	if hasUnfinishedOCILayout(slotPath) {
-		// Defensive: a valid `.flate-digest` should imply
+		// Defensive: a valid cached digest should imply
 		// applyLayerSelector ran to completion and wiped the OCI
 		// Image Layout artifacts. Atomic-rename makes this much less
 		// likely (a crashed run never publishes a final slot), but

--- a/pkg/source/oci/fetcher.go
+++ b/pkg/source/oci/fetcher.go
@@ -8,7 +8,7 @@
 //	fetch.go    — fetch workhorse, cache-hit gate, artifact composer
 //	auth.go     — TLS, registry-config, credential-store resolution
 //	resolve.go  — OCI ref parsing, semver tag picking, revision shape
-//	marker.go   — .flate-digest / .flate-verified slot markers
+//	marker.go   — cached-digest / verify-policy slot meta sidecar
 //	cosign.go   — cosign signature verification
 //	layer.go    — spec.layerSelector copy/extract
 package oci


### PR DESCRIPTION
Seventh autonomous code-cleanliness sweep — 8 packages, each verified behavior- and API-preserving. The yield is steadily converging (27→22→20→18→15→13→9 patches across passes #630–#636); most agents now report packages already clean.

## What changed
- **Extract shared helpers:** `mergeBaseWith` (baseline — 3 merge-base rungs); `buildCacheEntry` (depwait CEL compile); `rsipCount` + `addNormalizedRemotes` (discovery, 2 sites each); `commitArtifact` (git — `fetch` + `fetchViaMirror`).
- **Small idiom cleanups:** baseline `relToRepo` guard-clause; change `resolve` reads `f.objs` instead of re-threading the param; verify uses the package's own `GitVerificationMode` alias; helmchart array-zero check.
- **Doc accuracy:** drop stale `.flate-digest`/`.flate-verified` marker references (now the meta sidecar) in oci; drop stale Phase-2.2/indexCache breadcrumbs in helm.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- `f.objs` confirmed identical to the dropped param; `GitVerificationMode` is a true type alias.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set, binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)