### PR TITLE
refactor: deep cleanliness pass 5 (stale docs + guard-clause reorder)

### DIFF
--- a/pkg/helm/doc.go
+++ b/pkg/helm/doc.go
@@ -18,7 +18,7 @@
 //   - Options exposes the helm CLI flags flate understands
 //     (--kube-version, --api-versions, --no-hooks, etc.).
 //
-// The client is safe for concurrent use; chart downloads are cached
-// on disk keyed by chart name + version, and parallel first-loads
+// The client is safe for concurrent use; fetched chart bytes live in
+// the shared content-addressed source cache, and parallel first-loads
 // of the same chart coalesce through a per-path keylock.
 package helm

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -163,14 +163,14 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 		}
 	}
 
+	if f.canUseMirror(repo) {
+		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy)
+	}
+
 	url := repo.URL
 	// file:// URLs are accepted by go-git as bare filesystem paths.
 	if rest, ok := strings.CutPrefix(url, "file://"); ok {
 		url = rest
-	}
-
-	if f.canUseMirror(repo) {
-		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy)
 	}
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}

--- a/pkg/source/oci/resolve.go
+++ b/pkg/source/oci/resolve.go
@@ -19,7 +19,7 @@ import (
 //	oci://ghcr.io/owner/chart:tag  → ghcr.io/owner/chart
 //	oci://ghcr.io/owner/chart@sha  → ghcr.io/owner/chart
 //
-// The tag/digest is dropped here and re-supplied to oras.Copy below.
+// The tag/digest is dropped here and re-supplied to oras.Copy separately.
 func parseOCIRef(versioned string) (string, error) {
 	versioned = strings.TrimPrefix(versioned, "oci://")
 	// Strip ":<tag>" or "@<digest>" portion for the reference; oras


### PR DESCRIPTION
Fifth deep cleanliness sweep — 45 parallel per-package agents (the large majority reported already-clean). Three genuine improvements; nothing rejected.

## Changes
- **helm** (doc.go): fetched chart bytes live in the shared content-addressed `source.Cache` (per `client.go`), not "cached on disk keyed by chart name + version" — corrected the stale description.
- **source/git** (`fetch`): hoist the `canUseMirror` early-return above the clone-only `url`/`file://` setup, so the guard reads first and the url handling sits with its sole consumer (`cloneOpts`). Behavior-identical — `canUseMirror`/`fetchViaMirror` take `repo`, not the derived `url`, and the url computation is side-effect-free.
- **source/oci** (`parseOCIRef` doc): "re-supplied to oras.Copy below" → "...separately"; `oras.Copy` lives in fetch.go, not below this function — removed the false locality reference.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (helm/source-git/source-oci) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** vs `main` (#650): 12 identical; 11 DIFF repos byte-for-byte match the pass-4 non-determinism, and m00nwtchr-apps landed on 96692 (a value the base binary itself produces; stunner-operator resource-set + caBundle churn). All pre-existing non-determinism, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)