### PR TITLE
refactor: thirteenth behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"cmp"
-	"fmt"
 	"io"
 	"slices"
 
@@ -151,7 +150,7 @@ func collectRendered(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 	// should error rather than silently emit an empty render — a typo
 	// shouldn't look like a successful build of a nonexistent resource.
 	if name != "" && matched == 0 {
-		return nil, fmt.Errorf("no %s named %q in --path", kind, name)
+		return nil, noNamedError(kind, name)
 	}
 	return out, nil
 }

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"cmp"
-	"fmt"
 	"io"
 	"maps"
 	"slices"
@@ -228,7 +227,7 @@ func printResources[T manifest.BaseManifest](
 		pairs = append(pairs, pair{row, doc})
 	}
 	if !nameExists {
-		return fmt.Errorf("no %s named %q in --path", kind, sel.Name)
+		return noNamedError(kind, sel.Name)
 	}
 	// Sort the (row, doc) tuples by (namespace, name) so every output
 	// flavor — table/yaml/json — is deterministic across runs. (The rows

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,9 +1,18 @@
 package cli
 
+import "fmt"
+
 // firstArg returns the first positional arg, or "" when none was given.
 func firstArg(args []string) string {
 	if len(args) == 0 {
 		return ""
 	}
 	return args[0]
+}
+
+// noNamedError is the error build/get/test return when an explicit name
+// positional matches nothing of the given kind in --path. Single-sourced
+// so the three commands can't drift on the message.
+func noNamedError(kind, name string) error {
+	return fmt.Errorf("no %s named %q in --path", kind, name)
 }

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/spf13/cobra"
 
