### PR TITLE
fix: keep a re-rendered Kustomization Ready so dependents don't race quiescence

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -139,7 +139,20 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	if err := c.PreflightError(id); err != nil {
 		return err
 	}
-	c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
+	// wasReady: this is a re-reconcile of an already-Ready KS (re-emitted by
+	// its structural parent / coalesced re-submit). Suppress the pre-render
+	// progress-message Pending writes below so we don't transiently downgrade
+	// Ready→Pending: a re-run that turns out to be a no-op (fingerprint
+	// unchanged) must stay Ready throughout, or a dependent's quiescence-bound
+	// depwait can re-read the transient Pending at a transient pool drain and
+	// give up ("parent Kustomization not ready"). A genuine re-render (changed
+	// fingerprint) still downgrades at the "rendering" write below, after the
+	// dedup check, so dependents correctly re-gate.
+	cur, hasStatus := c.Store.GetStatus(id)
+	wasReady := hasStatus && cur.Status == store.StatusReady
+	if !wasReady {
+		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
+	}
 
 	deps := c.collectDeps(ks)
 	if len(deps) > 0 {
@@ -152,7 +165,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// namespace. See #102.
 		fresh, ok, err := base.AwaitRefresh[*manifest.Kustomization](
 			ctx, c.Controller, id, c.NewWaiter(id, ks.Timeout), deps,
-			"", base.DepFailed(id)) // status set above
+			"", base.DepFailed(id)) // empty pendingMsg: status set above (or kept Ready on a re-run)
 		if err != nil {
 			return err
 		}
@@ -164,13 +177,17 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		return err
 	}
 
-	c.Store.UpdateStatus(id, store.StatusPending, "resolving source artifact")
+	if !wasReady {
+		c.Store.UpdateStatus(id, store.StatusPending, "resolving source artifact")
+	}
 	sourceRoot, applyIgnore, err := c.resolveSource(ks)
 	if err != nil {
 		return err
 	}
 
-	c.Store.UpdateStatus(id, store.StatusPending, "expanding substitutions")
+	if !wasReady {
+		c.Store.UpdateStatus(id, store.StatusPending, "expanding substitutions")
+	}
 	// kustomize.Prepare clones ks and expands postBuild.substituteFrom —
 	// the same pre-render dance an embedder calling RenderFlux directly
 	// would perform. Keeping one canonical implementation here means
@@ -204,7 +221,15 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// from the parent index and the keep-set chain — a subsequent
 		// changed-only run silently mis-attributes children to a
 		// stale parent.
-		c.emitRenderedChildren(id, existing.Manifests)
+		//
+		// publish=false: do NOT re-AddObject the children. They were
+		// already published byte-identically by the render that set this
+		// cached artifact, so re-publishing only re-fires their listeners
+		// and re-submits already-settled children — churn that
+		// transiently un-Ready-s a parent and races quiescence (the
+		// "parent Kustomization not ready" non-determinism). Only the
+		// idempotent provenance + keep-set side-effects need to re-run.
+		c.emitRenderedChildren(id, existing.Manifests, false)
 		return nil
 	}
 
@@ -247,7 +272,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	if err := c.PreflightError(id); err != nil {
 		return err
 	}
-	c.emitRenderedChildren(id, docs)
+	c.emitRenderedChildren(id, docs, true)
 
 	c.Store.SetArtifact(id, &store.KustomizationArtifact{
 		Path:        filepath.Join(sourceRoot, ks.Path),

--- a/pkg/controllers/kustomization/dispatch.go
+++ b/pkg/controllers/kustomization/dispatch.go
@@ -28,7 +28,20 @@ import (
 // may be raw Kubernetes manifests flate doesn't track. SOPS-encrypted
 // secrets are debug-noted; ParseSecret wipes their values to the
 // PLACEHOLDER token the same way --wipe-secrets does for cleartext.
-func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[string]any) {
+//
+// publish gates the two event-firing store writes (AddObject for pass-1
+// reconcilables, AddObjects for pass-2 leaves). The fresh-render path
+// passes true. The fingerprint-dedup replay passes FALSE: the children
+// were already published byte-identically by the render that set the
+// cached artifact, so re-AddObject-ing them would only re-fire
+// EventObjectAdded and re-submit a coalesced re-reconcile of an already-
+// settled child — churn that transiently flips a Ready parent back to
+// Pending (controller.go:142) and, if a transient quiescence drain lands
+// in that window, makes a dependent's depwait give up ("parent ... not
+// ready"). The provenance (ReportRendered) and keep-set (KeepEmitted)
+// side-effects the replay exists for are idempotent and event-free, so
+// they still run on both paths; only the redundant republish is skipped.
+func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[string]any, publish bool) {
 	type parsed struct {
 		obj          manifest.BaseManifest
 		reconcilable bool
@@ -74,7 +87,9 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			continue // held for pass 2
 		case p.reconcilable:
 			keep(p.obj)
-			c.Store.AddObject(p.obj)
+			if publish {
+				c.Store.AddObject(p.obj)
+			}
 		default:
 			c.Store.AddRendered(p.obj)
 		}
@@ -88,7 +103,9 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 		}
 	}
 	c.ReportRendered(id, rendered)
-	c.Store.AddObjects(leaves)
+	if publish {
+		c.Store.AddObjects(leaves)
+	}
 }
 
 // shouldDispatchAsObject reports whether a render-emitted Flux

