### PR TITLE
refactor: deep cleanliness pass 3 (recompute hoist + stale docs)

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -131,7 +131,8 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		if isDir(slot) {
 			return slot, true, nil
 		}
-		if err := os.MkdirAll(filepath.Dir(slot), 0o750); err != nil {
+		parent := filepath.Dir(slot)
+		if err := os.MkdirAll(parent, 0o750); err != nil {
 			return "", false, fmt.Errorf("baseline cache parent: %w", err)
 		}
 		// Stage in a sibling temp dir on the same filesystem so the
@@ -139,7 +140,7 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		// same commit will either share the finished slot or fall
 		// through to their own stage (one wins the rename, the rest
 		// see ErrExist, discard the temp, and adopt the winner's slot).
-		if _, err := cas.Stage(filepath.Dir(slot), slot, "baseline staging", "baseline finalize",
+		if _, err := cas.Stage(parent, slot, "baseline staging", "baseline finalize",
 			func(staging string) error { return materialize(repo, hash, staging) },
 			func() bool { return isDir(slot) },
 		); err != nil {

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -36,21 +36,23 @@ var BuildMutex sync.Mutex
 // entirely in memory, using the same merge + build the kustomize-controller
 // performs.
 //
-// The source tree at sourceRoot is materialized once per run into an immutable
-// byte snapshot (cache.snapshot); each render derives its own private in-memory
-// filesystem from it, writes the merged kustomization.yaml + any pre-fetched
-// remote resources into that private fs, and builds with fluxkustomize.Build.
-// Nothing touches disk and no two renders share mutable state, so renders run
-// fully parallel with no staging lock. The in-memory fs is inherently sandboxed
-// (no real-FS reach; a path escaping the root simply does not exist), giving
+// sourceRoot is resolved and wrapped in a secure on-disk FS once per root
+// (memoized in cache.diskRootFor); each render derives its own private
+// memory-over-disk overlay from that shared disk FS, writes the merged
+// kustomization.yaml + any pre-fetched remote resources into the overlay's
+// in-memory layer, and builds with fluxkustomize.Build. The source tree is
+// never copied or mutated and no two renders share mutable state, so renders
+// run fully parallel with no staging lock. The secure disk layer confines reads
+// to the root (a path escaping it simply does not resolve), giving
 // SecureBuild's security posture for free.
 //
 // applyIgnore selects whether source-controller's default file exclusions
 // (.sops.yaml, binaries, CI dirs, in-tree .sourceignore) are applied while
-// materializing — true for working-tree / self-referential sources that never
-// passed through a fetcher's artifact filtering, false for already-filtered
-// fetched artifacts. spec.commonMetadata is applied post-build (the Generator
-// does not handle it, mirroring kustomize-controller's apply-time pass).
+// auto-generating a kustomization — true for working-tree / self-referential
+// sources that never passed through a fetcher's artifact filtering, false for
+// already-filtered fetched artifacts. spec.commonMetadata is applied post-build
+// (the Generator does not handle it, mirroring kustomize-controller's
+// apply-time pass).
 //
 // ctx is honored at coarse boundaries (entry, before build) because
 // fluxkustomize.Build does not itself accept a ctx.

--- a/pkg/kustomize/gitbase.go
+++ b/pkg/kustomize/gitbase.go
@@ -205,7 +205,8 @@ func trimPrefixFold(s, prefix string) (string, bool) {
 // once in the cached fetcher; this is a cheap in-RAM file copy. The directory
 // name keys on (repoURL, ref) only, so multiple subpaths of one repo+ref share
 // a single materialized copy. No cleanup is needed: each render derives a fresh
-// fs from the immutable snapshot, so there is never stale state to clear.
+// private in-memory overlay, so the copy lives only for that render and there is
+// never stale state to clear.
 func fetchGitBase(ctx context.Context, cache *TreeCache, memFS filesys.FileSystem, dir string, spec gitBaseSpec) (string, error) {
 	if cache.gitBase == nil {
 		return "", fmt.Errorf("kustomization references remote git base %q but no git fetcher is wired", spec.repoURL)

--- a/pkg/store/doc.go
+++ b/pkg/store/doc.go
@@ -10,8 +10,8 @@
 //
 // Three event types are dispatched as state evolves: ObjectAdded,
 // StatusUpdated, ArtifactUpdated. Callers subscribe via AddListener (sync,
-// returns an unsubscribe function) or via the high-level Watch* helpers
-// (return channels / wait on a single value).
+// returns an unsubscribe function) or block on the high-level Watch*
+// helpers, which return a single value once the awaited state is reached.
 //
 // Store is safe for concurrent use. Listeners run inline on the goroutine
 // that triggered the event — they MUST NOT block on Store operations, or


### PR DESCRIPTION
Third deep cleanliness sweep — 45 parallel per-package agents (most reported already-clean). Three genuine improvements; nothing rejected.

## Changes
- **baseline** (`materializeAt`): hoist the twice-computed `filepath.Dir(slot)` into `parent`, used by both `os.MkdirAll` and `cas.Stage`. Pure recompute elimination, behavior-identical.
- **kustomize** (`RenderFlux` doc in flux.go + gitbase.go note): the comment still described the removed `cache.snapshot` fully-in-memory approach; rewrote it to match the current memory-over-disk overlay (`cache.diskRootFor` → `MakeFsOnDiskSecure` → `newOverlayFS`). Verified against the live code.
- **store** (doc.go): the Watch* helpers (`WatchReady`/`WatchExists`) block and return a single value — they do **not** return channels. Corrected the stale description.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (baseline/kustomize/store) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** vs `main` (#648): 12 identical; the 12 DIFF repos are the same pre-existing non-determinism exonerated in passes 1–2 (caBundle/unlock/updatedAt/checksum/stunner), with identical line counts. Only code change is a provably-identical `filepath.Dir` hoist; the other two are doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)