### PR TITLE
fix: substitute postBuild ${VAR} in map-key position to match Flux

### DIFF
--- a/pkg/controllers/kustomization/substitute.go
+++ b/pkg/controllers/kustomization/substitute.go
@@ -19,8 +19,14 @@ import (
 // `replicas: ${REPLICAS}` (plain scalar) round-trips through envsubst
 // as int rather than string. Cheap pre-check on the decoded tree skips
 // the round-trip for the (common) case of docs with no `${` anywhere.
+//
+// The pre-check uses AnyStringNode (keys + values), not AnyStringLeaf:
+// envsubst runs over the serialized YAML text, so a `${VAR}` in key
+// position (e.g. `${OP_VAULT}: 1`) substitutes just like one in value
+// position. Gating on values alone would skip a key-only reference and
+// leave the var literal — a flate-only divergence from Flux.
 func substituteDoc(doc map[string]any, vars map[string]string) (map[string]any, error) {
-	if !manifest.AnyStringLeaf(doc, func(s string) bool { return strings.Contains(s, "${") }) {
+	if !manifest.AnyStringNode(doc, func(s string) bool { return strings.Contains(s, "${") }) {
 		return doc, nil
 	}
 	raw, err := yaml.Marshal(doc)

--- a/pkg/controllers/kustomization/substitute_test.go
+++ b/pkg/controllers/kustomization/substitute_test.go
@@ -69,6 +69,83 @@ func TestSubstituteDoc_NoSubstitutionShortCircuits(t *testing.T) {
 	}
 }
 
+// substituteDoc substitutes a `${VAR}` in MAP KEY position, matching
+// Flux (which runs envsubst over the serialized YAML text). This is the
+// ClusterSecretStore `vaults: { ${OP_VAULT}: 1 }` shape: the only `${`
+// in the doc sits in a key and the value is a non-string, so the old
+// values-only gate skipped the doc and left the key literal.
+func TestSubstituteDoc_SubstitutesMapKey(t *testing.T) {
+	doc := map[string]any{
+		"apiVersion": "external-secrets.io/v1",
+		"kind":       "ClusterSecretStore",
+		"spec": map[string]any{
+			"provider": map[string]any{
+				"onepassword": map[string]any{
+					"vaults": map[string]any{"${OP_VAULT}": 1},
+				},
+			},
+		},
+	}
+	out, err := substituteDoc(doc, map[string]string{"OP_VAULT": "homelab"})
+	if err != nil {
+		t.Fatalf("substituteDoc: %v", err)
+	}
+	vaults := out["spec"].(map[string]any)["provider"].(map[string]any)["onepassword"].(map[string]any)["vaults"].(map[string]any)
+	if _, stale := vaults["${OP_VAULT}"]; stale {
+		t.Errorf("key left unsubstituted; got keys %v", vaults)
+	}
+	v, ok := vaults["homelab"]
+	if !ok {
+		t.Fatalf("substituted key missing; got keys %v", vaults)
+	}
+	// The marshal/unmarshal round-trip still coerces the value even when
+	// the trigger was a key — `1` stays an int, not a string.
+	if iv, _ := v.(int); iv != 1 {
+		t.Errorf("value = %v (%T), want int 1", v, v)
+	}
+}
+
+// An escaped `$${VAR}` key unescapes to a literal `${VAR}` key — it must
+// not be excluded from the round-trip (the gate has to pass so envsubst
+// can do the unescaping) and must not be expanded. Matches Flux.
+func TestSubstituteDoc_EscapedDollarKey(t *testing.T) {
+	doc := map[string]any{
+		"data": map[string]any{"$${OP_VAULT}": 1},
+	}
+	out, err := substituteDoc(doc, map[string]string{"OP_VAULT": "homelab"})
+	if err != nil {
+		t.Fatalf("substituteDoc: %v", err)
+	}
+	data := out["data"].(map[string]any)
+	if _, ok := data["${OP_VAULT}"]; !ok {
+		t.Errorf("escaped key should unescape to literal ${OP_VAULT}; got %v", data)
+	}
+	if _, expanded := data["homelab"]; expanded {
+		t.Errorf("escaped key must not expand; got %v", data)
+	}
+}
+
+// When a key-position substitution makes two sibling keys collide, the
+// re-decode hits a duplicate key. go.yaml.in/yaml/v4 fails loudly on
+// that rather than silently last-wins, so substituteDoc surfaces it as
+// a render error (the reconcile fails) instead of dropping data —
+// documenting the behavior for this pathological misconfiguration.
+func TestSubstituteDoc_KeyCollisionErrors(t *testing.T) {
+	doc := map[string]any{
+		"data": map[string]any{"${OP_VAULT}": 1, "homelab": 2},
+	}
+	out, err := substituteDoc(doc, map[string]string{"OP_VAULT": "homelab"})
+	if err == nil {
+		t.Fatalf("expected a duplicate-key error on collision; got out=%#v", out)
+	}
+	if out != nil {
+		t.Errorf("expected nil doc on error; got %#v", out)
+	}
+	if !strings.Contains(err.Error(), "homelab") || !strings.Contains(err.Error(), "already defined") {
+		t.Errorf("error should name the colliding key; got %v", err)
+	}
+}
+
 // substituteDoc round-trips through YAML for type-coercion when `${`
 // is present — `replicas: ${N}` ends up as int after substitution.
 func TestSubstituteDoc_PreservesYAMLTypeCoercion(t *testing.T) {

--- a/pkg/manifest/deepcopy.go
+++ b/pkg/manifest/deepcopy.go
@@ -3,10 +3,13 @@ package manifest
 import "strings"
 
 // AnyStringLeaf reports whether any string leaf of v satisfies pred.
-// Walks nested maps and slices once. Used to detect features in
-// decoded YAML trees (`${VAR}` references for substitution gating,
-// wipe-placeholders for schema-skip, etc.) without paying for a
-// marshal round-trip.
+// Walks nested maps and slices once, inspecting only map values (not
+// keys). Used to detect features in decoded YAML trees (wipe-
+// placeholders for schema-skip, etc.) without paying for a marshal
+// round-trip. For substitution gating, use AnyStringNode — Flux
+// applies postBuild substitution to the serialized YAML text, where a
+// map key is just another token, so a key-only `${VAR}` must not be
+// missed.
 func AnyStringLeaf(v any, pred func(string) bool) bool {
 	switch t := v.(type) {
 	case string:
@@ -20,6 +23,34 @@ func AnyStringLeaf(v any, pred func(string) bool) bool {
 	case []any:
 		for _, vv := range t {
 			if AnyStringLeaf(vv, pred) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AnyStringNode reports whether any string node of v satisfies pred —
+// like AnyStringLeaf, but the map case also tests the KEY, not just the
+// value. This is the correct gate for postBuild substitution: Flux runs
+// drone/envsubst over the rendered YAML *text*, so a `${VAR}` in key
+// position (e.g. `${OP_VAULT}: 1`) is substituted exactly like one in
+// value position. A values-only walk would skip a doc whose only
+// reference sits in a key (with a non-string value), leaving the var
+// literal and diverging from Flux.
+func AnyStringNode(v any, pred func(string) bool) bool {
+	switch t := v.(type) {
+	case string:
+		return pred(t)
+	case map[string]any:
+		for k, vv := range t {
+			if pred(k) || AnyStringNode(vv, pred) {
+				return true
+			}
+		}
+	case []any:
+		for _, vv := range t {
+			if AnyStringNode(vv, pred) {
 				return true
 			}
 		}

--- a/pkg/manifest/deepcopy_test.go
+++ b/pkg/manifest/deepcopy_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"strings"
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -47,6 +48,70 @@ func TestDeepCopyMap_Isolation(t *testing.T) {
 func TestDeepCopyMap_Nil(t *testing.T) {
 	if DeepCopyMap(nil) != nil {
 		t.Errorf("nil source should produce nil")
+	}
+}
+
+// AnyStringNode gates the postBuild substitution round-trip. Unlike
+// AnyStringLeaf it must also see `${VAR}` in MAP KEY position — Flux
+// runs envsubst over the serialized YAML text, where a key is just
+// another token, so a key-only reference (e.g. `${OP_VAULT}: 1`) has to
+// trigger the round-trip or the var is left literal. The value-only and
+// no-match cases must stay identical to AnyStringLeaf (the parity sweep
+// below) so the change is inert for docs that were already handled.
+func TestAnyStringNode(t *testing.T) {
+	hasDollar := func(s string) bool { return strings.Contains(s, "${") }
+	cases := []struct {
+		name string
+		in   any
+		want bool
+	}{
+		// Cases shared with AnyStringLeaf — must match it exactly.
+		{"nil", nil, false},
+		{"empty map", map[string]any{}, false},
+		{"plain scalars only", map[string]any{"a": "literal", "b": 3, "c": true}, false},
+		{"top-level value with ${", map[string]any{"a": "${VAR}"}, true},
+		{"value nested in list", map[string]any{"data": []any{"first", "${VAR}", "third"}}, true},
+		{"value deeply nested", map[string]any{
+			"spec": map[string]any{"containers": []any{map[string]any{"image": "ghcr.io/x:${TAG}"}}},
+		}, true},
+		{"dollar but no brace", map[string]any{"a": "price$5"}, false},
+		// Key-position cases — these are where AnyStringNode diverges
+		// from (improves on) AnyStringLeaf.
+		{"key with ${, non-string value", map[string]any{"${OP_VAULT}": 1}, true},
+		{"key with ${ nested under a list", map[string]any{
+			"vaults": []any{map[string]any{"${OP_VAULT}": 1}},
+		}, true},
+		{"escaped $${ key still triggers", map[string]any{"$${OP_VAULT}": 1}, true},
+		{"plain key, no ${ anywhere", map[string]any{"vaults": map[string]any{"homelab": 1}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AnyStringNode(tc.in, hasDollar); got != tc.want {
+				t.Errorf("AnyStringNode(${) = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnyStringNode_ParityWithLeafOnValues pins that AnyStringNode and
+// AnyStringLeaf agree whenever no `${` sits in a key — i.e. the new
+// behavior is strictly additive (it only ever flips false→true for a
+// key-position match, never changes a value-driven result).
+func TestAnyStringNode_ParityWithLeafOnValues(t *testing.T) {
+	hasDollar := func(s string) bool { return strings.Contains(s, "${") }
+	valueOnly := []any{
+		nil,
+		map[string]any{},
+		map[string]any{"a": "literal", "b": 3},
+		map[string]any{"a": "${VAR}"},
+		map[string]any{"data": []any{"x", "${VAR}", "y"}},
+		map[string]any{"spec": map[string]any{"replicas": "${N}"}},
+		map[string]any{"a": "price$5"},
+	}
+	for i, v := range valueOnly {
+		if AnyStringNode(v, hasDollar) != AnyStringLeaf(v, hasDollar) {
+			t.Errorf("case %d: AnyStringNode and AnyStringLeaf disagree on a key-free tree", i)
+		}
 	}
 }
 
@@ -111,11 +176,11 @@ func TestHelmRelease_Clone_DeepCopiesEmbeddedSpec(t *testing.T) {
 	src := &HelmRelease{
 		Name: "plex", Namespace: "media",
 		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Install: &helmv2.Install{DisableHooks: false},
-			Upgrade: &helmv2.Upgrade{DisableHooks: false},
-			Rollback: &helmv2.Rollback{DisableHooks: false},
+			Install:   &helmv2.Install{DisableHooks: false},
+			Upgrade:   &helmv2.Upgrade{DisableHooks: false},
+			Rollback:  &helmv2.Rollback{DisableHooks: false},
 			Uninstall: &helmv2.Uninstall{DisableHooks: false},
-			Test: &helmv2.Test{Enable: false},
+			Test:      &helmv2.Test{Enable: false},
 			DriftDetection: &helmv2.DriftDetection{
 				Mode: helmv2.DriftDetectionWarn,
 			},


### PR DESCRIPTION
## Problem

A Kustomization `postBuild` `${VAR}` in **map-key position** — e.g. a 1Password `ClusterSecretStore`:

```yaml
spec:
  provider:
    onepassword:
      vaults:
        ${OP_VAULT}: 1
```

renders with `${OP_VAULT}` **left literal** under flate, while upstream Flux substitutes it. Flux applies postBuild substitution to the rendered YAML *text* (drone/envsubst), so a var in a key is substituted exactly like one in a value.

## Root cause

flate's substitution engine already matches Flux: `substituteDoc` marshals a doc → runs `fluxcd/pkg/envsubst` over the **text** → unmarshals back. The bug was the cheap pre-check that *gates* that round-trip. `substituteDoc` skipped the round-trip unless `manifest.AnyStringLeaf` found a `${`, and `AnyStringLeaf` walks map **values only** (`for _, vv := range t`). A doc whose only reference sits in a **key**, with a non-string value (like `1`), failed the gate and was returned untouched.

(A doc with any value-position `${...}` already substituted its keys correctly — envsubst then ran over the full serialized text. Only **key-only** docs were affected.)

## Fix

Add `manifest.AnyStringNode`, a key-aware sibling of `AnyStringLeaf` whose map case also tests the key, and use it as the substitution gate. `AnyStringLeaf` is left unchanged: its other caller, `ContainsValuePlaceholder`, is correctly values-only (wipe placeholders are fabricated as values, never keys).

That is the entire production change — every other `${`-detection site in the codebase reads typed scalar fields (`ValuesFrom.ValuesKey/.Name`, `DependsOn.Name`, source refs, `metadata.name`), not value-only tree-walks, so none is key-blind. The `substitute: disabled` opt-out is unaffected (enforced at the controller loop before `substituteDoc`).

## Tests

- `AnyStringNode`: key-position detection (incl. nested under a list, escaped `$${VAR}` key) + a parity sweep proving it agrees with `AnyStringLeaf` on every key-free tree (the change is strictly additive).
- `substituteDoc`: end-to-end key resolution with value type-coercion preserved; escaped `$${VAR}` key unescapes to a literal `${VAR}` key (matches Flux); a key-collision-after-substitution surfaces a duplicate-key render error rather than silently dropping data.

## Verification

- `gofmt`/`vet`/`golangci-lint` clean; `go test -race ./pkg/manifest/... ./pkg/controllers/kustomization/...`; full `go test ./...` green.
- Cross-repo byte-equivalence over 24 cluster paths vs `main`: every diff is the known caBundle / `checksum/secret` / `unlock`/`updatedAt` timestamp non-determinism or a flaky HelmRelease membership (proven to flap identically on the `main` binary) — **none attributable to this change**. The fix only alters output for the key-only-`${}` shape, which these clusters don't use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)