### PR TITLE
refactor: ninth behavior-preserving cleanliness pass

### DIFF
--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -28,6 +28,9 @@ type Column struct {
 	Key    string
 }
 
+// gutter is the fixed-width padding appended after each column except the last.
+const gutter = 4
+
 // Table renders rows of map[string]string into a fixed-width table.
 // Columns are sized to the widest cell + a 4-char gutter. Widths
 // are measured in runes (not bytes) so cells with multi-byte UTF-8
@@ -50,7 +53,7 @@ func Table(w io.Writer, cols []Column, rows []map[string]string) error {
 	// Each cell is padded to width+gutter; +1 for the per-row newline.
 	rowWidth := 0
 	for _, width := range widths {
-		rowWidth += width + 4
+		rowWidth += width + gutter
 	}
 	b.Grow((1 + len(rows)) * (rowWidth + 1))
 	last := len(cols) - 1
@@ -74,7 +77,7 @@ func writeCol(b *bytes.Buffer, value string, width int, last bool) {
 		return
 	}
 	// Write padding directly to avoid the temporary string that strings.Repeat allocates.
-	pad := max(width-utf8.RuneCountInString(value)+4, 1)
+	pad := max(width-utf8.RuneCountInString(value)+gutter, 1)
 	for range pad {
 		b.WriteByte(' ')
 	}

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -277,6 +277,14 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 		}
 		return nil, false
 	}
+	// tryRef resolves a ref name to its tip, then attempts the
+	// merge-base; ok=false when the ref is missing or has no merge-base.
+	tryRef := func(name plumbing.ReferenceName, source string) (*resolution, bool) {
+		if h, ok := resolveRef(repo, name); ok {
+			return mergeBaseWith(h, source)
+		}
+		return nil, false
+	}
 
 	// 1. @{u} via the branch config (go-git's ResolveRevision doesn't
 	//    accept @{u}; read branch.<name>.remote/.merge directly).
