### PR TITLE
refactor: deduplicate dispatch, fingerprint-dedup, and hashing across controllers

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -234,6 +234,34 @@ func (c *Controller) SetPendingUnlessReady(id manifest.NamedResource, msg string
 	c.Store.UpdateStatus(id, store.StatusPending, msg)
 }
 
+// FingerprintDedup short-circuits a reconcile when id's cached rendered
+// artifact carries a non-empty fingerprint equal to fp — the effective inputs
+// are byte-identical, so the expensive render (kustomize/helm) is skipped. It
+// still replays the cached docs through emit so the idempotent per-emission
+// side-effects (keep-set extension + parent provenance) fire on every reconcile
+// pass; emit is the controller's emitRenderedChildren(id, docs, publish=false)
+// closure. The replay deliberately does NOT re-publish the children: they were
+// already published byte-identically by the render that set this artifact, so
+// re-AddObject-ing them would only re-fire listeners and re-submit already-
+// settled resources — churn that can transiently un-Ready a parent and race
+// quiescence (the "not ready" non-determinism, see #657–#660).
+//
+// Returns (handled=true, err): the caller returns err. err is non-nil only when
+// a preflight error was discovered mid-flight. Returns (false, nil) to render
+// normally. Centralizes the byte-identical KS/HR dedup short-circuit.
+func (c *Controller) FingerprintDedup(id manifest.NamedResource, fp, logKind string, emit func(docs []map[string]any)) (bool, error) {
+	existing, ok := c.Store.GetArtifact(id).(store.RenderedArtifact)
+	if !ok || existing.RenderedFingerprint() == "" || existing.RenderedFingerprint() != fp {
+		return false, nil
+	}
+	if err := c.PreflightError(id); err != nil {
+		return true, err
+	}
+	slog.Debug(logKind+": skipped re-render (fingerprint unchanged)", "id", id.String())
+	emit(existing.RenderedManifests())
+	return true, nil
+}
+
 // NewWaiter constructs a depwait.Waiter pre-wired with the
 // controller's Store, Existence lookup, and Renders quiescence signal,
 // parented to id and budgeted from timeout. HR and KS controllers call
@@ -528,4 +556,45 @@ func RunWithStatus[T manifest.BaseManifest](
 		}
 	}
 	s.UpdateStatus(id, store.StatusReady, "")
