### PR TITLE
feat: render Helm with a deterministic clock (seed sprig time funcs)

### DIFF
--- a/pkg/diff/strip.go
+++ b/pkg/diff/strip.go
@@ -10,11 +10,14 @@ package diff
 //
 // These rotate on every Helm chart bump and carry no review-relevant
 // signal, so leaving them in surfaces a spurious change on every resource
-// a touched chart renders. Some are genuinely per-render random — e.g.
-// matrix-synapse's `registration_shared_secret | default (randAlphaNum
-// 24)`, which sprig draws from crypto/rand (not seedable; Helm exposes no
-// funcMap hook to override it) — so flate cannot make them stable and
-// stripping is what keeps a diff churn-free.
+// a touched chart renders. A `checksum/<x>` annotation also rotates
+// whenever the hashed ConfigMap/Secret content changes — but the diff
+// already shows that underlying change directly, so the annotation is
+// duplicate noise worth stripping regardless. (The per-render-random
+// component some checksums fold in — e.g. matrix-synapse's
+// `registration_shared_secret | default (randAlphaNum 24)` — is now made
+// reproducible by seeded rendering in pkg/helm/deterministic; this strip
+// stays for the legitimate content- and version-driven rotations.)
 //
 // Treat as read-only; copy before mutating.
 var DefaultStripAttrs = []string{
@@ -24,19 +27,18 @@ var DefaultStripAttrs = []string{
 	"chart",
 }
 
-// DefaultStripFields is the default set of dotted spec field-paths
-// deleted before diffing — the same noise-suppression rationale as
-// DefaultStripAttrs, but for volatile values a chart templates into the
-// spec rather than metadata. The TrueCharts common library emits
+// DefaultStripFields is the default set of dotted spec field-paths deleted
+// before diffing — for volatile values a chart templates into the spec
+// rather than metadata. It is empty: the one field it used to carry, the
+// TrueCharts common library's
 //
 //	spec.restic.unlock: {{ now | date "20060102150405" }}
 //
-// on every volsync ReplicationSource, so two diff sides rendered a second
-// apart (cold cache, or across machines) would otherwise show a spurious
-// `~ spec.restic.unlock` per backed-up app. Deleting the leaf keeps the
-// diff churn-free; raw `flate build` output still mirrors Helm.
+// on every volsync ReplicationSource, was a per-render timestamp. Seeded
+// rendering (pkg/helm/deterministic) now pins `now` to a fixed clock, so
+// the field renders identically on both diff sides; stripping it would
+// only hide a genuine change. The slice stays exported (non-nil) so
+// `--strip-field` and SDK consumers have a base set to extend.
 //
 // Treat as read-only; copy before mutating.
-var DefaultStripFields = []string{
-	"spec.restic.unlock",
-}
+var DefaultStripFields = []string{}

--- a/pkg/helm/deterministic/clock.go
+++ b/pkg/helm/deterministic/clock.go
@@ -1,0 +1,88 @@
+package deterministic
+
+import (
+	"text/template"
+	"time"
+)
+
+// FixedTime is the instant every time-based template function resolves to
+// under deterministic rendering. It is deliberately a fixed point in the
+// past: a chart computing `NotAfter = now + daysValid` still lands
+// plausibly in the future for any normal validity window, and the value
+// reads as a recognizable sentinel in rendered output. It must never
+// derive from the wall clock — reproducibility is the whole point.
+var FixedTime = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// clockFuncs returns deterministic replacements for sprig's time-based
+// functions. Two independent nondeterminism sources have to go:
+//
+//   - `now` is time.Now, and date/dateInZone/htmlDate/ago fall back to
+//     time.Now() whenever their argument isn't a recognized time type — so
+//     a bare `{{ date "fmt" }}` leaks the wall clock even with `now`
+//     overridden. Every fallback here uses FixedTime instead.
+//   - `date`/`htmlDate` format in the machine's "Local" zone, so one instant
+//     renders differently across machines. These force UTC, and an empty or
+//     "Local" zone is remapped to UTC, so output never depends on $TZ. An
+//     explicit named zone is still honored — it's a literal template
+//     argument and therefore deterministic.
+//
+// dateModify/toDate/unixEpoch/duration/durationRound are already
+// deterministic given their arguments and are left to sprig.
+func clockFuncs() template.FuncMap {
+	return template.FuncMap{
+		"now":            func() time.Time { return FixedTime },
+		"date":           func(format string, date any) string { return dateInZone(format, date, "UTC") },
+		"dateInZone":     dateInZone,
+		"date_in_zone":   dateInZone,
+		"htmlDate":       func(date any) string { return dateInZone("2006-01-02", date, "UTC") },
+		"htmlDateInZone": func(date any, zone string) string { return dateInZone("2006-01-02", date, zone) },
+		"ago":            dateAgo,
+	}
+}
+
+// dateInZone mirrors sprig.dateInZone but (1) defaults to FixedTime rather
+// than time.Now() for an unrecognized date argument and (2) treats an empty
+// or "Local" zone as UTC, so formatting never depends on $TZ.
+func dateInZone(format string, date any, zone string) string {
+	var t time.Time
+	switch date := date.(type) {
+	default:
+		t = FixedTime
+	case time.Time:
+		t = date
+	case *time.Time:
+		t = *date
+	case int64:
+		t = time.Unix(date, 0)
+	case int:
+		t = time.Unix(int64(date), 0)
+	case int32:
+		t = time.Unix(int64(date), 0)
+	}
+	if zone == "" || zone == "Local" {
+		zone = "UTC"
+	}
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		loc = time.UTC
+	}
+	return t.In(loc).Format(format)
+}
+
+// dateAgo mirrors sprig.dateAgo but measures elapsed time from FixedTime
+// rather than the wall clock, so a chart embedding `{{ ago … }}` renders
+// reproducibly.
+func dateAgo(date any) string {
+	var t time.Time
+	switch date := date.(type) {
+	default:
+		t = FixedTime
+	case time.Time:
+		t = date
+	case int64:
+		t = time.Unix(date, 0)
+	case int:
+		t = time.Unix(int64(date), 0)
+	}
+	return FixedTime.Sub(t).Round(time.Second).String()
+}