@@ -289,19 +297,15 @@ func resolve(repo *git.Repository, base string) (*resolution, error) {
 	// 2. origin/HEAD: a symbolic ref under refs/remotes/origin/HEAD
 	//    pointing at e.g. refs/remotes/origin/main. Resolve through
 	//    the symref to the underlying branch tip.
-	if h, ok := resolveRef(repo, plumbing.NewRemoteHEADReferenceName("origin")); ok {
-		if r, ok := mergeBaseWith(h, "merge-base with origin/HEAD"); ok {
-			return r, nil
-		}
+	if r, ok := tryRef(plumbing.NewRemoteHEADReferenceName("origin"), "merge-base with origin/HEAD"); ok {
+		return r, nil
 	}
 
 	// 3. Common defaults when origin/HEAD isn't set (older clones,
 	//    some self-hosted setups).
 	for _, name := range []string{"main", "master"} {
-		if h, ok := resolveRef(repo, plumbing.NewRemoteReferenceName("origin", name)); ok {
-			if r, ok := mergeBaseWith(h, "merge-base with origin/"+name); ok {
-				return r, nil
-			}
+		if r, ok := tryRef(plumbing.NewRemoteReferenceName("origin", name), "merge-base with origin/"+name); ok {
+			return r, nil
 		}
 	}
 

--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -346,9 +346,8 @@ func scanTree(root string) (map[string]fileMeta, error) {
 		if err != nil {
 			return err
 		}
-		base := d.Name()
 		if d.IsDir() {
-			if p != root && shouldSkipDir(base) {
+			if p != root && shouldSkipDir(d.Name()) {
 				return fs.SkipDir
 			}
 			return nil
@@ -414,12 +413,5 @@ func hashFile(path string) (string, error) {
 }
 
 func shouldSkipDir(name string) bool {
-	if strings.HasPrefix(name, ".") {
-		return true
-	}
-	switch name {
-	case "node_modules", "vendor":
-		return true
-	}
-	return false
+	return strings.HasPrefix(name, ".") || name == "node_modules" || name == "vendor"
 }

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -292,8 +292,15 @@ func (f *Filter) AddEmitted(emitter manifest.NamedResource, child manifest.BaseM
 	// the recurse can't cause `child` to be silently dropped.
 	// addEmittedLocked reads primary and (when gated through) does
 	// the addRecursive walk under the same WLock.
-	added := f.addEmittedLocked(emitter, child)
-	if f.OnAdd == nil || len(added) == 0 {
+	f.fireOnAdd(f.addEmittedLocked(emitter, child))
+}
+
+// fireOnAdd dispatches OnAdd for every newly-keep'd id. Always called
+// OUTSIDE f.mu: callbacks may take other locks (e.g. the Store's mu via
+// Refire), and holding f.mu here would invert lock order against
+// concurrent ShouldReconcile readers. No-op when OnAdd is unset.
+func (f *Filter) fireOnAdd(added []manifest.NamedResource) {
+	if f.OnAdd == nil {
 		return
 	}
 	for _, newID := range added {
@@ -339,16 +346,7 @@ func (f *Filter) addUngated(id manifest.NamedResource) {
 	if !f.Enabled() {
 		return
 	}
-	added := f.addRecursive(id)
-	if f.OnAdd == nil || len(added) == 0 {
-		return
-	}
-	// Call OnAdd outside the lock — callbacks may take other locks
-	// (e.g. the Store's mu via Refire) and we don't want to invert
-	// lock order with concurrent ShouldReconcile readers.
-	for _, newID := range added {
-		f.OnAdd(newID)
-	}
+	f.fireOnAdd(f.addRecursive(id))
 }
 
 // addRecursive adds id (and transitive deps) to keep AND primary,

--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -56,10 +56,7 @@ func normalizeManifest(m map[string]any, attrs, fields []string, hook func(map[s
 // binary payloads are present.
 func docsContainBinaryData(docs []Doc) bool {
 	for _, d := range docs {
-		if manifest.DocKind(d.Manifest) != manifest.KindConfigMap {
-			continue
-		}
-		if _, ok := d.Manifest["binaryData"].(map[string]any); ok {
+		if _, ok := configMapBinaryData(d.Manifest); ok {
 			return true
 		}
 	}
@@ -72,16 +69,23 @@ func docsContainBinaryData(docs []Doc) bool {
 // not "which base64 character flipped." Hash-prefix summaries
 // preserve that signal while keeping the diff legible.
 func redactBinaryData(doc map[string]any) {
-	if manifest.DocKind(doc) != manifest.KindConfigMap {
-		return
-	}
-	binaryData, ok := doc["binaryData"].(map[string]any)
+	binaryData, ok := configMapBinaryData(doc)
 	if !ok {
 		return
 	}
 	for k, v := range binaryData {
 		binaryData[k] = binaryDataSummary(v)
 	}
+}
+
+// configMapBinaryData returns a manifest's binaryData map when it is a
+// ConfigMap carrying one — the only shape redactBinaryData rewrites.
+func configMapBinaryData(m map[string]any) (map[string]any, bool) {
+	if manifest.DocKind(m) != manifest.KindConfigMap {
+		return nil, false
+	}
+	bd, ok := m["binaryData"].(map[string]any)
+	return bd, ok
 }
 
 // binaryDataSummary returns a stable, content-derived placeholder for

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -140,7 +140,6 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	d.repoRoot = repoRoot
 	if err := d.loadManifests(ctx, repoRoot); err != nil {
 		return nil, err
 	}
@@ -208,13 +207,6 @@ type discoverer struct {
 	loader      *loader.Loader
 	sourceFiles map[manifest.NamedResource]string
 	sourceRefs  map[manifest.NamedResource][]manifest.NamedResource
-	// repoRoot is the resolved .git ancestor of cfg.Path (or cfg.Path
-	// when no .git exists). Stored here because every consumer of
-	// loader.BuildParentIndexFromPrefixes / loader.KSPathPrefixesWithCache
-	// needs the repo-relative root used to resolve KS spec.path entries,
-	// and passing cfg.Path silently misreads `components:` lookups when
-	// the user pointed --path at a subdir.
-	repoRoot string
 }
 
 // loadManifests scans cfg.Path, then iteratively follows each loaded

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -95,35 +95,23 @@ func ApplyNamespaceInheritanceWithRefs(s *store.Store, sourceFiles map[manifest.
 // top-level Flux Operator and HelmChart source objects after namespace
 // inheritance has had a chance to project kustomize/Flux namespaces.
 func ApplyDefaultNamespaces(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
-	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSet](s, manifest.KindResourceSet),
-		func(o *manifest.ResourceSet) *manifest.ResourceSet {
-			c := *o
-			c.Namespace = manifest.DefaultNamespace
-			return &c
-		})
-	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider),
-		func(o *manifest.ResourceSetInputProvider) *manifest.ResourceSetInputProvider {
-			c := *o
-			c.Namespace = manifest.DefaultNamespace
-			return &c
-		})
-	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.HelmChartSource](s, manifest.KindHelmChart),
-		func(o *manifest.HelmChartSource) *manifest.HelmChartSource {
-			c := *o
-			c.Namespace = manifest.DefaultNamespace
-			return &c
-		})
+	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSet](s, manifest.KindResourceSet))
+	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider))
+	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.HelmChartSource](s, manifest.KindHelmChart))
 }
 
 // applyDefaultNS assigns manifest.DefaultNamespace to every object in objs
-// whose current namespace is empty, then reindexes it in the store.
-// withNS must return a new object (shallow copy) with the namespace set.
-func applyDefaultNS[T manifest.BaseManifest](s *store.Store, sourceFiles map[manifest.NamedResource]string, objs []T, withNS func(T) T) {
+// whose current namespace is empty, then reindexes it in the store. The
+// shallow copy is produced by cloneWithNamespace, which already rewrites
+// the namespace for these kinds — so the per-type copy lives in one place.
+func applyDefaultNS[T manifest.BaseManifest](s *store.Store, sourceFiles map[manifest.NamedResource]string, objs []T) {
 	for _, obj := range objs {
 		if obj.Named().Namespace != "" {
 			continue
 		}
-		reindexObject(s, sourceFiles, obj.Named(), withNS(obj))
+		if updated := cloneWithNamespace(obj, manifest.DefaultNamespace); updated != nil {
+			reindexObject(s, sourceFiles, obj.Named(), updated)
+		}
 	}
 }
 

--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -22,6 +22,11 @@ type providerInputs struct {
 	inputs []map[string]any // each set already carries its `provider` block
 }
 
+// isPermute reports whether rs selects the Permute input strategy.
+func isPermute(rs *manifest.ResourceSet) bool {
+	return rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute
+}
+
 // buildInputSets gathers per-provider input lists then dispatches on
 // spec.inputStrategy. The ResourceSet's own inline spec.inputs are
 // treated as "provider 0", followed by each referenced
@@ -48,7 +53,7 @@ func buildInputSets(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[s
 		return nil, err
 	}
 
-	if rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
+	if isPermute(rs) {
 		return permute(groups, rs.InputStrategy.IncludeEmptyProviders)
 	}
 	// Default: Flatten — pre-size out to total input count across all

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -72,7 +72,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 	// falling through to renderResources' "no matrix → render once
 	// with nil" fallback, which only applies under Flatten where an
 	// empty matrix legitimately means "static resources, no inputs".
-	if len(inputs) == 0 && rs.InputStrategy != nil && rs.InputStrategy.Name == fluxopv1.InputStrategyPermute {
+	if len(inputs) == 0 && isPermute(rs) {
 		return nil, nil
 	}
 

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -72,7 +72,7 @@ const (
 
 // pathSep is the platform separator as a string, used by join so it can
 // stay allocation-free for the separator itself.
-var pathSep = string(filepath.Separator)
+const pathSep = string(filepath.Separator)
 
 // join appends segs to a clean base separated by pathSep, without a
 // filepath.Clean pass. New guarantees Root is clean; all callers pass

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -108,16 +108,16 @@ func httpChartArtifact(chartURL, dir, version, digest string) *store.SourceArtif
 // N concurrent chart fetches against the same repo coalesce on indexLocks so
 // exactly one HTTP fetch runs.
 func (f *Fetcher) fetchIndex(ctx context.Context, cacheKey, indexURL string, opts []getter.Option) (*repo.IndexFile, error) {
-	if v, ok := f.indexCache.Load(cacheKey); ok {
-		return v.(*repo.IndexFile), nil
+	if idx, ok := f.cachedIndex(cacheKey); ok {
+		return idx, nil
 	}
 	release, err := f.indexLocks.Acquire(ctx, cacheKey)
 	if err != nil {
 		return nil, err
 	}
 	defer release()
-	if v, ok := f.indexCache.Load(cacheKey); ok {
-		return v.(*repo.IndexFile), nil
+	if idx, ok := f.cachedIndex(cacheKey); ok {
+		return idx, nil
 	}
 	g, err := getter.NewHTTPGetter()
 	if err != nil {
@@ -146,6 +146,15 @@ func (f *Fetcher) fetchIndex(ctx context.Context, cacheKey, indexURL string, opt
 	}
 	f.indexCache.Store(cacheKey, idx)
 	return idx, nil
+}
+
+// cachedIndex returns the memoized index.yaml for cacheKey, if present.
+func (f *Fetcher) cachedIndex(cacheKey string) (*repo.IndexFile, bool) {
+	v, ok := f.indexCache.Load(cacheKey)
+	if !ok {
+		return nil, false
+	}
+	return v.(*repo.IndexFile), true
 }
 
 func chartDownloadKey(r *manifest.HelmRepository, chartName string, cv *repo.ChartVersion, chartURL, digest string) string {

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -114,15 +114,11 @@ func (s *Store) SetArtifact(id manifest.NamedResource, artifact Artifact) {
 	sh := s.shardFor(id)
 	sh.mu.Lock()
 	prev, exists := sh.artifacts[id]
-	// Trivial fast path: the same pointer is being re-set. Identical
-	// content by construction; skip reflection entirely. This is the
-	// hot path when a fetcher caches its own SourceArtifact and
-	// re-publishes it on every refresh tick.
-	if exists && prev == artifact {
-		sh.mu.Unlock()
-		return
-	}
-	if exists && reflect.DeepEqual(prev, artifact) {
+	// Dedup cheapest-first: pointer identity (the hot path when a
+	// fetcher caches its own SourceArtifact and re-publishes the same
+	// pointer every refresh tick, skipping reflection entirely) before
+	// the reflect.DeepEqual fallback for distinct-pointer equal content.
+	if exists && (prev == artifact || reflect.DeepEqual(prev, artifact)) {
 		sh.mu.Unlock()
 		return
 	}


### PR DESCRIPTION
Ninth autonomous code-cleanliness sweep — 10 packages, each verified behavior- and API-preserving. The codebase is now exemplary: most of the 45 packages produce no patch, and remaining changes are micro-polish.

## What changed
- **De-duplicate:** `tryRef` (baseline — resolveRef+mergeBase rungs); `fireOnAdd` (change — 2 OnAdd dispatch sites); `configMapBinaryData` (diff); `applyDefaultNS` reuses the canonical `cloneWithNamespace`, dropping three per-type copy closures (loader); `isPermute` (resourceset); `cachedIndex` (helmchart); `gutter` const (format).
- **Dead code:** discovery drops the write-only `repoRoot` field.
- **Idioms:** cacheroot `pathSep` `var`→`const`; store folds the two artifact-dedup branches into one; change flattens `shouldSkipDir`.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- `cloneWithNamespace` confirmed to return the identical non-nil shallow copy for all three kinds it now serves; `repoRoot` confirmed never read.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set, binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)