@@ -73,7 +72,7 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 			})
 			runErr = scopedRunError(o, res, c, runErr)
 			if name != "" && report.Matched == 0 {
-				return errors.Join(fmt.Errorf("no %s named %q in --path", testKindName(kinds), name), runErr)
+				return errors.Join(noNamedError(testKindName(kinds), name), runErr)
 			}
 			if err := report.Write(cmd.OutOrStdout()); err != nil {
 				return errors.Join(err, runErr)

--- a/pkg/source/blob/refs.go
+++ b/pkg/source/blob/refs.go
@@ -102,8 +102,7 @@ func (r *Refs) Put(key, digest string) error {
 	if err != nil {
 		return err
 	}
-	unlockGC := rLockGC()
-	defer unlockGC()
+	defer rLockGC()()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if err := atomic.WriteFile(final, []byte(digest), 0o600, false); err != nil {

--- a/pkg/source/blob/store.go
+++ b/pkg/source/blob/store.go
@@ -78,8 +78,7 @@ func (s *Store) PutBytes(ctx context.Context, content []byte, filename string) (
 	dir := s.Path(digest)
 	parent := filepath.Dir(dir)
 
-	unlockGC := rLockGC()
-	defer unlockGC()
+	defer rLockGC()()
 
 	release, err := s.locks.Acquire(ctx, digest)
 	if err != nil {

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -1,6 +1,7 @@
 package helmchart
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
@@ -62,11 +63,7 @@ func (f *Fetcher) fetchHTTPChart(ctx context.Context, r *manifest.HelmRepository
 		return art, nil
 	}
 
-	g, err := getter.NewHTTPGetter()
-	if err != nil {
-		return nil, err
-	}
-	buf, err := g.Get(chartURL, allOpts...)
+	buf, err := httpGet(chartURL, allOpts)
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", chartURL, err)
 	}
@@ -119,11 +116,7 @@ func (f *Fetcher) fetchIndex(ctx context.Context, cacheKey, indexURL string, opt
 	if idx, ok := f.cachedIndex(cacheKey); ok {
 		return idx, nil
 	}
-	g, err := getter.NewHTTPGetter()
-	if err != nil {
-		return nil, err
-	}
-	buf, err := g.Get(indexURL, opts...)
+	buf, err := httpGet(indexURL, opts)
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", indexURL, err)
 	}
@@ -183,6 +176,16 @@ func absChartURL(base, urlStr string) (string, error) {
 		return "", err
 	}
 	return baseURL.ResolveReference(u).String(), nil
+}
+
+// httpGet fetches url with helm's HTTP getter and the given options. Callers
+// wrap the error with their own context (index fetch vs chart download).
+func httpGet(url string, opts []getter.Option) (*bytes.Buffer, error) {
+	g, err := getter.NewHTTPGetter()
+	if err != nil {
+		return nil, err
+	}
+	return g.Get(url, opts...)
 }
 
 func safeName(s string) string {

--- a/pkg/store/events.go
+++ b/pkg/store/events.go
@@ -34,33 +34,35 @@ type Listener func(id manifest.NamedResource, payload any)
 // listener.
 type Unsubscribe func()
 
+// onTyped registers fn for event, asserting each dispatched payload to
+// T before invoking fn. A miss yields T's zero value (the assertion
+// never panics) — the payload type is fixed per event kind, so the
+// assertion always succeeds in practice. Backs the typed On* wrappers.
+func onTyped[T any](s *Store, event EventKind, fn func(manifest.NamedResource, T), replay bool) Unsubscribe {
+	return s.AddListener(event, func(id manifest.NamedResource, p any) {
+		v, _ := p.(T)
+		fn(id, v)
+	}, replay)
+}
+
 // OnObject registers fn for every EventObjectAdded with a typed
 // payload. When replay is true, fn fires synchronously for every
 // object already in the store before returning — useful when wiring
 // a UI mid-render. Listeners MUST NOT block the dispatching goroutine.
 func (s *Store) OnObject(fn func(manifest.NamedResource, manifest.BaseManifest), replay bool) Unsubscribe {
-	return s.AddListener(EventObjectAdded, func(id manifest.NamedResource, p any) {
-		obj, _ := p.(manifest.BaseManifest)
-		fn(id, obj)
-	}, replay)
+	return onTyped(s, EventObjectAdded, fn, replay)
 }
 
 // OnStatus registers fn for every EventStatusUpdated with the typed
 // StatusInfo payload. Same blocking / replay semantics as OnObject.
 func (s *Store) OnStatus(fn func(manifest.NamedResource, StatusInfo), replay bool) Unsubscribe {
-	return s.AddListener(EventStatusUpdated, func(id manifest.NamedResource, p any) {
-		info, _ := p.(StatusInfo)
-		fn(id, info)
-	}, replay)
+	return onTyped(s, EventStatusUpdated, fn, replay)
 }
 
 // OnArtifact registers fn for every EventArtifactUpdated with the
 // typed Artifact payload.
 func (s *Store) OnArtifact(fn func(manifest.NamedResource, Artifact), replay bool) Unsubscribe {
-	return s.AddListener(EventArtifactUpdated, func(id manifest.NamedResource, p any) {
-		art, _ := p.(Artifact)
-		fn(id, art)
-	}, replay)
+	return onTyped(s, EventArtifactUpdated, fn, replay)
 }
 
 // --- Listener bus implementation ---


### PR DESCRIPTION
Thirteenth autonomous code-cleanliness sweep — 4 de-duplications across 4 packages (three rejected as churn).

## What changed
- **cli** — `noNamedError` single-sources the "no &lt;kind&gt; named &lt;name&gt; in --path" error shared by build/get/test.
- **store** — `onTyped[T]` generic collapses the `OnObject`/`OnStatus`/`OnArtifact` typed-listener wrappers.
- **helmchart** — `httpGet` helper (chart download + index fetch).
- **source/blob** — `defer rLockGC()()` matching the existing task.go idiom.

## Rejected
- pkg/discovery — the god-object doc-rationale trim (third time proposed).
- pkg/loader — removing the "kustomize precedence" comment (adds domain framing, not pure restatement).
- pkg/source/sourceignore — a single-return refactor that calls `NewMatcher` unconditionally then discards it in the `withDefaults` branch (wasted construction).

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- **Cross-repo byte-equivalence** across 14 clusters: 8 byte-identical PASS; the 6 DIFFs match the known-flaky baseline exactly (binary-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)