### PR TITLE
refactor: deep cleanliness pass 6 (iter.Seq + stale-doc/type fixes)

### DIFF
--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -1,6 +1,7 @@
 package change
 
 import (
+	"iter"
 	"strings"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -87,31 +88,33 @@ func memoize(cache map[string][]manifest.NamedResource, file string, compute fun
 	return result
 }
 
-// matchingPrefixes invokes yield with each slash-terminated, whole-segment
-// prefix of file+"/" that has at least one claim, from longest to shortest.
-// These are exactly the c.path values strings.HasPrefix(file+"/", c.path)
-// would have matched in the old full scan: c.path ends in "/", so a match
-// means c.path is file+"/" truncated at some "/" boundary. Probing each
-// directory prefix in byPrefix replaces the O(claims) HasPrefix loop with
-// O(depth) map hits. Prefix substrings share file's backing array, so no
-// per-probe allocation. Yield returns false to stop early.
-func (idx ownershipIndex) matchingPrefixes(file string, yield func(ids []manifest.NamedResource) bool) {
-	prefixed := file + "/"
-	// Candidate prefixes are prefixed[:k] for every k where prefixed[k-1]
-	// is '/', longest first. The full prefixed (k==len, a claim on file's
-	// own directory) is the first candidate; each earlier "/" truncation
-	// follows.
-	for end := len(prefixed); end > 0; {
-		if ids, ok := idx.byPrefix[prefixed[:end]]; ok {
-			if !yield(ids) {
-				return
+// matchingPrefixes yields the claim group at each slash-terminated,
+// whole-segment prefix of file+"/" that has at least one claim, from
+// longest to shortest. These are exactly the c.path values
+// strings.HasPrefix(file+"/", c.path) would have matched in the old full
+// scan: c.path ends in "/", so a match means c.path is file+"/" truncated
+// at some "/" boundary. Probing each directory prefix in byPrefix replaces
+// the O(claims) HasPrefix loop with O(depth) map hits. Prefix substrings
+// share file's backing array, so no per-probe allocation.
+func (idx ownershipIndex) matchingPrefixes(file string) iter.Seq[[]manifest.NamedResource] {
+	return func(yield func(ids []manifest.NamedResource) bool) {
+		prefixed := file + "/"
+		// Candidate prefixes are prefixed[:k] for every k where prefixed[k-1]
+		// is '/', longest first. The full prefixed (k==len, a claim on file's
+		// own directory) is the first candidate; each earlier "/" truncation
+		// follows.
+		for end := len(prefixed); end > 0; {
+			if ids, ok := idx.byPrefix[prefixed[:end]]; ok {
+				if !yield(ids) {
+					return
+				}
 			}
+			i := strings.LastIndexByte(prefixed[:end-1], '/')
+			if i < 0 {
+				break
+			}
+			end = i + 1
 		}
-		i := strings.LastIndexByte(prefixed[:end-1], '/')
-		if i < 0 {
-			break
-		}
-		end = i + 1
 	}
 }
 
@@ -120,12 +123,10 @@ func (idx ownershipIndex) matchingPrefixes(file string, yield func(ids []manifes
 // play. Results are memoized — see ownershipIndex doc.
 func (idx ownershipIndex) ownersOf(file string) []manifest.NamedResource {
 	return memoize(idx.ownersCache, file, func() []manifest.NamedResource {
-		var owners []manifest.NamedResource
-		idx.matchingPrefixes(file, func(ids []manifest.NamedResource) bool {
-			owners = ids // longest match first — take it and stop
-			return false
-		})
-		return owners
+		for ids := range idx.matchingPrefixes(file) {
+			return ids // longest match first — take it and stop
+		}
+		return nil
 	})
 }
 
@@ -141,14 +142,13 @@ func (idx ownershipIndex) ancestorsOf(file string) []manifest.NamedResource {
 	return memoize(idx.ancestorsCache, file, func() []manifest.NamedResource {
 		var ancestors []manifest.NamedResource
 		first := true
-		idx.matchingPrefixes(file, func(ids []manifest.NamedResource) bool {
+		for ids := range idx.matchingPrefixes(file) {
 			if first {
 				first = false // longest match — skip (it's what ownersOf returns)
-				return true
+				continue
 			}
 			ancestors = append(ancestors, ids...)
-			return true
-		})
+		}
 		return ancestors
 	})
 }

--- a/pkg/diff/format.go
+++ b/pkg/diff/format.go
@@ -38,8 +38,8 @@ const (
 
 // isDyffText reports whether f renders the whole doc set natively through
 // dyff (see renderNative) rather than through the per-resource unified-diff
-// path (FormatDiff). The zero value defaults to the github style at the
-// call site (see RenderDocs), so it is handled there rather than here.
+// path (FormatDiff). The zero value defaults to the human style in
+// renderNative, so it is handled there rather than here.
 func (f Format) isDyffText() bool {
 	switch f {
 	case FormatGitHub, FormatHuman, FormatBrief, FormatGitLab, FormatGitea:

--- a/pkg/loader/existence.go
+++ b/pkg/loader/existence.go
@@ -33,7 +33,7 @@ import (
 //     SourceFiles map regardless of whether the object reached the
 //     store. The index doesn't duplicate that bookkeeping.
 //
-// Thread-safe: the loader walks files concurrently from one goroutine
+// Thread-safe: the loader walks files serially from one goroutine
 // today, but lazy-promotion from depwait can be invoked from
 // reconcile-worker goroutines. Cheap RW mutex keeps the contract
 // clear if either side grows concurrency later.

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -121,8 +121,8 @@ func SupportsStatus(kind string) bool {
 // readyCondition builds the Ready condition that corresponds to the
 // (status, message) pair UpdateStatus accepts. Reason is derived from
 // Status; Message is passed through verbatim.
-func readyCondition(status Status, message string) metav1.Condition {
-	c := metav1.Condition{
+func readyCondition(status Status, message string) Condition {
+	c := Condition{
 		Type:    ConditionReady,
 		Message: message,
 	}
@@ -143,7 +143,7 @@ func readyCondition(status Status, message string) metav1.Condition {
 // statusInfoFromConditions projects the rollup StatusInfo from the
 // Ready condition. Returns (zero, false) when no Ready condition is
 // present.
-func statusInfoFromConditions(conds []metav1.Condition) (StatusInfo, bool) {
+func statusInfoFromConditions(conds []Condition) (StatusInfo, bool) {
 	for _, c := range conds {
 		if c.Type != ConditionReady {
 			continue


### PR DESCRIPTION
Sixth deep cleanliness sweep — 45 parallel per-package agents. Four genuine improvements; nothing rejected.

## Changes
- **change** (`ownership.go`): `matchingPrefixes` returns an `iter.Seq[[]NamedResource]` instead of taking a manual `yield func(...) bool`; `ownersOf`/`ancestorsOf` range over it. The hand-rolled push-iterator is exactly what `iter.Seq` formalizes — behavior-identical (longest-first; first-match-stops for owners; skip-longest-then-collect for ancestors).
- **diff** (`isDyffText` doc): the zero `Format` value resolves to the **human** style inside `renderNative` (`RenderDocs` routes `""` → `renderNative` → `FormatHuman`), not "github at the call site". Corrected.
- **loader** (`existence.go` doc): fix the oxymoronic "walks files concurrently from one goroutine" → "serially from one goroutine".
- **store** (`status.go`): `readyCondition`/`statusInfoFromConditions` use the package's own `Condition` alias (`= metav1.Condition`) for vocabulary consistency. Identical type.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (change/diff/loader/store) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** vs `main` (#651): 12 identical (incl. all change-detection paths exercising the `iter.Seq` conversion). 11 DIFF repos byte-for-byte match the known non-determinism; m00nwtchr-apps landed on 96692 (a base-produced value; stunner-operator resource-set churn). All pre-existing, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)