### PR TITLE
perf: benchmark-gated warm-path optimizations (round 2)

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -10,6 +10,7 @@ import (
 
 	chart "helm.sh/helm/v4/pkg/chart/v2"
 	"helm.sh/helm/v4/pkg/chart/v2/loader"
+	"helm.sh/helm/v4/pkg/cli"
 
 	"github.com/home-operations/flate/internal/keylock"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -88,6 +89,34 @@ type Client struct {
 	// TemplateCacheBytes<=0). Both Get and Put handle nil receivers
 	// cleanly so the render path doesn't need extra wiring guards.
 	templateCache *templateCache
+
+	// settings is the helm CLI environment built once per Client and
+	// shared across every Template call. cli.New() reads ~20 env vars
+	// and allocates an EnvSettings + a *genericclioptions.ConfigFlags
+	// (~15 allocs / 1.1 KB) — work that is identical for every HR in a
+	// run, so building it per Template was pure waste on the uncached
+	// render path. Only RESTClientGetter() (the embedded *ConfigFlags)
+	// is consumed downstream, and that type guards its lazy-init caches
+	// with internal mutexes, so the shared getter is safe under the
+	// concurrent renders the orchestrator drives. Built lazily under
+	// settingsOnce so construction stays allocation-free for callers
+	// that never render (e.g. LocateChart-only embedders).
+	settingsOnce sync.Once
+	settings     *cli.EnvSettings
+}
+
+// envSettings returns the per-Client helm CLI environment, building it
+// exactly once. cli.New() is HR-invariant (env-var driven) so every
+// Template call reuses the same EnvSettings instead of re-reading the
+// environment and re-allocating the ConfigFlags. The returned getter
+// (*genericclioptions.ConfigFlags) is concurrency-safe: its lazy REST
+// caches are mutex-guarded, and flate's DryRunClient render path never
+// touches them.
+func (c *Client) envSettings() *cli.EnvSettings {
+	c.settingsOnce.Do(func() {
+		c.settings = cli.New()
+	})
+	return c.settings
 }
 
 // chartCacheEntry pairs the parsed chart with the (mtime, size) of

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -12,7 +12,6 @@ import (
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/common"
 	chart "helm.sh/helm/v4/pkg/chart/v2"
-	"helm.sh/helm/v4/pkg/cli"
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"sigs.k8s.io/yaml"
 
@@ -42,10 +41,8 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 		return "", err
 	}
 
-	settings := cli.New()
-
 	cfg := new(action.Configuration)
-	if err := cfg.Init(settings.RESTClientGetter(), hr.ReleaseNamespace(), ""); err != nil {
+	if err := cfg.Init(c.envSettings().RESTClientGetter(), hr.ReleaseNamespace(), ""); err != nil {
 		return "", fmt.Errorf("helm init: %w", err)
 	}
 	cfg.Capabilities = caps

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -12,6 +12,7 @@ import (
 	fluxkustomize "github.com/fluxcd/pkg/kustomize"
 	fluxfilesys "github.com/fluxcd/pkg/kustomize/filesys"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source/sourceignore"
@@ -67,22 +68,26 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 		return nil, err
 	}
 
-	if r, err := filepath.EvalSymlinks(sourceRoot); err == nil {
-		sourceRoot = r
-	}
-
-	// Memory-over-disk overlay: source files are read from a secure on-disk FS
-	// rooted at sourceRoot (no real-FS reach beyond root; symlinks evaluated),
-	// while the merged kustomization.yaml + any pre-fetched remote resources are
-	// written to an in-memory layer that shadows disk. The source tree is never
-	// copied or mutated, and renders stay fully parallel (each gets its own
-	// overlay). Reading source from disk also sidesteps the in-memory fs's
-	// filename restriction, so trees with exotic names (spaces, etc.) render.
-	diskFS, err := fluxfilesys.MakeFsOnDiskSecure(sourceRoot)
+	// Resolve the source root and build its secure on-disk FS once per root.
+	// Both are pure functions of sourceRoot and the secure FS is an immutable,
+	// goroutine-safe value, so cache.diskRootFor memoizes them across every KS
+	// that shares this root — sparing each render a duplicate EvalSymlinks +
+	// CleanedAbs syscall pair.
+	dr, err := cache.diskRootFor(sourceRoot)
 	if err != nil {
-		return nil, fmt.Errorf("kustomize: secure fs %s: %w", sourceRoot, err)
+		return nil, err
 	}
-	memFS := newOverlayFS(diskFS)
+	sourceRoot = dr.root
+
+	// Memory-over-disk overlay: source files are read from the secure on-disk
+	// FS rooted at sourceRoot (no real-FS reach beyond root; symlinks
+	// evaluated), while the merged kustomization.yaml + any pre-fetched remote
+	// resources are written to an in-memory layer that shadows disk. The source
+	// tree is never copied or mutated, and renders stay fully parallel (each
+	// gets its own overlay). Reading source from disk also sidesteps the
+	// in-memory fs's filename restriction, so trees with exotic names (spaces,
+	// etc.) render.
+	memFS := newOverlayFS(dr.diskFS)
 
 	subDir := filepath.Join(sourceRoot, subPath)
 	if info, statErr := os.Stat(subDir); statErr != nil || !info.IsDir() {
@@ -146,6 +151,38 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 		return nil, fmt.Errorf("kustomize render %s: %w", subPath, err)
 	}
 	return out, nil
+}
+
+// diskRoot holds the per-sourceRoot invariants RenderFlux reuses across every
+// Kustomization that targets the same root: the symlink-resolved absolute root
+// and its secure on-disk FS. diskFS is an immutable fsSecure value over a
+// stateless MakeFsOnDisk, so it is safe to share read-only across goroutines.
+type diskRoot struct {
+	root   string
+	diskFS filesys.FileSystem
+}
+
+// diskRootFor returns the cached diskRoot for sourceRoot, computing and
+// memoizing it on first use. The (EvalSymlinks, MakeFsOnDiskSecure) pair it
+// performs is a pure function of sourceRoot, so the result is shared across the
+// run's renders of that root. Errors are not cached — they are rare and the
+// caller wants each to surface — and carry the same wrapping the inline path
+// used. Keyed by the raw input sourceRoot (already validated non-empty).
+func (c *TreeCache) diskRootFor(sourceRoot string) (*diskRoot, error) {
+	if v, ok := c.diskRoots.Load(sourceRoot); ok {
+		return v.(*diskRoot), nil
+	}
+	resolved := sourceRoot
+	if r, err := filepath.EvalSymlinks(sourceRoot); err == nil {
+		resolved = r
+	}
+	diskFS, err := fluxfilesys.MakeFsOnDiskSecure(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("kustomize: secure fs %s: %w", resolved, err)
+	}
+	dr := &diskRoot{root: resolved, diskFS: diskFS}
+	actual, _ := c.diskRoots.LoadOrStore(sourceRoot, dr)
+	return actual.(*diskRoot), nil
 }
 
 // applyCommonMetadata merges spec.commonMetadata.labels and

--- a/pkg/kustomize/tree.go
+++ b/pkg/kustomize/tree.go
@@ -26,6 +26,16 @@ type TreeCache struct {
 	// Kustomizations is fetched once. See remotefetch.go.
 	remoteFetches sync.Map // url string -> *remoteFetch
 
+	// diskRoots memoizes the per-sourceRoot invariants RenderFlux derives
+	// before every build: the symlink-resolved root and its secure on-disk
+	// FS (see flux.go). Both are pure functions of the input sourceRoot, and
+	// the secure FS (fsSecure) is an immutable value over a stateless
+	// MakeFsOnDisk — safe to share read-only across the many Kustomizations
+	// that target the same root, sparing each render a redundant EvalSymlinks
+	// + CleanedAbs syscall pair. Bounded by the run's distinct source roots
+	// (typically one). See diskRoot. Keyed by the raw input sourceRoot.
+	diskRoots sync.Map // sourceRoot string -> *diskRoot
+
 	// gitBase resolves a remote kustomize git base (a repo URL at a bare ref)
 	// to an on-disk worktree. The one injected seam: pkg/kustomize cannot import
 	// pkg/source/git (import cycle). nil ⇒ a git-base resource fails with a

--- a/pkg/orchestrator/depgraph.go
+++ b/pkg/orchestrator/depgraph.go
@@ -76,17 +76,28 @@ func (g *dependencyGraph) ReplaceEdges(id manifest.NamedResource, deps []manifes
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	oldSet := g.outEdges[id]
+
+	// No-change fast path. The post-Bootstrap listener replays a
+	// ReplaceEdges per id on every reconcile, and in a stable graph
+	// almost every call passes deps identical to what's already
+	// installed. Detect that against the existing oldSet WITHOUT
+	// allocating the newSet map (the dominant per-reconcile allocation
+	// on the warm path). The set built from deps equals oldSet iff every
+	// dep is already in oldSet and every oldSet member appears in deps
+	// — the second scan over the (tiny) deps slice makes this correct
+	// even when deps carries duplicates, matching the map-dedup the
+	// slow path below performs.
+	if edgeSetEqual(oldSet, deps) {
+		return
+	}
+
 	newSet := make(map[manifest.NamedResource]struct{}, len(deps))
 	for _, d := range deps {
 		// Self-edges produce a trivial 1-node cycle. Keep them so
 		// the cycle-detection step records the failure; callers
 		// don't filter them.
 		newSet[d] = struct{}{}
-	}
-
-	oldSet := g.outEdges[id]
-	if maps.Equal(oldSet, newSet) {
-		return
 	}
 
 	// Diff so we can take the fast paths below.
@@ -200,6 +211,30 @@ func (g *dependencyGraph) findPathLocked(
 		stack = append(stack, frame{node: next, children: sortedNeighbors(g.outEdges[next])})
 	}
 	return nil, false
+}
+
+// edgeSetEqual reports whether the set of distinct entries in deps
+// equals the key set of oldSet, without allocating. Used by ReplaceEdges
+// to skip the newSet map build on the no-change fast path (the common
+// case on every post-Bootstrap reconcile replay).
+//
+// Correct even when deps contains duplicates: the first loop rejects any
+// dep missing from oldSet, and the second loop rejects any oldSet member
+// missing from deps. Both passing implies dedup(deps) == keys(oldSet)
+// regardless of repeats. deps lists are tiny (Flux dependsOn is a
+// handful of entries), so the inner linear scan over deps is cheap.
+func edgeSetEqual(oldSet map[manifest.NamedResource]struct{}, deps []manifest.NamedResource) bool {
+	for _, d := range deps {
+		if _, ok := oldSet[d]; !ok {
+			return false
+		}
+	}
+	for k := range oldSet {
+		if !slices.Contains(deps, k) {
+			return false
+		}
+	}
+	return true
 }
 
 // sortedNeighbors returns the keys of edges in deterministic order


### PR DESCRIPTION
Round 2 targets the **warm steady state** (cache reused — what repeated `flate` runs hit; cold git materialization is a one-time CI cost that warm runs skip). Each change is benchmark-proven, race-clean, and byte-identical.

| subsystem | optimization | gate benchmark | result |
|---|---|---|---|
| **orchestrator** | `ReplaceEdges` no-change fast path (allocation-free `edgeSetEqual`, skip throwaway map on unchanged reconcile replay) | `FailDependsOnCycles_Incremental` | 303µs → **170µs** (−44%), 2999→999 allocs, 575KB→48KB |
| **helm** | hoist `cli.New()` behind `sync.Once` (was rebuilt per-Template, *before* the cache check, so warm hits paid for it) | `Template_AppTemplateChart` | 8130ns → **5400ns** (−34% warm-hit) |
| **kustomize** | memoize per-sourceRoot `EvalSymlinks`+secure-FS in TreeCache (shared across KSes of a root) | `RenderFlux_MultiKSPerRoot` | −71 allocs / −6KB per render (p=0.000) |

Three subsystems returned **NOWIN** (gate rejecting unprovable changes): helm-schema (validation isn't on the warm cache-hit path; no injection seam without forking helm), helm-templatedocs (already pooled, no CopyYNode in this package), kustomize-overlay (the cost is flux's secure-FS `EvalSymlinks`, a dependency — partially addressed by the kustomize memoize above).

## Verification
- gofmt clean · `go build`/`go vet` clean · `go test -race ./...` (37 pkgs) all pass · `golangci-lint` **0 issues**.
- Gate benchmarks re-confirmed combined (orchestrator 170µs, helm 5.4µs, kustomize 2461 allocs).
- **Byte-equivalence across all 24 paths**: every deterministic repo identical. m00nwtchr showed a transient diff, root-caused to **pre-existing** non-determinism — the unchanged `main` binary renders the stunner-gateway-operator chart with a ~478-line swing in **4 of 12 runs**; when the perf binary lands on the majority output it is byte-identical to base. (Flagged separately for a determinism fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)