--- a/pkg/controllers/kustomization/dispatch_test.go
+++ b/pkg/controllers/kustomization/dispatch_test.go
@@ -121,7 +121,7 @@ func TestEmitRenderedChildrenBatchesLeafDispatch(t *testing.T) {
 	c.emitRenderedChildren(parent, []map[string]any{
 		fluxKustomizationDoc("a", "b"),
 		fluxKustomizationDoc("b", "a"),
-	})
+	}, true)
 	if !sawBOnA {
 		t.Fatal("first leaf dispatch did not see later emitted sibling")
 	}
@@ -148,13 +148,73 @@ func TestEmitRenderedChildren_DropsKustomizeBuildDirective(t *testing.T) {
 	c.emitRenderedChildren(parent, []map[string]any{
 		kustomizeConfigDoc(),                 // build directive — must be dropped
 		fluxKustomizationDoc("real", "real"), // real child — must be stored
-	})
+	}, true)
 
 	if leaked {
 		t.Error("kustomize.config build directive was emitted to the store (phantom Kustomization//)")
 	}
 	if s.GetObject(manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "real"}) == nil {
 		t.Error("real Flux Kustomization child was not stored")
+	}
+}
+
+// recordingTracker is a minimal base.RenderTracker that records the
+// parent→children provenance MarkRenderedBatch is handed, so a test can
+// assert the dedup-skip replay still reports provenance even when it no
+// longer re-publishes the children to the store.
+type recordingTracker struct {
+	children map[manifest.NamedResource][]manifest.NamedResource
+}
+
+func (r *recordingTracker) MarkRenderedBatch(parent manifest.NamedResource, children []manifest.NamedResource) {
+	if r.children == nil {
+		r.children = map[manifest.NamedResource][]manifest.NamedResource{}
+	}
+	r.children[parent] = append(r.children[parent], children...)
+}
+
+// TestEmitRenderedChildren_DedupSkip_NoStoreWrites pins Part B of the
+// re-emission-churn fix: the fingerprint-dedup replay (publish=false)
+// must NOT re-AddObject the children — re-firing EventObjectAdded
+// re-submits already-settled children, the churn that transiently
+// un-Ready-s a parent KS and races quiescence ("parent ... not ready").
+// The idempotent provenance side-effect (MarkRenderedBatch) MUST still
+// fire so the parent index stays correct on every pass (#102). The
+// fresh-render path (publish=true) still publishes.
+func TestEmitRenderedChildren_DedupSkip_NoStoreWrites(t *testing.T) {
+	s := store.New()
+	c := &Controller{Controller: base.New(s, task.New())}
+	rt := &recordingTracker{}
+	c.SetRenderTracker(rt)
+
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "parent"}
+	child := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "real"}
+	docs := []map[string]any{fluxKustomizationDoc("real", "real")}
+
+	var events int
+	s.AddListener(store.EventObjectAdded, func(_ manifest.NamedResource, _ any) {
+		events++
+	}, false)
+
+	// Dedup-skip replay: no events, store untouched, provenance recorded.
+	c.emitRenderedChildren(parent, docs, false)
+	if events != 0 {
+		t.Errorf("publish=false fired %d EventObjectAdded; want 0 (no republish churn)", events)
+	}
+	if s.GetObject(child) != nil {
+		t.Error("publish=false AddObject'd a leaf child; want the store left untouched")
+	}
+	if got := rt.children[parent]; len(got) != 1 || got[0] != child {
+		t.Errorf("publish=false provenance = %v; want [%v] (MarkRenderedBatch must still fire)", got, child)
+	}
+
+	// Fresh render: events fire and the child lands in the store.
+	c.emitRenderedChildren(parent, docs, true)
+	if events != 1 {
+		t.Errorf("publish=true fired %d EventObjectAdded; want 1 (the leaf published)", events)
+	}
+	if s.GetObject(child) == nil {
+		t.Error("publish=true did not store the leaf child")
 	}
 }
 

