### PR TITLE
refactor: twelfth behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"cmp"
-	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -82,10 +81,10 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 			// Per-resource Run failures: emit whatever we rendered, then
 			// flip the exit code so CI pipelines piping `flate build` into
 			// kubectl apply don't silently apply a half-rendered tree.
-			// errors.Join surfaces both an emit-time IO failure AND the
+			// emitResult surfaces both an emit-time IO failure AND the
 			// partial-failure list — previously the emit error masked
 			// the run failures, so CI fixed the wrong thing.
-			return errors.Join(emitErr, scopedRunError(o, res, c, runErr))
+			return emitResult(emitErr, o, res, c, runErr)
 		},
 	}
 	bindCommon(cmd.Flags(), c, format.OutputYAML, format.OutputJSON)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -575,6 +575,14 @@ func scopedRunError(o *orchestrator.Orchestrator, res *orchestrator.Result, c *c
 	return errors.Join(aggregateScopedFailures(failed), errors.Join(extras...))
 }
 
+// emitResult joins an emit-time error with the scoped run error so a
+// partial render still surfaces both the IO/format failure and any
+// per-resource reconcile failures. A nil emitErr collapses to just the run
+// error (and both nil to nil) via errors.Join's nil handling.
+func emitResult(emitErr error, o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags, runErr error) error {
+	return errors.Join(emitErr, scopedRunError(o, res, c, runErr))
+}
+
 // resourceAggregatePrefix is the leading text of the error
 // aggregateScopedFailures produces. nonResourceRunErrors uses it to tell
 // the per-resource failure aggregate apart from incidental run errors, so

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"cmp"
-	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -125,10 +124,7 @@ func newGetAllCmd() *cobra.Command {
 			if o == nil {
 				return runErr
 			}
-			if err := printCluster(cmd.OutOrStdout(), o, c, c.output); err != nil {
-				return errors.Join(err, scopedRunError(o, res, c, runErr))
-			}
-			return scopedRunError(o, res, c, runErr)
+			return emitResult(printCluster(cmd.OutOrStdout(), o, c, c.output), o, res, c, runErr)
 		},
 	}
 	bindCommon(cmd.Flags(), c, format.OutputYAML, format.OutputJSON)
@@ -155,10 +151,7 @@ func newGetImagesCmd() *cobra.Command {
 				return runErr
 			}
 			imgs := slices.Sorted(maps.Keys(collectImages(o, res, c)))
-			if err := emitImageList(cmd.OutOrStdout(), imgs, c.output); err != nil {
-				return errors.Join(err, scopedRunError(o, res, c, runErr))
-			}
-			return scopedRunError(o, res, c, runErr)
+			return emitResult(emitImageList(cmd.OutOrStdout(), imgs, c.output), o, res, c, runErr)
 		},
 	}
 	bindCommon(cmd.Flags(), c, format.OutputName, format.OutputYAML, format.OutputJSON)
@@ -191,10 +184,7 @@ func resourceListCmd[T manifest.BaseManifest](
 				Name:   firstArg(args),
 				Labels: l.labels,
 			}