+}
+
+// OnReconcile builds the EventObjectAdded listener every controller registers
+// in Start. It collapses the previously-duplicated onObjectAdded shape across
+// the source/kustomization/helmrelease controllers into one generic: match the
+// id, type-assert the payload to T, PreGate on suspension, fail-fast on a
+// preflight error, then Submit the reconcile wrapped in RunWithStatus.
+//
+// The per-controller bits are the parameters: match (a single-kind check for
+// KS/HR, a fetcher-registered check for source), suspended (the Suspend field
+// for KS/HR, the Suspendable interface for source), the logKind label, and the
+// typed reconcile fn. PreflightFailure is safe to call for every controller —
+// it returns ("", false) when no preflight reporter is wired (source), so the
+// shared check is a no-op there.
+func OnReconcile[T manifest.BaseManifest](
+	ctx context.Context,
+	c *Controller,
+	match func(manifest.NamedResource) bool,
+	suspended func(T) bool,
+	logKind string,
+	reconcile func(context.Context, T) error,
+) store.Listener {
+	return func(id manifest.NamedResource, payload any) {
+		if !match(id) {
+			return
+		}
+		obj, ok := payload.(T)
+		if !ok {
+			return
+		}
+		if c.PreGate(id, suspended(obj)) {
+			return
+		}
+		if msg, failed := c.PreflightFailure(id); failed {
+			c.Store.UpdateStatus(id, store.StatusFailed, msg)
+			return
+		}
+		c.Submit(ctx, id, func(ctx context.Context) {
+			RunWithStatus(ctx, c.Store, id, logKind, reconcile)
+		})
+	}
 }

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -8,9 +8,11 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
 )
 
 func TestRunWithStatus_Success(t *testing.T) {
@@ -275,5 +277,117 @@ func TestController_DoubleCloseIsSafe(t *testing.T) {
 
 	if got := fired.Load(); got != 0 {
 		t.Fatalf("listener fired %d times after double Close; want 0", got)
+	}
+}
+
+// TestOnReconcile pins the shared dispatch-listener builder that replaced the
+// three controllers' near-identical onObjectAdded: it must ignore ids the match
+// predicate rejects, bail (via PreGate) on suspended objects without running
+// the reconcile, mark a preflight-failed id Failed without running it, and run
+// the reconcile only for a matching, non-suspended, preflight-clean object.
+func TestOnReconcile(t *testing.T) {
+	s := store.New()
+	ts := task.New()
+	c := base.New(s, ts)
+	c.SetPreflight(func(id manifest.NamedResource) (string, bool) {
+		return "synthetic cycle", id.Name == "preflightfail"
+	})
+	c.StartLifecycle("test")
+	t.Cleanup(func() { c.Close(); ts.BlockTillDone() })
+
+	var ran atomic.Int64
+	c.AddListener(store.EventObjectAdded, base.OnReconcile(t.Context(), c,
+		func(id manifest.NamedResource) bool { return id.Kind == manifest.KindHelmRelease },
+		func(hr *manifest.HelmRelease) bool { return hr.Name == "suspended" },
+		"helmrelease",
+		func(_ context.Context, _ *manifest.HelmRelease) error { ran.Add(1); return nil },
+	))
+
+	// Non-matching kind → ignored entirely (no status written).
+	ks := &manifest.Kustomization{Name: "k", Namespace: "ns"}
+	s.AddObject(ks)
+	// Matching but suspended → PreGate bails to Ready/"suspended", no reconcile.
+	susHR := &manifest.HelmRelease{Name: "suspended", Namespace: "ns"}
+	s.AddObject(susHR)
+	// Matching but preflight-failed → Failed, no reconcile.
+	pfHR := &manifest.HelmRelease{Name: "preflightfail", Namespace: "ns"}
+	s.AddObject(pfHR)
+	// Matching, clean → reconcile runs → Ready.
+	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
+	s.AddObject(hr)
+
+	testutil.WaitForStatus(t, s, hr.Named(), store.StatusReady)
+
+	if got := ran.Load(); got != 1 {
+		t.Errorf("reconcile ran %d times; want 1 (only the matching, non-suspended, preflight-clean HR)", got)
+	}
+	if _, ok := s.GetStatus(ks.Named()); ok {
+		t.Error("non-matching kind got a status; OnReconcile must ignore it")
+	}
+	if info, _ := s.GetStatus(susHR.Named()); info.Message != "suspended" {
+		t.Errorf("suspended HR status = %+v; want Ready/suspended via PreGate", info)
+	}
+	if info, _ := s.GetStatus(pfHR.Named()); info.Status != store.StatusFailed {
+		t.Errorf("preflight-failed HR status = %+v; want Failed", info)
+	}
+}
+
+// TestFingerprintDedup pins the shared dedup short-circuit: it skips (returns
+// handled=true) and replays the cached docs through emit only when a rendered
+// artifact with a matching non-empty fingerprint exists; otherwise it returns
+// handled=false so the caller renders. A preflight error surfaces as
+// (handled=true, err) without emitting.
+func TestFingerprintDedup(t *testing.T) {
+	s := store.New()
+	c := base.New(s, nil)
+	ks := &manifest.Kustomization{Name: "k", Namespace: "ns"}
+	s.AddObject(ks)
+	id := ks.Named()
+	docs := []map[string]any{{"kind": "ConfigMap"}}
+	s.SetArtifact(id, &store.KustomizationArtifact{Manifests: docs, Fingerprint: "fp1"})
+
+	var emitted int
+	emit := func([]map[string]any) { emitted++ }
+
+	// Fingerprint mismatch → render (not handled), no emit.
+	if handled, err := c.FingerprintDedup(id, "other", "kustomization", emit); handled || err != nil {
+		t.Errorf("mismatch: handled=%v err=%v; want false,nil", handled, err)
+	}
+	// Match → handled, emit replays the cached docs.
+	if handled, err := c.FingerprintDedup(id, "fp1", "kustomization", emit); !handled || err != nil {
+		t.Errorf("match: handled=%v err=%v; want true,nil", handled, err)
+	}
+	// No artifact for the id → render (not handled).
+	none := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "none"}
+	if handled, _ := c.FingerprintDedup(none, "fp1", "kustomization", emit); handled {
+		t.Error("no-artifact id: handled=true; want false")
+	}
+	if emitted != 1 {
+		t.Errorf("emit called %d times; want 1 (only on the match)", emitted)
+	}
+
+	// Empty fingerprint never matches (safe re-render), even fp==""==stored.
+	s.SetArtifact(id, &store.KustomizationArtifact{Manifests: docs, Fingerprint: ""})
+	if handled, _ := c.FingerprintDedup(id, "", "kustomization", emit); handled {
+		t.Error("empty fingerprint matched; want never-match (false)")
+	}
+}
+
+// TestFingerprintDedup_PreflightError: a match that coincides with a
+// mid-flight preflight failure returns (handled=true, err) and does not emit.
+func TestFingerprintDedup_PreflightError(t *testing.T) {
+	s := store.New()
+	c := base.New(s, nil)
+	ks := &manifest.Kustomization{Name: "k", Namespace: "ns"}
+	s.AddObject(ks)
+	id := ks.Named()
+	s.SetArtifact(id, &store.KustomizationArtifact{Fingerprint: "fp1"})
+	c.SetPreflight(func(manifest.NamedResource) (string, bool) { return "cycle detected", true })
+
+	handled, err := c.FingerprintDedup(id, "fp1", "kustomization", func([]map[string]any) {
+		t.Error("emit must not run when a preflight error is surfaced")
+	})
+	if !handled || err == nil {
+		t.Errorf("preflight error: handled=%v err=%v; want true, non-nil", handled, err)
 	}
 }

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -135,7 +135,10 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("helmrelease")
 	c.AddListener(store.EventObjectAdded, c.onRawProducerAdded())
