### PR TITLE
fix(kustomize): propagate filepath.SkipDir to the disk layer in overlayFS.Walk

### DIFF
--- a/pkg/kustomize/generate_test.go
+++ b/pkg/kustomize/generate_test.go
@@ -399,3 +399,46 @@ func TestGenerateManifest_SourceIgnoreFiltersScan(t *testing.T) {
 		t.Fatal("expected generate/scan to fail on the unfiltered .sops.yaml, got nil")
 	}
 }
+
+// TestFindOrGenerate_MemoryPopulatedSubdirNotDescended is the zariel cnpg-system
+// regression. An auto-generated parent (no kustomization.yaml) over a subdir
+// that DOES carry a kustomization.yaml must list the subdir (./cnpg) as a
+// resource and never the subdir's kustomization.yaml file — even when preflight
+// has rewritten a remote resource under that subdir into the memory layer. That
+// memory write makes the subdir exist in both overlay layers; before the
+// overlayFS.Walk SkipDir fix, the disk walk re-descended the SkipDir'd subdir
+// and added ./cnpg/kustomization.yaml as a stray resource (which kustomize then
+// failed to decode: "missing metadata.name").
+func TestFindOrGenerate_MemoryPopulatedSubdirNotDescended(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		// Parent dir intentionally has NO kustomization.yaml -> auto-generate.
+		"cnpg/kustomization.yaml":  existingKustomization("./app/cm.yaml"),
+		"cnpg/app/cm.yaml":         cmYAML("cnpg-cm"),
+		"other/kustomization.yaml": existingKustomization("./cm.yaml"),
+		"other/cm.yaml":            cmYAML("other-cm"),
+	})
+	fsys := testOverlayFS(t, root)
+	// Simulate preflightRemoteResources rewriting a remote resource under cnpg/
+	// into memory, so cnpg/ exists in BOTH the memory and disk layers.
+	seed := filepath.Join(root, "cnpg", "app", remoteResourcePrefix+"deadbeef.yaml")
+	if err := fsys.WriteFile(seed, []byte(cmYAML("remote"))); err != nil {
+		t.Fatalf("seed memory: %v", err)
+	}
+
+	data, _, foundExisting, err := findOrGenerateKustomization(fsys, root, nil)
+	if err != nil {
+		t.Fatalf("findOrGenerateKustomization: %v", err)
+	}
+	if foundExisting {
+		t.Fatal("expected auto-generate (root has no kustomization.yaml)")
+	}
+	got := string(data)
+	if strings.Contains(got, "kustomization.yaml") {
+		t.Errorf("auto-generated kustomization lists a kustomization.yaml file as a resource:\n%s", got)
+	}
+	for _, want := range []string{"./cnpg", "./other"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("auto-generated kustomization missing %q resource:\n%s", want, got)
+		}
+	}
+}

--- a/pkg/kustomize/overlayfs.go
+++ b/pkg/kustomize/overlayfs.go
@@ -80,15 +80,28 @@ func (fs overlayFS) Glob(pattern string) ([]string, error) {
 
 func (fs overlayFS) Walk(path string, walkFn filepath.WalkFunc) error {
 	visited := make(map[string]struct{})
+	// skipped records directories whose memory-layer visit returned SkipDir.
+	// The disk walk must honor that too: a dir the caller asked to skip in
+	// memory must not have its disk subtree descended into — otherwise a
+	// SkipDir'd kustomize package (added once by scanManifests) is re-walked
+	// on disk and its kustomization.yaml is picked up as a stray resource.
+	skipped := make(map[string]struct{})
 	if fs.memory.Exists(path) {
 		if err := fs.memory.Walk(path, func(p string, info os.FileInfo, err error) error {
 			visited[p] = struct{}{}
-			return walkFn(p, info, err)
+			ret := walkFn(p, info, err)
+			if ret == filepath.SkipDir && info != nil && info.IsDir() {
+				skipped[p] = struct{}{}
+			}
+			return ret
 		}); err != nil {
 			return err
 		}
 	}
 	return fs.disk.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if _, ok := skipped[p]; ok {
+			return filepath.SkipDir
+		}
 		if _, ok := visited[p]; ok {
 			return nil
 		}

--- a/pkg/kustomize/overlayfs_test.go
+++ b/pkg/kustomize/overlayfs_test.go
@@ -1,0 +1,62 @@
+package kustomize
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// TestOverlayFS_WalkPropagatesSkipDir pins the contract that a directory the
+// caller SkipDirs during the memory-layer walk is NOT re-descended on the disk
+// layer. Regression for the cnpg-system bug (issue: a kustomization.yaml decoded
+// as a resource): preflight populates the memory layer under an app subdir,
+// scanManifests SkipDirs that subdir (adding it once as a kustomize package),
+// and the disk walk must then skip its subtree too — otherwise it picks up the
+// subdir's kustomization.yaml as a stray resource. The walk must still surface
+// disk-only children of directories that were NOT skipped (no over-skip).
+func TestOverlayFS_WalkPropagatesSkipDir(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"app/kustomization.yaml": existingKustomization("./inner.yaml"),
+		"app/inner.yaml":         cmYAML("inner"),
+		"lib/disk.yaml":          cmYAML("libdisk"),
+	})
+	fsys := testOverlayFS(t, root)
+	// Mirror preflightRemoteResources: a rewritten file under app/ (so app/
+	// exists in BOTH layers and is walked from memory) and one under lib/.
+	for _, rel := range []string{"app/mem.yaml", "lib/mem.yaml"} {
+		if err := fsys.WriteFile(filepath.Join(root, rel), []byte(cmYAML("mem"))); err != nil {
+			t.Fatalf("seed memory %s: %v", rel, err)
+		}
+	}
+
+	var visited []string
+	err := fsys.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return rerr
+		}
+		visited = append(visited, rel)
+		if rel == "app" && info.IsDir() {
+			return filepath.SkipDir // scanManifests treats app/ as a self-contained package
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	// app/ was SkipDir'd: none of its children — disk OR memory — may be delivered.
+	for _, bad := range []string{"app/kustomization.yaml", "app/inner.yaml", "app/mem.yaml"} {
+		if slices.Contains(visited, bad) {
+			t.Errorf("SkipDir not honored on the disk layer: walk descended into %q\nvisited=%v", bad, visited)
+		}
+	}
+	// lib/ was NOT skipped: its disk-only child must still surface.
+	if !slices.Contains(visited, "lib/disk.yaml") {
+		t.Errorf("over-skip: disk-only file lib/disk.yaml was not visited\nvisited=%v", visited)
+	}
+}