-			if err := printResources(cmd.OutOrStdout(), o, sel, c, c.output, kind, cols, mapper); err != nil {
-				return errors.Join(err, scopedRunError(o, res, c, runErr))
-			}
-			return scopedRunError(o, res, c, runErr)
+			return emitResult(printResources(cmd.OutOrStdout(), o, sel, c, c.output, kind, cols, mapper), o, res, c, runErr)
 		},
 	}
 	bindCommon(cmd.Flags(), c, format.OutputTable, format.OutputYAML, format.OutputJSON, format.OutputName)

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -166,32 +166,24 @@ func (c *Controller) onRawProducerAdded() store.Listener {
 // coverage to a new kind means adding a case here (see the rawProducerIndex
 // field comment).
 func rawProducerTargetID(raw *manifest.RawObject) (manifest.NamedResource, bool) {
+	secretID := func(name string) manifest.NamedResource {
+		if name == "" {
+			name = raw.Name
+		}
+		return manifest.NamedResource{Kind: manifest.KindSecret, Namespace: raw.Namespace, Name: name}
+	}
 	switch raw.Kind {
 	case "ExternalSecret":
 		target, _ := raw.Spec["target"].(map[string]any)
-		targetName, _ := target["name"].(string)
-		if targetName == "" {
-			targetName = raw.Name
-		}
-		return manifest.NamedResource{
-			Kind:      manifest.KindSecret,
-			Namespace: raw.Namespace,
-			Name:      targetName,
-		}, true
+		name, _ := target["name"].(string)
+		return secretID(name), true
 	case "SealedSecret":
-		targetName := raw.Name
-		if tmpl, _ := raw.Spec["template"].(map[string]any); tmpl != nil {
-			if metadata, _ := tmpl["metadata"].(map[string]any); metadata != nil {
-				if name, _ := metadata["name"].(string); name != "" {
-					targetName = name
-				}
-			}
-		}
-		return manifest.NamedResource{
-			Kind:      manifest.KindSecret,
-			Namespace: raw.Namespace,
-			Name:      targetName,
-		}, true
+		// Indexing a nil map yields the zero value, so the failed
+		// intermediate asserts flow through without explicit nil checks.
+		tmpl, _ := raw.Spec["template"].(map[string]any)
+		metadata, _ := tmpl["metadata"].(map[string]any)
+		name, _ := metadata["name"].(string)
+		return secretID(name), true
 	default:
 		return manifest.NamedResource{}, false
 	}

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -207,14 +207,10 @@ func (w *Waiter) Watch(ctx context.Context, deps []manifest.DependencyRef) <-cha
 	var wg sync.WaitGroup
 	for _, dep := range deps {
 		wg.Go(func() {
-			// Recover from panics in watchOne (e.g. malformed CEL expression
-			// evaluating against an unexpected payload type) so the whole
-			// run isn't killed. The dep is reported failed instead.
-			//
-			// Send unconditionally — `out` is buffered to len(deps) so
-			// the send never blocks. The previous select-on-ctx silently
-			// dropped events on cancellation, leaving the consumer with
-			// a Pending dep that would time out at the full budget.
+			// Send unconditionally — `out` is buffered to len(deps) so the
+			// send never blocks, and a select-on-ctx here would silently
+			// drop the event on cancellation, leaving the consumer with a
+			// dep that times out at the full budget.
 			out <- w.safeWatchOne(ctx, dep, timeout)
 		})
 	}

--- a/pkg/discovery/orphans.go
+++ b/pkg/discovery/orphans.go
@@ -39,8 +39,7 @@ func (d *discoverer) promoteOrphans(prefixes []loader.KSPathPrefix) {
 		if d.cfg.Store.GetObject(id) != nil {
 			continue
 		}
-		file, hasFile := d.sourceFiles[id]
-		if hasFile {
+		if file, ok := d.sourceFiles[id]; ok {
 			if _, covered := loader.LongestParent(prefixes, file, id); covered {
 				continue
 			}

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -137,7 +137,7 @@ func longestStrictParent(prefixes []KSPathPrefix, file string, self manifest.Nam
 //
 // childKind=KindKustomization for the KS→KS parent map; pass
 // KindHelmRelease for the HR→KS map. The orchestrator builds both
-// (see discovery.Run → mergeParents).
+// and merges them (see discovery.Run).
 //
 // repoRoot is the filesystem root used to read each KS's
 // kustomization.yaml when folding `components:` into the prefix set;

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -6,7 +6,7 @@
 //	remotebase.go — FetchRemoteBase: anonymous kustomize remote git base
 //	auth.go       — SecretRef → transport.AuthMethod resolution
 //	tls.go        — spec.secretRef.ca.crt → *tls.Config
-//	ssh.go        — SSH URL / user extraction
+//	ssh.go        — SSH host-key callbacks (known_hosts / insecure)
 //	checkout.go   — checkoutRef + updateSubmodules
 //	resolve.go    — ref → commit hash (mirror path)
 //	marker.go     — slot revision sidecar (.flate-meta.json) + worktree HEAD lookup

--- a/pkg/source/oci/fetch.go
+++ b/pkg/source/oci/fetch.go
@@ -75,7 +75,8 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	if repo.Reference != nil {
 		ref = *repo.Reference
 	}
-	resolveSlot, resolvedDigest, err := cachedOCIResolve(ctx, cache, repo, ref, authIdentity(repo))
+	authID := authIdentity(repo)
+	resolveSlot, resolvedDigest, err := cachedOCIResolve(ctx, cache, repo, ref, authID)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +109,7 @@ func fetch(ctx context.Context, f *Fetcher, repo *manifest.OCIRepository, regist
 	if resolvedDigest == "" {
 		slotRef = source.MutableCacheKey(slotRef)
 	}
-	slot, err := cache.Slot(ctx, repo.URL, slotRef, authIdentity(repo))
+	slot, err := cache.Slot(ctx, repo.URL, slotRef, authID)
 	if err != nil {
 		return nil, fmt.Errorf("cache slot for %s: %w", versioned, err)
 	}

--- a/pkg/source/sourceignore/matcher.go
+++ b/pkg/source/sourceignore/matcher.go
@@ -39,7 +39,7 @@ func New(root string, extra *string, withDefaults bool) (*Matcher, error) {
 	if err != nil {
 		return nil, fmt.Errorf("sourceignore abs: %w", err)
 	}
-	domain := strings.Split(abs, string(filepath.Separator))
+	domain := splitPath(abs)
 
 	patterns, err := flux.LoadIgnorePatterns(abs, domain)
 	if err != nil {
@@ -58,6 +58,11 @@ func New(root string, extra *string, withDefaults bool) (*Matcher, error) {
 // Match reports whether rel (a path relative to the matcher's root, using the
 // OS separator) is excluded. isDir distinguishes directory-only patterns.
 func (m *Matcher) Match(rel string, isDir bool) bool {
-	segments := slices.Concat(m.domain, strings.Split(rel, string(filepath.Separator)))
+	segments := slices.Concat(m.domain, splitPath(rel))
 	return m.matcher.Match(segments, isDir)
+}
+
+// splitPath breaks p into its components using the OS path separator.
+func splitPath(p string) []string {
+	return strings.Split(p, string(filepath.Separator))
 }

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -13,7 +13,7 @@ type EventKind int
 
 const (
 	// EventObjectAdded fires when a new manifest is added (or when a
-	// listener is registered with Flush=true, to replay existing state).
+	// listener is registered with flush=true, to replay existing state).
 	EventObjectAdded EventKind = iota + 1
 	// EventStatusUpdated fires when status transitions.
 	EventStatusUpdated


### PR DESCRIPTION
Twelfth autonomous code-cleanliness sweep — 9 cleanups across 9 packages (two rejected as churn).

## What changed
- **De-duplicate:** `cli emitResult` unifies the four emit-then-scope paths onto `build.go`'s already-shipping `errors.Join` convention; `helmrelease secretID` closure (ExternalSecret + SealedSecret, nil-safe template lookup); `oci` hoists a doubly-called `authIdentity`; `sourceignore splitPath`; `discovery` scopes its map read into the `if`.
- **Doc accuracy:** depwait send-comment; loader/git/store stale references.

## Notes
- `cli emitResult`: I'm reversing my pass-11 rejection of this pattern. `build.go` already ships unconditional `errors.Join(emitErr, scoped)`, so it's the established/tested convention; `emitResult` unifies all four paths to it. cobra consumes a `RunE` error by `.Error()` string + nil-ness (exit code), and `errors.Is` unwraps through a single-error `*joinError` — observably identical. The e2e tests gate it.

## Rejected
- pkg/kustomize `newKustomization()` — a TypeMeta-only 2-site extraction a pass-11 agent already explicitly declined as marginal.
- pkg/manifest — the recurring constants.go trailing-blank trim.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- **Cross-repo byte-equivalence** across 14 clusters: 8 byte-identical PASS; the 6 DIFFs match the known-flaky baseline exactly (binary-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)