### PR TITLE
refactor: eighth behavior-preserving cleanliness pass

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -47,12 +47,12 @@ func Table(w io.Writer, cols []Column, rows []map[string]string) error {
 		}
 	}
 	var b bytes.Buffer
-	// +1 newline per row (header + data rows); each cell padded to width+gutter
-	totalCols := 0
+	// Each cell is padded to width+gutter; +1 for the per-row newline.
+	rowWidth := 0
 	for _, width := range widths {
-		totalCols += width + 4
+		rowWidth += width + 4
 	}
-	b.Grow((1 + len(rows)) * (totalCols + 1))
+	b.Grow((1 + len(rows)) * (rowWidth + 1))
 	last := len(cols) - 1
 	for i, c := range cols {
 		writeCol(&b, c.Header, widths[i], i == last)

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -105,6 +105,12 @@ type Filter struct {
 
 type nameKey struct{ kind, name string }
 
+// keyOf is the (Kind, Name) namespace-agnostic key for id, used by the
+// empty-namespace fallback indexes (keepByName, producersByName).
+func keyOf(id manifest.NamedResource) nameKey {
+	return nameKey{id.Kind, id.Name}
+}
+
 // NewFilter constructs a fully-resolved Filter in one shot. It walks
 // the file-level Changes set, attributes each change to the most
 // specific Flux Kustomization that owns it, then expands transitive
@@ -192,10 +198,8 @@ func (f *Filter) ShouldReconcile(id manifest.NamedResource) bool {
 	if _, ok := f.keep[id]; ok {
 		return true
 	}
-	if _, ok := f.keepByName[nameKey{id.Kind, id.Name}]; ok {
-		return true
-	}
-	return false
+	_, ok := f.keepByName[keyOf(id)]
+	return ok
 }
 
 // ProducersFor returns Flux Kustomizations that render the file-backed
@@ -232,7 +236,7 @@ func (f *Filter) producersFor(id manifest.NamedResource) []manifest.NamedResourc
 	}
 	out := f.producersByID[id]
 	if id.Namespace != "" {
-		out = appendUniqueProducers(out, f.producersByName[nameKey{id.Kind, id.Name}])
+		out = appendUniqueProducers(out, f.producersByName[keyOf(id)])
 	}
 	return out
 }
@@ -370,7 +374,7 @@ func (f *Filter) addRecursive(id manifest.NamedResource) []manifest.NamedResourc
 func (f *Filter) markKept(id manifest.NamedResource) {
 	f.keep[id] = struct{}{}
 	if id.Namespace == "" {
-		f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+		f.keepByName[keyOf(id)] = struct{}{}
 	}
 }
 