### PR DESCRIPTION
## The bug

Rendering a Flux Kustomization whose `spec.path` is a directory **without** a kustomization.yaml (flate auto-generates one) fails when a subdir's subtree references a **remote** (HTTP/git) resource:

```
flux kustomize generator: failed to decode Kubernetes YAML from .../cnpg-system/kustomization.yaml:
missing metadata.name in object {{kustomize.config.k8s.io/v1beta1 Kustomization} ...}
```

A `kustomization.yaml` (a kustomize config file, never a k8s resource) ends up in the auto-generated parent's `resources:` list.

## Root cause

`overlayFS.Walk` walks the memory layer, then the disk layer, deduping by path. When the memory walk's `walkFn` returns `filepath.SkipDir` for a directory, the dir was recorded in `visited` but the disk walk returned `nil` (not `SkipDir`) for visited paths — so **the disk walk descended into a directory the caller asked to skip**. In `scanManifests`, that re-walks a SkipDir'd kustomize package and adds its `kustomization.yaml` as a stray resource.

It only triggers when a subdir exists in **both** layers — i.e. when `preflightRemoteResources` rewrote a remote resource under that subdir into memory. Regression from the in-memory render redesign (#626); v0.3.3 used flux's real generator on a plain on-disk fs with no overlay and was immune.

## Fix

Track dirs the memory walk `SkipDir`'d and return `SkipDir` for them in the disk walk too (~10 lines in `overlayFS.Walk`). `scanManifests` / `kustomizationFileIn` / `preflight.go` are correct and unchanged.

## Blast radius (real repos, generator decode errors at the flux bootstrap entrypoint)

| repo | before | after |
|---|---|---|
| zariel/home-ops | 92 | **0** |
| bo0tzz/clusterfuck | 98 | **0** |
| drag0n141/home-ops | 204 | **0** |
| 7 other clusters | 0 | 0 |

Fixed HEAD renders zariel's `k8s/flux` **byte-identical to v0.3.3**.

## Why it was missed

The cross-repo byte-equivalence harness pointed `--path` at each cluster's `apps` subdir — which renders the per-app Flux KS CRs individually (each has a real kustomization.yaml, no auto-generate) and never renders the top-level `cluster-apps` KS. The auto-generate path was untested, and `overlayFS.Walk` had no unit test at all.

## Tests (both fail without the fix)
- **`overlayfs_test.go` (new)** — a dir in both layers, SkipDir'd in the memory walk, must not be descended on disk; a non-skipped shared dir still yields its disk-only children (no over-skip).
- **`generate_test.go`** — zariel-shaped auto-generate over a memory-populated subdir must list `./cnpg`, never `./cnpg/kustomization.yaml`.

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- Containment: on the existing apps-dir harness paths, fixed vs buggy output is identical except the pre-existing cert/timestamp-flaky repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)