-	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
+	c.AddListener(store.EventObjectAdded, base.OnReconcile(ctx, c.Controller,
+		func(id manifest.NamedResource) bool { return id.Kind == manifest.KindHelmRelease },
+		func(hr *manifest.HelmRelease) bool { return hr.Suspend },
+		"helmrelease", c.reconcile))
 }
 
 // onRawProducerAdded returns a listener that indexes RawObject producers
@@ -186,28 +189,6 @@ func rawProducerTargetID(raw *manifest.RawObject) (manifest.NamedResource, bool)
 		return secretID(name), true
 	default:
 		return manifest.NamedResource{}, false
-	}
-}
-
-func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
-	return func(id manifest.NamedResource, payload any) {
-		if id.Kind != manifest.KindHelmRelease {
-			return
-		}
-		hr, ok := payload.(*manifest.HelmRelease)
-		if !ok {
-			return
-		}
-		if c.PreGate(id, hr.Suspend) {
-			return
-		}
-		if msg, failed := c.PreflightFailure(id); failed {
-			c.Store.UpdateStatus(id, store.StatusFailed, msg)
-			return
-		}
-		c.Submit(ctx, id, func(ctx context.Context) {
-			base.RunWithStatus(ctx, c.Store, id, "helmrelease", c.reconcile)
-		})
 	}
 }
 
@@ -325,34 +306,18 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		return err
 	}
 