@@ -592,7 +596,7 @@ func (f *Filter) resolve() {
 
 	// NOTE: queue grows inside the loop via enqueuePrimary/enqueueAncestor.
 	// Re-evaluate len(queue) each iteration; do NOT convert to `range queue`
-	// (intrange linter must not auto-fix this — see //nolint above).
+	// (intrange linter must not auto-fix this — see //nolint below).
 	for head := 0; head < len(queue); head++ { //nolint:intrange // queue grows during iteration
 		_, headPrimary := primary[queue[head]]
 		// transitiveDeps reads the consumer from the Store; that covers
@@ -670,7 +674,7 @@ func (f *Filter) resolve() {
 	f.keepByName = make(map[nameKey]struct{})
 	for id := range keep {
 		if id.Namespace == "" {
-			f.keepByName[nameKey{id.Kind, id.Name}] = struct{}{}
+			f.keepByName[keyOf(id)] = struct{}{}
 		}
 	}
 }
@@ -758,7 +762,7 @@ func buildProducerIndex(sourceFiles map[manifest.NamedResource]string, owners ow
 		}
 		byID[id] = appendUniqueProducers(byID[id], producers)
 		if id.Namespace == "" {
-			key := nameKey{id.Kind, id.Name}
+			key := keyOf(id)
 			byName[key] = appendUniqueProducers(byName[key], producers)
 		}
 	}

--- a/pkg/loader/transformer_ns.go
+++ b/pkg/loader/transformer_ns.go
@@ -38,17 +38,17 @@ const transformerScanMaxDepth = 6
 // Resolving the namespace here, at load time, lets the leaf KS render
 // into the right namespace on its first pass — the load-time analog of
 // the same NamespaceTransformer kustomize would apply, mirroring how
-// ApplyNamespaceInheritance front-runs kustomize-controller's
+// ApplyNamespaceInheritanceWithRefs front-runs kustomize-controller's
 // apply-time namespace defaulting.
 //
 // Only spec.targetNamespace is set (never metadata.namespace), so the
 // KS's store id stays stable. The value reaches rendered children via
 // ks.Contents (RenderFlux feeds it to kustomize) and reaches
 // store-resident namespace-less resources under spec.path via
-// ApplyNamespaceInheritance's existing projection, which now sees a
-// populated targetNamespace.
+// ApplyNamespaceInheritanceWithRefs's existing projection, which now sees
+// a populated targetNamespace.
 //
-// Runs before ApplyNamespaceInheritance (see discovery.applyNamespaces).
+// Runs before ApplyNamespaceInheritanceWithRefs (see discovery.applyNamespaces).
 func StampTransformerTargetNamespaces(s *store.Store, sourceFiles map[manifest.NamedResource]string, repoRoot string) {
 	if len(sourceFiles) == 0 {
 		return

--- a/pkg/source/git/checkout.go
+++ b/pkg/source/git/checkout.go
@@ -30,10 +30,11 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef, sparse []s
 	}
 	switch {
 	case ref.Commit != "":
-		if err := validateCommitBranch(repo, plumbing.NewHash(ref.Commit), ref.Branch); err != nil {
+		hash := plumbing.NewHash(ref.Commit)
+		if err := validateCommitBranch(repo, hash, ref.Branch); err != nil {
 			return err
 		}
-		return checkout(func(o *git.CheckoutOptions) { o.Hash = plumbing.NewHash(ref.Commit) })
+		return checkout(func(o *git.CheckoutOptions) { o.Hash = hash })
 	case ref.Name != "":
 		// Full ref name takes precedence (e.g. "refs/pull/420/head",
 		// "refs/tags/v1.2.3"). Resolve against the cloned repo so the

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -83,7 +83,6 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		}
 		paths[i] = p
 	}
-	certPath, keyPath, caPath := paths[0], paths[1], paths[2]
 	if paths == [3]string{} {
 		cleanup()
 		// A secret present but carrying none of the TLS keys is malformed
@@ -91,5 +90,5 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
 			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
 	}
-	return []getter.Option{getter.WithTLSClientConfig(certPath, keyPath, caPath)}, cleanup, nil
+	return []getter.Option{getter.WithTLSClientConfig(paths[0], paths[1], paths[2])}, cleanup, nil
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -139,7 +139,7 @@ func New() *Store {
 // shardFor returns the shard owning id's Kind. The hash is FNV-1a
 // over id.Kind — short, well-distributed, stdlib (`hash/fnv`).
 func (s *Store) shardFor(id manifest.NamedResource) *shard {
-	return s.shards[kindShardIndex(id.Kind)]
+	return s.shardForKind(id.Kind)
 }
 
 // shardForKind is the kind-only sibling of shardFor for entrypoints

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -96,7 +96,7 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 	go func() {
 		started := time.Now()
 		defer s.wgActive.Done()
-		defer s.taskDone()
+		defer s.decrActive()
 		defer func() {
 			if d := time.Since(started); d > time.Second {
 				slog.Debug("task complete", "name", name, "duration", d)
@@ -120,15 +120,16 @@ func (s *Service) Go(ctx context.Context, name string, fn func(context.Context))
 	}()
 }
 
-// taskDone is deferred in Go so both clean returns and panics fire
-// the decrement and quiescence notification.
-func (s *Service) taskDone() {
-	now := s.active.Add(-1)
-	s.notifyQuiescence(now)
+// decrActive drops the active count by one and notifies any quiescence
+// waiters the new count has satisfied. Deferred in Go so both clean
+// returns and panics fire the decrement, and reused by YieldQuiescent's
+// depwait hop.
+func (s *Service) decrActive() {
+	s.notifyQuiescence(s.active.Add(-1))
 }
 
 // notifyQuiescence is called on every active-count decrement —
-// goroutine exit (taskDone) AND YieldQuiescent entry — so
+// goroutine exit AND YieldQuiescent entry (both via decrActive) — so
 // depwait-blocked tasks don't prevent the pool from reaching
 // quiescence on their own absence of productive work.
 func (s *Service) notifyQuiescence(now int64) {
@@ -163,7 +164,7 @@ func (s *Service) QuiescenceCh(threshold int64) <-chan struct{} {
 	s.quiesceMu.Lock()
 	defer s.quiesceMu.Unlock()
 	// Re-read active under quiesceMu so we don't race a concurrent
-	// taskDone that already closed waiters at the current threshold.
+	// decrActive that already closed waiters at the current threshold.
 	if s.active.Load() <= threshold {
 		close(ch)
 		return ch
@@ -231,14 +232,13 @@ func (s *Service) releaseSlot() func() {
 //
 // Both the active increment and the slot re-acquire are deferred so
 // a panic inside fn still restores both counters; without that,
-// Service.Go's outer `defer s.taskDone()` would over-decrement on
+// Service.Go's outer `defer s.decrActive()` would over-decrement on
 // unwind.
 func (s *Service) YieldQuiescent(fn func()) {
 	if s.sem != nil {
 		defer s.releaseSlot()()
 	}
-	now := s.active.Add(-1)
-	s.notifyQuiescence(now)
+	s.decrActive()
 	defer s.active.Add(1)
 	fn()
 }


### PR DESCRIPTION
Eighth autonomous code-cleanliness sweep — 7 packages, each verified behavior- and API-preserving. The loop is near its floor: most agents now report packages already clean after five-to-seven prior passes.

## What changed
- **De-duplicate:** `keyOf` (change — 6 `nameKey{Kind,Name}` sites); `decrActive` (task — goroutine-exit + `YieldQuiescent`); `shardFor` delegates to `shardForKind` (store); drop now-dead cert/key/ca locals (helmchart); hoist a doubly-computed commit hash (git).
- **Doc accuracy:** loader corrects three references to the renamed `ApplyNamespaceInheritanceWithRefs`; format renames the misleading `totalCols` local to `rowWidth` (it holds row width in chars, not a column count).

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set, binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)