### PR TITLE
fix: hold active for reconcilable dep waits so a transient pool drain can't drop them

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -409,15 +409,33 @@ func (c *Controller) Await(
 	runWait := func() {
 		sum = depwait.WaitAll(w.Watch(ctx, deps))
 	}
-	if w.ReadyNow(deps) {
+	switch {
+	case w.ReadyNow(deps):
+		// Every dep already Ready — resolve immediately, no park.
 		runWait()
-	} else {
-		// YieldQuiescent (not YieldSlot): the wait is on OTHER tasks'
-		// work, so this task isn't producing anything while parked.
-		// Decrementing active lets QuiescenceCh fire on a render-only
-		// dep the moment no productive task remains. The ReadyNow fast
-		// path above keeps an immediately-unblocked producer counted as
-		// active so consumers do not observe a false drained pool.
+	case w.AllPresentReconcilable(deps):
+		// Every dep is a present, CEL-free Kustomization/HelmRelease — a
+		// reconcilable resource whose producer is MULTI-HOP (it parks on its
+		// own deps/chart source before writing its terminal status). A wait on
+		// such a dep is the transient-drain victim: a far-off source fetch
+		// exiting can drop the pool to 0 in the window before the dep's HR
+		// re-activates and goes Ready, firing a FALSE quiescence that drops
+		// this waiter. YieldSlot (release the worker slot but STAY active)
+		// keeps the pool non-zero across that handoff. Safe because a present
+		// reconcilable dep always terminalizes (so we resolve on its terminal
+		// wake); dependsOn cycles can't hang here — the orchestrator's preflight
+		// cycle detector fails their members before they reach this park; and
+		// `active` feeds only QuiescenceCh, so holding it has no other effect.
+		// Source-kind / ReadyExpr deps stay on the give-up path below.
+		c.Tasks.YieldSlot(runWait)
+	default:
+		// At least one dep is absent / render-only (may never be produced) or
+		// carries a ReadyExpr (may never satisfy): keep the quiescence-bound
+		// give-up. YieldQuiescent decrements active so QuiescenceCh fires the
+		// moment no productive task remains and the wait fast-fails instead of
+		// hanging. The ReadyNow fast path above keeps an immediately-unblocked
+		// producer counted as active so consumers do not observe a false
+		// drained pool.
 		c.Tasks.YieldQuiescent(runWait)
 	}
 	if sum.AnyFailed() {

--- a/pkg/controllers/base/transient_quiescence_test.go
+++ b/pkg/controllers/base/transient_quiescence_test.go
@@ -1,0 +1,90 @@
+package base_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/controllers/base"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+// svcRenders adapts a task.Service into depwait.RenderInflight so a test
+// Waiter's quiescence wait is bound to the real pool's active counter.
+type svcRenders struct{ svc *task.Service }
+
+func (r svcRenders) QuiescenceCh() <-chan struct{} { return r.svc.QuiescenceCh(0) }
+
+// TestAwait_TransientDrain_DoesNotDropPresentDepChain pins the
+// transient-quiescence fix against the real task.Service active counter,
+// exercised through base.Await (the fix site).
+//
+// Chain: src (a present source) ← mid (an HR whose own Await is parked on
+// src) ← leaf (an HR whose Await is parked on mid). All present + status-
+// bearing. When src's producer task writes Ready and EXITS, decrActive can
+// drop the pool to 0 in the handoff window BEFORE mid re-activates and
+// renders — a transient drain that, before the fix, fired QuiescenceCh and
+// made leaf give up ("not ready") even though mid was mid-resume.
+//
+// The drain is forced deterministically: src's Ready+exit is gated on
+// chSrcGo (after mid+leaf have parked), and mid is held at its post-resume /
+// pre-Ready point on chMidGo (so leaf observes mid Pending when the drain
+// fires). With the fix, a wait on present status-bearing deps uses YieldSlot
+// (stays active) instead of YieldQuiescent, so the pool never hits 0 across
+// the chain and leaf waits through to mid's terminal Ready.
+func TestAwait_TransientDrain_DoesNotDropPresentDepChain(t *testing.T) {
+	svc := task.New()
+	s := store.New()
+	c := base.New(s, svc)
+	c.SetDepwait(nil, svcRenders{svc})
+
+	src := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "storage", Name: "src"}
+	mid := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "storage", Name: "mid"}
+	leaf := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "storage", Name: "leaf"}
+	s.UpdateStatus(src, store.StatusPending, "fetching")
+	s.UpdateStatus(mid, store.StatusPending, "rendering")
+	s.UpdateStatus(leaf, store.StatusPending, "rendering")
+
+	chSrcGo := make(chan struct{})
+	chMidGo := make(chan struct{})
+	midResumed := make(chan struct{})
+	leafErr := make(chan error, 1)
+	var entered sync.WaitGroup
+	entered.Add(2)
+
+	// Producer: hold active until released, then write Ready and return
+	// (the return's decrActive is what drops the pool).
+	svc.Go(context.Background(), "src", func(context.Context) {
+		<-chSrcGo
+		s.UpdateStatus(src, store.StatusReady, "")
+	})
+	// mid: Await(src); on resume hold Pending until chMidGo, then Ready.
+	svc.Go(context.Background(), "mid", func(ctx context.Context) {
+		entered.Done()
+		_ = c.Await(ctx, mid, c.NewWaiter(mid, nil), testutil.DepRefs(src), "", base.DepFailed(mid))
+		close(midResumed)
+		<-chMidGo
+		s.UpdateStatus(mid, store.StatusReady, "")
+	})
+	// leaf: Await(mid) — the present dep whose producer (mid) is resumable.
+	svc.Go(context.Background(), "leaf", func(ctx context.Context) {
+		entered.Done()
+		leafErr <- c.Await(ctx, leaf, c.NewWaiter(leaf, nil), testutil.DepRefs(mid), "", base.DepFailed(leaf))
+	})
+
+	entered.Wait()
+	time.Sleep(50 * time.Millisecond)  // let mid+leaf reach the WatchReady park
+	close(chSrcGo)                     // src → Ready, src task exits → transient active==0
+	<-midResumed                       // mid resumed past its wait; mid still Pending
+	time.Sleep(100 * time.Millisecond) // window for leaf to (wrongly) act on the drain
+	close(chMidGo)                     // mid → Ready
+
+	if err := <-leafErr; err != nil {
+		t.Fatalf("leaf dropped by a TRANSIENT pool drain during mid's resume handoff: %v", err)
+	}
+	svc.BlockTillDone()
+}

