### PR TITLE
refactor: gate the HelmRelease dedup-replay source re-emit (mirror KS publish gate)

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -340,13 +340,18 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 			return err
 		}
 		slog.Debug("helmrelease: skipped re-render (fingerprint unchanged)", "id", id.String())
-		// Skip helm.TemplateDocs (the expensive bit), but replay the
-		// cached docs through the dispatch loop so any source CRs
-		// rendered by the chart (tofu-controller's OCIRepository,
-		// crossplane's Provider) re-fire EventObjectAdded for any
-		// listener that joined after the original render. Matches the
-		// KS-side dedup-replay pattern.
-		c.emitRenderedChildren(id, existing.Manifests)
+		// Skip helm.TemplateDocs (the expensive bit) but replay the cached
+		// docs so the idempotent per-emission side-effects (KeepEmitted
+		// keep-set + ReportRendered provenance) fire on every reconcile pass.
+		// publish=false: do NOT re-AddObject the chart-emitted source CRs.
+		// Unlike a KS's children, an HR-emitted source has a single emitter
+		// and the source controller never mutates the stored object, so the
+		// replay re-emits a byte-identical object — Store.AddObject's DeepEqual
+		// gate already no-ops it (no event). Gating it makes that explicit and
+		// mirrors the KS dedup-replay; #658/#659 (SetPendingUnlessReady) keep a
+		// re-emitted source Ready regardless, so the skipped re-emit can't drop
+		// a consumer.
+		c.emitRenderedChildren(id, existing.Manifests, false)
 		return nil
 	}
 
@@ -377,7 +382,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	if err := c.PreflightError(id); err != nil {
 		return err
 	}
-	c.emitRenderedChildren(id, docs)
+	c.emitRenderedChildren(id, docs, true)
 
 	c.Store.SetArtifact(id, &store.HelmReleaseArtifact{Manifests: docs, Fingerprint: fp})
 	return nil
