### PR TITLE
refactor: deep cleanliness pass (loader/manifest/values)

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -173,9 +173,9 @@ func resolveDataPath(base, rel string) (string, bool) {
 	if filepath.IsAbs(rel) {
 		return filepath.Clean(rel), true
 	}
+	cleanBase := filepath.Clean(base)
 	abs := filepath.Clean(filepath.Join(base, rel))
-	cleanBase := filepath.Clean(base) + string(filepath.Separator)
-	if abs != filepath.Clean(base) && !strings.HasPrefix(abs+string(filepath.Separator), cleanBase) {
+	if abs != cleanBase && !strings.HasPrefix(abs+string(filepath.Separator), cleanBase+string(filepath.Separator)) {
 		return "", false
 	}
 	return abs, true

--- a/pkg/manifest/io.go
+++ b/pkg/manifest/io.go
@@ -63,7 +63,7 @@ func ReleaseDoc(m map[string]any) {
 // ReleaseIfNotRetained returns doc to the pool unless obj retains a
 // reference to the top-level map. Currently only *Kustomization
 // retains (via its Contents field) — every other ParseDoc result
-// either round-trips through JSON (decodeTyped) or aliases an inner
+// either round-trips through JSON (decodeInto) or aliases an inner
 // submap that clear(top) doesn't touch.
 //
 // Callers should invoke this after every successful ParseDoc whose

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -1587,7 +1587,7 @@ func TestFlattenLists(t *testing.T) {
 // bug introduced by reusing a cleared map[string]any across decodes.
 //
 // Covers the three retention shapes:
-//   - HelmRelease (decodeTyped JSON round-trip, no doc retention)
+//   - HelmRelease (decodeInto JSON round-trip, no doc retention)
 //   - Kustomization (retains the TOP-LEVEL doc as Contents — must not
 //     be returned to the pool)
 //   - ConfigMap (aliases the inner data submap; clear(top) leaves the

--- a/pkg/values/doc.go
+++ b/pkg/values/doc.go
@@ -10,6 +10,8 @@
 //   - Deep merge follows Helm semantics: nested maps are merged, but
 //     lists are REPLACED entirely (not concatenated).
 //   - When a valuesFrom reference is optional and the target ConfigMap /
-//     Secret is missing, a placeholder string is substituted so the
-//     downstream YAML still parses and diffs are meaningful.
+//     Secret (or values key) is missing, it is skipped silently so the
+//     render proceeds; a wiped Secret value (a placeholder token the
+//     manifest parser injects for SOPS-encrypted data) is treated as
+//     empty rather than failing the whole HelmRelease.
 package values


### PR DESCRIPTION
Deep cleanliness sweep — parallel per-package agents, adversarially reviewed. Three genuine improvements kept; two churn/lossy patches rejected.

## Changes

- **loader** (`resolveDataPath`): `cleanBase` now holds the *cleaned base* and the separator is appended at the prefix check, so the variable matches its name. Algebraically identical condition — byte-equivalent.
- **manifest**: fix stale doc comments referencing the old `decodeTyped` name (renamed to `decodeInto`) in `io.go` and `manifest_test.go`.
- **values**: correct a factually-wrong doc comment — optional-missing `valuesFrom` refs are *skipped silently* (`continue`, values.go:293), not placeholder-substituted; a wiped-Secret placeholder is treated as empty (values.go:492).

## Rejected this pass
- `kustomize` `newKustomization()` extraction — marginal 2-site TypeMeta de-dup (already declined in passes 11 & 12).
- `source` `doc.go` deletion — would destroy the package's unique go-git/oras-go + SHA256 cache-keying docs (`source.go` carries a *different* package comment); a proper merge is judgment-heavy editorial work outside a behavior-preserving sweep.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (loader/manifest/values) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** (apps + flux entrypoints) vs `main`: 12 identical; the 12 DIFF repos reproduce the **exact same diff** base-vs-base with an identical binary (cert `caBundle`, `unlock` tokens, infisical `updatedAt`, secret checksums, stunner resource-set) — all pre-existing non-determinism, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)