--- a/pkg/helm/deterministic/clock_test.go
+++ b/pkg/helm/deterministic/clock_test.go
@@ -1,0 +1,43 @@
+package deterministic
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDateInZone_DefaultsToFixedTimeAndForcesUTC pins the two determinism
+// fixes in the ported date helper: an unrecognized argument falls back to
+// FixedTime (not the wall clock), and an empty or "Local" zone is treated
+// as UTC so formatting never depends on $TZ. An explicit time and an
+// explicit named zone are honored unchanged.
+func TestDateInZone_DefaultsToFixedTimeAndForcesUTC(t *testing.T) {
+	// Unrecognized arg → FixedTime, not time.Now().
+	if got := dateInZone("20060102150405", "not-a-time", "UTC"); got != "20200101000000" {
+		t.Errorf(`dateInZone default branch = %q, want "20200101000000"`, got)
+	}
+	// Explicit time honored.
+	ts := time.Date(2021, 6, 7, 8, 9, 10, 0, time.UTC)
+	if got := dateInZone("2006-01-02", ts, "UTC"); got != "2021-06-07" {
+		t.Errorf("dateInZone(ts) = %q, want 2021-06-07", got)
+	}
+	// Empty and "Local" zones both render in UTC (machine-independent).
+	empty := dateInZone("150405", ts, "")
+	local := dateInZone("150405", ts, "Local")
+	if empty != "080910" || local != "080910" {
+		t.Errorf(`empty/Local zone not forced to UTC: ""=%q Local=%q, want 080910`, empty, local)
+	}
+}
+
+// TestClockFuncs_DateForcesUTC pins that the registered "date" override
+// formats in UTC with a FixedTime fallback — so `{{ now | date … }}` is
+// reproducible across machines, not just across runs on one machine.
+func TestClockFuncs_DateForcesUTC(t *testing.T) {
+	fm := clockFuncs()
+	date, ok := fm["date"].(func(string, any) string)
+	if !ok {
+		t.Fatalf(`"date" override has unexpected type %T`, fm["date"])
+	}
+	if got := date("20060102150405", FixedTime); got != "20200101000000" {
+		t.Errorf(`date(FixedTime) = %q, want "20200101000000"`, got)
+	}
+}

