### PR TITLE
refactor: centralize the no-transient-downgrade guard as base.SetPendingUnlessReady

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -214,6 +214,26 @@ func (c *Controller) PreflightError(id manifest.NamedResource) error {
 	return nil
 }
 
+// SetPendingUnlessReady writes a StatusPending progress message for id,
+// UNLESS id is already StatusReady. A no-op re-reconcile (a parent render
+// re-emitting the object with stamped ownership labels, a coalesced re-run)
+// must not transiently downgrade Ready→Pending: a dependent's quiescence-bound
+// depwait can re-read that transient Pending at a transient task-pool drain and
+// give up ("not ready"), dropping the dependent nondeterministically.
+//
+// Use for the progress writes that PRECEDE a reconcile's no-op (fingerprint /
+// artifact) short-circuit. The genuine-work downgrade AFTER that check should
+// stay an unconditional UpdateStatus so a real re-render re-gates dependents.
+// Re-reading status per call is equivalent to capturing it once at reconcile
+// entry: the coalescer serializes per-id, so nothing mutates an id's own status
+// mid-reconcile. See #657 (kustomization) / #658 (source).
+func (c *Controller) SetPendingUnlessReady(id manifest.NamedResource, msg string) {
+	if info, ok := c.Store.GetStatus(id); ok && info.Status == store.StatusReady {
+		return
+	}
+	c.Store.UpdateStatus(id, store.StatusPending, msg)
+}
+
 // NewWaiter constructs a depwait.Waiter pre-wired with the
 // controller's Store, Existence lookup, and Renders quiescence signal,
 // parented to id and budgeted from timeout. HR and KS controllers call

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -282,7 +282,15 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return err
 	}
 
-	c.Store.UpdateStatus(id, store.StatusPending, "resolving chart")
+	// SetPendingUnlessReady, not a raw UpdateStatus: this pre-dedup progress
+	// write must not transiently downgrade an already-Ready HR on a no-op
+	// re-run (re-emitted by its parent KS render — HR retains labels, so a
+	// stamped re-emit re-runs). An HR that dependsOn this one has a
+	// quiescence-bound wait that could re-read the transient Pending at a
+	// transient pool drain and drop. The genuine-render downgrade at "rendering
+	// chart" below (after the fingerprint dedup) stays unconditional. See
+	// base.SetPendingUnlessReady (#657/#658).
+	c.SetPendingUnlessReady(id, "resolving chart")
 	// helm.Prepare clones hr, resolves chartRef, and expands values —
 	// the same pre-render dance an embedder calling TemplateDocs
 	// directly performs. Keeping one canonical implementation here

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -2,6 +2,7 @@ package helmrelease
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -790,5 +791,77 @@ func TestController_CollectHRDepsPrunesUnchangedDeps(t *testing.T) {
 	cFull, _ := newTestController(t, nil)
 	if got := cFull.collectHRDeps(hr); len(got) != 2 {
 		t.Errorf("disabled filter must not prune; collectHRDeps = %+v", got)
+	}
+}
+
+// TestController_AlreadyReady_NoTransientPending pins the base
+// SetPendingUnlessReady guard at the HelmRelease level (the #657/#658 dedup
+// closing the analogous HR gap): a no-op re-reconcile of an already-Ready HR
+// (re-emitted by its parent KS render with stamped ownership labels — HR
+// retains labels, so a stamped re-emit re-runs and the label-insensitive
+// fingerprint dedup-skips) must NOT transiently flip Ready→Pending at the
+// pre-dedup "resolving chart" write. An HR that dependsOn this one waits
+// quiescence-bound and could re-read that transient Pending at a transient pool
+// drain and drop. The genuine-render downgrade after the dedup check is
+// unaffected.
+func TestController_AlreadyReady_NoTransientPending(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml", "apiVersion: v2\nname: mychart\nversion: 0.1.0\n")
+	testutil.WriteFile(t, dir, "mychart/templates/configmap.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\ndata:\n  k: v\n")
+
+	_, st := newTestController(t, nil)
+	src := &manifest.GitRepository{Name: "charts", Namespace: "flux-system"}
+	st.AddObject(src)
+	st.SetArtifact(src.Named(), &store.SourceArtifact{
+		Kind: manifest.KindGitRepository, URL: "file://" + dir, LocalPath: dir,
+	})
+	st.UpdateStatus(src.Named(), store.StatusReady, "")
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			Interval: metav1Duration(time.Hour),
+			Timeout:  ptrDuration(100 * time.Millisecond),
+		},
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "charts", RepoNamespace: "flux-system",
+			RepoKind: manifest.KindGitRepository,
+		},
+	}
+	st.AddObject(hr)
+	testutil.WaitForStatus(t, st, hr.Named(), store.StatusReady)
+
+	var mu sync.Mutex
+	var sawPending bool
+	st.AddListener(store.EventStatusUpdated, func(id manifest.NamedResource, payload any) {
+		if id != hr.Named() {
+			return
+		}
+		if info, ok := payload.(store.StatusInfo); ok && info.Status == store.StatusPending {
+			mu.Lock()
+			sawPending = true
+			mu.Unlock()
+		}
+	}, false)
+
+	// Re-emit with stamped ownership labels: HR retains labels so AddObject's
+	// DeepEqual gate fails and the listener re-fires a coalesced re-run, but the
+	// label-insensitive fingerprint matches → dedup-skip no-op.
+	stamped := hr.Clone()
+	stamped.Labels = map[string]string{
+		"kustomize.toolkit.fluxcd.io/name":      "parent",
+		"kustomize.toolkit.fluxcd.io/namespace": "flux-system",
+	}
+	st.AddObject(stamped)
+	time.Sleep(50 * time.Millisecond) // let the coalesced re-run land
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sawPending {
+		t.Error("no-op re-reconcile of an already-Ready HelmRelease transiently downgraded it to Pending (the quiescence-race window)")
+	}
+	if info, _ := st.GetStatus(hr.Named()); info.Status != store.StatusReady {
+		t.Errorf("HR not Ready after no-op re-run: %+v", info)
 	}
 }

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -139,20 +139,15 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	if err := c.PreflightError(id); err != nil {
 		return err
 	}