--- a/pkg/depwait/depwait.go
+++ b/pkg/depwait/depwait.go
@@ -235,6 +235,42 @@ func (w *Waiter) ReadyNow(deps []manifest.DependencyRef) bool {
 	return true
 }
 
+// AllPresentReconcilable reports whether every dep is a present, CEL-free
+// Kustomization or HelmRelease — a *reconcilable* resource whose own reconcile
+// is multi-hop (it parks on its own deps / chart source before rendering).
+// base.Await parks a wait on such deps with YieldSlot (stay active, release
+// only the worker slot) rather than YieldQuiescent (decrement active).
+//
+// Why only reconcilable deps. The transient-drain false-drop hits a waiter
+// whose dep is produced by a MULTI-HOP producer: e.g. an HR (snapshot-
+// controller) parked on its OCIRepository chart source. When that source's
+// fetch task exits, decrActive can drop the pool to 0 in the window BEFORE the
+// HR re-activates and writes its own terminal status — firing a false
+// quiescence that drops the waiter (volsync) even though its dep is mid-resume.
+// Holding the waiter's own `active` (YieldSlot) keeps the pool non-zero across
+// that handoff. It's safe because a present reconcilable dep ALWAYS terminalizes
+// (Ready on success/suspend/filter-skip; Failed on error/panic; Failed-via-
+// preflight on a dependsOn cycle — caught before it could park), so the wait is
+// guaranteed to end on a terminal wake. `active` feeds only QuiescenceCh, so
+// holding it has no other effect.
+//
+// Source-kind deps (the chart-source / sourceRef waits) are deliberately
+// EXCLUDED: a source's producer is single-hop (the fetch writes the terminal
+// status BEFORE its own decrActive), so the quiescence give-up both stays safe
+// and keeps the fast-fail short-circuit of the post-Failed grace. ReadyExpr
+// deps are excluded too (the CEL may never satisfy even once the dep is
+// terminal). Both keep YieldQuiescent.
+func (w *Waiter) AllPresentReconcilable(deps []manifest.DependencyRef) bool {
+	for _, dep := range deps {
+		id := dep.NamedResource
+		reconcilable := id.Kind == manifest.KindKustomization || id.Kind == manifest.KindHelmRelease
+		if dep.ReadyExpr != "" || !reconcilable || !w.depExists(id) {
+			return false
+		}
+	}
+	return len(deps) > 0
+}
+
 func (w *Waiter) readyNow(dep manifest.DependencyRef) bool {
 	id := dep.NamedResource
 	if !w.depExists(id) {

--- a/pkg/depwait/resolvable_test.go
+++ b/pkg/depwait/resolvable_test.go
@@ -1,0 +1,57 @@
+package depwait
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// AllPresentReconcilable gates base.Await's YieldSlot-vs-YieldQuiescent choice:
+// true only when every dep is a present, CEL-free Kustomization/HelmRelease (a
+// reconcilable, multi-hop producer — the transient-drain victim that must hold
+// active). A source-kind dep (single-hop producer), an absent dep, or a
+// ReadyExpr dep must keep the quiescence give-up.
+func TestAllPresentReconcilable(t *testing.T) {
+	s := store.New()
+
+	presentHR := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "hr"}
+	s.UpdateStatus(presentHR, store.StatusPending, "rendering")
+	presentKS := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "ks"}
+	s.UpdateStatus(presentKS, store.StatusPending, "rendering")
+
+	absent := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "ghost"}
+
+	// A present source-kind dep: single-hop producer → excluded (stays on the
+	// quiescence give-up so the post-Failed fast-fail short-circuit survives).
+	presentSrc := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "ns", Name: "src"}
+	s.UpdateStatus(presentSrc, store.StatusPending, "fetching")
+
+	w := &Waiter{Store: s}
+	ref := func(id manifest.NamedResource) manifest.DependencyRef {
+		return manifest.DependencyRef{NamedResource: id}
+	}
+
+	cases := []struct {
+		name string
+		deps []manifest.DependencyRef
+		want bool
+	}{
+		{"present HR", []manifest.DependencyRef{ref(presentHR)}, true},
+		{"present KS", []manifest.DependencyRef{ref(presentKS)}, true},
+		{"present HR + KS", []manifest.DependencyRef{ref(presentHR), ref(presentKS)}, true},
+		{"present source kind", []manifest.DependencyRef{ref(presentSrc)}, false},
+		{"absent", []manifest.DependencyRef{ref(absent)}, false},
+		{"present HR with ReadyExpr", []manifest.DependencyRef{{NamedResource: presentHR, ReadyExpr: "true"}}, false},
+		{"mixed present HR + absent", []manifest.DependencyRef{ref(presentHR), ref(absent)}, false},
+		{"mixed present HR + source", []manifest.DependencyRef{ref(presentHR), ref(presentSrc)}, false},
+		{"empty", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := w.AllPresentReconcilable(tc.deps); got != tc.want {
+				t.Errorf("AllPresentReconcilable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A rare (~1/20) render non-determinism remained after #665: in a fully-resolvable `dependsOn` chain (`snapshot-controller` ← `volsync` ← `democratic-csi`, all present and in-scope) a HelmRelease was occasionally dropped from the render.

## Mechanism

The task pool's `active` counter is decremented by `YieldQuiescent` while a task parks on a depwait; `QuiescenceCh(0)` fires when it hits 0, and depwait then gives up ("not ready") so `base.Await` drops the dependent. The chain is **multi-hop** — `snapshot-controller` is itself an HR parked on its OCIRepository chart source. When that fetch task **exits**, `decrActive` can drop the pool to 0 in the handoff window *before* `snapshot-controller` re-activates and writes its terminal status — firing a **false** quiescence that drops `volsync` (whose dep is mid-resume). Warm-cache vs network timing decides whether the window opens.

## Fix

In `base.Await`, park a wait on **present, CEL-free Kustomization/HelmRelease** deps with `YieldSlot` (release the worker slot but **stay active**) instead of `YieldQuiescent` (decrement `active`):

```go
switch {
case w.ReadyNow(deps):            runWait()                 // already Ready
case w.AllPresentReconcilable(deps): c.Tasks.YieldSlot(runWait)   // multi-hop producers → hold active
default:                          c.Tasks.YieldQuiescent(runWait) // absent/render-only/CEL → keep the give-up
}
```

Such deps are exactly the transient-drain victims (their producers are multi-hop), and they **always terminalize**, so staying active keeps the pool non-zero across the handoff and the wait resolves on the dep's terminal wake. No active-counter surgery; can't hang cycles (the orchestrator's preflight cycle detector fails cyclic members before they reach this park); and `active` feeds only `QuiescenceCh`.

**Source-kind and ReadyExpr deps are deliberately excluded** (kept on `YieldQuiescent`): a source's producer is single-hop (writes its terminal status *before* its own `decrActive`), so the quiescence give-up stays safe *and* preserves the fast-fail short-circuit of the post-Failed grace — a Failed chart source still fails fast, not after the 3s grace.

## Tests

- A `base.Await`-level repro driving the multi-hop chain through the real `task.Service` `active` counter (forces the handoff deterministically; 5/5 failing pre-fix, 20/20 passing post-fix under `-race`).
- An `AllPresentReconcilable` predicate unit test (HR/KS present → true; source-kind / absent / ReadyExpr / non-reconcilable → false).
- Existing quiescence invariants (`quiescence_bound_test.go`, chart-source fast-fail) stay green unchanged.

## Verification

- gofmt/vet/golangci-lint 0; `go test -race ./pkg/depwait/... ./pkg/controllers/... ./pkg/task/... ./pkg/store/...`; full `go test ./...` green.
- **Determinism:** joryirving `apps/test` renders deterministically **40/40** (was ~1/20 flap); `apps/main` + `apps/utility` stay deterministic.
- **No-hang sweep:** `build all` across all 24 cross-repo paths + a changed-only `diff` run — every run terminates (validates "present reconcilable deps always terminalize").
- **Cross-repo byte-equivalence vs `main`:** unchanged beyond the known caBundle/checksum/timestamp non-determinism, **except** the intended flap-recovery on joryirving `apps/test` (where `main` non-deterministically drops the chain and this build renders it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)