@@ -478,6 +483,16 @@ func (c *Controller) materializeHelmChartSource(id manifest.NamedResource, hr *m
 // fresh-render path and the fingerprint-dedup replay path so the
 // per-doc side-effects fire on every reconcile pass.
 //
+// publish gates the event-firing Store.AddObject of source CRs. The
+// fresh-render path passes true. The fingerprint-dedup replay passes
+// FALSE: the sources were already published byte-identically by the
+// render that set the cached artifact (the source controller writes only
+// artifact + status, never the stored object), so re-AddObject-ing them
+// is a Store.AddObject DeepEqual no-op anyway. The idempotent side-effects
+// the replay exists for — KeepEmitted (keep-set) + ReportRendered
+// (provenance) — are event-free and still run on both paths. Mirrors the
+// KS dedup-replay publish gate (#657).
+//
 // A single-pass loop is safe here because isFluxSourceKind restricts
 // AddObject dispatch to pure source kinds (HelmRepository,
 // OCIRepository, GitRepository, Bucket, HelmChartSource,
@@ -486,7 +501,7 @@ func (c *Controller) materializeHelmChartSource(id manifest.NamedResource, hr *m
 // which guards leaf KS/HR controllers that read ConfigMap/Secret
 // substituteFrom data emitted in the same batch. HR-emitting-HR or
 // HR-emitting-KS is deliberately excluded from this controller.
-func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[string]any) {
+func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[string]any, publish bool) {
 	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
 	// Accumulate every source-kind child id so the renderedSet write
 	// flushes through MarkRenderedBatch in a single lock acquisition.
@@ -517,7 +532,9 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 			// in kustomization.emitRenderedChildren.
 			childID := obj.Named()
 			c.KeepEmitted(id, obj)
-			c.Store.AddObject(obj)
+			if publish {
+				c.Store.AddObject(obj)
+			}
 			rendered = append(rendered, childID)
 		} else {
 			c.Store.AddRendered(obj)

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -526,7 +526,7 @@ func TestEmitRenderedChildren_SourceKindGetsKeepEmittedAndMarkRendered(t *testin
 		"data":       map[string]any{"key": "value"},
 	}
 
-	c.emitRenderedChildren(parent, []map[string]any{ociDoc, cmDoc})
+	c.emitRenderedChildren(parent, []map[string]any{ociDoc, cmDoc}, true)
 
 	// markRendered must have been called exactly once, for the OCIRepository.
 	if got := len(tracker.calls); got != 1 {
@@ -564,6 +564,72 @@ func TestEmitRenderedChildren_SourceKindGetsKeepEmittedAndMarkRendered(t *testin
 	}
 }
 
+// TestEmitRenderedChildren_DedupReplay_NoStoreWrites pins the publish gate
+// (mirrors the KS TestEmitRenderedChildren_DedupSkip_NoStoreWrites): the
+// fingerprint-dedup replay (publish=false) must NOT re-AddObject the
+// chart-emitted source CRs — re-emit is a DeepEqual no-op anyway, and gating it
+// makes that explicit. The idempotent side-effects the replay exists for —
+// KeepEmitted (keep-set) + ReportRendered (provenance) — MUST still fire.
+func TestEmitRenderedChildren_DedupReplay_NoStoreWrites(t *testing.T) {
+	st := store.New()
+	ts := task.New()
+	hc, err := helm.NewClient(cacheroot.New(t.TempDir()))
+	if err != nil {
+		t.Fatalf("helm.NewClient: %v", err)
+	}
+	hc.SetSourceResolver(helm.NewStoreSourceResolver(st))
+
+	tracker := &spyTracker{}
+	parent := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "flux-system", Name: "tofu"}
+	filter := change.NewFilter(
+		change.NewSet([]string{"apps/tofu/helmrelease.yaml"}),
+		map[manifest.NamedResource]string{parent: "apps/tofu/helmrelease.yaml"},
+		"",
+		testutil.MapLister{},
+	)
+	c := New(st, ts, hc, helm.Options{}, false)
+	c.Configure(ReconcileOptions{Filter: filter, RenderTracker: tracker})
+	c.Start(context.Background())
+	t.Cleanup(func() { c.Close(); ts.BlockTillDone() })
+
+	ociDoc := map[string]any{
+		"apiVersion": "source.toolkit.fluxcd.io/v1beta2",
+		"kind":       "OCIRepository",
+		"metadata":   map[string]any{"name": "tofu-oci", "namespace": "flux-system"},
+		"spec":       map[string]any{"url": "oci://ghcr.io/tofu/tofu"},
+	}
+	ociID := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "tofu-oci"}
+
+	var events int
+	st.AddListener(store.EventObjectAdded, func(_ manifest.NamedResource, _ any) { events++ }, false)
+
+	// Dedup replay: no AddObject, no event, store untouched — but the keep-set
+	// and provenance side-effects still fire.
+	c.emitRenderedChildren(parent, []map[string]any{ociDoc}, false)
+
+	if events != 0 {
+		t.Errorf("publish=false fired %d EventObjectAdded; want 0 (no source re-emit)", events)
+	}
+	if obj := st.GetObject(ociID); obj != nil {
+		t.Error("publish=false AddObject'd a source CR; want the store left untouched")
+	}
+	if len(tracker.calls) != 1 || tracker.calls[0].child != ociID {
+		t.Errorf("publish=false provenance = %v; want one MarkRendered for %v", tracker.calls, ociID)
+	}
+	if !filter.ShouldReconcile(ociID) {
+		t.Error("publish=false did not extend the keep set (KeepEmitted must still run)")
+	}
+
+	// Fresh render publishes: event fires and the source lands in the store.
+	c.emitRenderedChildren(parent, []map[string]any{ociDoc}, true)
+	if events != 1 {
+		t.Errorf("publish=true fired %d EventObjectAdded; want 1", events)
+	}
+	if obj := st.GetObject(ociID); obj == nil {
+		t.Error("publish=true did not store the source CR")
+	}
+}
+
 func TestEmitRenderedChildren_NilTrackerAndNilFilterAreNoops(t *testing.T) {
 	st := store.New()
 	ts := task.New()
@@ -589,7 +655,7 @@ func TestEmitRenderedChildren_NilTrackerAndNilFilterAreNoops(t *testing.T) {
 		"spec":       map[string]any{"url": "oci://ghcr.io/example"},
 	}
 	// Must not panic when tracker and filter are nil.
-	c.emitRenderedChildren(parent, []map[string]any{ociDoc})
+	c.emitRenderedChildren(parent, []map[string]any{ociDoc}, true)
 
 	// OCIRepository is still added to the store even without tracker/filter.
 	ociID := manifest.NamedResource{


### PR DESCRIPTION
## Why

The HelmRelease controller's `emitRenderedChildren` re-emits chart-rendered source CRs (OCIRepository/HelmRepository/etc.) on both the fresh-render path and the fingerprint-dedup replay, but lacked the `publish bool` gate the Kustomization controller got in #657. This completes the KS/source/HR symmetry around the dedup-replay.

## Investigation (this is hardening, not a bug fix)

The HR dedup-replay was already **inert**:
- An HR-emitted source CR has a **single emitter**, and the source controller **never mutates the stored object** (writes only artifact + status). So the replay re-emits a byte-identical object → `Store.AddObject`'s `reflect.DeepEqual` gate already no-ops it (no event, no churn).
- Even if it fired, #658/#659 (`SetPendingUnlessReady`) keep a re-emitted source Ready, and a late consumer is covered by `WatchReady`'s atomic subscribe+read.
- This differs from the KS case (KS children exist twice — file-loaded *and* render-emitted/stamped — so they genuinely differ and churn). HR sources don't.

## What

- `emitRenderedChildren(id, docs)` → `emitRenderedChildren(id, docs, publish bool)`. Gate **only** the event-firing `Store.AddObject` of sources behind `publish`; keep `KeepEmitted` (keep-set), the `rendered` accumulation, `AddRendered`, and `ReportRendered` (provenance) on both paths. Fresh render passes `true`; dedup-replay passes `false`.
- Correct the stale call-site comment, which claimed the replay re-fires `EventObjectAdded` for late listeners (DeepEqual defeats that; `WatchReady` makes it unnecessary). The function doc now states the accurate intent.

Byte-output-neutral — the gated re-emit was a DeepEqual no-op.

## Verification

- Fail-before/pass-after test: `publish=false` fires zero `EventObjectAdded` and stores nothing, but `KeepEmitted` + `ReportRendered` still record the source (proving the side-effects are preserved). Confirmed it fails when the gate is removed.
- `gofmt`/`go vet`/`golangci-lint` 0; `go test -race ./pkg/controllers/...` green; full `go test ./...` green.
- **Cross-repo byte-equivalence vs main unchanged** across all 24 paths (only the known caBundle/checksum/timestamp non-determinism remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)