### PR TITLE
refactor: deep cleanliness pass 4 (dedup + modern idioms)

### DIFF
--- a/pkg/change/detect.go
+++ b/pkg/change/detect.go
@@ -191,13 +191,11 @@ func detectViaGit(before, after string) (*Set, error) {
 			continue
 		}
 		p := filepath.ToSlash(string(rawPath))
-		var rel string
-		switch {
-		case strings.HasPrefix(p, beforePrefix):
-			rel = p[len(beforePrefix):]
-		case strings.HasPrefix(p, afterPrefix):
-			rel = p[len(afterPrefix):]
-		default:
+		rel, ok := strings.CutPrefix(p, beforePrefix)
+		if !ok {
+			rel, ok = strings.CutPrefix(p, afterPrefix)
+		}
+		if !ok {
 			// Unexpected path shape — skip rather than mis-attribute.
 			// Defensive only: git always reports paths under the input
 			// directories we passed.

--- a/pkg/diff/html.go
+++ b/pkg/diff/html.go
@@ -109,8 +109,8 @@ type sRow struct {
 // theme. Identical resources are dropped, matching renderUnified; an empty
 // diff produces no output at all, like the other formats.
 func renderHTML(left, right []Doc, opts Options) ([]byte, error) {
-	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields, opts.Normalize)
-	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields, opts.Normalize)
+	left = opts.normalize(left)
+	right = opts.normalize(right)
 
 	hl, css, err := newHighlighter()
 	if err != nil {

--- a/pkg/diff/native.go
+++ b/pkg/diff/native.go
@@ -19,11 +19,11 @@ import (
 // document-level "order changed" note. Both are rare in practice for
 // content diffs.
 func renderNative(left, right []Doc, opts Options) ([]byte, error) {
-	from, err := multiDocInput("from", normalizeDocs(left, opts.StripAttrs, opts.StripFields, opts.Normalize))
+	from, err := multiDocInput("from", opts.normalize(left))
 	if err != nil {
 		return nil, err
 	}
-	to, err := multiDocInput("to", normalizeDocs(right, opts.StripAttrs, opts.StripFields, opts.Normalize))
+	to, err := multiDocInput("to", opts.normalize(right))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -10,6 +10,12 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// normalize applies o's strip/normalize config to a doc set — the
+// shared pre-diff scrub every render path runs on both its inputs.
+func (o Options) normalize(docs []Doc) []Doc {
+	return normalizeDocs(docs, o.StripAttrs, o.StripFields, o.Normalize)
+}
+
 // normalizeDocs clones each Doc's manifest and rewrites fields that
 // should not participate verbatim in human-facing diffs: the listed
 // annotation/label keys (chart-bump noise like helm.sh/chart,

--- a/pkg/diff/unified.go
+++ b/pkg/diff/unified.go
@@ -20,8 +20,8 @@ func joinNS(ns, name string) string {
 // changed pair's YAML, and concatenates the bodies. Identical resources
 // are dropped. Not Kubernetes-aware — see unifiedBody.
 func renderUnified(left, right []Doc, opts Options) ([]byte, error) {
-	left = normalizeDocs(left, opts.StripAttrs, opts.StripFields, opts.Normalize)
-	right = normalizeDocs(right, opts.StripAttrs, opts.StripFields, opts.Normalize)
+	left = opts.normalize(left)
+	right = opts.normalize(right)
 	var b bytes.Buffer
 	first := true
 	for _, p := range pair(left, right) {

--- a/pkg/manifest/parse.go
+++ b/pkg/manifest/parse.go
@@ -188,8 +188,8 @@ func checkAPIVersion(doc map[string]any, want string) error {
 
 // requireMetadata pulls name + namespace from a non-nil metadata block.
 func requireMetadata(kind string, doc map[string]any) (name, ns string, err error) {
-	md, ok := doc["metadata"].(map[string]any)
-	if !ok || md == nil {
+	md, _ := doc["metadata"].(map[string]any)
+	if md == nil {
 		return "", "", inputf("%s missing metadata", kind)
 	}
 	name, _ = md["name"].(string)

--- a/pkg/manifest/strip.go
+++ b/pkg/manifest/strip.go
@@ -70,7 +70,7 @@ func stripObjectMetadata(parent map[string]any, attrs []string) {
 
 // stripMetadataInList walks parent[listKey] as a []any of
 // map[string]any objects and strips attrs from each item's metadata.
-// Covers StatefulSet volumeClaimTemplates and List items uniformly.
+// Used for StatefulSet volumeClaimTemplates.
 func stripMetadataInList(parent map[string]any, listKey string, attrs []string) {
 	items, ok := parent[listKey].([]any)
 	if !ok {

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -230,7 +230,6 @@ func (o *Orchestrator) awaitDrain(ctx context.Context) error {
 	}()
 	select {
 	case <-done:
-		return errors.Join(o.finalize(), ctx.Err())
 	case <-ctx.Done():
 		// Wait for in-flight tasks to wind down before finalizing so
 		// the store snapshot is internally consistent, then preserve
@@ -238,8 +237,10 @@ func (o *Orchestrator) awaitDrain(ctx context.Context) error {
 		// may never acquire a worker slot once ctx is canceled; a clean
 		// partial snapshot must not look like a successful full run.
 		<-done
-		return errors.Join(o.finalize(), ctx.Err())
 	}
+	// Either path finalizes the same way: the store is fully drained and
+	// any cancellation is folded into the returned error.
+	return errors.Join(o.finalize(), ctx.Err())
 }
 
 // prewarmGitMirrors fires Prewarm against every discovered

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -119,11 +119,8 @@ func (f *Fetcher) resolveTransport(repo *manifest.GitRepository) (transport.Auth
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
 func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
-	if repo == nil {
-		return nil, errors.New("git repository is nil")
-	}
-	if repo.URL == "" {
-		return nil, fmt.Errorf("%w: GitRepository %s missing url", manifest.ErrInput, repo.RepoName())
+	if err := validateRepo(repo); err != nil {
+		return nil, err
 	}
 
 	refLabel := "HEAD"
@@ -219,6 +216,18 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		return nil, err
 	}
 	return commitArtifact(repo, slot, art)
+}
+
+// validateRepo guards the shared preconditions Fetch and Prewarm both
+// require before touching the network: a non-nil CR with a URL.
+func validateRepo(repo *manifest.GitRepository) error {
+	if repo == nil {
+		return errors.New("git repository is nil")
+	}
+	if repo.URL == "" {
+		return fmt.Errorf("%w: GitRepository %s missing url", manifest.ErrInput, repo.RepoName())
+	}
+	return nil
 }
 
 func effectiveNamedRef(ref manifest.GitRepositoryRef) string {
@@ -387,11 +396,8 @@ func (f *Fetcher) canUseMirror(repo *manifest.GitRepository) bool {
 // returned to the user — the real Fetch path will hit the same
 // error and produce the canonical status update.
 func (f *Fetcher) Prewarm(ctx context.Context, repo *manifest.GitRepository) error {
-	if repo == nil {
-		return errors.New("git repository is nil")
-	}
-	if repo.URL == "" {
-		return fmt.Errorf("%w: GitRepository %s missing url", manifest.ErrInput, repo.RepoName())
+	if err := validateRepo(repo); err != nil {
+		return err
 	}
 	if repo.Provider != "" && repo.Provider != sourcev1.GitProviderGeneric {
 		// The real Fetch path would reject this too; skip silently so

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log/slog"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -138,15 +139,13 @@ func (s *Service) notifyQuiescence(now int64) {
 	if len(s.quiesceWaiters) == 0 {
 		return
 	}
-	kept := s.quiesceWaiters[:0]
-	for _, w := range s.quiesceWaiters {
+	s.quiesceWaiters = slices.DeleteFunc(s.quiesceWaiters, func(w quiesceWaiter) bool {
 		if now <= w.threshold {
 			close(w.ch)
-			continue
+			return true
 		}
-		kept = append(kept, w)
-	}
-	s.quiesceWaiters = kept
+		return false
+	})
 }
 
 // QuiescenceCh returns a channel closed when the active-task count

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -80,21 +80,15 @@ func (p *storeProvider) Secret(namespace, name string) *manifest.Secret {
 // Nested maps recurse; lists and scalars from override fully replace
 // values from base — matching Helm's merge semantics. Both inputs
 // are read-only.
+//
+// Implemented as deepMergeShared over a fresh shallow copy of base:
+// the copy makes the top-level map owned, and deepMergeShared's
+// copy-on-collision recursion keeps every borrowed (base) sub-tree
+// read-only, so neither input is mutated.
 func DeepMerge(base, override map[string]any) map[string]any {
 	out := make(map[string]any, len(base)+len(override))
 	maps.Copy(out, base)
-	for k, v := range override {
-		if existing, ok := out[k]; ok {
-			ebm, eok := existing.(map[string]any)
-			vbm, vok := v.(map[string]any)
-			if eok && vok {
-				out[k] = DeepMerge(ebm, vbm)
-				continue
-			}
-		}
-		out[k] = v
-	}
-	return out
+	return deepMergeShared(out, override)
 }
 
 // DeepMergeInto merges override's keys into dst in place. Same merge


### PR DESCRIPTION
Fourth deep cleanliness sweep — 45 parallel per-package agents, adversarially reviewed. Seven genuine improvements; nothing rejected.

## Changes
- **change** (`detectViaGit`): `strings.CutPrefix` (the repo idiom) replaces a `HasPrefix`+manual-slice `switch`; drops `var rel` + duplicated slicing. Precedence/skip preserved.
- **diff**: extract `Options.normalize`, collapsing the 6 identical `normalizeDocs(docs, o.StripAttrs, o.StripFields, o.Normalize)` calls in renderHTML/renderNative/renderUnified.
- **manifest**: `requireMetadata` drops the redundant `!ok` (a failed map assertion already yields nil, so `md == nil` suffices); narrow `stripMetadataInList`'s doc to its sole call site (volumeClaimTemplates).
- **orchestrator** (`awaitDrain`): fold the two identical `errors.Join(finalize, ctx.Err())` returns into one after the select.
- **source/git**: extract `validateRepo` for the nil/empty-URL precondition shared verbatim by `fetch` and `Prewarm`.
- **task** (`notifyQuiescence`): `slices.DeleteFunc` replaces the manual filter-in-place; same close-on-expired + keep-rest semantics, race-clean.
- **values** (`DeepMerge`): delegate to `deepMergeShared` — its inline recursion was an exact duplicate. Identical values + reference-sharing; base/override stay read-only.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (all 7 packages) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** vs `main` (#649): 12 identical, including all HR-values-heavy repos (confirms the `DeepMerge` delegation). The 12 DIFF repos are the same pre-existing non-determinism exonerated in passes 1–3 (caBundle/unlock/updatedAt/checksum/stunner) — byte-for-byte identical signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)