### PR TITLE
feat: seed Helm's random template funcs (deterministic checksum/secret)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gonvenience/ytbx v1.5.0
 	github.com/google/cel-go v0.28.1
 	github.com/google/go-cmp v0.7.0
+	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.15.0
 	github.com/homeport/dyff v1.12.0
 	github.com/minio/minio-go/v7 v7.2.0
@@ -101,7 +102,6 @@ require (
 	github.com/gonvenience/text v1.0.10 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect

--- a/pkg/helm/deterministic/funcs.go
+++ b/pkg/helm/deterministic/funcs.go
@@ -6,17 +6,21 @@ import (
 )
 
 // Funcs returns deterministic overrides for the nondeterministic sprig
-// functions Helm exposes to chart templates. Assign the result to a
-// render's action.Configuration.CustomTemplateFuncs; the engine applies
+// functions Helm exposes to chart templates, all driven by a fixed clock and
+// a single seeded stream derived from seed (see SeedFor). Assign the result
+// to a render's action.Configuration.CustomTemplateFuncs; the engine applies
 // it after sprig (maps.Copy in engine.initFunMap), so these entries win —
 // uniformly, including inside tpl/include and subcharts.
 //
-// Construct one FuncMap per render (per action.Configuration). The
-// overrides are stateless today (a fixed clock); later tiers add a
-// per-render seeded random stream, so the FuncMap must never be memoized
-// or shared across goroutines.
-func Funcs() template.FuncMap {
+// Construct one FuncMap per render (per action.Configuration). The random
+// overrides share a stateful stream that advances on every draw, so the
+// FuncMap is NOT safe for concurrent use and must never be memoized or shared
+// across goroutines. Helm renders a chart's templates sequentially, so within
+// one render the stream is consumed in a deterministic order.
+func Funcs(seed []byte) template.FuncMap {
+	s := newStream(seed)
 	fm := template.FuncMap{}
 	maps.Copy(fm, clockFuncs())
+	maps.Copy(fm, randFuncs(s))
 	return fm
 }

--- a/pkg/helm/deterministic/funcs_test.go
+++ b/pkg/helm/deterministic/funcs_test.go
@@ -10,7 +10,7 @@ import (
 // chart's `{{ now | date … }}` renders identically every time instead of
 // drawing the wall clock.
 func TestFuncs_NowIsFixed(t *testing.T) {
-	fm := Funcs()
+	fm := Funcs(SeedFor("rel", "ns"))
 	raw, ok := fm["now"]
 	if !ok {
 		t.Fatal(`Funcs() missing "now" override`)
@@ -27,7 +27,7 @@ func TestFuncs_NowIsFixed(t *testing.T) {
 		t.Errorf("now() repeat = %v, want FixedTime %v", got, FixedTime)
 	}
 	// Stable across an independently constructed FuncMap.
-	other, ok := Funcs()["now"].(func() time.Time)
+	other, ok := Funcs(SeedFor("rel", "ns"))["now"].(func() time.Time)
 	if !ok {
 		t.Fatal(`fresh Funcs() "now" override has unexpected type`)
 	}

--- a/pkg/helm/deterministic/rand.go
+++ b/pkg/helm/deterministic/rand.go
@@ -1,0 +1,120 @@
+package deterministic
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+	"math"
+	"math/big"
+	"text/template"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+// randFuncs returns deterministic overrides for sprig's crypto/rand- and
+// math/rand-backed string/byte/int/uuid functions, all drawing from the
+// per-render stream instead of the process entropy source.
+//
+// The string generators are a faithful port of Masterminds/goutils
+// CryptoRandom (the consumer behind sprig's randAlpha* helpers) with its sole
+// randomness draw — getCryptoRandomInt = crypto/rand.Int(rand.Reader, …) —
+// swapped to read from the stream. Because crypto/rand.Int's reduction is
+// unchanged, output is byte-identical to goutils given the same stream bytes;
+// only the bytes' source is deterministic.
+func randFuncs(s *stream) template.FuncMap {
+	return template.FuncMap{
+		"randAlphaNum": func(n int) string { return cryptoRandom(s, n, 0, 0, true, true) },
+		"randAlpha":    func(n int) string { return cryptoRandom(s, n, 0, 0, true, false) },
+		"randNumeric":  func(n int) string { return cryptoRandom(s, n, 0, 0, false, true) },
+		"randAscii":    func(n int) string { return cryptoRandom(s, n, 32, 127, false, false) },
+		"randBytes":    func(n int) (string, error) { return randBytes(s, n) },
+		"randInt":      func(minN, maxN int) int { return int(randomInt(s, maxN-minN)) + minN },
+		"uuidv4":       func() string { return uuidv4(s) },
+	}
+}
+
+// randomInt mirrors goutils.getCryptoRandomInt but reads from the stream.
+func randomInt(s *stream, n int) int64 {
+	v, err := rand.Int(s, big.NewInt(int64(n)))
+	if err != nil {
+		// crypto/rand.Int only errors on a non-positive bound; sprig's
+		// randInt(min,max) with max<=min and randAscii/etc. with count>0
+		// never reach it. Match math/rand.Intn's panic on a bad bound.
+		panic(err)
+	}
+	return v.Int64()
+}
+
+// cryptoRandom is a faithful port of Masterminds/goutils CryptoRandom (chars
+// always nil in sprig's usage) with its randomness draw replaced by the
+// stream. count<=0 yields "" — matching sprig, which swallows goutils' error.
+func cryptoRandom(s *stream, count, start, end int, letters, numbers bool) string {
+	if count <= 0 {
+		return ""
+	}
+	if start == 0 && end == 0 {
+		if !letters && !numbers {
+			end = math.MaxInt32
+		} else {
+			end = 'z' + 1
+			start = ' '
+		}
+	}
+	buffer := make([]rune, count)
+	gap := end - start
+	for count != 0 {
+		count--
+		//nolint:gosec // G115: randomInt(s,gap) ∈ [0,gap) so the sum is ≤ end ≤ MaxInt32 — always a valid rune.
+		ch := rune(randomInt(s, gap) + int64(start))
+		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {
+			switch {
+			case ch >= 56320 && ch <= 57343: // low surrogate range
+				if count == 0 {
+					count++
+				} else {
+					buffer[count] = ch
+					count--
+					//nolint:gosec // G115: 55296+[0,128) is a valid surrogate-range rune.
+					buffer[count] = rune(55296 + randomInt(s, 128))
+				}
+			case ch >= 55296 && ch <= 56191: // high surrogate range (partial)
+				if count == 0 {
+					count++
+				} else {
+					//nolint:gosec // G115: 56320+[0,128) is a valid surrogate-range rune.
+					buffer[count] = rune(56320 + randomInt(s, 128))
+					count--
+					buffer[count] = ch
+				}
+			case ch >= 56192 && ch <= 56319: // private high surrogate, skip
+				count++
+			default:
+				buffer[count] = ch
+			}
+		} else {
+			count++
+		}
+	}
+	return string(buffer)
+}
+
+// randBytes mirrors sprig.randBytes (base64 of count random bytes), reading
+// from the stream instead of crypto/rand.
+func randBytes(s *stream, count int) (string, error) {
+	buf := make([]byte, count)
+	if _, err := io.ReadFull(s, buf); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf), nil
+}
+
+// uuidv4 mirrors sprig.uuidv4 (a v4 UUID) but draws its 16 bytes from the
+// stream, so the same seed yields the same UUID.
+func uuidv4(s *stream) string {
+	u, err := uuid.NewRandomFromReader(s)
+	if err != nil {
+		panic(err)
+	}
+	return u.String()
+}

--- a/pkg/helm/deterministic/rand_test.go
+++ b/pkg/helm/deterministic/rand_test.go
@@ -1,0 +1,118 @@
+package deterministic
+
+import (
+	"encoding/base64"
+	"testing"
+	"unicode"
+
+	"github.com/google/uuid"
+)
+
+// TestRandFuncs_SameSeedSameSequence pins that two independently constructed
+// FuncMaps with the same seed replay an identical stream: calling the same
+// generators in the same order yields equal output. This is the property that
+// makes a cache hit match a cache miss.
+func TestRandFuncs_SameSeedSameSequence(t *testing.T) {
+	a := Funcs(SeedFor("rel", "ns"))
+	b := Funcs(SeedFor("rel", "ns"))
+
+	an := a["randAlphaNum"].(func(int) string)
+	bn := b["randAlphaNum"].(func(int) string)
+	for i := range 3 {
+		if x, y := an(24), bn(24); x != y {
+			t.Fatalf("randAlphaNum draw %d differs across same-seed maps: %q vs %q", i, x, y)
+		}
+	}
+	if x, y := a["uuidv4"].(func() string)(), b["uuidv4"].(func() string)(); x != y {
+		t.Errorf("uuidv4 differs across same-seed maps: %q vs %q", x, y)
+	}
+	ab, err := a["randBytes"].(func(int) (string, error))(32)
+	if err != nil {
+		t.Fatalf("randBytes a: %v", err)
+	}
+	bb, err := b["randBytes"].(func(int) (string, error))(32)
+	if err != nil {
+		t.Fatalf("randBytes b: %v", err)
+	}
+	if ab != bb {
+		t.Errorf("randBytes differs across same-seed maps: %q vs %q", ab, bb)
+	}
+	if x, y := a["randInt"].(func(int, int) int)(0, 1000), b["randInt"].(func(int, int) int)(0, 1000); x != y {
+		t.Errorf("randInt differs across same-seed maps: %d vs %d", x, y)
+	}
+}
+
+// TestRandFuncs_DifferentSeedDiffers confirms the seed actually varies output
+// — two releases that render the same chart get independent random material.
+func TestRandFuncs_DifferentSeedDiffers(t *testing.T) {
+	a := Funcs(SeedFor("rel-a", "ns"))["randAlphaNum"].(func(int) string)
+	b := Funcs(SeedFor("rel-b", "ns"))["randAlphaNum"].(func(int) string)
+	if a(24) == b(24) {
+		t.Error("different seeds produced identical randAlphaNum output")
+	}
+}
+
+// TestRandFuncs_CharacterClassesAndShape pins that the deterministic ports
+// keep sprig's contracts: right length, right character class, and a valid v4
+// UUID / correctly sized randBytes.
+func TestRandFuncs_CharacterClassesAndShape(t *testing.T) {
+	fm := Funcs(SeedFor("rel", "ns"))
+
+	alpha := fm["randAlpha"].(func(int) string)(64)
+	if n := len([]rune(alpha)); n != 64 {
+		t.Errorf("randAlpha length = %d, want 64", n)
+	}
+	for _, r := range alpha {
+		if !unicode.IsLetter(r) {
+			t.Errorf("randAlpha produced non-letter %q in %q", r, alpha)
+			break
+		}
+	}
+	for _, r := range fm["randNumeric"].(func(int) string)(64) {
+		if !unicode.IsDigit(r) {
+			t.Errorf("randNumeric produced non-digit %q", r)
+			break
+		}
+	}
+	for _, r := range fm["randAlphaNum"].(func(int) string)(64) {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) {
+			t.Errorf("randAlphaNum produced non-alphanumeric %q", r)
+			break
+		}
+	}
+
+	u := fm["uuidv4"].(func() string)()
+	parsed, err := uuid.Parse(u)
+	if err != nil {
+		t.Fatalf("uuidv4 not a valid UUID: %q: %v", u, err)
+	}
+	if parsed.Version() != 4 {
+		t.Errorf("uuidv4 version = %d, want 4 (%q)", parsed.Version(), u)
+	}
+
+	rb, err := fm["randBytes"].(func(int) (string, error))(32)
+	if err != nil {
+		t.Fatalf("randBytes: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(rb)
+	if err != nil {
+		t.Fatalf("randBytes not valid base64: %v", err)
+	}
+	if len(decoded) != 32 {
+		t.Errorf("randBytes decoded to %d bytes, want 32", len(decoded))
+	}
+
+	if v := fm["randInt"].(func(int, int) int)(10, 20); v < 10 || v >= 20 {
+		t.Errorf("randInt(10,20) = %d, want [10,20)", v)
+	}
+}
+
+// TestRandFuncs_StreamAdvances confirms successive draws on one FuncMap differ
+// (the shared stream advances), so a chart generating two secrets doesn't get
+// the same value twice.
+func TestRandFuncs_StreamAdvances(t *testing.T) {
+	gen := Funcs(SeedFor("rel", "ns"))["randAlphaNum"].(func(int) string)
+	if first, second := gen(24), gen(24); first == second {
+		t.Errorf("successive randAlphaNum draws identical (stream not advancing): %q", first)
+	}
+}

--- a/pkg/helm/deterministic/stream.go
+++ b/pkg/helm/deterministic/stream.go
@@ -1,0 +1,37 @@
+package deterministic
+
+import (
+	"crypto/sha256"
+	"math/rand/v2"
+)
+
+// SeedFor derives a render's deterministic seed from inputs already folded
+// into computeTemplateKey — the release name and namespace (both in keyHR).
+// Seeding only from key inputs is the load-bearing invariant: a cache hit
+// and a cache miss for the same key must produce identical bytes, so the
+// seed must never draw from anything outside the key (least of all the wall
+// clock). The NUL separator keeps ("ab","c") from colliding with ("a","bc").
+func SeedFor(releaseName, releaseNamespace string) []byte {
+	sum := sha256.Sum256([]byte(releaseName + "\x00" + releaseNamespace))
+	return sum[:]
+}
+
+// stream is the single deterministic randomness source a render's overrides
+// share: a ChaCha8 keyed by the seed. Its Read returns exactly len(p) bytes
+// with a nil error — the contract crypto/rand-style consumers (crypto/rand.Int,
+// io.ReadFull, and, in the cert tier, rsa.GenerateKey / x509.CreateCertificate)
+// expect from an io.Reader. ChaCha8's algorithm is fixed by the standard
+// library, so a given seed yields the same byte sequence across Go releases.
+//
+// A stream is stateful — each draw advances it — and therefore NOT safe for
+// concurrent use. Build one per render (Helm renders a chart's templates
+// sequentially, so a single stream is consumed in a deterministic order).
+type stream struct{ c *rand.ChaCha8 }
+
+func newStream(seed []byte) *stream {
+	var key [32]byte
+	copy(key[:], seed)
+	return &stream{c: rand.NewChaCha8(key)}
+}
+
+func (s *stream) Read(p []byte) (int, error) { return s.c.Read(p) }

--- a/pkg/helm/deterministic_render_test.go
+++ b/pkg/helm/deterministic_render_test.go
@@ -56,3 +56,42 @@ func TestTemplate_DeterministicNow(t *testing.T) {
 		t.Errorf("rendered stamp not pinned to FixedTime (2020-01-01):\n%s", first)
 	}
 }
+
+// TestTemplate_DeterministicRandom is the Tier 2 integration guard: a chart
+// that templates randAlphaNum/uuidv4 — plus a sha256 over a random value, the
+// shape behind checksum/secret annotations — must render byte-identically
+// across two UNCACHED renders. sprig draws these from crypto/rand; the
+// override seeds them from the release identity. Caching is disabled so
+// byte-identity can only come from the seeded stream.
+func TestTemplate_DeterministicRandom(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml",
+		"apiVersion: v2\nname: mychart\nversion: 0.1.0\ndescription: t\n")
+	testutil.WriteFile(t, dir, "mychart/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\n  annotations:\n    checksum/secret: {{ randAlphaNum 24 | sha256sum | quote }}\ndata:\n  token: {{ randAlphaNum 24 | quote }}\n  id: {{ uuidv4 | quote }}\n")
+
+	cli, err := NewClientWithOptions(cacheroot.New(t.TempDir()), ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewClientWithOptions: %v", err)
+	}
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "chart-repo",
+			RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
+		},
+	}
+
+	first, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	second, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if first != second {
+		t.Errorf("uncached renders differ — random funcs not deterministic:\n first=%q\nsecond=%q", first, second)
+	}
+}

--- a/pkg/helm/template.go
+++ b/pkg/helm/template.go
@@ -47,12 +47,16 @@ func (c *Client) Template(ctx context.Context, hr *manifest.HelmRelease, hrValue
 		return "", fmt.Errorf("helm init: %w", err)
 	}
 	cfg.Capabilities = caps
-	// Override sprig's nondeterministic template functions (now → a fixed
-	// clock, and in later tiers seeded random/cert funcs) so the render is
-	// byte-reproducible. Helm v4 applies CustomTemplateFuncs last when
-	// building the engine FuncMap, so these win over sprig. Build a fresh
-	// map per render — never share it across goroutines.
-	cfg.CustomTemplateFuncs = deterministic.Funcs()
+	// Override sprig's nondeterministic template functions (a fixed clock
+	// plus seeded random/uuid funcs, and in the cert tier seeded keys/certs)
+	// so the render is byte-reproducible. Helm v4 applies CustomTemplateFuncs
+	// last when building the engine FuncMap, so these win over sprig. The seed
+	// derives only from release name+namespace (both in the render-cache key),
+	// so a cache hit matches a cache miss. Build a fresh map per render — the
+	// random stream is stateful and must not be shared across goroutines.
+	cfg.CustomTemplateFuncs = deterministic.Funcs(
+		deterministic.SeedFor(hr.ReleaseName(), hr.ReleaseNamespace()),
+	)
 
 	inst, disableHooks, err := newInstallAction(cfg, hr, opts, caps)
 	if err != nil {


### PR DESCRIPTION
## What

Tier 2 of deterministic rendering (after the clock tier, #667). Adds a per-render seeded randomness stream and points sprig's `crypto/rand`- and `math/rand`-backed functions at it, so `randAlphaNum`-derived values — and the `checksum/secret(s)` annotations charts sha256 over them — render identically run to run.

`pkg/helm/deterministic` additions:
- **`stream.go`**: `SeedFor(name, namespace)` → sha256 (32 bytes), and a `math/rand/v2.ChaCha8` keyed by it. Its `Read` returns exactly `len(p)` bytes with a nil error — the contract `crypto/rand.Int`/`io.ReadFull` expect from an `io.Reader`. Stateful → one per render. **The seed derives only from release name + namespace, both already in `computeTemplateKey`**, so a cache hit reproduces a cache miss byte-for-byte; it must never draw from outside the key.
- **`rand.go`**: `randAlphaNum`/`randAlpha`/`randAscii`/`randNumeric` are a faithful port of Masterminds/goutils `CryptoRandom` (the consumer behind sprig's helpers) with its lone `crypto/rand.Int` draw swapped for the stream — byte-identical to goutils given the same stream bytes. `randBytes` (`io.ReadFull`), `randInt` (`crypto/rand.Int`), and `uuidv4` (`uuid.NewRandomFromReader`) likewise.
- **`funcs.go`**: `Funcs` now takes the seed, builds one stream, and merges the clock + random overrides; `template.go` passes `SeedFor(release, namespace)`.

Helm renders a chart's templates sequentially, so the shared stream is consumed in a deterministic order; the FuncMap is built per render and must not be shared across goroutines (documented). Promotes `github.com/google/uuid` to a direct dependency.

## Verification

- Unit: same seed → identical sequence; different seed → differs; character-class/shape/length; stream advances.
- Integration: an uncached double-render of a `randAlphaNum`/`uuidv4`/`checksum` chart is byte-identical.
- Empirical before/after: **boemeltrein**, which churned `checksum/secrets` after #667, now renders **fully identically** run to run.
- Full gate green. Cross-repo over 24 paths: **0 structural diffs, 0 exit mismatches, no collateral** — `unlock`/`updatedAt` now match base (both clock-pinned); the only remaining base-vs-branch changes are the intended `checksum/*` seeding plus pre-existing `caBundle` crypto-rand noise (the cert tier, next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)