### PR TITLE
refactor: deep cleanliness pass 2 (dedup, dead-code, stale comments)

### DIFF
--- a/pkg/depwait/cel.go
+++ b/pkg/depwait/cel.go
@@ -106,15 +106,14 @@ func (e *celCompileErr) Error() string { return e.err.Error() }
 func (e *celCompileErr) Unwrap() error { return e.err }
 
 func compileReadyExpr(expr string) (cel.Program, error) {
-	if v, ok := celCache.Load(expr); ok {
-		e := v.(celCacheEntry)
-		return e.prog, e.err
+	v, ok := celCache.Load(expr)
+	if !ok {
+		// LoadOrStore: concurrent compiles of the same expr both race; the
+		// loser's entry is discarded and we return the winner's. cel-go's
+		// compilation is deterministic so the two results are equivalent.
+		v, _ = celCache.LoadOrStore(expr, buildCacheEntry(expr))
 	}
-	// LoadOrStore: concurrent compiles of the same expr both race; the
-	// loser's entry is discarded and we return the winner's. cel-go's
-	// compilation is deterministic so the two results are equivalent.
-	actual, _ := celCache.LoadOrStore(expr, buildCacheEntry(expr))
-	e := actual.(celCacheEntry)
+	e := v.(celCacheEntry)
 	return e.prog, e.err
 }
 

--- a/pkg/kustomize/generate.go
+++ b/pkg/kustomize/generate.go
@@ -98,20 +98,14 @@ func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]an
 		kus.BuildMetadata = []string{"originAnnotations"}
 	}
 
-	if v, ok, err := unstructured.NestedString(obj, specField, targetNSField); err != nil {
+	if err := setNestedString(&kus.Namespace, obj, specField, targetNSField); err != nil {
 		return nil, "", err
-	} else if ok {
-		kus.Namespace = v
 	}
-	if v, ok, err := unstructured.NestedString(obj, specField, namePrefixField); err != nil {
+	if err := setNestedString(&kus.NamePrefix, obj, specField, namePrefixField); err != nil {
 		return nil, "", err
-	} else if ok {
-		kus.NamePrefix = v
 	}
-	if v, ok, err := unstructured.NestedString(obj, specField, nameSuffixField); err != nil {
+	if err := setNestedString(&kus.NameSuffix, obj, specField, nameSuffixField); err != nil {
 		return nil, "", err
-	} else if ok {
-		kus.NameSuffix = v
 	}
 
 	patches, err := decodeTypedSlice[fluxapis.Patch](obj, specField, patchesField)
@@ -200,6 +194,20 @@ func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]an
 		return nil, "", err
 	}
 	return manifest, kfile, nil
+}
+
+// setNestedString assigns the nested string at fields to *dst when present,
+// leaving *dst untouched when the field is absent — mirroring flux's
+// "set only when ok" handling of targetNamespace/namePrefix/nameSuffix.
+func setNestedString(dst *string, obj map[string]any, fields ...string) error {
+	v, ok, err := unstructured.NestedString(obj, fields...)
+	if err != nil {
+		return err
+	}
+	if ok {
+		*dst = v
+	}
+	return nil
 }
 
 // kustomizationFileIn returns the path of the first recognized kustomization