--- a/pkg/helm/deterministic/doc.go
+++ b/pkg/helm/deterministic/doc.go
@@ -1,0 +1,19 @@
+// Package deterministic provides drop-in replacements for the
+// nondeterministic functions Helm exposes to chart templates through
+// sprig — the time- and crypto/rand-backed ones (now, randAlphaNum,
+// genCA, …) — so flate renders byte-identically run to run.
+//
+// Helm v4 applies action.Configuration.CustomTemplateFuncs LAST when it
+// assembles the engine FuncMap (maps.Copy over sprig's defaults in
+// engine.initFunMap), so an entry returned here OVERRIDES the sprig
+// built-in of the same name, uniformly — including inside tpl/include and
+// subcharts. pkg/helm assigns Funcs() to cfg.CustomTemplateFuncs once per
+// render.
+//
+// The replacements preserve Helm's output SHAPE (a real timestamp string,
+// a valid-length random string, a valid PEM certificate) while making the
+// VALUE reproducible. flate renders for offline review and diff and never
+// applies its output to a cluster, so a fixed clock — and, in later tiers,
+// a seeded randomness stream — is a safe deterministic stand-in for the
+// material the live controller draws freshly at apply time.
+package deterministic

--- a/pkg/helm/deterministic/funcs.go
+++ b/pkg/helm/deterministic/funcs.go
@@ -1,0 +1,22 @@
+package deterministic
+
+import (
+	"maps"
+	"text/template"
+)
+
+// Funcs returns deterministic overrides for the nondeterministic sprig
+// functions Helm exposes to chart templates. Assign the result to a
+// render's action.Configuration.CustomTemplateFuncs; the engine applies
+// it after sprig (maps.Copy in engine.initFunMap), so these entries win —
+// uniformly, including inside tpl/include and subcharts.
+//
+// Construct one FuncMap per render (per action.Configuration). The
+// overrides are stateless today (a fixed clock); later tiers add a
+// per-render seeded random stream, so the FuncMap must never be memoized
+// or shared across goroutines.
+func Funcs() template.FuncMap {
+	fm := template.FuncMap{}
+	maps.Copy(fm, clockFuncs())
+	return fm
+}

--- a/pkg/helm/deterministic/funcs_test.go
+++ b/pkg/helm/deterministic/funcs_test.go
@@ -1,0 +1,37 @@
+package deterministic
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFuncs_NowIsFixed pins Tier 1: the "now" override returns FixedTime
+// (a constant), stably across calls and across independent FuncMaps, so a
+// chart's `{{ now | date … }}` renders identically every time instead of
+// drawing the wall clock.
+func TestFuncs_NowIsFixed(t *testing.T) {
+	fm := Funcs()
+	raw, ok := fm["now"]
+	if !ok {
+		t.Fatal(`Funcs() missing "now" override`)
+	}
+	now, ok := raw.(func() time.Time)
+	if !ok {
+		t.Fatalf(`"now" override has type %T, want func() time.Time`, raw)
+	}
+	if got := now(); !got.Equal(FixedTime) {
+		t.Errorf("now() = %v, want FixedTime %v", got, FixedTime)
+	}
+	// Stable on a repeat call (no hidden per-call state).
+	if got := now(); !got.Equal(FixedTime) {
+		t.Errorf("now() repeat = %v, want FixedTime %v", got, FixedTime)
+	}
+	// Stable across an independently constructed FuncMap.
+	other, ok := Funcs()["now"].(func() time.Time)
+	if !ok {
+		t.Fatal(`fresh Funcs() "now" override has unexpected type`)
+	}
+	if got := other(); !got.Equal(FixedTime) {
+		t.Errorf("now() from a fresh FuncMap = %v, want FixedTime %v", got, FixedTime)
+	}
+}