-	// wasReady: this is a re-reconcile of an already-Ready KS (re-emitted by
-	// its structural parent / coalesced re-submit). Suppress the pre-render
-	// progress-message Pending writes below so we don't transiently downgrade
-	// Ready→Pending: a re-run that turns out to be a no-op (fingerprint
-	// unchanged) must stay Ready throughout, or a dependent's quiescence-bound
-	// depwait can re-read the transient Pending at a transient pool drain and
-	// give up ("parent Kustomization not ready"). A genuine re-render (changed
-	// fingerprint) still downgrades at the "rendering" write below, after the
-	// dedup check, so dependents correctly re-gate.
-	cur, hasStatus := c.Store.GetStatus(id)
-	wasReady := hasStatus && cur.Status == store.StatusReady
-	if !wasReady {
-		c.Store.UpdateStatus(id, store.StatusPending, "resolving dependencies")
-	}
+	// SetPendingUnlessReady (not a raw UpdateStatus) on every pre-render
+	// progress write: a no-op re-reconcile of an already-Ready KS (re-emitted
+	// by its structural parent / coalesced re-run) must not transiently
+	// downgrade Ready→Pending, or a dependent's quiescence-bound depwait can
+	// re-read it at a transient pool drain and give up ("parent Kustomization
+	// not ready"). The genuine-render downgrade at "rendering" below (after the
+	// fingerprint dedup) stays unconditional so a changed re-render re-gates
+	// dependents. See base.SetPendingUnlessReady (#657).
+	c.SetPendingUnlessReady(id, "resolving dependencies")
 
 	deps := c.collectDeps(ks)
 	if len(deps) > 0 {
@@ -165,7 +160,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// namespace. See #102.
 		fresh, ok, err := base.AwaitRefresh[*manifest.Kustomization](
 			ctx, c.Controller, id, c.NewWaiter(id, ks.Timeout), deps,
-			"", base.DepFailed(id)) // empty pendingMsg: status set above (or kept Ready on a re-run)
+			"", base.DepFailed(id)) // empty pendingMsg: status set above (kept Ready on a no-op re-run)
 		if err != nil {
 			return err
 		}
@@ -177,17 +172,13 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		return err
 	}
 
-	if !wasReady {
-		c.Store.UpdateStatus(id, store.StatusPending, "resolving source artifact")
-	}
+	c.SetPendingUnlessReady(id, "resolving source artifact")
 	sourceRoot, applyIgnore, err := c.resolveSource(ks)
 	if err != nil {
 		return err
 	}
 