--- a/pkg/orchestrator/cycles.go
+++ b/pkg/orchestrator/cycles.go
@@ -130,8 +130,7 @@ func (o *Orchestrator) rebuildDependencyGraphFromStore() {
 // sameKindDepTargets pulls the dependsOn list from a Kustomization /
 // HelmRelease and filters it down to entries of the same kind. Flux's
 // spec.dependsOn is kind-homogeneous (KS deps on KS, HR deps on HR);
-// stripping cross-kind entries here matches the legacy buildDepGraph
-// behavior and keeps the graph's invariant intact.
+// stripping cross-kind entries here keeps the graph's invariant intact.
 func sameKindDepTargets(obj manifest.BaseManifest, kind string) []manifest.NamedResource {
 	var deps []manifest.DependencyRef
 	switch v := obj.(type) {

--- a/pkg/orchestrator/depgraph.go
+++ b/pkg/orchestrator/depgraph.go
@@ -16,8 +16,7 @@ import (
 // Edges are partitioned by kind: a Kustomization's dependsOn refers
 // only to other Kustomizations (Flux spec), and the same for
 // HelmReleases. Cross-kind edges are dropped by callers before they
-// reach ReplaceEdges so cycle detection stays kind-homogeneous (matches
-// the buildDepGraph behavior preserved on the slow path).
+// reach ReplaceEdges so cycle detection stays kind-homogeneous.
 //
 // All operations are safe for concurrent use; the mutex guards the
 // in/out edge maps and the failure-membership cache. ReplaceEdges

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -489,24 +489,22 @@ func mirrorRefSpecs(ref *manifest.GitRepositoryRef) mirror.FetchPlan {
 	}
 	switch {
 	case ref.Name != "":
-		return mirror.FetchPlan{RefSpecs: []config.RefSpec{
-			config.RefSpec("+" + ref.Name + ":" + ref.Name),
-		}}
+		return singleMirrorRefSpec(ref.Name)
 	case ref.SemVer != "":
-		return mirror.FetchPlan{RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/tags/*:refs/tags/*"),
-		}}
+		return singleMirrorRefSpec("refs/tags/*")
 	case ref.Tag != "":
-		return mirror.FetchPlan{RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/tags/" + ref.Tag + ":refs/tags/" + ref.Tag),
-		}}
+		return singleMirrorRefSpec("refs/tags/" + ref.Tag)
 	case ref.Branch != "":
-		return mirror.FetchPlan{RefSpecs: []config.RefSpec{
-			config.RefSpec("+refs/heads/" + ref.Branch + ":refs/heads/" + ref.Branch),
-		}}
+		return singleMirrorRefSpec("refs/heads/" + ref.Branch)
 	default:
 		return mirror.FetchPlan{}
 	}
+}
+
+// singleMirrorRefSpec builds a FetchPlan carrying one force-update mirror
+// refspec (+src:src) — the shape every narrow per-ref fetch above uses.
+func singleMirrorRefSpec(src string) mirror.FetchPlan {
+	return mirror.FetchPlan{RefSpecs: []config.RefSpec{config.RefSpec("+" + src + ":" + src)}}
 }
 
 // authIdentity returns the cache-key auth tag for a GitRepository.

--- a/pkg/source/gittree/materialize.go
+++ b/pkg/source/gittree/materialize.go
@@ -110,7 +110,9 @@ func Materialize(ctx context.Context, repo *git.Repository, hash plumbing.Hash, 
 				}
 				continue
 			}
-			if entry.Mode != filemode.Symlink && !entry.Mode.IsFile() {
+			// IsFile is true for regular, executable, and symlink modes;
+			// every other mode (e.g. the Empty placeholder) is skipped.
+			if !entry.Mode.IsFile() {
 				continue
 			}
 			select {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -397,8 +397,10 @@ func Mutate[T interface {
 		}
 		cloned := obj.Clone()
 		mutate(cloned)
-		// Dedup parallel to AddObject — equal mutations no-op.
-		if reflect.DeepEqual(sh.objects[id], cloned) {
+		// Dedup parallel to AddObject — equal mutations no-op. obj is
+		// the value already read from sh.objects[id] under this lock, so
+		// compare against it directly rather than re-indexing the map.
+		if reflect.DeepEqual(obj, cloned) {
 			return true
 		}
 		sh.setLocked(id, cloned)


### PR DESCRIPTION
Second deep cleanliness sweep — 45 parallel per-package agents, adversarially reviewed. Six genuine improvements kept; one rejected.

## Changes
- **depwait** (`compileReadyExpr`): collapse the duplicate type-assert/return tail into one path (`Load` → `LoadOrStore`-on-miss). Behavior + race semantics identical.
- **kustomize** (`generateManifest`): extract `setNestedString`, de-duplicating three identical `NestedString`-and-set blocks (`targetNamespace`/`namePrefix`/`nameSuffix`).
- **source/git** (`mirrorRefSpecs`): extract `singleMirrorRefSpec`, de-duplicating four identical `+src:src` force-update `FetchPlan` constructions (refspecs verified byte-identical for every branch).
- **source/gittree** (`Materialize`): drop the redundant `Mode != Symlink` guard — go-git's `filemode.IsFile()` already returns true for `Symlink` (verified in v5.19.1 source), so the term was dead; documented the coverage.
- **orchestrator** (`cycles.go`/`depgraph.go`): remove stale references to `buildDepGraph`, a function that no longer exists anywhere in the tree.
- **store** (`Mutate`): the dedup compares against the `obj` already read under the shard lock instead of re-indexing `sh.objects[id]` — provably the same `(dynamic-type, value)` pair, drops a redundant map lookup.

## Rejected
- `discovery` doc.go — deletes a genuine architectural-rationale paragraph (load-phase separation/testability) over a single stale line-count metric; deleting useful "why" docs isn't a cleanliness win.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (all 6 packages, incl. depwait 20s race run) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** (apps + flux entrypoints) vs `main` (#647): 12 identical. The 12 DIFF repos all reproduce pre-existing non-determinism (`caBundle`/`unlock`/`updatedAt`/`checksum`/stunner resource-set) — confirmed via base-vs-base with an identical binary. m00nwtchr-apps's structural churn is the stunner operator's conditional RBAC/Deployment set; base-vs-base ×3 yields 96449/96692/96692, so the branch's 96692 is a value the base itself produces. No symlink/path anomaly from the gittree change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)