### PR TITLE
refactor: eleventh behavior-preserving cleanliness pass

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -128,7 +128,7 @@ func repoRemoteURLs(repo *git.Repository) []string {
 func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.Layout) (string, bool, error) {
 	if layout.Root != "" {
 		slot := layout.Baseline(hash.String())
-		if info, err := os.Stat(slot); err == nil && info.IsDir() {
+		if isDir(slot) {
 			return slot, true, nil
 		}
 		if err := os.MkdirAll(filepath.Dir(slot), 0o750); err != nil {
@@ -141,7 +141,7 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		// see ErrExist, discard the temp, and adopt the winner's slot).
 		if _, err := cas.Stage(filepath.Dir(slot), slot, "baseline staging", "baseline finalize",
 			func(staging string) error { return materialize(repo, hash, staging) },
-			func() bool { info, statErr := os.Stat(slot); return statErr == nil && info.IsDir() },
+			func() bool { return isDir(slot) },
 		); err != nil {
 			return "", false, err
 		}
@@ -412,6 +412,14 @@ func isShallow(repo *git.Repository) bool {
 	}
 	_, err = os.Stat(filepath.Join(wt.Filesystem.Root(), ".git", "shallow"))
 	return err == nil
+}
+
+// isDir reports whether path exists and is a directory. Used to detect
+// a finished baseline cache slot, both before staging and as the adopt
+// predicate after losing the finalize race.
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 // shortRev formats a hash as the conventional 7-char prefix used in

--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -67,34 +67,44 @@ func buildOwnership(objs ObjectLister, repoRoot string, cache *manifest.Componen
 	}
 }
 
+// memoize returns cache[file], computing and storing it via compute on
+// a miss. The empty-file short-circuit is shared by both lookups: an
+// empty path has no owner or ancestor.
+func memoize(cache map[string][]manifest.NamedResource, file string, compute func() []manifest.NamedResource) []manifest.NamedResource {
+	if file == "" {
+		return nil
+	}
+	if cached, ok := cache[file]; ok {
+		return cached
+	}
+	result := compute()
+	cache[file] = result
+	return result
+}
+
 // ownersOf returns every KS that claims the longest-matching prefix
 // of file. Multiple KSes are possible when a shared component is in
 // play. Results are memoized — see ownershipIndex doc.
 func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
-	if file == "" {
-		return nil
-	}
-	if cached, ok := idx.ownersCache[file]; ok {
-		return cached
-	}
-	prefixed := file + "/" // so prefix matching catches whole-segment boundaries
-	var bestLen int
-	var owners []manifest.NamedResource
-	for _, c := range idx.claims {
-		if len(c.path) < bestLen {
-			break // sorted longest-first; nothing shorter can beat
+	return memoize(idx.ownersCache, file, func() []manifest.NamedResource {
+		prefixed := file + "/" // so prefix matching catches whole-segment boundaries
+		var bestLen int
+		var owners []manifest.NamedResource
+		for _, c := range idx.claims {
+			if len(c.path) < bestLen {
+				break // sorted longest-first; nothing shorter can beat
+			}
+			if !strings.HasPrefix(prefixed, c.path) {
+				continue
+			}
+			if len(c.path) > bestLen {
+				bestLen = len(c.path)
+				owners = owners[:0]
+			}
+			owners = append(owners, c.id)
 		}
-		if !strings.HasPrefix(prefixed, c.path) {
-			continue
-		}
-		if len(c.path) > bestLen {
-			bestLen = len(c.path)
-			owners = owners[:0]
-		}
-		owners = append(owners, c.id)
-	}
-	idx.ownersCache[file] = owners
-	return owners
+		return owners
+	})
 }
 
 // ancestorsOf returns every Kustomization whose claim is a strict
@@ -106,27 +116,22 @@ func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
 // failures when the leaf renders. See #58. Results are memoized —
 // see ownershipIndex doc.
 func (idx ownershipIndex) ancestorsOf(file string) []manifest.NamedResource {
-	if file == "" {
-		return nil
-	}
-	if cached, ok := idx.ancestorsCache[file]; ok {
-		return cached
-	}
-	prefixed := file + "/"
-	var bestLen int
-	var ancestors []manifest.NamedResource
-	for _, c := range idx.claims {
-		if !strings.HasPrefix(prefixed, c.path) {
-			continue
+	return memoize(idx.ancestorsCache, file, func() []manifest.NamedResource {
+		prefixed := file + "/"
+		var bestLen int
+		var ancestors []manifest.NamedResource
+		for _, c := range idx.claims {
+			if !strings.HasPrefix(prefixed, c.path) {
+				continue
+			}
+			if bestLen == 0 {
+				bestLen = len(c.path) // first (longest) match — skip
+				continue
+			}
+			if len(c.path) < bestLen {
+				ancestors = append(ancestors, c.id)
+			}
 		}
-		if bestLen == 0 {
-			bestLen = len(c.path) // first (longest) match — skip
-			continue
-		}
-		if len(c.path) < bestLen {
-			ancestors = append(ancestors, c.id)
-		}
-	}
-	idx.ancestorsCache[file] = ancestors
-	return ancestors
+		return ancestors
+	})
 }

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -86,7 +86,7 @@ type Controller struct {
 	unsub   []store.Unsubscribe
 
 	// kindLabel prefixes coalescer keys ("source/", "kustomization/",
-	// "helmrelease/") and labels panic logs. Set by Start.
+	// "helmrelease/"). Set by StartLifecycle.
 	kindLabel string
 
 	// Shared KS/HR depwait and preflight state. Set via SetDepwait,

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -82,16 +82,9 @@ func KSPathPrefixesWithCache(s *store.Store, repoRoot string, cache *manifest.Co
 // return reports whether a parent was found. prefixes is expected to
 // be the sorted output of KSPathPrefixesWithCache.
 func LongestParent(prefixes []KSPathPrefix, file string, self manifest.NamedResource) (manifest.NamedResource, bool) {
-	slashFile := filepath.ToSlash(file)
-	for _, p := range prefixes {
-		if p.ID == self {
-			continue
-		}
-		if strings.HasPrefix(slashFile, p.Prefix) {
-			return p.ID, true
-		}
-	}
-	return manifest.NamedResource{}, false
+	// A nil selfPrefixes set skips no candidate as a peer, which is exactly
+	// "deepest ancestor excluding self" — see longestStrictParent.
+	return longestStrictParent(prefixes, file, self, nil)
 }
 
 // longestStrictParent is LongestParent restricted to a *strict*

--- a/pkg/resourceset/render.go
+++ b/pkg/resourceset/render.go
@@ -78,16 +78,18 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 
 	seen := make(map[string]struct{})
 	var docs []map[string]any
-	appendUnique := func(doc map[string]any) {
-		key := DedupKey(doc)
-		if key == "" {
-			return
+	appendUnique := func(rendered []map[string]any) {
+		for _, doc := range rendered {
+			key := DedupKey(doc)
+			if key == "" {
+				continue
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			docs = append(docs, doc)
 		}
-		if _, dup := seen[key]; dup {
-			return
-		}
-		seen[key] = struct{}{}
-		docs = append(docs, doc)
 	}
 
 	for i, raw := range rs.Resources {
@@ -95,9 +97,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 		if err != nil {
 			return nil, fmt.Errorf("ResourceSet %s: spec.resources[%d]: %w", rs.Named().NamespacedName(), i, err)
 		}
-		for _, doc := range rendered {
-			appendUnique(doc)
-		}
+		appendUnique(rendered)
 	}
 
 	if rs.ResourcesTemplate != "" {
@@ -105,9 +105,7 @@ func Render(rs *manifest.ResourceSet, resolve ProviderResolver) ([]map[string]an
 		if err != nil {
 			return nil, fmt.Errorf("ResourceSet %s: spec.resourcesTemplate: %w", rs.Named().NamespacedName(), err)
 		}
-		for _, doc := range rendered {
-			appendUnique(doc)
-		}
+		appendUnique(rendered)
 	}
 
 	for _, doc := range docs {

--- a/pkg/source/git/checkout.go
+++ b/pkg/source/git/checkout.go
@@ -28,28 +28,40 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef, sparse []s
 		set(opts)
 		return wt.Checkout(opts)
 	}
+	checkoutHash := func(h plumbing.Hash) error {
+		return checkout(func(o *git.CheckoutOptions) { o.Hash = h })
+	}
+	// tryCheckoutRevision resolves rev and, on success, checks out the
+	// resolved hash. The bool reports whether rev resolved so callers can
+	// fall through to an alternate lookup when it didn't.
+	tryCheckoutRevision := func(rev plumbing.Revision) (bool, error) {
+		h, err := repo.ResolveRevision(rev)
+		if err != nil {
+			return false, nil
+		}
+		return true, checkoutHash(*h)
+	}
 	switch {
 	case ref.Commit != "":
 		hash := plumbing.NewHash(ref.Commit)
 		if err := validateCommitBranch(repo, hash, ref.Branch); err != nil {
 			return err
 		}
-		return checkout(func(o *git.CheckoutOptions) { o.Hash = hash })
+		return checkoutHash(hash)
 	case ref.Name != "":
 		// Full ref name takes precedence (e.g. "refs/pull/420/head",
 		// "refs/tags/v1.2.3"). Resolve against the cloned repo so the
 		// explicitly fetched ref wins; branch refs may still exist only
 		// under refs/remotes/origin from the default clone refspec.
-		rev := plumbing.Revision(ref.Name)
-		if h, err := repo.ResolveRevision(rev); err == nil {
-			return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
+		if done, err := tryCheckoutRevision(plumbing.Revision(ref.Name)); done {
+			return err
 		}
 		// Fall through: try resolving as a remote-tracking ref. This
 		// handles refs/heads/<branch> by mapping to refs/remotes/origin/<branch>.
 		if rest, ok := strings.CutPrefix(ref.Name, "refs/heads/"); ok {
 			remote := plumbing.NewRemoteReferenceName("origin", rest)
-			if h, err := repo.ResolveRevision(plumbing.Revision(remote)); err == nil {
-				return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
+			if done, err := tryCheckoutRevision(plumbing.Revision(remote)); done {
+				return err
 			}
 		}
 		return fmt.Errorf("%w: unable to resolve git ref %q", manifest.ErrInput, ref.Name)
@@ -58,16 +70,16 @@ func checkoutRef(repo *git.Repository, ref manifest.GitRepositoryRef, sparse []s
 		if err != nil {
 			return err
 		}
-		return checkout(func(o *git.CheckoutOptions) { o.Hash = h })
+		return checkoutHash(h)
 	case ref.Tag != "":
-		if h, err := repo.ResolveRevision(plumbing.Revision("refs/tags/" + ref.Tag)); err == nil {
-			return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
+		if done, err := tryCheckoutRevision(plumbing.Revision("refs/tags/" + ref.Tag)); done {
+			return err
 		}
 		return checkout(func(o *git.CheckoutOptions) { o.Branch = plumbing.NewTagReferenceName(ref.Tag) })
 	case ref.Branch != "":
 		remoteRef := plumbing.NewRemoteReferenceName("origin", ref.Branch)
-		if h, err := repo.ResolveRevision(plumbing.Revision(remoteRef)); err == nil {
-			return checkout(func(o *git.CheckoutOptions) { o.Hash = *h })
+		if done, err := tryCheckoutRevision(plumbing.Revision(remoteRef)); done {
+			return err
 		}
 		return checkout(func(o *git.CheckoutOptions) { o.Branch = plumbing.NewBranchReferenceName(ref.Branch) })
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -302,9 +302,8 @@ func (sh *shard) deleteLocked(id manifest.NamedResource) bool {
 	delete(sh.objects, id)
 	delete(sh.conditions, id)
 	delete(sh.artifacts, id)
-	if inner := sh.byName[id.Kind]; inner != nil {
-		delete(inner, nameKey(id.Namespace, id.Name))
-	}
+	// delete is a no-op on a nil map, so byName[id.Kind] needs no guard.
+	delete(sh.byName[id.Kind], nameKey(id.Namespace, id.Name))
 	return true
 }
 
@@ -468,10 +467,8 @@ func (s *Store) GetByName(kind, namespace, name string) manifest.BaseManifest {
 	sh := s.shardForKind(kind)
 	sh.mu.RLock()
 	defer sh.mu.RUnlock()
-	if inner := sh.byName[kind]; inner != nil {
-		return inner[nameKey(namespace, name)]
-	}
-	return nil
+	// Indexing a nil map (unseen kind) yields nil — no guard needed.
+	return sh.byName[kind][nameKey(namespace, name)]
 }
 
 // ListObjects returns every stored manifest, optionally filtered by kind,


### PR DESCRIPTION
Eleventh autonomous code-cleanliness sweep — 7 genuine de-duplications across 7 packages (two agent suggestions rejected as churn).

## What changed
- **change** — extract `memoize()` collapsing the identical empty-check + cache-lookup + store in `ownersOf`/`ancestorsOf`.
- **source/git** — extract `checkoutHash` + `tryCheckoutRevision`, folding the repeated `ResolveRevision`-then-checkout fall-through cases.
- **loader** — `LongestParent` delegates to `longestStrictParent(..., nil)` (a nil self-prefix set skips no peer — byte-identical).
- **baseline** `isDir` helper · **resourceset** `appendUnique` takes a batch · **store** drops unnecessary nil-map guards (`delete`/index are nil-safe in Go) · **base** doc fix.

## Rejected (kept the bar high)
- internal/cli — collapsing `if err != nil { return Join(err, scoped) } return scoped` into `return Join(err, scoped)` wraps the clean success path in a `*joinError`, changing the returned error's structure (same pattern I declined in pass-10's finalize).
- pkg/discovery — re-proposed deletion of accurate design-rationale from the package doc.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- `longestStrictParent(..., nil)` proven identical to the old `LongestParent`; `tryCheckoutRevision` fall-through proven equivalent.
- **Cross-repo byte-equivalence** across 14 clusters: 8 byte-identical PASS; 5 of 6 DIFFs match the known-flaky baseline exactly. m00nwtchr's DIFF was larger this run, but a **base-vs-base run reproduced 546 lines of whole-resource variance** (its infisical/kuma charts render a non-deterministic resource set) — binary-independent, pass-11 exonerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)