--- a/pkg/controllers/kustomization/reconcile_test.go
+++ b/pkg/controllers/kustomization/reconcile_test.go
@@ -3,6 +3,7 @@ package kustomization
 import (
 	"context"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -132,6 +133,131 @@ func TestReconcile_FingerprintDedup_SkipsRender(t *testing.T) {
 	secondFP := s.GetArtifact(ks.Named()).(*store.KustomizationArtifact).Fingerprint
 	if firstFP != secondFP {
 		t.Errorf("fingerprint changed across label-only re-AddObject: %q vs %q", firstFP, secondFP)
+	}
+}
+
+// TestReconcile_AlreadyReady_NoTransientPending pins Part A of the
+// re-emission-churn fix: a re-reconcile of an already-Ready KS that
+// turns out to be a no-op (fingerprint unchanged, dedup-skip) must NOT
+// transiently flip the status Ready→Pending. That transient window is
+// exactly what a dependent's quiescence-bound depwait can re-read at a
+// transient pool drain and give up on ("parent Kustomization not
+// ready"). Pre-fix the unconditional UpdateStatus(Pending) at the top
+// of reconcile fired on every re-run; post-fix it is suppressed when
+// the object is already Ready.
+func TestReconcile_AlreadyReady_NoTransientPending(t *testing.T) {
+	_, s, _ := newControllerWithFixture(t)
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "./apps",
+			SourceRef: kustomizev1.CrossNamespaceSourceReference{
+				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
+			},
+		},
+		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
+		Contents: map[string]any{},
+	}
+	s.AddObject(ks)
+	testutil.WaitForStatus(t, s, ks.Named(), store.StatusReady)
+
+	var mu sync.Mutex
+	var sawPending bool
+	s.AddListener(store.EventStatusUpdated, func(id manifest.NamedResource, payload any) {
+		if id != ks.Named() {
+			return
+		}
+		if info, ok := payload.(store.StatusInfo); ok && info.Status == store.StatusPending {
+			mu.Lock()
+			sawPending = true
+			mu.Unlock()
+		}
+	}, false)
+
+	// Re-emit with kustomize ownership labels stamped: AddObject's
+	// DeepEqual gate fails (labels differ) so the listener re-fires a
+	// coalesced re-run, but the fingerprint matches → dedup-skip no-op.
+	stamped := ks.Clone()
+	stamped.Labels = map[string]string{
+		"kustomize.toolkit.fluxcd.io/name":      "parent",
+		"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+	}
+	s.AddObject(stamped)
+	time.Sleep(50 * time.Millisecond) // let the coalesced re-run land
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sawPending {
+		t.Error("no-op re-reconcile of an already-Ready KS transiently downgraded it to Pending (the quiescence-race window)")
+	}
+	if info, _ := s.GetStatus(ks.Named()); info.Status != store.StatusReady {
+		t.Errorf("KS not Ready after no-op re-run: %+v", info)
+	}
+}
+
+// TestReconcile_GenuineReRender_DoesDowngrade is the byte-determinism
+// guard for Part A: a re-reconcile whose effective spec CHANGED
+// (fingerprint differs, e.g. #102 structural-parent-injected
+// targetNamespace) MUST still downgrade to Pending before re-rendering,
+// so a dependent re-gates on the new output rather than reading a
+// stale-Ready parent. Proves the wasReady guard suppresses only the
+// pre-fingerprint progress writes, not the genuine "rendering"
+// downgrade.
+func TestReconcile_GenuineReRender_DoesDowngrade(t *testing.T) {
+	_, s, _ := newControllerWithFixture(t)
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{
+			Path: "./apps",
+			SourceRef: kustomizev1.CrossNamespaceSourceReference{
+				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
+			},
+		},
+		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
+		Contents: map[string]any{},
+	}
+	s.AddObject(ks)
+	testutil.WaitForStatus(t, s, ks.Named(), store.StatusReady)
+	firstFP := s.GetArtifact(ks.Named()).(*store.KustomizationArtifact).Fingerprint
+
+	var mu sync.Mutex
+	var sawPending bool
+	s.AddListener(store.EventStatusUpdated, func(id manifest.NamedResource, payload any) {
+		if id != ks.Named() {
+			return
+		}
+		if info, ok := payload.(store.StatusInfo); ok && info.Status == store.StatusPending {
+			mu.Lock()
+			sawPending = true
+			mu.Unlock()
+		}
+	}, false)
+
+	// Re-emit with a genuine spec change (targetNamespace) → fingerprint
+	// differs → real re-render, not a dedup-skip.
+	changed := ks.Clone()
+	changed.TargetNamespace = "elsewhere"
+	s.AddObject(changed)
+
+	// Poll for the artifact to re-render under the new fingerprint.
+	var secondFP string
+	for range 200 {
+		if art, ok := s.GetArtifact(ks.Named()).(*store.KustomizationArtifact); ok {
+			if art.Fingerprint != firstFP {
+				secondFP = art.Fingerprint
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !sawPending {
+		t.Error("genuine re-render did not downgrade to Pending; dependents would read a stale-Ready parent")
+	}
+	if secondFP == "" || secondFP == firstFP {
+		t.Errorf("fingerprint did not change after spec mutation (%q → %q); not a genuine re-render", firstFP, secondFP)
 	}
 }
 

--- a/pkg/controllers/kustomization/reemit_determinism_test.go
+++ b/pkg/controllers/kustomization/reemit_determinism_test.go
@@ -1,0 +1,108 @@
+package kustomization
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/kustomize"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+// TestReconcile_ParentReemitChurn_DependentStaysReady is the integration
+// regression for the re-emission-churn determinism bug. A dependent that
+// waits (quiescence-bound) on a parent Kustomization must reach Ready even
+// while that parent is being re-emitted by churn (a stamped, no-op
+// re-AddObject — exactly what a structural grandparent's dedup-skip replay
+// did before this fix).
+//
+// Pre-fix: the parent's coalesced re-run transiently flipped Ready→Pending
+// at the top of reconcile (controller.go:142), and the dependent's
+// quiescence-bound depwait, re-reading at a transient pool drain, gave up
+// with "parent Kustomization not ready" — nondeterministically dropping the
+// dependent's rendered resources. Post-fix (A: a no-op re-run of an
+// already-Ready KS doesn't downgrade; B: the dedup-skip path no longer
+// re-publishes children, so the churn stops) the parent stays Ready and the
+// dependent renders on every iteration.
+func TestReconcile_ParentReemitChurn_DependentStaysReady(t *testing.T) {
+	for i := range 30 {
+		root := t.TempDir()
+		testutil.WriteFileAt(t, filepath.Join(root, "apps", "kustomization.yaml"),
+			"resources:\n- cm.yaml\n")
+		testutil.WriteFileAt(t, filepath.Join(root, "apps", "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: default}
+data: {greeting: hi}
+`)
+
+		s := store.New()
+		bootstrap := &manifest.GitRepository{
+			Name: "flux-system", Namespace: "flux-system",
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
+		}
+		s.AddObject(bootstrap)
+		s.SetArtifact(bootstrap.Named(), &store.SourceArtifact{
+			Kind: manifest.KindGitRepository, URL: "file://" + root, LocalPath: root,
+		})
+		s.UpdateStatus(bootstrap.Named(), store.StatusReady, "ready")
+
+		tasks := task.New()
+		c := New(s, tasks, kustomize.NewTreeCache(), true)
+		c.Configure(Options{Renders: tasksRenderInflight{tasks}})
+		c.Start(context.Background())
+
+		mkKS := func(name string, deps []manifest.DependencyRef) *manifest.Kustomization {
+			return &manifest.Kustomization{
+				Name: name, Namespace: "flux-system",
+				KustomizationSpec: kustomizev1.KustomizationSpec{
+					Path:    "./apps",
+					Timeout: &metav1.Duration{Duration: 50 * time.Millisecond},
+					SourceRef: kustomizev1.CrossNamespaceSourceReference{
+						Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
+					},
+				},
+				SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
+				DependsOn: deps,
+				Contents:  map[string]any{},
+			}
+		}
+
+		parent := mkKS("parent", nil)
+		s.AddObject(parent)
+		testutil.WaitForStatus(t, s, parent.Named(), store.StatusReady)
+
+		// Churn the settled parent with stamped, no-op re-emits (the
+		// AddObject DeepEqual gate fails on the label delta, re-firing a
+		// coalesced re-run that dedup-skips) while a dependent waits on it
+		// with a short timeout. The dependent's wait is quiescence-bound
+		// (Renders wired above), the same path the production HR/KS gate uses.
+		dep := mkKS("dep", []manifest.DependencyRef{{NamedResource: parent.Named()}})
+		for j := range 3 {
+			stamped := parent.Clone()
+			stamped.Labels = map[string]string{
+				"kustomize.toolkit.fluxcd.io/name":      "grandparent",
+				"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+				"churn":                                 string(rune('a' + j)),
+			}
+			s.AddObject(stamped)
+		}
+		s.AddObject(dep)
+
+		info := testutil.WaitForStatus(t, s, dep.Named(), store.StatusReady)
+		if info.Status != store.StatusReady {
+			t.Fatalf("iter %d: dependent KS = %v (%q); want Ready (parent stays Ready across re-emit churn)", i, info.Status, info.Message)
+		}
+
+		c.Close()
+		tasks.BlockTillDone()
+	}
+}


### PR DESCRIPTION
## The bug

`flate build all` over a real Flux repo dropped a HelmRelease **nondeterministically** — on `boemeltrein/.../kubernetes` ~2–5/15 warm-cache runs failed with `parent Kustomization … not ready: not ready` and a short render. Byte-determinism is a flate guarantee, so this is a real correctness bug.

## Root cause (pinned by instrumentation)

A throwaway-worktree instrumented build captured the exact sequence:

```
→ Pending "resolving dependencies"   parent KS reconcile pass #1 (controller.go:142)
→ Ready (Succeeded)                   pass #1 done
→ Pending "resolving dependencies"   pass #2 starts IMMEDIATELY (coalescer re-run)
[transient quiescence drain] dependent re-reads parent = Pending → ErrQuiesced → FAILS
→ Ready (Succeeded)                   pass #2 done (dedup-skip, no-op) — too late
```

Two factors combine:
- **The reconcile wrote `StatusPending` unconditionally at its top**, *before* the fingerprint dedup check. A coalesced re-run of an already-Ready KS (re-emitted by its structural parent) flashed Ready→Pending even when the run was a no-op.
- **A dependent's quiescence-bound wait re-read the parent at a *transient* pool drain** (active momentarily 0 while ~1.5s helm renders were still pending) and gave up. (`Refire`/changed-only paths confirmed *not* involved.)

## The fix (Kustomization controller; byte-output-neutral)

- **Don't downgrade an already-Ready KS to Pending on a re-reconcile** until a real re-render is committed: the pre-fingerprint progress writes are guarded on `!wasReady`. The genuine-render downgrade at `"rendering"` (after the fingerprint check) is **kept**, so a changed re-render (the #102 parent-injected `targetNamespace` case) still downgrades and dependents re-gate.
- **The fingerprint-dedup replay no longer re-publishes children** — `emitRenderedChildren` gains a `publish bool`; the dedup-skip path passes `false`. The children were already published byte-identically by the render that set the cached artifact, so re-`AddObject`-ing them only re-fires listeners and re-submits already-settled children. The idempotent provenance (`markRendered`) and keep-set (`Filter.AddEmitted`, #260/#308) side-effects the replay exists for still run on both paths.

## Verification

- **Determinism:** boemeltrein `kubernetes` + `kubernetes/flux-system`, warm cache, **30/30 runs identical at 74560 lines, 0 failures** (was 2–5/15).
- **Cross-repo byte-equivalence vs main:** the affected path now renders the previously-dropped resources deterministically (where `main` intermittently fails+drops); all other repos byte-identical modulo the known caBundle/checksum/timestamp non-determinism.
- `gofmt`/`go vet`/`golangci-lint` 0; `go test -race ./pkg/controllers/... ./pkg/store/... ./pkg/depwait/... ./pkg/task/... ./pkg/change/... ./pkg/orchestrator/...` green (incl. the #260/#308/#418 keep-set and dependsOn-cycle suites); full `go test ./...` green.
- New regression tests: `TestEmitRenderedChildren_DedupSkip_NoStoreWrites` (dedup-skip fires zero `EventObjectAdded` but keeps provenance), `TestReconcile_AlreadyReady_NoTransientPending` (no-op re-run keeps Ready), `TestReconcile_GenuineReRender_DoesDowngrade` (changed re-render still downgrades — the #102 guard), and an end-to-end re-emit-churn determinism test.

## Scope

Localized to the Kustomization controller. Does **not** touch the wait core (`WatchReady`) or #655 quiescence semantics. The HelmRelease controller has an analogous dedup replay that re-emits source CRs (not KSes) and is not the confirmed cause; left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)