### PR TITLE
fix: resolve replacements-based targetNamespace so base HelmReleases aren't empty-namespaced

### DIFF
--- a/pkg/loader/transformer_ns.go
+++ b/pkg/loader/transformer_ns.go
@@ -21,12 +21,17 @@ import (
 const transformerScanMaxDepth = 6
 
 // StampTransformerTargetNamespaces fills empty spec.targetNamespace on
-// file-loaded Flux Kustomizations from a builtin NamespaceTransformer
-// that an enclosing kustomize overlay applies.
+// file-loaded Flux Kustomizations from the namespace an enclosing kustomize
+// overlay injects — via EITHER a builtin NamespaceTransformer (flatops) or a
+// `replacements:` rule copying a Namespace's name into spec.targetNamespace
+// (home-operations). (Name kept for git-history continuity though it now
+// covers both patterns; see resolveInjectedTargetNamespace.)
 //
 // flatops-style repos keep resources namespace-less "for DRYness" and
 // inject the namespace via a shared NamespaceTransformer that sets
-// spec.targetNamespace on every Kustomization (issue #528). That
+// spec.targetNamespace on every Kustomization (issue #528). home-operations
+// repos do the same with an overlay `namespace:` directive plus a
+// `replacements:` rule (kubernetes/components/replacements/ks.yaml). That
 // injection only happens when the overlay is kustomize-built — and when
 // the overlay is rendered by a further-up, itself render-emitted parent,
 // the injection lands *after* flate has already fired the leaf KS's
@@ -65,7 +70,7 @@ func StampTransformerTargetNamespaces(s *store.Store, sourceFiles map[manifest.N
 		if !ok {
 			continue
 		}
-		ns := resolveOverlayTransformerNamespace(repoRoot, file, cache)
+		ns := resolveOverlayInjectedNamespace(repoRoot, file, cache)
 		if ns == "" {
 			continue
 		}
@@ -84,17 +89,18 @@ type nsResolution struct {
 	ok bool
 }
 
-// resolveOverlayTransformerNamespace walks up the ancestor directories
-// of a Flux KS's source file and returns the namespace injected by the
-// nearest enclosing overlay's NamespaceTransformer. Deepest enclosing
-// overlay wins (first hit walking up), matching kustomize's "closest
-// overlay" semantics.
-func resolveOverlayTransformerNamespace(repoRoot, file string, cache map[string]nsResolution) string {
+// resolveOverlayInjectedNamespace walks up the ancestor directories of a
+// Flux KS's source file and returns the namespace injected by the nearest
+// enclosing overlay — via either a NamespaceTransformer or a
+// targetNamespace-injecting `replacements:` rule. Deepest enclosing overlay
+// wins (first hit walking up), matching kustomize's "closest overlay"
+// semantics.
+func resolveOverlayInjectedNamespace(repoRoot, file string, cache map[string]nsResolution) string {
 	dir := path.Dir(filepath.ToSlash(file))
 	for dir != "." && dir != "/" && dir != "" {
 		res, ok := cache[dir]
 		if !ok {
-			res = resolveTransformerTargetNamespace(repoRoot, dir)
+			res = resolveInjectedTargetNamespace(repoRoot, dir)
 			cache[dir] = res
 		}
 		if res.ok {
@@ -130,6 +136,118 @@ func resolveTransformerTargetNamespace(repoRoot, overlayDir string) nsResolution
 		return nsResolution{ns: td.Namespace, ok: true}
 	}
 	return nsResolution{}
+}
+
+// resolveInjectedTargetNamespace resolves the namespace an enclosing
+// overlay injects onto Flux Kustomizations via EITHER supported pattern: a
+// builtin NamespaceTransformer (flatops) or a `replacements:` rule copying a
+// Namespace's name into spec.targetNamespace (home-operations). Transformer
+// first, then replacement; both key on the same overlay dir, so the caller's
+// per-dir cache and deepest-overlay-wins walk are unaffected.
+func resolveInjectedTargetNamespace(repoRoot, overlayDir string) nsResolution {
+	if r := resolveTransformerTargetNamespace(repoRoot, overlayDir); r.ok {
+		return r
+	}
+	return resolveReplacementTargetNamespace(repoRoot, overlayDir)
+}
+
+// resolveReplacementTargetNamespace inspects the kustomization.yaml at
+// overlayDir. When it carries BOTH a `namespace:` directive AND a
+// `replacements:` rule that copies a Namespace's metadata.name into
+// Kustomization spec.targetNamespace, the directive value is the namespace
+// that replacement injects — because the same `namespace:` directive renames
+// the source Namespace to that value before the copy runs. Requiring the
+// directive is conservative: an overlay with the rule but no directive (the
+// Namespace would keep a literal component name) is left unstamped rather
+// than guessed, and a bare `namespace:` directive with no targetNamespace
+// rule is owned by metadata.namespace inheritance, not us.
+func resolveReplacementTargetNamespace(repoRoot, overlayDir string) nsResolution {
+	d, ok := readKustomizeDirectives(repoRoot, overlayDir)
+	if !ok || d.Namespace == "" || len(d.Replacements) == 0 {
+		return nsResolution{}
+	}
+	for _, r := range d.Replacements {
+		if replacementInjectsKustomizationTargetNamespace(repoRoot, overlayDir, r) {
+			return nsResolution{ns: d.Namespace, ok: true}
+		}
+	}
+	return nsResolution{}
+}
+
+// replacementInjectsKustomizationTargetNamespace reports whether r is a
+// Namespace-name → Kustomization.spec.targetNamespace replacement, handling
+// both the inline (`{source, targets}`) and external (`{path: <file>}`)
+// forms. The path file is a YAML list of replacement objects.
+func replacementInjectsKustomizationTargetNamespace(repoRoot, overlayDir string, r replacementDirective) bool {
+	if r.Source != nil {
+		return docIsNamespaceNameReplacementForKustomization(r.Source, r.Targets)
+	}
+	if r.Path == "" {
+		return false
+	}
+	ref, ok := resolveRef(overlayDir, r.Path)
+	if !ok {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot, ref)) //nolint:gosec // path composed from known cluster layout
+	if err != nil {
+		return false
+	}
+	var rules []replacementDirective
+	if err := yaml.Unmarshal(data, &rules); err != nil {
+		return false
+	}
+	return slices.ContainsFunc(rules, func(rr replacementDirective) bool {
+		return docIsNamespaceNameReplacementForKustomization(rr.Source, rr.Targets)
+	})
+}
+
+// docIsNamespaceNameReplacementForKustomization reports whether a kustomize
+// replacement (source + targets) copies a Namespace's metadata.name into the
+// spec.targetNamespace of Flux Kustomizations — the precise shape
+// kubernetes/components/replacements/ks.yaml uses.
+func docIsNamespaceNameReplacementForKustomization(source map[string]any, targets []any) bool {
+	if source == nil {
+		return false
+	}
+	if kind, _ := source["kind"].(string); kind != "Namespace" {
+		return false
+	}
+	if !replacementFieldMatches(source, "metadata.name") {
+		return false
+	}
+	return slices.ContainsFunc(targets, func(raw any) bool {
+		t, ok := raw.(map[string]any)
+		if !ok {
+			return false
+		}
+		sel, _ := t["select"].(map[string]any)
+		if sel == nil {
+			return false
+		}
+		if kind, _ := sel["kind"].(string); kind != manifest.KindKustomization {
+			return false
+		}
+		if group, _ := sel["group"].(string); group != manifest.FluxKustomizeDomain {
+			return false
+		}
+		return replacementFieldMatches(t, "spec.targetNamespace")
+	})
+}
+
+// replacementFieldMatches reports whether m references the dotted path want
+// via either `fieldPath` (string — the canonical replacement-source form) or
+// `fieldPaths` (list — the target form). Accepting both on either side costs
+// nothing and tolerates hand-written variants.
+func replacementFieldMatches(m map[string]any, want string) bool {
+	if fp, ok := m["fieldPath"].(string); ok && fp == want {
+		return true
+	}
+	fps, _ := m["fieldPaths"].([]any)
+	return slices.ContainsFunc(fps, func(v any) bool {
+		s, _ := v.(string)
+		return s == want
+	})
 }
 
 // subtreeHasNamespaceTransformer reports whether the kustomize subtree
@@ -214,10 +332,23 @@ func resolveRef(baseDir, ref string) (string, bool) {
 // kustomizeDirectives is the subset of a kustomization.yaml that
 // transformer-namespace resolution and self-production attribution read.
 type kustomizeDirectives struct {
-	Namespace    string   `yaml:"namespace"`
-	Resources    []string `yaml:"resources"`
-	Transformers []string `yaml:"transformers"`
-	Components   []string `yaml:"components"`
+	Namespace    string                 `yaml:"namespace"`
+	Resources    []string               `yaml:"resources"`
+	Transformers []string               `yaml:"transformers"`
+	Components   []string               `yaml:"components"`
+	Replacements []replacementDirective `yaml:"replacements"`
+}
+
+// replacementDirective captures a single `replacements:` entry. kustomize
+// allows two shapes: an external file ref (`{path: <file>}`, where the file
+// is a YAML list of replacement objects) or an inline replacement object
+// (`{source, targets}`). Both decode into this one struct via plain
+// yaml.Unmarshal — the file form leaves Source/Targets nil, the inline form
+// leaves Path empty.
+type replacementDirective struct {
+	Path    string         `yaml:"path"`
+	Source  map[string]any `yaml:"source"`
+	Targets []any          `yaml:"targets"`
 }
 
 // readKustomizeDirectives reads the kustomization file in dir (resolved

--- a/pkg/loader/transformer_ns_test.go
+++ b/pkg/loader/transformer_ns_test.go
@@ -213,3 +213,195 @@ resources:
 		t.Errorf("TargetNamespace=%q want inner (deepest overlay)", got.TargetNamespace)
 	}
 }
+
+// nsReplacementRule is the home-operations replacement that copies a
+// Namespace's name into every Flux Kustomization's spec.targetNamespace
+// (kubernetes/components/replacements/ks.yaml). The file is a YAML list.
+const nsReplacementRule = `- source:
+    kind: Namespace
+    fieldPath: metadata.name
+  targets:
+    - select:
+        kind: Kustomization
+        group: kustomize.toolkit.fluxcd.io
+      fieldPaths:
+        - spec.targetNamespace
+      options:
+        create: true
+`
+
+// stampReplacementsKS is the shared harness for the replacements-pattern
+// tests: store a leaf KS under overlayDir/app, run the stamp, return the
+// resolved TargetNamespace.
+func stampReplacementsKS(t *testing.T, root, overlayDir, overlayKustomization string) *manifest.Kustomization {
+	t.Helper()
+	writeFile(t, root, overlayDir+"/kustomization.yaml", overlayKustomization)
+	s := store.New()
+	ks := leafKS("app", "./"+overlayDir+"/app/workload")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): overlayDir + "/app/ks.yaml",
+	}
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	return got
+}
+
+// home-operations injects targetNamespace via `namespace:` + a
+// `replacements:` file ref (not a NamespaceTransformer). The leaf KS must
+// pick up the overlay's namespace as its targetNamespace.
+func TestStampTransformerTargetNamespaces_ReplacementsFileRef(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "components/replacements/ks.yaml", nsReplacementRule)
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - path: ../../components/replacements/ks.yaml
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "storage" {
+		t.Errorf("TargetNamespace=%q want storage", got.TargetNamespace)
+	}
+	// RenderFlux feeds Contents to kustomize, so the raw doc must carry it.
+	spec, _ := got.Contents["spec"].(map[string]any)
+	if spec["targetNamespace"] != "storage" {
+		t.Errorf("Contents spec.targetNamespace=%v want storage", spec["targetNamespace"])
+	}
+}
+
+// The replacement rule inlined directly under `replacements:` (no path ref).
+func TestStampTransformerTargetNamespaces_ReplacementsInline(t *testing.T) {
+	root := t.TempDir()
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - source:
+      kind: Namespace
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: Kustomization
+          group: kustomize.toolkit.fluxcd.io
+        fieldPaths:
+          - spec.targetNamespace
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "storage" {
+		t.Errorf("TargetNamespace=%q want storage", got.TargetNamespace)
+	}
+}
+
+// A replacement that writes a DIFFERENT field (spec.path) must not be
+// mistaken for a targetNamespace injection — no stamp.
+func TestStampTransformerTargetNamespaces_ReplacementsNotTargetingTargetNamespace(t *testing.T) {
+	root := t.TempDir()
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - source:
+      kind: Namespace
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: Kustomization
+          group: kustomize.toolkit.fluxcd.io
+        fieldPaths:
+          - spec.path
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (replacement not targeting targetNamespace)", got.TargetNamespace)
+	}
+}
+
+// The targetNamespace value is derived from the overlay's `namespace:`
+// directive (the Namespace the replacement reads is renamed to it). With no
+// directive present, the value is unknown — skip rather than guess.
+func TestStampTransformerTargetNamespaces_ReplacementsNoNamespaceDirective(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "components/replacements/ks.yaml", nsReplacementRule)
+	got := stampReplacementsKS(t, root, "apps/storage", `replacements:
+  - path: ../../components/replacements/ks.yaml
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (no namespace directive)", got.TargetNamespace)
+	}
+}
+
+// Wrong source kind (ConfigMap, not Namespace) must not match.
+func TestStampTransformerTargetNamespaces_ReplacementsWrongSourceKind(t *testing.T) {
+	root := t.TempDir()
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - source:
+      kind: ConfigMap
+      name: settings
+      fieldPath: data.namespace
+    targets:
+      - select:
+          kind: Kustomization
+          group: kustomize.toolkit.fluxcd.io
+        fieldPaths:
+          - spec.targetNamespace
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (source not a Namespace)", got.TargetNamespace)
+	}
+}
+
+// The replacement source may spell the path as `fieldPaths: [metadata.name]`
+// (plural) rather than `fieldPath:` — accept both.
+func TestStampTransformerTargetNamespaces_ReplacementsSourceFieldPathsPlural(t *testing.T) {
+	root := t.TempDir()
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - source:
+      kind: Namespace
+      fieldPaths:
+        - metadata.name
+    targets:
+      - select:
+          kind: Kustomization
+          group: kustomize.toolkit.fluxcd.io
+        fieldPaths:
+          - spec.targetNamespace
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "storage" {
+		t.Errorf("TargetNamespace=%q want storage (plural source fieldPaths)", got.TargetNamespace)
+	}
+}
+
+// Deepest enclosing overlay wins for the replacements pattern too.
+func TestStampTransformerTargetNamespaces_ReplacementsDeepestOverlayWins(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "components/replacements/ks.yaml", nsReplacementRule)
+	writeFile(t, root, "apps/outer/kustomization.yaml", `namespace: outer
+replacements:
+  - path: ../../components/replacements/ks.yaml
+resources:
+  - ./inner
+`)
+	writeFile(t, root, "apps/outer/inner/kustomization.yaml", `namespace: inner
+replacements:
+  - path: ../../../components/replacements/ks.yaml
+resources:
+  - ./app/ks.yaml
+`)
+	s := store.New()
+	ks := leafKS("app", "./apps/outer/inner/app/workload")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{
+		ks.Named(): "apps/outer/inner/app/ks.yaml",
+	}
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	if got.TargetNamespace != "inner" {
+		t.Errorf("TargetNamespace=%q want inner (deepest overlay)", got.TargetNamespace)
+	}
+}


### PR DESCRIPTION
## Problem

A render non-determinism: a HelmRelease rendered from the home-operations `apps/base/...` cross-tree layout (e.g. `democratic-csi` in joryirving's `apps/test`) would render its full object set on most runs and **vanish entirely** on others, depending on chart-fetch (warm-cache vs network) timing.

## Root cause — empty-namespaced rendered children

flate derived a Flux Kustomization's `spec.targetNamespace` at load time **only** from the `transformers:` → builtin `NamespaceTransformer` pattern (`StampTransformerTargetNamespaces`, #528). The standard home-operations layout injects it differently — the enclosing overlay has:

```yaml
namespace: storage
components: [../../../components/namespace]              # adds a Namespace, renamed to `storage` by the directive
replacements: [../../../components/replacements/ks.yaml] # Namespace.metadata.name → Kustomization.spec.targetNamespace
```

flate honored the `namespace:` directive (the KS got `metadata.namespace=storage`) but never applied the **replacements-based** `targetNamespace`, so the KS rendered its base HelmReleases with an **empty namespace**.

That empty-namespace identity was the root of the flap: the rendered HRs collided with their file-loaded copies (which *did* get a namespace via `ApplyNamespaceInheritance`) under two conflicting identities, and the resulting namespace-less *phantom* `dependsOn` graph (`democratic-csi → volsync → snapshot-controller`) raced orchestrator quiescence — rendering fully or being dropped depending on timing.

## Fix

Extend the load-time resolver (`pkg/loader/transformer_ns.go`) to also recognize the replacements pattern: detect a `replacements:` rule (inline or via a `path:` file ref) whose **source** is a `Namespace`'s `metadata.name` and whose **target** writes `Kustomization.spec.targetNamespace`, and stamp the enclosing overlay's `namespace:` value (= the renamed Namespace's name = the injected `targetNamespace`). The existing stamping loop, ancestor walk, per-dir cache, and deepest-overlay-wins semantics are reused unchanged via a small combinator (transformer first, then replacement).

Requires **both** a `namespace:` directive AND a qualifying replacement, so the must-NOT-stamp cases are preserved: a bare `namespace:` directive (owned by `metadata.namespace` inheritance), a replacement targeting a different field, or a wrong source kind are all left alone.

## Effect

The base HRs now render with the correct namespace (matching real Flux), collapsing the two identities into one and resolving the `dependsOn` chain deterministically — `apps/main` and `apps/utility` render byte-identically across 20–30 runs, and the dominant democratic-csi flap is gone.

> Not byte-neutral by design: rendered resources in repos using this layout now carry their correct namespace where they were previously empty — an intended correctness improvement. A rarer, **pre-existing** transient-quiescence race in fully-resolvable `dependsOn` chains remains (apps/test flaps ~1/20) and is tracked separately with a deterministic repro in hand.

## Tests

- replacements via `{path:}` file ref and inline → KS stamped (asserts typed field + `Contents.spec.targetNamespace`);
- must-NOT-stamp negatives: replacement targets a different field; no `namespace:` directive; wrong source kind;
- plural source `fieldPaths: [metadata.name]`; deepest-overlay-wins;
- existing transformer-pattern tests stay green (the combinator tries transformer first).

## Verification

- gofmt/vet/golangci-lint 0; `go test -race ./pkg/loader/... ./pkg/discovery/...`; full `go test ./...` green.
- Determinism: joryirving `apps/main` + `apps/utility` 20–30× → byte-identical; democratic-csi renders every run, correctly `storage`-namespaced (0 empty `helm.toolkit.fluxcd.io/namespace` labels, was 8).
- Cross-repo vs `main`: only joryirving (the repo using this layout) changes — intended namespace corrections; all other paths' diffs are unchanged from the known caBundle/checksum/timestamp non-determinism baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)