### PR TITLE
refactor: tenth behavior-preserving cleanliness pass

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -141,15 +141,13 @@ type Config struct {
 
 // Orchestrator wires controllers and drives reconciliation.
 type Orchestrator struct {
-	cfg       Config
-	store     *store.Store
-	tasks     *task.Service
-	src       *sourcectrl.Controller
-	ksc       *kustomization.Controller
-	hrc       *helmrelease.Controller
-	helm      *helm.Client
-	treeCache *kustomize.TreeCache
-	filter    *change.Filter
+	cfg    Config
+	store  *store.Store
+	tasks  *task.Service
+	src    *sourcectrl.Controller
+	ksc    *kustomization.Controller
+	hrc    *helmrelease.Controller
+	filter *change.Filter
 
 	// gitFetcher holds the typed *git.Fetcher constructed in New so
 	// Run can drive Prewarm against every discovered GitRepository in
@@ -410,8 +408,6 @@ func New(cfg Config) (*Orchestrator, error) {
 		ksc:            kustomization.New(st, ts, treeCache, cfg.WipeSecrets),
 		hrc:            helmrelease.New(st, ts, helmClient, cfg.HelmOptions, cfg.WipeSecrets),
 		rendered:       newRenderedSet(),
-		helm:           helmClient,
-		treeCache:      treeCache,
 		componentCache: manifest.NewComponentCache(),
 		depGraph:       newDependencyGraph(),
 		gitFetcher:     gitFetcher,

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -53,7 +53,7 @@ func (f *Fetcher) fetchHTTPChart(ctx context.Context, r *manifest.HelmRepository
 	if art, ok := f.chartArtifactByDigest(chartURL, cv.Version, wantDigest); ok {
 		return art, nil
 	}
-	release, err := f.downloadLocks.Acquire(ctx, chartDownloadKey(r, chartName, cv, chartURL, wantDigest))
+	release, err := f.downloadLocks.Acquire(ctx, chartDownloadKey(r, chartName, cv.Version, chartURL, wantDigest))
 	if err != nil {
 		return nil, err
 	}
@@ -157,11 +157,11 @@ func (f *Fetcher) cachedIndex(cacheKey string) (*repo.IndexFile, bool) {
 	return v.(*repo.IndexFile), true
 }
 
-func chartDownloadKey(r *manifest.HelmRepository, chartName string, cv *repo.ChartVersion, chartURL, digest string) string {
+func chartDownloadKey(r *manifest.HelmRepository, chartName, version, chartURL, digest string) string {
 	if digest != "" {
 		return "sha256:" + digest
 	}
-	return safeName(r.Namespace+"-"+r.Name+"-"+chartName) + "-" + cv.Version + "@" + chartURL
+	return safeName(r.Namespace+"-"+r.Name+"-"+chartName) + "-" + version + "@" + chartURL
 }
 
 func normalizeChartDigest(digest string) string {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -367,17 +367,15 @@ func TestE2E_BootstrapErrorSurfacesNotMasked(t *testing.T) {
 	// returns it; Render nils the Result; the CLI must surface the
 	// underlying error rather than running the testrunner on partial
 	// state.
-	if err := os.WriteFile(filepath.Join(dir, "ks.yaml"), []byte(`---
+	testutil.WriteFile(t, dir, "ks.yaml", `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata: {name: apps, namespace: flux-system}
 spec:
   path: ./apps
   sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "rs.yaml"), []byte(`---
+`)
+	testutil.WriteFile(t, dir, "rs.yaml", `---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
 metadata: {name: broken-rs, namespace: flux-system}
@@ -386,9 +384,7 @@ spec:
     apiVersion: v1
     kind: ConfigMap
     metadata: {name: << nope >>, namespace: ns}
-`), 0o600); err != nil {
-		t.Fatal(err)
-	}
+`)
 
 	out, code := runCLIExpectErr(t, "test", "all", "--path", dir)
 	if code == 0 {


### PR DESCRIPTION
Tenth autonomous code-cleanliness sweep — the inflection point. A full 45-package sweep yielded only 3 genuine cleanups; the other agent suggestions were rejected as taste-level churn (deleting accurate doc-rationale, an unverifiable doc-comment rewrite).

## What changed (3 genuine, behavior- and API-preserving)
- **orchestrator** — drop the dead `helm`/`treeCache` struct fields (assigned in `New`, never read).
- **helmchart** — narrow `chartDownloadKey`'s param from `*repo.ChartVersion` to the `version string` it actually uses.
- **test/e2e** — reuse `testutil.WriteFile` for two inline `os.WriteFile`+`t.Fatal` blocks.

## Rejected (kept the bar high)
- pkg/diff — a doc rewrite asserting the zero-`Format` routing resolves to `FormatHuman`; the three existing comments contradict each other and I couldn't verify the new claim without tracing `RenderDocs`/`renderNative`, so I declined to merge an unverified behavioral doc.
- pkg/discovery, pkg/store — deletions of accurate design-rationale / cheapest-first-dedup comments; loss of genuine "why," not cleanup.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- `helm`/`treeCache` confirmed to have zero reads across the package.
- **Cross-repo byte-equivalence** across 14 production clusters: 8 byte-identical PASS; the 6 DIFFs are the documented known-flaky set, binary-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)