### PR TITLE
refactor: deep cleanliness pass 7 (dedup + accurate docs)

### DIFF
--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -32,6 +32,7 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	type parsed struct {
 		obj          manifest.BaseManifest
 		reconcilable bool
+		leaf         bool // held for pass 2 (Kustomization / HelmRelease)
 	}
 	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
 	objs := make([]parsed, 0, len(docs))
@@ -49,7 +50,12 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		if manifest.IsKustomizeBuildDirective(obj) {
 			continue // build input, not a cluster resource — never store it
 		}
-		objs = append(objs, parsed{obj: obj, reconcilable: shouldDispatchAsObject(obj)})
+		reconcilable := shouldDispatchAsObject(obj)
+		objs = append(objs, parsed{
+			obj:          obj,
+			reconcilable: reconcilable,
+			leaf:         reconcilable && isLeafReconcilable(obj),
+		})
 	}
 	// Accumulate every reconcilable child's id across both passes so
 	// the renderedSet write can flush through MarkRenderedBatch in a
@@ -63,20 +69,20 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	}
 	// Pass 1 — data first.
 	for _, p := range objs {
-		if p.reconcilable && isLeafReconcilable(p.obj) {
-			continue
-		}
-		if p.reconcilable {
+		switch {
+		case p.leaf:
+			continue // held for pass 2
+		case p.reconcilable:
 			keep(p.obj)
 			c.Store.AddObject(p.obj)
-		} else {
+		default:
 			c.Store.AddRendered(p.obj)
 		}
 	}
 	// Pass 2 — leaf reconcilables.
 	var leaves []manifest.BaseManifest
 	for _, p := range objs {
-		if p.reconcilable && isLeafReconcilable(p.obj) {
+		if p.leaf {
 			keep(p.obj)
 			leaves = append(leaves, p.obj)
 		}

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -244,18 +244,24 @@ func (w *Waiter) readyNow(dep manifest.DependencyRef) bool {
 		return true
 	}
 	if dep.ReadyExpr != "" && !w.AdditiveReadyExpr {
-		ev, done := w.tryReadyExpr(dep.ReadyExpr, id)
-		return done && ev.Status == DepReady
+		return w.readyExprSatisfied(dep.ReadyExpr, id)
 	}
 	info, ok := w.Store.GetStatus(id)
 	if !ok || info.Status != store.StatusReady {
 		return false
 	}
 	if dep.ReadyExpr != "" {
-		ev, done := w.tryReadyExpr(dep.ReadyExpr, id)
-		return done && ev.Status == DepReady
+		return w.readyExprSatisfied(dep.ReadyExpr, id)
 	}
 	return true
+}
+
+// readyExprSatisfied reports whether expr produced a definitive Ready
+// result for id right now (no waiting). A clean false, a transient eval
+// error, or a compile failure all read as "not ready".
+func (w *Waiter) readyExprSatisfied(expr string, id manifest.NamedResource) bool {
+	ev, done := w.tryReadyExpr(expr, id)
+	return done && ev.Status == DepReady
 }
 
 // safeWatchOne wraps watchOne with panic recovery — a malformed CEL

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -298,9 +298,9 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider, cache *C
 		// The Prepare path clones hr before calling here, so its sub-trees
 		// are owned by this reconcile. Build the inline layer ON TOP of
 		// values (inline wins on collision). In the share path values may
-		// alias cache sub-trees, so use functional DeepMerge (no in-place
-		// mutation of a shared node); in the owned path DeepMergeInto is
-		// fine and avoids the extra top-level allocation.
+		// alias cache sub-trees, so use deepMergeShared (copy-on-write, so a
+		// shared node is cloned before it is written through); in the owned
+		// path DeepMergeInto is fine and avoids that clone.
 		if share {
 			// Owned accumulator, read-only hr.Values: merge in place with
 			// copy-on-write so sub-maps still aliasing the cache canonical
@@ -458,13 +458,14 @@ func bagValueAsString(v any) (string, error) {
 // by kind, namespace, name, valuesKey, content-hash) and deep-merged.
 //
 // share selects the merge strategy, decided once per HR by the caller:
-//   - share=true (the HR has NO TargetPath ref): functional DeepMerge,
-//     which SHARES the cached canonical's non-colliding sub-trees by
-//     reference instead of deep-copying them. Safe because nothing in
-//     this HR mutates the accumulator in place and the cache canonical
-//     is read-only downstream (helm copies the input on entry). M HRs
-//     referencing the same ConfigMap then share one parsed tree instead
-//     of each deep-copying it.
+//   - share=true (the HR has NO TargetPath ref): deepMergeShared, which
+//     folds the canonical into the owned accumulator in place and SHARES
+//     its non-colliding sub-trees by reference instead of deep-copying
+//     them (map collisions copy-on-write so the canonical is never
+//     mutated). Safe because nothing in this HR mutates a shared node and
+//     the cache canonical is read-only downstream (helm copies the input
+//     on entry). M HRs referencing the same ConfigMap then share one
+//     parsed tree instead of each deep-copying it.
 //   - share=false (the HR has a TargetPath ref somewhere): eager
 //     DeepMergeInto over a DeepCopyMap of the canonical, so the
 //     accumulator is FULLY OWNED and the in-place strvals write that a


### PR DESCRIPTION
Seventh deep cleanliness sweep — 45 parallel per-package agents (the large majority already-clean). Three genuine improvements.

## Changes
- **controllers/kustomization** (`emitRenderedChildren`): compute each child's leaf-reconcilable flag once at parse time (held on the `parsed` struct) instead of recomputing `isLeafReconcilable` in both passes; pass 1's nested if/else becomes a `switch`. Behavior-identical.
- **depwait**: extract `readyExprSatisfied` for the `tryReadyExpr` + `done && ev.Status == DepReady` check duplicated across `readyNow`'s two branches; names the non-obvious "definitive Ready right now" condition.
- **values**: correct the merge-strategy comments — the share path calls `deepMergeShared` (in-place copy-on-write), not "functional DeepMerge"; the old wording contradicted both the call and the adjacent comment.

## Verification
- gofmt clean · `go build ./...` · `go vet` · `go test -race` (controllers-kustomization/depwait/values) · `golangci-lint` 0 issues.
- **Byte-equivalence across 24 paths** vs `main` (#652): 12 identical (incl. the controller emit path); 11 DIFF repos byte-for-byte match the known non-determinism, m00nwtchr-apps in-band (96692, a base-produced value). All pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)