-	// Fingerprint dedup: when the same HR id gets re-AddObject'd with
-	// the same effective spec (e.g. the parent KS render stamps
-	// kustomize.toolkit.fluxcd.io/{name,namespace} labels onto a
-	// previously-loaded HR and re-emits it via Store.AddObject), skip
-	// the helm render — its output would be byte-identical. Without
-	// this, flate runs helm.Template twice for every HR a parent KS
-	// owns, which surfaces as duplicate "warning: cannot overwrite
-	// table..." log lines from helm's coalescer and roughly doubles
-	// the HR-render time on real-world trees.
+	// Fingerprint dedup (helm.TemplateDocs is the hot path): skip the
+	// re-render and replay the cached artifact's side-effects when the
+	// effective spec is byte-identical to the cached artifact — the common
+	// trigger is a parent KS re-emitting this HR with stamped ownership
+	// labels. The shared helper publishes nothing (publish=false; an
+	// HR-emitted source CR re-emit is a DeepEqual no-op anyway) — see its doc
+	// for the rationale (#657–#660). fp is reused for SetArtifact below.
 	fp := helmReleaseFingerprint(hr)
-	if existing, ok := c.Store.GetArtifact(id).(*store.HelmReleaseArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
-		if err := c.PreflightError(id); err != nil {
-			return err
-		}
-		slog.Debug("helmrelease: skipped re-render (fingerprint unchanged)", "id", id.String())
-		// Skip helm.TemplateDocs (the expensive bit) but replay the cached
-		// docs so the idempotent per-emission side-effects (KeepEmitted
-		// keep-set + ReportRendered provenance) fire on every reconcile pass.
-		// publish=false: do NOT re-AddObject the chart-emitted source CRs.
-		// Unlike a KS's children, an HR-emitted source has a single emitter
-		// and the source controller never mutates the stored object, so the
-		// replay re-emits a byte-identical object — Store.AddObject's DeepEqual
-		// gate already no-ops it (no event). Gating it makes that explicit and
-		// mirrors the KS dedup-replay; #658/#659 (SetPendingUnlessReady) keep a
-		// re-emitted source Ready regardless, so the skipped re-emit can't drop
-		// a consumer.
-		c.emitRenderedChildren(id, existing.Manifests, false)
-		return nil
+	if handled, err := c.FingerprintDedup(id, fp, "helmrelease", func(docs []map[string]any) {
+		c.emitRenderedChildren(id, docs, false)
+	}); handled {
+		return err
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering chart")

--- a/pkg/controllers/helmrelease/fingerprint.go
+++ b/pkg/controllers/helmrelease/fingerprint.go
@@ -1,8 +1,6 @@
 package helmrelease
 
 import (
-	"encoding/json"
-
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -13,14 +11,11 @@ import (
 // and metadata.annotations on purpose — kustomize-controller-emitted
 // HRs differ from their file-loaded sources only in label stamping,
 // and re-rendering on a label diff is pure waste. Returns "" when
-// json.Marshal fails (degrades safely: an empty fingerprint never
-// matches, so the dedup short-circuit is skipped and we re-render).
+// the payload can't be hashed (degrades safely: manifest.Fingerprint
+// returns "", which never matches, so the dedup short-circuit is
+// skipped and we re-render).
 func helmReleaseFingerprint(hr *manifest.HelmRelease) string {
-	raw, err := json.Marshal(helmReleaseFingerprintPayload(hr))
-	if err != nil {
-		return ""
-	}
-	return manifest.SHA256Hex(raw)
+	return manifest.Fingerprint(helmReleaseFingerprintPayload(hr))
 }
 
 func helmReleaseFingerprintPayload(hr *manifest.HelmRelease) any {

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -8,7 +8,6 @@ package kustomization
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"path/filepath"
 	"slices"
 
@@ -109,29 +108,10 @@ func (c *Controller) Configure(opts Options) {
 // Start registers the listener that drives reconciliation.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("kustomization")
-	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
-}
-
-func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
-	return func(id manifest.NamedResource, payload any) {
-		if id.Kind != manifest.KindKustomization {
-			return
-		}
-		ks, ok := payload.(*manifest.Kustomization)
-		if !ok {
-			return
-		}
-		if c.PreGate(id, ks.Suspend) {
-			return
-		}
-		if msg, failed := c.PreflightFailure(id); failed {
-			c.Store.UpdateStatus(id, store.StatusFailed, msg)
-			return
-		}
-		c.Submit(ctx, id, func(ctx context.Context) {
-			base.RunWithStatus(ctx, c.Store, id, "kustomization", c.reconcile)
-		})
-	}
+	c.AddListener(store.EventObjectAdded, base.OnReconcile(ctx, c.Controller,
+		func(id manifest.NamedResource) bool { return id.Kind == manifest.KindKustomization },
+		func(ks *manifest.Kustomization) bool { return ks.Suspend },
+		"kustomization", c.reconcile))
 }
 
 func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) error {
@@ -191,37 +171,16 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		return err
 	}
 
-	// Fingerprint dedup: the same id may receive multiple AddObject
-	// events with the same effective spec (e.g. when the structural
-	// parent re-emits this KS after running its own render, stamping
-	// kustomize.toolkit.fluxcd.io ownership labels). kustomize.RenderFlux
-	// is the hot path; skip it and reuse the prior artifact when the
-	// post-Prepare inputs are byte-identical. Same pattern as HR (#219).
+	// Fingerprint dedup (kustomize.RenderFlux is the hot path): skip the
+	// re-render and replay the cached artifact's side-effects when the
+	// post-Prepare inputs are byte-identical to the cached artifact. The
+	// shared helper publishes nothing (publish=false) — see its doc for the
+	// churn/quiescence rationale (#657–#660). fp is reused for SetArtifact below.
 	fp := kustomizationFingerprint(ks, sourceRoot)
-	if existing, ok := c.Store.GetArtifact(id).(*store.KustomizationArtifact); ok && existing.Fingerprint != "" && existing.Fingerprint == fp {
-		if err := c.PreflightError(id); err != nil {
-			return err
-		}
-		slog.Debug("kustomization: skipped re-render (fingerprint unchanged)", "id", id.String())
-		// Skip kustomize.RenderFlux (the expensive bit), but still
-		// replay the cached artifact through emitRenderedChildren so
-		// the per-emission side-effects (markRendered for parent
-		// provenance + Filter.AddEmitted for runtime keep-set
-		// extension, see #260/#308) fire on every reconcile pass.
-		// Without this, a re-emit that hits dedup drops the child
-		// from the parent index and the keep-set chain — a subsequent
-		// changed-only run silently mis-attributes children to a
-		// stale parent.
-		//
-		// publish=false: do NOT re-AddObject the children. They were
-		// already published byte-identically by the render that set this
-		// cached artifact, so re-publishing only re-fires their listeners
-		// and re-submits already-settled children — churn that
-		// transiently un-Ready-s a parent and races quiescence (the
-		// "parent Kustomization not ready" non-determinism). Only the
-		// idempotent provenance + keep-set side-effects need to re-run.
-		c.emitRenderedChildren(id, existing.Manifests, false)
-		return nil
+	if handled, err := c.FingerprintDedup(id, fp, "kustomization", func(docs []map[string]any) {
+		c.emitRenderedChildren(id, docs, false)
+	}); handled {
+		return err
 	}
 
 	c.Store.UpdateStatus(id, store.StatusPending, "rendering")

--- a/pkg/controllers/kustomization/fingerprint.go
+++ b/pkg/controllers/kustomization/fingerprint.go
@@ -1,8 +1,6 @@
 package kustomization
 
 import (
-	"encoding/json"
-
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
@@ -15,10 +13,10 @@ import (
 // annotations are excluded on purpose: kustomize-controller-emitted
 // children carry stamped ownership labels that don't affect the
 // rendered manifests, and re-rendering on that delta is pure waste.
-// Returns "" when json.Marshal fails — empty fingerprints never
-// match, so the dedup short-circuit degrades safely into re-render.
+// Degrades safely into a re-render when the payload can't be hashed
+// (manifest.Fingerprint returns "", which never matches the dedup check).
 func kustomizationFingerprint(ks *manifest.Kustomization, sourceRoot string) string {
-	payload := struct {
+	return manifest.Fingerprint(struct {
 		Path                string
 		SourceRoot          string
 		Contents            map[string]any
@@ -30,10 +28,5 @@ func kustomizationFingerprint(ks *manifest.Kustomization, sourceRoot string) str
 		Contents:            ks.Contents,
 		PostBuildSubstitute: ks.PostBuildSubstitute,
 		Spec:                ks.KustomizationSpec,
-	}
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return ""
-	}
-	return manifest.SHA256Hex(raw)
+	})
 }

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -70,29 +70,16 @@ func (c *Controller) Configure(opts FetchOptions) {
 // Close is called.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("source")
-	c.AddListener(store.EventObjectAdded, c.onObjectAdded(ctx))
-}
-
-func (c *Controller) onObjectAdded(ctx context.Context) store.Listener {
-	return func(id manifest.NamedResource, payload any) {
-		if _, registered := c.Fetchers[id.Kind]; !registered {
-			return
-		}
-		obj, ok := payload.(manifest.BaseManifest)
-		if !ok {
-			return
-		}
-		sus, _ := obj.(src.Suspendable)
-		if c.PreGate(id, sus != nil && sus.Suspended()) {
-			return
-		}
-		// Coalesce per-id so a duplicate AddObject for the same source
-		// (e.g. a parent KS re-emits a child source on re-render)
-		// doesn't race two concurrent fetches into the same cache slot.
-		c.Submit(ctx, id, func(ctx context.Context) {
-			base.RunWithStatus(ctx, c.Store, id, "source", c.reconcile)
-		})
-	}
+	// Match any kind with a registered fetcher (not a single kind like KS/HR),
+	// and read Suspend via the Suspendable interface. Coalescing in Submit
+	// means a duplicate AddObject for the same source (e.g. a parent KS
+	// re-emitting a child source on re-render) doesn't race two concurrent
+	// fetches into the same cache slot. Source wires no preflight reporter, so
+	// OnReconcile's PreflightFailure check is a no-op here.
+	c.AddListener(store.EventObjectAdded, base.OnReconcile(ctx, c.Controller,
+		func(id manifest.NamedResource) bool { _, ok := c.Fetchers[id.Kind]; return ok },
+		func(obj manifest.BaseManifest) bool { s, _ := obj.(src.Suspendable); return s != nil && s.Suspended() },
+		"source", c.reconcile))
 }
 
 // reconcile fetches the source artifact via the registered Fetcher and

--- a/pkg/manifest/hash.go
+++ b/pkg/manifest/hash.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 )
 
 // SHA256Hex returns the hex-encoded SHA-256 digest of data. It is the
@@ -16,4 +17,18 @@ import (
 func SHA256Hex(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
+}
+
+// Fingerprint returns a stable content hash of payload — json.Marshal
+// followed by SHA256Hex. It returns "" when marshaling fails: an empty
+// fingerprint never matches a dedup comparison, so callers degrade safely
+// into a re-render rather than a false cache hit. Used by the controllers'
+// render-input fingerprints (kustomizationFingerprint / helmReleaseFingerprint),
+// which differ only in their payload struct.
+func Fingerprint(payload any) string {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return SHA256Hex(raw)
 }

--- a/pkg/store/artifact.go
+++ b/pkg/store/artifact.go
@@ -19,6 +19,11 @@ type Artifact interface {
 type RenderedArtifact interface {
 	Artifact
 	RenderedManifests() []map[string]any
+	// RenderedFingerprint is the stable hash of the inputs that produced
+	// RenderedManifests (named distinctly from the Fingerprint field). The
+	// controllers' shared dedup short-circuit (base.Controller.FingerprintDedup)
+	// compares it to skip a re-render whose inputs are byte-identical.
+	RenderedFingerprint() string
 }
 
 // SourceArtifact is the unified working-tree artifact produced by
@@ -63,6 +68,9 @@ func (*KustomizationArtifact) artifact() {}
 // RenderedManifests implements RenderedArtifact.
 func (a *KustomizationArtifact) RenderedManifests() []map[string]any { return a.Manifests }
 
+// RenderedFingerprint implements RenderedArtifact.
+func (a *KustomizationArtifact) RenderedFingerprint() string { return a.Fingerprint }
+
 // HelmReleaseArtifact is the rendered output of a HelmRelease template.
 //
 // Fingerprint is a stable hash of the inputs that determine the
@@ -83,6 +91,9 @@ func (*HelmReleaseArtifact) artifact() {}
 
 // RenderedManifests implements RenderedArtifact.
 func (a *HelmReleaseArtifact) RenderedManifests() []map[string]any { return a.Manifests }
+
+// RenderedFingerprint implements RenderedArtifact.
+func (a *HelmReleaseArtifact) RenderedFingerprint() string { return a.Fingerprint }
 
 // --- Store operations on artifacts ---
 


### PR DESCRIPTION
## Why

The three reconcile controllers (`kustomization`, `helmrelease`, `source`, all embedding `*base.Controller`) carried genuinely-duplicated logic that the determinism series (#657–#660) made visible. Two read-only sweeps mapped it; this lifts the real duplication into `base`/`manifest` (continuing the #39/#453/#659 consolidation). **Pure, byte-output-neutral refactor.**

## What

- **`base.OnReconcile[T]`** — one generic `EventObjectAdded` listener builder replacing the ~85%-identical `onObjectAdded` in all three controllers (match the id → type-assert `T` → `PreGate(suspended)` → fail-fast on preflight → `Submit`+`RunWithStatus`). The per-controller bits are parameters: a match predicate (single-kind for KS/HR, fetcher-registered for source), a suspend extractor (`Suspend` field vs `Suspendable` interface), the log-kind, and the reconcile fn. `PreflightFailure` is a safe no-op for source (it wires none).
- **`base.Controller.FingerprintDedup`** (+ `RenderedArtifact.RenderedFingerprint()`) — the byte-identical KS/HR fingerprint-dedup short-circuit collapses to one helper; the determinism rationale now lives in one doc.
- **`manifest.Fingerprint(any)`** — the `json.Marshal → "" → SHA256Hex` boilerplate the two fingerprint fns shared; their bodies become one-liners over their (distinct) payload structs.

## Deliberately NOT unified (structurally different, not duplication — confirmed by both sweeps)

`emitRenderedChildren` (two-pass KS vs single-pass HR), the divergent reconcile skeletons (`kustomize.RenderFlux` vs `helm.TemplateDocs`, source resolution), the inline `PreflightError` yield-guards, and the parent-gate asymmetry.

## Verification

- New `base` unit tests: `OnReconcile` (match-miss / suspend / preflight-fail / happy) and `FingerprintDedup` (mismatch / match / no-artifact / empty-fp / preflight-error).
- The existing end-to-end controller/dispatch/fingerprint tests (unchanged) are the primary regression guard — all green under `-race`.
- `gofmt`/`go vet`/`golangci-lint` 0; `go test -race ./pkg/controllers/... ./pkg/store/... ./pkg/manifest/...`; full `go test ./...` green.
- **Cross-repo byte-equivalence vs main unchanged** across all 24 paths (only the known caBundle/checksum/timestamp non-determinism remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)