### PR TITLE
refactor: fourteenth behavior-preserving cleanliness pass

### DIFF
--- a/internal/cli/images.go
+++ b/internal/cli/images.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/home-operations/flate/internal/format"
@@ -41,7 +42,7 @@ func emitImageList(w io.Writer, imgs []string, out string) error {
 		return format.YAML(w, imgs)
 	}
 	for _, img := range imgs {
-		if _, err := io.WriteString(w, img+"\n"); err != nil {
+		if _, err := fmt.Fprintln(w, img); err != nil {
 			return err
 		}
 	}

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -31,8 +31,9 @@ func WriteFileAt(t testing.TB, path, body string) {
 // WriteFile and WriteFileAt delegate to once they've computed the path.
 func writeFileWithParents(t testing.TB, path, body string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
 	}
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -186,7 +186,7 @@ func buildHTMLResource(p pairedResource, from, to string, hl *highlighter) htmlR
 
 	id := joinNS(p.namespace, p.name)
 	res := htmlResource{
-		Title:  p.kind + " " + id,
+		Title:  p.label(),
 		Kind:   p.kind,
 		Name:   id,
 		Parent: htmlParent(p.parent),

--- a/pkg/diff/pair.go
+++ b/pkg/diff/pair.go
@@ -16,6 +16,12 @@ type pairedResource struct {
 	a, b                  map[string]any
 }
 
+// label is the resource's human-facing title, e.g. "Deployment apps/web" —
+// the heading the unified and HTML paths put above each resource's diff.
+func (p pairedResource) label() string {
+	return p.kind + " " + joinNS(p.namespace, p.name)
+}
+
 // pairKey identifies a resource for cross-set matching.
 type pairKey struct {
 	// pPath disambiguates two KS parents with the same (kind, ns, name)

--- a/pkg/diff/unified.go
+++ b/pkg/diff/unified.go
@@ -25,7 +25,7 @@ func renderUnified(left, right []Doc, opts Options) ([]byte, error) {
 	var b bytes.Buffer
 	first := true
 	for _, p := range pair(left, right) {
-		body, err := unifiedBody(p.a, p.b, p.kind+" "+joinNS(p.namespace, p.name))
+		body, err := unifiedBody(p.a, p.b, p.label())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -232,8 +232,8 @@ func (w *walker) descend(ctx context.Context, dir string) (int, error) {
 	w.visited[dir] = struct{}{}
 
 	// readKustomizationAt returns the resolved file path alongside the
-	// parsed body so descend can hand both forward to walkKustomize /
-	// walkComponentData without re-opening the same kustomization.yaml.
+	// parsed body so descend can hand both to recordGenerators and
+	// walkKustomize without re-opening the same kustomization.yaml.
 	k, kpath := readKustomizationAt(dir)
 	if k != nil {
 		// Harvest configMapGenerator/secretGenerator entries
@@ -449,13 +449,10 @@ func (w *walker) scanBootstrapFluxKS(dir string, k *kustomization, kpath string)
 			if ks.Path == "" && ks.SourceKind == "" && ks.SourceName == "" {
 				continue
 			}
-			id := obj.Named()
-			if w.loader.skipExisting(id) {
+			if w.loader.skipExisting(obj.Named()) {
 				continue
 			}
-			w.loader.Store.AddObject(obj)
-			w.loader.recordSource(id, abs)
-			w.loader.recordSourceRefs(obj)
+			w.loader.addObject(obj, abs)
 			count++
 		}
 	}
@@ -665,12 +662,19 @@ func (l *Loader) loadFile(path string) (int, error) {
 			l.recordSourceRefs(obj)
 			continue
 		}
-		l.Store.AddObject(obj)
-		l.recordSource(id, path)
-		l.recordSourceRefs(obj)
+		l.addObject(obj, path)
 		count++
 	}
 	return count, nil
+}
+
+// addObject commits obj to the Store and records its source-file and
+// source-ref bookkeeping. Keeps the AddObject/recordSource/recordSourceRefs
+// triplet in one place — shared by the file-load and bootstrap-sibling paths.
+func (l *Loader) addObject(obj manifest.BaseManifest, path string) {
+	l.Store.AddObject(obj)
+	l.recordSource(obj.Named(), path)
+	l.recordSourceRefs(obj)
 }
 
 // recordDataFile parses absPath and records any ConfigMap/Secret

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
 	"helm.sh/helm/v4/pkg/getter"
@@ -29,7 +30,7 @@ func (f *Fetcher) fetchHTTPChart(ctx context.Context, r *manifest.HelmRepository
 		return nil, err
 	}
 	defer cleanup()
-	allOpts := append(authOpts, tlsOpts...)
+	allOpts := slices.Concat(authOpts, tlsOpts)
 
 	indexURL := strings.TrimSuffix(r.URL, "/") + "/index.yaml"
 	idx, err := f.fetchIndex(ctx, r.Namespace+"/"+r.Name+"@"+indexURL, indexURL, allOpts)


### PR DESCRIPTION
Fourteenth (final) autonomous code-cleanliness sweep — 5 de-duplications across 5 packages (two rejected as churn).

## What changed
- **diff** — extract `pairedResource.label()` de-duplicating the `<kind> <ns/name>` title across the unified + HTML render paths.
- **loader** — `addObject()` folds the `AddObject` + `recordSource` + `recordSourceRefs` triplet shared by the file-load and bootstrap-sibling paths.
- **helmchart** — `slices.Concat` over `append(authOpts, tlsOpts...)` (also removes a latent append-aliasing footgun).
- **cli** `fmt.Fprintln` over `io.WriteString(img+"\n")`; **testutil** hoists a doubly-computed `filepath.Dir`.

## Rejected
- pkg/discovery — the god-object doc-rationale trim (fourth time proposed).
- pkg/source/sourceignore — a single-return refactor that constructs `NewMatcher` then discards it in the `withDefaults` branch.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- **Cross-repo byte-equivalence** across 14 clusters: 8 byte-identical PASS; the 6 DIFFs match the known-flaky baseline exactly (binary-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)