### PR TITLE
fix: don't transiently re-downgrade an already-Ready ExistenceFetcher source

### DIFF
--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -115,7 +115,21 @@ func (c *Controller) reconcile(ctx context.Context, obj manifest.BaseManifest) e
 		return nil
 	}
 
-	c.Store.UpdateStatus(id, store.StatusPending, "fetching")
+	// Mirror the artifact-gate protection above for no-artifact
+	// (ExistenceFetcher) kinds: a HelmRepository never sets an artifact, so
+	// the gate never short-circuits its re-runs. Without this, a re-emitted
+	// HelmRepository flips Ready→Pending→Ready, and a consumer's
+	// quiescence-bound chart-source wait (helmrelease.awaitChartSource) could
+	// re-read the transient Pending at a transient pool drain and drop the
+	// release. A re-fetch of an already-Ready source is idempotent (the fetch
+	// still runs below), so keeping Ready across it is correct — we only
+	// suppress the cosmetic Pending write. Mirrors the Kustomization wasReady
+	// guard (#657).
+	cur, hasStatus := c.Store.GetStatus(id)
+	wasReady := hasStatus && cur.Status == store.StatusReady
+	if !wasReady {
+		c.Store.UpdateStatus(id, store.StatusPending, "fetching")
+	}
 	started := time.Now()
 
 	// Release the worker slot during the fetch so consumers of this

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"maps"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
@@ -201,5 +204,64 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 	}
 	if f.calls != 0 {
 		t.Errorf("filtered-out source must not fetch; calls=%d", f.calls)
+	}
+}
+
+// TestController_ExistenceFetcher_NoTransientPendingOnReemit hardens the
+// source path against the #657-class race. HelmRepository is the lone
+// ExistenceFetcher (Fetch returns (nil,nil)), so it never sets an artifact
+// and the reconcile's artifact short-circuit never catches its re-runs.
+// Without the wasReady guard, a re-emitted HelmRepository flips
+// Ready→Pending→Ready, and a consumer's quiescence-bound chart-source wait
+// (helmrelease.awaitChartSource, which waits on the DECLARED HelmRepository
+// before materializing a synthetic HelmChart) could re-read that transient
+// Pending at a transient pool drain and drop the release. The source must
+// stay Ready across a no-op re-run.
+func TestController_ExistenceFetcher_NoTransientPendingOnReemit(t *testing.T) {
+	_, st := newController(t, map[string]src.Fetcher{
+		manifest.KindHelmRepository: src.ExistenceFetcher{},
+	})
+	repo := &manifest.HelmRepository{
+		Name: "charts", Namespace: "flux-system",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example", Type: "default"},
+	}
+	st.AddObject(repo)
+	testutil.WaitForStatus(t, st, repo.Named(), store.StatusReady)
+
+	var mu sync.Mutex
+	var sawPending bool
+	st.AddListener(store.EventStatusUpdated, func(id manifest.NamedResource, payload any) {
+		if id != repo.Named() {
+			return
+		}
+		if info, ok := payload.(store.StatusInfo); ok && info.Status == store.StatusPending {
+			mu.Lock()
+			sawPending = true
+			mu.Unlock()
+		}
+	}, false)
+
+	// Re-emit with a benign spec diff (Interval) so AddObject's DeepEqual gate
+	// fails and the listener re-fires a coalesced re-run. (flate's
+	// HelmRepository drops metadata.labels, so a label-only stamp would
+	// DeepEqual-match and NOT re-run — a spec field is required.)
+	// ExistenceFetcher ignores the spec, so this re-run is a no-op fetch.
+	reemit := &manifest.HelmRepository{
+		Name: "charts", Namespace: "flux-system",
+		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
+			URL: "https://charts.example", Type: "default",
+			Interval: metav1.Duration{Duration: time.Hour},
+		},
+	}
+	st.AddObject(reemit)
+	time.Sleep(50 * time.Millisecond) // let the coalesced re-run land
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sawPending {
+		t.Error("ExistenceFetcher source transiently downgraded Ready→Pending on a no-op re-run (the quiescence-race window)")
+	}
+	if info, _ := st.GetStatus(repo.Named()); info.Status != store.StatusReady {
+		t.Errorf("source not Ready after no-op re-run: %+v", info)
 	}
 }


### PR DESCRIPTION
## Why

Hardening follow-up to #657 (the analogous Kustomization fix). While checking whether the HelmRelease controller's dedup-replay could drop a resource the same way, I found a real (if currently timing-inert) gap:

- A HelmRelease's **first** `awaitChartSource` (`helmrelease/controller.go:299`) quiescence-waits on its **declared** chart source *before* materialization — by design, so the HelmRepository is Ready and resolvable before it's repointed to a synthetic HelmChart (`:310`). So when the chart source is a **HelmRepository**, the HR genuinely depwaits on the HelmRepository itself, every reconcile.
- The source controller is otherwise dedup-first: the artifact gate (`source/controller.go:114`) returns *before* the Pending write (`:118`), so artifact-backed kinds (Git/OCI/Bucket/HelmChart/ExternalArtifact) never re-downgrade Ready→Pending on a no-op re-run.
- But **HelmRepository is the lone `ExistenceFetcher`** (`orchestrator.go:371`) — its `Fetch` returns `(nil, nil)`, so `SetArtifact` is never called and the gate never catches its re-runs. **Every re-run writes Pending at `:118`** — the same transient window that drove #657 — and a consumer's quiescence-bound chart-source wait could re-read it at a transient pool drain and drop the release.

Inert **today** (an `ExistenceFetcher` settles Ready instantly, before any HR awaits it — 0 source drops across 24 cross-repo runs), but timing-dependent, not structurally precluded.

## What

Mirror the #657 Kustomization `wasReady` guard: skip the `"fetching"` Pending write when the source is already Ready. The fetch still runs (idempotent for an `ExistenceFetcher`), so keeping Ready across a no-op re-run is correct — only the cosmetic Pending status write is suppressed.

## Verification

- Fail-before/pass-after: the new test fails without the guard ("transiently downgraded Ready→Pending"), passes with it.
- `gofmt`/`go vet`/`golangci-lint` 0; `go test -race ./pkg/controllers/...` green; full `go test ./...` green.
- **Cross-repo byte-equivalence vs main unchanged** (status-only change → byte-output-neutral): no new diffs across 24 paths; only the known caBundle/checksum/timestamp non-determinism remains.
- First-run / Failed-retry / `--allow-missing-secrets` soft-skip paths are unaffected (the guard only suppresses the downgrade for already-Ready sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)