--- a/pkg/helm/deterministic_render_test.go
+++ b/pkg/helm/deterministic_render_test.go
@@ -1,0 +1,58 @@
+package helm
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
+)
+
+// TestTemplate_DeterministicNow is the Tier 1 integration guard: a chart
+// that templates `now` must render byte-identically across two UNCACHED
+// renders. sprig registers `now` as time.Now, so with nanosecond precision
+// two renders would differ run to run; the cfg.CustomTemplateFuncs override
+// pins it to deterministic.FixedTime. Caching is disabled (zero-value
+// ClientOptions) so byte-identity can only come from the override, not a
+// cache hit — and the rendered value must reflect the fixed 2020 clock.
+func TestTemplate_DeterministicNow(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml",
+		"apiVersion: v2\nname: mychart\nversion: 0.1.0\ndescription: t\n")
+	// Nanosecond-precision format: an un-overridden time.Now would reliably
+	// differ between the two renders, so this genuinely guards the override
+	// rather than coincidentally passing at second precision.
+	testutil.WriteFile(t, dir, "mychart/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\ndata:\n  stamp: {{ now | date \"20060102150405.000000000\" | quote }}\n")
+
+	cli, err := NewClientWithOptions(cacheroot.New(t.TempDir()), ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewClientWithOptions: %v", err)
+	}
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
+
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "chart-repo",
+			RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
+		},
+	}
+
+	first, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	second, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if first != second {
+		t.Errorf("uncached renders differ — `now` not deterministic:\n first=%q\nsecond=%q", first, second)
+	}
+	if !strings.Contains(first, "20200101000000") {
+		t.Errorf("rendered stamp not pinned to FixedTime (2020-01-01):\n%s", first)
+	}
+}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -15,6 +15,7 @@ import (
 	release "helm.sh/helm/v4/pkg/release/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/home-operations/flate/pkg/helm/deterministic"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/values"
 )
@@ -46,6 +47,12 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 		return "", fmt.Errorf("helm init: %w", err)
 	}
 	cfg.Capabilities = caps
+	// Override sprig's nondeterministic template functions (now → a fixed
+	// clock, and in later tiers seeded random/cert funcs) so the render is
+	// byte-reproducible. Helm v4 applies CustomTemplateFuncs last when
+	// building the engine FuncMap, so these win over sprig. Build a fresh
+	// map per render — never share it across goroutines.
+	cfg.CustomTemplateFuncs = deterministic.Funcs()
 
 	inst, disableHooks, err := newInstallAction(cfg, hr, opts, caps)
 	if err != nil {


### PR DESCRIPTION
## What

First tier of making `flate build` byte-reproducible run to run by seeding the nondeterministic functions Helm exposes to chart templates via sprig.

Helm v4 exposes `action.Configuration.CustomTemplateFuncs`, applied **last** when the engine assembles its FuncMap (`maps.Copy` over sprig in `engine.initFunMap`), so an entry there **overrides** the sprig built-in of the same name — uniformly, including inside `tpl`/`include` and subcharts. (The `strip.go` comment claiming *"Helm exposes no funcMap hook to override it"* predates v4 and is corrected here.)

New leaf package `pkg/helm/deterministic` returns overrides assigned per render to `cfg.CustomTemplateFuncs` in `helm.Client.Template`:

- **`now`** → a `FixedTime` constant (`2020-01-01T00:00:00Z`), the only nullary clock source charts draw from (e.g. `{{ now | date … }}`).
- **the date family** (`date`/`dateInZone`/`htmlDate`/`htmlDateInZone`/`ago`) ported from sprig with two changes: the `time.Now()` fallback for an unrecognized argument becomes `FixedTime` (so a bare `{{ date "fmt" }}` can't leak the wall clock), and `date`/`htmlDate` force **UTC** (empty/`"Local"` zone → UTC) so output never depends on `$TZ`. An explicit named zone is still honored.

Always-on: flate renders for offline review/diff and never applies its output, so a fixed clock is a safe, reproducible stand-in. It mirrors Helm's output **shape** (a real timestamp string), just with a pinned value.

With `now` pinned, volsync's `spec.restic.unlock: {{ now | date … }}` renders identically on both diff sides, so it is **dropped from `diff.DefaultStripFields`** (stripping it would only hide a genuine change). The `"checksum/"` strip stays — those rotate on legitimate content/version bumps independent of randomness.

This is **Tier 1 of a 3-tier stack** (clock → seeded random → seeded certs).

## Verification

- Unit + integration tests: an uncached double-render of a `now`-using chart is byte-identical and pinned to `FixedTime`; instrument-first confirmed (unwired → renders differ at ns precision, today's wall clock).
- Full gate: `gofmt`/`vet`/`golangci-lint` 0, `go test -race` on helm/diff/manifest, full suite green.
- Cross-repo over 24 paths: **zero structural diffs, zero exit mismatches, no collateral**. The entire universe of base-vs-branch changes is the intended `unlock`/`updatedAt` pinning (base wall-clock → branch `FixedTime`) plus pre-existing `caBundle`/`checksum` crypto-rand noise (addressed in the following tiers). Branch run-to-run: `unlock`/`updatedAt` now deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)