### PR TITLE
fix: bind dependency waits to fetch completion, not a wall clock

### DIFF
--- a/pkg/controllers/helmrelease/chartsource_determinism_test.go
+++ b/pkg/controllers/helmrelease/chartsource_determinism_test.go
@@ -1,0 +1,253 @@
+package helmrelease
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/home-operations/flate/pkg/helm"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+// tasksRenderInflight mirrors the orchestrator's orchestratorRenderInflight:
+// quiescence is "the task pool drained to no productive work" — QuiescenceCh(0),
+// because depwait callers reach it from inside YieldQuiescent (already
+// decremented their own slot).
+type tasksRenderInflight struct{ ts *task.Service }
+
+func (r tasksRenderInflight) QuiescenceCh() <-chan struct{} { return r.ts.QuiescenceCh(0) }
+
+// newChartSourceTestController builds an HR controller wired with a real task
+// service exposed to the test, plus a render-quiescence signal backed by that
+// service — the production shape, so awaitChartSource's YieldQuiescent +
+// QuiescenceCh park behaves exactly as it does under the orchestrator.
+func newChartSourceTestController(t *testing.T) (*Controller, *store.Store, *task.Service) {
+	t.Helper()
+	st := store.New()
+	ts := task.New()
+	hc, err := helm.NewClient(cacheroot.New(t.TempDir()))
+	if err != nil {
+		t.Fatalf("helm.NewClient: %v", err)
+	}
+	hc.SetSourceResolver(helm.NewStoreSourceResolver(st))
+	c := New(st, ts, hc, helm.Options{}, false)
+	c.Configure(ReconcileOptions{Renders: tasksRenderInflight{ts}})
+	c.Start(context.Background())
+	t.Cleanup(func() {
+		c.Close()
+		ts.BlockTillDone()
+	})
+	return c, st, ts
+}
+
+func chartSourceTestHR() *manifest.HelmRelease {
+	return &manifest.HelmRelease{
+		Name: "stunner", Namespace: "stunner-system",
+		// 50ms per-dep wall clock — far shorter than the simulated fetch.
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			Timeout: &metav1.Duration{Duration: 50 * time.Millisecond},
+		},
+		Chart: manifest.HelmChart{
+			RepoKind:      manifest.KindHelmRepository,
+			RepoNamespace: "stunner-system",
+			RepoName:      "stunner",
+			Name:          "stunner",
+			Version:       "1.2.0",
+		},
+	}
+}
+
+func addStunnerRepo(st *store.Store) {
+	st.AddObject(&manifest.HelmRepository{
+		Name: "stunner", Namespace: "stunner-system",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://l7mp.io/stunner"},
+	})
+}
+
+// TestAwaitChartSource_ParksOnQuiescenceNotWallClock is the stunner
+// determinism regression. A synthetic HelmChart whose fetch finishes only
+// AFTER the per-dep DefaultTimeout/spec.timeout must still be observed Ready —
+// the wait is bound to fetch-task completion (quiescence), not the wall clock.
+//
+// Before the fix awaitChartSource rode hr.Timeout (50ms) in watchOne and
+// returned "chart source ... not ready: timeout" because the simulated fetch
+// only sets Ready at 200ms — exactly the bug that dropped the stunner HR's
+// ~478 lines nondeterministically. After the fix it parks on quiescence and
+// returns nil every time.
+func TestAwaitChartSource_ParksOnQuiescenceNotWallClock(t *testing.T) {
+	// Repeat to assert determinism: the outcome must not depend on whether
+	// the fetch beats the wall clock (it never does here — 200ms >> 50ms).
+	for i := range 25 {
+		c, st, ts := newChartSourceTestController(t)
+		addStunnerRepo(st)
+		hr := chartSourceTestHR()
+
+		hr2, repointed := c.materializeHelmChartSource(hr.Named(), hr)
+		if !repointed {
+			t.Fatalf("iter %d: materialize did not repoint a HelmRepository chart", i)
+		}
+		srcID := chartSourceID(hr2)
+		if info, ok := st.GetStatus(srcID); !ok || info.Status != store.StatusPending {
+			t.Fatalf("iter %d: synthetic chart not seeded Pending (ok=%v status=%v)", i, ok, info.Status)
+		}
+
+		ctx := context.Background()
+		// Simulated fetch task: holds the pool active (a plain Go body keeps
+		// active incremented), sets Ready at 200ms — well past the 50ms
+		// per-dep budget — then returns, dropping active so quiescence fires.
+		ts.Go(ctx, "fake-fetch", func(context.Context) {
+			time.Sleep(200 * time.Millisecond)
+			st.UpdateStatus(srcID, store.StatusReady, "")
+		})
+
+		// The HR wait must run inside a task body (YieldQuiescent corrupts the
+		// active counter if called outside one), exactly as the real reconcile.
+		errCh := make(chan error, 1)
+		ts.Go(ctx, "hr-wait", func(context.Context) {
+			errCh <- c.awaitChartSource(ctx, hr.Named(), hr2)
+		})
+
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("iter %d: awaitChartSource returned %v; want nil (chart became Ready at 200ms, must not time out at the 50ms wall clock)", i, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iter %d: awaitChartSource did not return (parked wait never woke)", i)
+		}
+	}
+}
+
+// TestAwaitChartSource_FailedFetchStillFastFails guards the no-regression
+// edge: a synthetic chart whose fetch FAILS must surface that fast (via the
+// quiesce re-read), not hang to a ceiling.
+func TestAwaitChartSource_FailedFetchStillFastFails(t *testing.T) {
+	c, st, ts := newChartSourceTestController(t)
+	addStunnerRepo(st)
+	hr := chartSourceTestHR()
+	hr.Timeout = &metav1.Duration{Duration: 5 * time.Second} // long: prove we don't ride it
+
+	hr2, repointed := c.materializeHelmChartSource(hr.Named(), hr)
+	if !repointed {
+		t.Fatal("materialize did not repoint")
+	}
+	srcID := chartSourceID(hr2)
+
+	ctx := context.Background()
+	start := time.Now()
+	ts.Go(ctx, "fake-fetch-fail", func(context.Context) {
+		time.Sleep(50 * time.Millisecond)
+		st.UpdateStatus(srcID, store.StatusFailed, "fetch failed: boom")
+	})
+	errCh := make(chan error, 1)
+	ts.Go(ctx, "hr-wait", func(context.Context) {
+		errCh <- c.awaitChartSource(ctx, hr.Named(), hr2)
+	})
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("awaitChartSource returned nil for a Failed chart source; want an error")
+		}
+		if !errors.Is(err, manifest.ErrObjectNotFound) {
+			t.Fatalf("error = %v; want wrapped ErrObjectNotFound", err)
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Fatalf("fast-fail took %v; expected well under the 5s hr.Timeout", elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("awaitChartSource did not return on a Failed fetch")
+	}
+}
+
+// TestAwaitChartSource_DeclaredGitChartSourceParks is the infisical-shaped
+// regression: a DECLARED (non-synthetic) GitRepository-backed chart source —
+// the case the old synthetic-only gate missed — must also be waited for by
+// fetch outcome, not abandoned at the wall clock. The source is present+Pending
+// and flips Ready at 200ms with a 50ms hr.Timeout; the park must hold until the
+// fetch completes so awaitChartSource returns nil every run.
+func TestAwaitChartSource_DeclaredGitChartSourceParks(t *testing.T) {
+	for i := range 25 {
+		c, st, ts := newChartSourceTestController(t)
+		hr := &manifest.HelmRelease{
+			Name: "infisical", Namespace: "infisical",
+			HelmReleaseSpec: helmv2.HelmReleaseSpec{
+				Timeout: &metav1.Duration{Duration: 50 * time.Millisecond},
+			},
+			// chartRef → GitRepository: a declared chart source the controller
+			// does NOT materialize (materializeHelmChartSource is HelmRepository-only).
+			Chart: manifest.HelmChart{
+				RepoKind:      manifest.KindGitRepository,
+				RepoNamespace: "infisical",
+				RepoName:      "infisical",
+			},
+		}
+		srcID := chartSourceID(hr)
+		// Present + Pending = fetch in flight (a status seed stands in for the
+		// source controller's dispatched git fetch).
+		st.UpdateStatus(srcID, store.StatusPending, "fetching")
+
+		ctx := context.Background()
+		ts.Go(ctx, "fake-git-fetch", func(context.Context) {
+			time.Sleep(200 * time.Millisecond)
+			st.UpdateStatus(srcID, store.StatusReady, "")
+		})
+		errCh := make(chan error, 1)
+		ts.Go(ctx, "hr-wait", func(context.Context) {
+			errCh <- c.awaitChartSource(ctx, hr.Named(), hr)
+		})
+
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("iter %d: awaitChartSource returned %v; want nil (declared git chart source Ready at 200ms must not time out at 50ms)", i, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iter %d: awaitChartSource did not return", i)
+		}
+	}
+}
+
+// TestAwaitChartSource_AbsentSourceFastFails confirms the gate did NOT widen to
+// absent/typo'd sources: a chart source with no store entry is a no-op for the
+// AwaitFetch park (GetStatus !ok) and still fast-fails via the bounded c.Await,
+// rather than parking on quiescence.
+func TestAwaitChartSource_AbsentSourceFastFails(t *testing.T) {
+	c, _, _ := newChartSourceTestController(t)
+	// A direct HelmChart ref that was never added to the store.
+	hr := &manifest.HelmRelease{
+		Name: "app", Namespace: "apps",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			Timeout: &metav1.Duration{Duration: 50 * time.Millisecond},
+		},
+		Chart: manifest.HelmChart{
+			RepoKind:      manifest.KindHelmChart,
+			RepoNamespace: "apps",
+			RepoName:      "missing-chart",
+		},
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var err error
+	start := time.Now()
+	c.Tasks.Go(context.Background(), "absent-wait", func(context.Context) {
+		defer wg.Done()
+		err = c.awaitChartSource(context.Background(), hr.Named(), hr)
+	})
+	wg.Wait()
+	if err == nil {
+		t.Fatal("awaitChartSource returned nil for an absent source; want a not-found error")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("absent-source wait took %v; expected to fast-fail near the wall clock", elapsed)
+	}
+}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -387,6 +387,12 @@ func chartSourceID(hr *manifest.HelmRelease) manifest.NamedResource {
 // propagates a soft-skip (--allow-missing-secrets on the source's auth marks it
 // Ready but writes no artifact, so fail here rather than letting the render fail
 // later with a confusing chart-not-found).
+//
+// The chart source is a status-bearing dependency that flate itself fetches
+// (synthetic HelmChart, declared OCIRepository/GitRepository/HelmChart), so the
+// depwait this drives binds the wait to the fetch's completion (orchestrator
+// quiescence) rather than the per-dep wall clock — a slow fetch is waited for by
+// OUTCOME instead of dropped nondeterministically. See depwait.Waiter.watchOne.
 func (c *Controller) awaitChartSource(ctx context.Context, id manifest.NamedResource, hr *manifest.HelmRelease) error {
 	srcID := chartSourceID(hr)
 	if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout),

--- a/pkg/controllers/kustomization/source_determinism_test.go
+++ b/pkg/controllers/kustomization/source_determinism_test.go
@@ -1,0 +1,99 @@
+package kustomization
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/kustomize"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+// tasksRenderInflight mirrors the orchestrator's orchestratorRenderInflight:
+// QuiescenceCh(0), since depwait callers reach it from inside YieldQuiescent.
+type tasksRenderInflight struct{ ts *task.Service }
+
+func (r tasksRenderInflight) QuiescenceCh() <-chan struct{} { return r.ts.QuiescenceCh(0) }
+
+// TestReconcile_SourceRefParksOnFetch is the global-determinism regression for
+// the Kustomization sourceRef path (the analogue of the HR chart-source bug).
+// A KS whose GitRepository sourceRef is still being fetched (present+Pending)
+// when its short spec.timeout would expire must NOT be skipped: the reconcile
+// parks on the fetch's completion (orchestrator quiescence) and renders once
+// the source goes Ready. Before the fix the KS rode the 50ms wall clock,
+// resolveSource saw no artifact, and the KS Failed — dropping its rendered
+// resources nondeterministically.
+func TestReconcile_SourceRefParksOnFetch(t *testing.T) {
+	for i := range 10 {
+		root := t.TempDir()
+		testutil.WriteFileAt(t, filepath.Join(root, "apps", "kustomization.yaml"),
+			"resources:\n- cm.yaml\n")
+		testutil.WriteFileAt(t, filepath.Join(root, "apps", "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: default}
+data: {greeting: hi}
+`)
+
+		s := store.New()
+		// The KS's sourceRef: present but PENDING (fetch in flight), no artifact
+		// yet — stands in for a slow GitRepository fetch dispatched by the source
+		// controller.
+		src := &manifest.GitRepository{
+			Name: "apps-src", Namespace: "flux-system",
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
+		}
+		s.AddObject(src)
+		s.UpdateStatus(src.Named(), store.StatusPending, "fetching")
+
+		tasks := task.New()
+		c := New(s, tasks, kustomize.NewTreeCache(), true)
+		c.Configure(Options{Renders: tasksRenderInflight{tasks}})
+		c.Start(context.Background())
+
+		// The fetch completes only at 200ms — far past the KS's 50ms timeout.
+		// A plain task body holds the pool active until it returns (Ready set
+		// before decrActive), exactly like the source controller's YieldSlot.
+		srcID := src.Named()
+		tasks.Go(context.Background(), "fake-git-fetch", func(context.Context) {
+			time.Sleep(200 * time.Millisecond)
+			s.SetArtifact(srcID, &store.SourceArtifact{
+				Kind: manifest.KindGitRepository, URL: "file://" + root, LocalPath: root,
+			})
+			s.UpdateStatus(srcID, store.StatusReady, "ready")
+		})
+
+		ks := &manifest.Kustomization{
+			Name: "apps", Namespace: "flux-system",
+			KustomizationSpec: kustomizev1.KustomizationSpec{
+				Path:    "./apps",
+				Timeout: &metav1.Duration{Duration: 50 * time.Millisecond},
+				SourceRef: kustomizev1.CrossNamespaceSourceReference{
+					Kind: manifest.KindGitRepository, Name: "apps-src", Namespace: "flux-system",
+				},
+			},
+			SourceKind: manifest.KindGitRepository, SourceName: "apps-src", SourceNamespace: "flux-system",
+			Contents: map[string]any{},
+		}
+		s.AddObject(ks)
+
+		// Fix → parks until the source is Ready (200ms) → renders → Ready.
+		// Broken → rode the 50ms clock → resolveSource saw no artifact → Failed,
+		// and this WaitForStatus(Ready) would time out.
+		info := testutil.WaitForStatus(t, s, ks.Named(), store.StatusReady)
+		if info.Status != store.StatusReady {
+			t.Fatalf("iter %d: KS status = %v (%q); want Ready (parked for the in-flight sourceRef fetch)", i, info.Status, info.Message)
+		}
+
+		c.Close()
+		tasks.BlockTillDone()
+	}
+}

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -291,10 +291,15 @@ func (w *Waiter) safeWatchOne(ctx context.Context, dep manifest.DependencyRef, t
 }
 
 func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeout time.Duration) Event {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	id := dep.NamedResource
+
+	// boundCtx applies the per-dep wall-clock budget to the paths that wait on a
+	// dep which is NOT a present, status-bearing object: an absent dep (typo'd
+	// or not-yet-produced — resolveMissing also consults RenderInflight for
+	// render-only deps), a status-less kind (WatchExists), or a CEL ReadyExpr.
+	// A genuinely-missing dep must still fast-fail near DefaultTimeout.
+	boundCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	// Fail fast on deps that never made it into the store: branch on
 	// the Existence index (when wired) before burning MissingGrace.
@@ -302,13 +307,13 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 	// — the latter covers controllers that update status before
 	// AddObject (and unit tests that set status only).
 	if !w.depExists(id) {
-		if err := w.resolveMissing(ctx, id); err != nil {
+		if err := w.resolveMissing(boundCtx, id); err != nil {
 			return *err
 		}
 	}
 
 	if !store.SupportsStatus(id.Kind) {
-		_, err := w.Store.WatchExists(ctx, id)
+		_, err := w.Store.WatchExists(boundCtx, id)
 		return classify(id, err, "")
 	}
 
@@ -318,15 +323,26 @@ func (w *Waiter) watchOne(ctx context.Context, dep manifest.DependencyRef, timeo
 	// expires). Matches Flux's default semantics — the CEL is the
 	// authoritative readiness signal.
 	if dep.ReadyExpr != "" && !w.AdditiveReadyExpr {
-		return w.watchReadyExpr(ctx, id, dep.ReadyExpr)
+		return w.watchReadyExpr(boundCtx, id, dep.ReadyExpr)
 	}
 
-	// Pass the orchestrator's quiescence channel (when wired) so the
-	// store's post-Failed grace can short-circuit the moment no other
-	// reconcile is in flight — a typo'd dependsOn won't be saved by a
-	// future re-emit, and burning the full grace adds visible wall time
-	// to errored runs (worst case: 3s × depth of chained parent gates).
-	info, err := w.Store.WatchReady(ctx, id, w.quiesceCh())
+	// Present, status-bearing dependency. A present-but-not-Ready dep may still
+	// be made Ready by an in-flight producer — a source fetch, a parent KS
+	// render — that can legitimately outrun DefaultTimeout. Abandoning it at the
+	// per-dep wall clock races that producer and drops resources
+	// nondeterministically (the chart-source / dependsOn determinism bug). When
+	// a quiescence signal is wired, bind the wait to orchestrator quiescence on
+	// the PARENT ctx instead: WatchReady returns on Ready (a producer finished)
+	// and gives up only once the pool drains with the dep still not Ready (no
+	// producer left, after a final re-read). Fetches are bounded, so quiescence
+	// always arrives. Without a quiescence signal (legacy embedders / tests)
+	// keep the wall-clock budget. The same channel also short-circuits the
+	// post-Failed grace the moment no other reconcile is in flight.
+	waitCtx, quiesce := boundCtx, w.quiesceCh()
+	if quiesce != nil {
+		waitCtx = ctx
+	}
+	info, err := w.Store.WatchReady(waitCtx, id, quiesce)
 	if err != nil {
 		return classify(id, err, info.Message)
 	}
@@ -612,6 +628,10 @@ func classify(dep manifest.NamedResource, err error, fallback string) Event {
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		return Event{Dep: dep, Status: DepTimeout, Reason: "timeout"}
+	case errors.Is(err, store.ErrQuiesced):
+		// The pool drained with the dep still not Ready — no producer left to
+		// satisfy it. Same outcome as a timeout (dependency unavailable).
+		return Event{Dep: dep, Status: DepTimeout, Reason: "not ready"}
 	case errors.Is(err, context.Canceled):
 		return Event{Dep: dep, Status: DepCancelled, Reason: "cancelled"}
 	}

--- a/pkg/depwait/quiescence_bound_test.go
+++ b/pkg/depwait/quiescence_bound_test.go
@@ -1,0 +1,97 @@
+package depwait
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestWatchOne_QuiescenceBound_WaitsPastWallClock is the core determinism
+// regression: a PRESENT but not-Ready dependency (a source still fetching, an
+// HR still rendering) must be waited for by the producer's OUTCOME, not
+// abandoned at the per-dep wall clock. With a RenderInflight wired, the wait is
+// bound to quiescence on the parent ctx; a Ready that lands well after the
+// 50ms Timeout must still be observed. Before the fix watchOne capped the wait
+// at Timeout and returned DepTimeout — the chart-source / dependsOn flake.
+func TestWatchOne_QuiescenceBound_WaitsPastWallClock(t *testing.T) {
+	dep := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "slow"}
+	s := store.New()
+	s.UpdateStatus(dep, store.StatusPending, "fetching")
+
+	// Quiescence never fires (a producer is still in flight), so the wait can
+	// only end on the dep going Ready.
+	neverQuiesce := make(chan struct{})
+	w := &Waiter{
+		Store:   s,
+		Timeout: 50 * time.Millisecond,
+		Renders: rendersStub{quiesce: func() <-chan struct{} { return neverQuiesce }},
+	}
+
+	go func() {
+		time.Sleep(150 * time.Millisecond) // > the 50ms wall clock
+		s.UpdateStatus(dep, store.StatusReady, "")
+	}()
+
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
+	if sum.AnyFailed() {
+		t.Fatalf("present-Pending dep with a Ready at 150ms must be waited for past the %v wall clock; got failure %q",
+			w.Timeout, sum.Messages[dep])
+	}
+}
+
+// TestWatchOne_QuiescenceBound_GivesUpOnQuiescence verifies the terminator: a
+// present dep that never becomes Ready is given up the moment the pool drains
+// (no producer left), classified DepTimeout "not ready" — NOT rid to the full
+// (here 5s) wall clock.
+func TestWatchOne_QuiescenceBound_GivesUpOnQuiescence(t *testing.T) {
+	dep := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "stuck"}
+	s := store.New()
+	s.UpdateStatus(dep, store.StatusPending, "fetching")
+
+	quiesce := make(chan struct{})
+	w := &Waiter{
+		Store:   s,
+		Timeout: 5 * time.Second, // long: prove we give up on quiescence, not this
+		Renders: rendersStub{quiesce: func() <-chan struct{} { return quiesce }},
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(quiesce) // pool drained, dep still Pending
+	}()
+
+	start := time.Now()
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
+	if !sum.AnyFailed() {
+		t.Fatal("a never-Ready dep must be given up on quiescence")
+	}
+	if got := sum.Messages[dep]; got != "not ready" {
+		t.Errorf("give-up reason = %q; want %q", got, "not ready")
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("give-up took %v; expected to terminate at quiescence (~50ms), not the 5s wall clock", elapsed)
+	}
+}
+
+// TestWatchOne_NoRenders_KeepsWallClock confirms the legacy path: with no
+// RenderInflight wired, a present-Pending dep still fails at the wall-clock
+// Timeout (quiescence-binding only applies when a signal is wired).
+func TestWatchOne_NoRenders_KeepsWallClock(t *testing.T) {
+	dep := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "ns", Name: "p"}
+	s := store.New()
+	s.UpdateStatus(dep, store.StatusPending, "fetching")
+
+	w := &Waiter{Store: s, Timeout: 50 * time.Millisecond} // Renders nil
+	start := time.Now()
+	sum := WaitAll(w.Watch(context.Background(), testutil.DepRefs(dep)))
+	if !sum.AnyFailed() {
+		t.Fatal("without a quiescence signal a never-Ready dep must time out at the wall clock")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("wall-clock fail took %v; expected ~Timeout", elapsed)
+	}
+}

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	"helm.sh/helm/v4/pkg/getter"
 	repo "helm.sh/helm/v4/pkg/repo/v1"
@@ -179,6 +180,19 @@ func absChartURL(base, urlStr string) (string, error) {
 	return baseURL.ResolveReference(u).String(), nil
 }
 
+// helmHTTPTimeout bounds a single helm HTTP request (an index.yaml or a
+// chart .tgz). A liveness backstop, not a determinism knob: the chart-source
+// wait is now bound to fetch-task completion rather than a per-dep wall
+// clock, and helm's getter builds an http.Client{Timeout: 0} (unbounded)
+// that ignores ctx, so a socket that connects but never delivers bytes would
+// keep the task pool's active count above zero and wedge the whole run.
+// Sized per-request (not per-retry-budget) and large enough that a slow-but-
+// live repo still completes — l7mp.io routinely takes tens of seconds, with
+// an occasional retried EOF — while a dead socket always terminates. A var so
+// tests can shrink it; mutate only before a run starts (same discipline as
+// store.FailedGrace) to stay race-clean.
+var helmHTTPTimeout = 120 * time.Second
+
 // httpGet fetches url with helm's HTTP getter and the given options. Callers
 // wrap the error with their own context (index fetch vs chart download).
 func httpGet(url string, opts []getter.Option) (*bytes.Buffer, error) {
@@ -186,6 +200,10 @@ func httpGet(url string, opts []getter.Option) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Prepend the liveness timeout so a caller-supplied WithTimeout (none
+	// today) still overrides it — getter applies options in order, last
+	// write wins. source.WithRetry layers attempts on top.
+	opts = append([]getter.Option{getter.WithTimeout(helmHTTPTimeout)}, opts...)
 	return g.Get(url, opts...)
 }
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -358,6 +358,67 @@ func TestStore_WatchReady_TransitionsToReady(t *testing.T) {
 	}
 }
 
+// TestStore_WatchReady_QuiesceStillPendingGivesUp: when the embedder's quiesce
+// signal fires while the resource is still not terminal, WatchReady gives up
+// with ErrQuiesced (the pool drained — no producer left to make it Ready).
+func TestStore_WatchReady_QuiesceStillPendingGivesUp(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}
+	s.UpdateStatus(id, StatusPending, "fetching")
+
+	quiesce := make(chan struct{})
+	close(quiesce) // already quiescent
+
+	_, err := s.WatchReady(context.Background(), id, quiesce)
+	if !errors.Is(err, ErrQuiesced) {
+		t.Fatalf("err = %v; want ErrQuiesced", err)
+	}
+}
+
+// TestStore_WatchReady_QuiesceRereadsReady: a Ready committed before the quiesce
+// signal closes (RunWithStatus writes Ready before the producing task's
+// decrActive) is observed by the quiesce arm's re-read, even if select picks
+// quiesce over the pending wake.
+func TestStore_WatchReady_QuiesceRereadsReady(t *testing.T) {
+	for range 200 { // stress the wake/quiesce select ordering
+		s := New()
+		id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}
+		s.UpdateStatus(id, StatusPending, "fetching")
+		quiesce := make(chan struct{})
+		go func() {
+			s.UpdateStatus(id, StatusReady, "") // terminal BEFORE quiesce closes
+			close(quiesce)
+		}()
+		info, err := s.WatchReady(context.Background(), id, quiesce)
+		if err != nil {
+			t.Fatalf("err = %v; want Ready (quiesce arm must re-read the committed Ready)", err)
+		}
+		if info.Status != StatusReady {
+			t.Fatalf("status = %v; want Ready", info.Status)
+		}
+	}
+}
+
+// TestStore_WatchReady_QuiesceRereadsFailed: a Failed committed before quiesce
+// fast-fails via the quiesce re-read (no wasted grace window).
+func TestStore_WatchReady_QuiesceRereadsFailed(t *testing.T) {
+	s := New()
+	id := manifest.NamedResource{Kind: "GitRepository", Name: "r"}
+	s.UpdateStatus(id, StatusFailed, "boom")
+
+	quiesce := make(chan struct{})
+	close(quiesce)
+
+	_, err := s.WatchReady(context.Background(), id, quiesce)
+	var rfe *manifest.ResourceFailedError
+	if !errors.As(err, &rfe) {
+		t.Fatalf("err = %v; want *ResourceFailedError", err)
+	}
+	if rfe.Reason != "boom" {
+		t.Errorf("reason = %q; want boom", rfe.Reason)
+	}
+}
+
 func TestStore_WatchReady_FailedYieldsError(t *testing.T) {
 	withFailedGrace(t, 50*time.Millisecond)
 	s := New()

--- a/pkg/store/watch.go
+++ b/pkg/store/watch.go
@@ -25,6 +25,13 @@ import (
 // down.
 var FailedGrace = 3 * time.Second
 
+// ErrQuiesced is returned by WatchReady when the embedder's quiesce signal
+// fires while the watched resource is still not terminal (not Ready/Failed):
+// the task pool drained, so no in-flight producer can make it Ready, and the
+// wait gives up. Quiescence-bound callers (depwait with a wired RenderInflight)
+// treat this as "dependency not ready" — see depwait.classify.
+var ErrQuiesced = errors.New("dependency not ready before quiescence")
+
 // WatchReady blocks until the resource reaches Ready status — or
 // stays Failed for FailedGrace without flipping to Ready, in which
 // case it returns the Failed StatusInfo and a *ResourceFailedError.
@@ -93,14 +100,8 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource, quies
 	// timer per call on the depwait hot path.
 	var graceTimer *time.Timer
 	var graceCh <-chan time.Time
-	// quiesced flips true the first time the embedder's quiesce
-	// channel fires — see the quiesce case below. Once set, any
-	// later Failed observation short-circuits the grace; armGrace
-	// also checks it so a Failed already pending when quiesce
-	// arrives doesn't re-arm a useless grace.
-	quiesced := false
 	armGrace := func() {
-		if quiesced || graceTimer != nil {
+		if graceTimer != nil {
 			return
 		}
 		graceTimer = time.NewTimer(FailedGrace)
@@ -134,35 +135,34 @@ func (s *Store) WatchReady(ctx context.Context, id manifest.NamedResource, quies
 			case StatusFailed:
 				f := info
 				currentFailed = &f
-				// If the embedder already signalled quiescence, no
-				// re-emit is coming — return the Failed immediately
-				// instead of arming a wasted grace window. This is
-				// the dominant termination path for typo'd dependsOn:
-				// quiesce fires when the orchestrator's task pool
-				// drains, then the parent KS's status flips to
-				// Failed, and we land here.
-				if quiesced {
-					return failNow()
-				}
 				armGrace()
 			}
 		case <-graceCh:
 			return failNow()
 		case <-quiesce:
-			// Embedder signalled "no future reconcile can re-emit
-			// this dep". Two cases:
-			//   - Failed already observed: short-circuit the grace
-			//     immediately (no point waiting for a re-emit that
-			//     can't happen).
-			//   - Failed not yet observed: record the quiesced state
-			//     so the next Failed transition skips the grace, and
-			//     nil out the channel so the closed receive doesn't
-			//     busy-spin.
+			// The embedder's task pool drained: no in-flight producer can still
+			// re-emit or make this dep Ready (a source fetch, a parent render).
+			// RunWithStatus writes the terminal Ready/Failed BEFORE the
+			// producing task's decrActive — which is what closes this channel —
+			// so any terminal status is durably committed by now. Re-read once,
+			// then give up if the dep is still not terminal (no producer left).
+			// This is the primary terminator for quiescence-bound callers
+			// (depwait passes the parent ctx, not a wall-clock budget) and it
+			// short-circuits the post-Failed grace for an already-Failed dep.
+			if info, ok := s.GetStatus(id); ok {
+				switch info.Status {
+				case StatusReady:
+					return info, nil
+				case StatusFailed:
+					f := info
+					currentFailed = &f
+					return failNow()
+				}
+			}
 			if currentFailed != nil {
 				return failNow()
 			}
-			quiesced = true
-			quiesce = nil
+			return StatusInfo{}, ErrQuiesced
 		case <-ctx.Done():
 			// Propagate ctx.Err() ONLY when the caller explicitly
 			// cancelled (context.Canceled) — otherwise (per-dep


### PR DESCRIPTION
## Problem
`flate build all` rendered **non-deterministically** for repos with remote sources — entire HelmRelease/Kustomization resource sets appeared or vanished run-to-run (m00nwtchr `kubernetes/flux` flipped between 121187 / 120709 / 119684 lines). Byte-determinism is a stated flate guarantee.

## Root cause (not helm `.Capabilities`)
A consumer waiting on a dependency that an **in-flight producer** will still make Ready abandoned the wait at the per-dep `DefaultTimeout` (30s):
- a **source flate is fetching** — HR chart source (synthetic HelmChart, or declared OCIRepository/GitRepository/HelmChart) and KS `sourceRef`; and
- a **`dependsOn` HR** that is itself slow because *its* chart is still fetching (e.g. `karakeep` → `openebs`).

When a fetch outran 30s (debug trace: l7mp.io chart **71s** — slow server + a transient `unexpected EOF` retry) the consumer was skipped **even though the fetch later succeeded**, so output depended on fetch latency racing a wall clock. The race detector finds no data race; it's a logic/timing dependency. (The stunner operator resources that flickered are *unconditional* in the chart — not a capability gate.)

## Fix
In `depwait.watchOne`, a **present but not-Ready, status-bearing** dependency now binds to orchestrator **quiescence** instead of the wall clock when a `RenderInflight` signal is wired:
- the source reconcile holds the task pool's `active` count up while fetching (`YieldSlot`), and `RunWithStatus` writes the terminal Ready/Failed **before** the task's `decrActive` — so `WatchReady` wakes on Ready (a producer finished) and gives up only once the pool drains with the dep still not Ready, after a **final status re-read** so a terminal status landing in the same tick as quiescence is observed (`store.ErrQuiesced` → `DepTimeout "not ready"`);
- the wall-clock budget is **kept** for paths no producer is satisfying: absent/typo'd deps (`resolveMissing`), status-less kinds (`WatchExists`), CEL `ReadyExpr`, and legacy embedders with no quiescence signal.

This generalizes across **every** source consumer and `dependsOn`/parent edge in one place (subsuming an earlier source-only approach). `base`/KS controllers are unchanged; HR is a doc comment only.

## Verification
- `go test -race ./pkg/depwait/... ./pkg/store/... ./pkg/controllers/... ./pkg/source/...` + `go test ./...` green; gofmt/vet/`golangci-lint` 0. New unit tests: depwait quiescence-binding (waits past wall clock for a late Ready; gives up on quiescence; legacy keeps wall clock), `WatchReady` quiesce re-read (Ready/Failed/give-up), and HR + KS controller determinism harnesses.
- **Determinism:** 12 cold m00nwtchr-flux runs → **0 source-timeout, 0 dependsOn-timeout** (was a 7/5 line-count flip); clean runs render the full **121187**, identical to a warm-cache render.
- **No regression:** warm `main` vs this branch byte-identical on m00nwtchr/onedr0p/bjw/zariel flux.
- Adversarially reviewed (deadlock/liveness/lost-wake/fidelity/regression): sound.

## Scope / follow-ups
- **Out of scope:** genuine upstream fetch failure (l7mp.io `EOF` exhausting all 3 retries → source `Failed` → consumer skipped) is upstream-transient and warm-cache-immune.
- **Liveness follow-up:** the quiescence-bound wait relies on every fetch terminating. helm's ctx-deaf HTTP getter keeps its explicit 120s per-request timeout (`helmHTTPTimeout`); git/OCI honor ctx. A black-hole git/OCI host (no `ResponseHeaderTimeout`) remains a pre-existing latent hang — recommend adding a transport-level response-header timeout in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)