-	if !wasReady {
-		c.Store.UpdateStatus(id, store.StatusPending, "expanding substitutions")
-	}
+	c.SetPendingUnlessReady(id, "expanding substitutions")
 	// kustomize.Prepare clones ks and expands postBuild.substituteFrom —
 	// the same pre-render dance an embedder calling RenderFlux directly
 	// would perform. Keeping one canonical implementation here means

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -115,21 +115,15 @@ func (c *Controller) reconcile(ctx context.Context, obj manifest.BaseManifest) e
 		return nil
 	}
 
-	// Mirror the artifact-gate protection above for no-artifact
-	// (ExistenceFetcher) kinds: a HelmRepository never sets an artifact, so
-	// the gate never short-circuits its re-runs. Without this, a re-emitted
-	// HelmRepository flips Ready→Pending→Ready, and a consumer's
-	// quiescence-bound chart-source wait (helmrelease.awaitChartSource) could
-	// re-read the transient Pending at a transient pool drain and drop the
-	// release. A re-fetch of an already-Ready source is idempotent (the fetch
-	// still runs below), so keeping Ready across it is correct — we only
-	// suppress the cosmetic Pending write. Mirrors the Kustomization wasReady
-	// guard (#657).
-	cur, hasStatus := c.Store.GetStatus(id)
-	wasReady := hasStatus && cur.Status == store.StatusReady
-	if !wasReady {
-		c.Store.UpdateStatus(id, store.StatusPending, "fetching")
-	}
+	// SetPendingUnlessReady, not a raw UpdateStatus: the artifact gate above
+	// protects artifact-backed kinds from re-downgrading on a re-run, but a
+	// no-artifact ExistenceFetcher (HelmRepository) never sets one, so without
+	// this a re-emitted HelmRepository flips Ready→Pending→Ready and a
+	// consumer's quiescence-bound chart-source wait could re-read the transient
+	// Pending at a transient pool drain and drop the release. The fetch below
+	// still runs (idempotent), so keeping Ready across a no-op re-run is
+	// correct. See base.SetPendingUnlessReady (#658).
+	c.SetPendingUnlessReady(id, "fetching")
 	started := time.Now()
 
 	// Release the worker slot during the fetch so consumers of this


### PR DESCRIPTION
## Why

#657 (kustomization) and #658 (source) each grew the same block — capture "is this object already Ready" and skip the pre-dedup `StatusPending` progress write so a no-op re-reconcile doesn't transiently flip Ready→Pending (which a dependent's quiescence-bound depwait can re-read at a transient pool drain and drop). Same invariant in two places.

## What

Lift it into one place — `base.Controller.SetPendingUnlessReady(id, msg)` — and convert the call sites:
- **kustomization**: `resolving dependencies` / `resolving source artifact` / `expanding substitutions`
- **source**: `fetching`

Re-reading status per call is equivalent to the previous capture-once `wasReady` (the coalescer serializes per-id, so nothing mutates an id's own status mid-reconcile). **Byte-output-neutral.**

While consolidating, this also **closes the analogous gap in the HelmRelease controller**, which had the *same* unguarded pre-dedup write — `UpdateStatus(Pending, "resolving chart")` at `controller.go:285`, before its fingerprint dedup. HR retains `metadata.labels`, so a parent-KS render re-emits it stamped and it re-runs; the label-insensitive fingerprint then dedup-skips, but the unguarded write had already flashed Ready→Pending. An HR that `dependsOn` this one (a quiescence-bound HR→HR edge) could re-read that transient Pending and drop — the exact #657 shape, previously unguarded. Routing `:285` through the shared helper closes it.

The genuine-render downgrades (`rendering` / `rendering chart` / `applying N objects`, after each controller's dedup check) stay unconditional so a real re-render re-gates dependents.

## Verification

- New HR regression test (fail-before/pass-after: stashing the guard makes the already-Ready HR transiently downgrade → fails; with it → passes).
- `gofmt`/`go vet`/`golangci-lint` 0; `go test -race ./pkg/controllers/...` green; full `go test ./...` green.
- **Cross-repo byte-equivalence vs main unchanged** across all 24 paths (byte-output-neutral; only the known caBundle/checksum/timestamp non-determinism remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)