### PR TITLE
feat: deterministic Helm certs via ed25519; simplify random funcs to stdlib

### DIFF
--- a/pkg/helm/deterministic/cert.go
+++ b/pkg/helm/deterministic/cert.go
@@ -1,0 +1,237 @@
+package deterministic
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"text/template"
+	"time"
+)
+
+// certFuncs returns deterministic overrides for sprig's certificate and
+// private-key generators. All generated material is ed25519: ed25519.GenerateKey
+// reads the seeded stream directly (unlike rsa/ecdsa.GenerateKey, which route
+// through crypto/rand's CustomReader and discard a custom reader), and ed25519
+// signatures are deterministic (RFC 8032). Combined with a stream-derived serial
+// and FixedTime validity, every cert/key renders identically run to run — with
+// no hand-rolled crypto and no seeded reader handed to x509.CreateCertificate.
+//
+// flate renders for offline review and never applies its output, so an ed25519
+// caBundle/key is a valid, deterministic stand-in for the random RSA material the
+// live controller mints at apply time (which a render could never match anyway).
+//
+// genPrivateKey returns a deterministic ed25519 key for every known type — stdlib
+// cannot make rsa/ecdsa keygen deterministic. The *WithKey variants keep their
+// signatures but ignore the supplied PEM and generate an ed25519 key, so output
+// stays deterministic regardless of the caller's key type.
+func certFuncs(s *stream) template.FuncMap {
+	return template.FuncMap{
+		"genPrivateKey":   func(typ string) string { return genPrivateKey(s, typ) },
+		"buildCustomCert": buildCustomCert,
+		"genCA":           func(cn string, days int) (certificate, error) { return genCA(s, cn, days) },
+		"genCAWithKey":    func(cn string, days int, _ string) (certificate, error) { return genCA(s, cn, days) },
+		"genSelfSignedCert": func(cn string, ips, alternateDNS []any, days int) (certificate, error) {
+			return genSelfSignedCert(s, cn, ips, alternateDNS, days)
+		},
+		"genSelfSignedCertWithKey": func(cn string, ips, alternateDNS []any, days int, _ string) (certificate, error) {
+			return genSelfSignedCert(s, cn, ips, alternateDNS, days)
+		},
+		"genSignedCert": func(cn string, ips, alternateDNS []any, days int, ca certificate) (certificate, error) {
+			return genSignedCert(s, cn, ips, alternateDNS, days, ca)
+		},
+		"genSignedCertWithKey": func(cn string, ips, alternateDNS []any, days int, ca certificate, _ string) (certificate, error) {
+			return genSignedCert(s, cn, ips, alternateDNS, days, ca)
+		},
+	}
+}
+
+// certificate mirrors sprig's type: an unexported type with exported fields, so
+// templates read .Cert/.Key and a genCA value flows into genSignedCert's ca arg.
+type certificate struct {
+	Cert string
+	Key  string
+}
+
+// issue generates a deterministic ed25519 key, finishes the template (serial from
+// the stream, validity from FixedTime), signs it, and PEM-encodes both. A nil
+// signerKey means self-signed (parent and signer are the freshly generated cert
+// and key). x509.CreateCertificate is handed the stream, but never reads it: the
+// serial is pre-set and ed25519 signing consumes no randomness.
+func issue(s *stream, tmpl, parent *x509.Certificate, signerKey ed25519.PrivateKey, days int) (certificate, error) {
+	pub, priv, err := ed25519.GenerateKey(s)
+	if err != nil {
+		return certificate{}, fmt.Errorf("generating ed25519 key: %w", err)
+	}
+	serial, err := rand.Int(s, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return certificate{}, fmt.Errorf("generating serial: %w", err)
+	}
+	tmpl.SerialNumber = serial
+	tmpl.NotBefore = FixedTime
+	tmpl.NotAfter = FixedTime.Add(24 * time.Hour * time.Duration(days))
+	if signerKey == nil {
+		parent, signerKey = tmpl, priv
+	}
+	der, err := x509.CreateCertificate(s, tmpl, parent, pub, signerKey)
+	if err != nil {
+		return certificate{}, fmt.Errorf("creating certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return certificate{}, fmt.Errorf("marshaling key: %w", err)
+	}
+	return certificate{
+		Cert: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})),
+		Key:  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})),
+	}, nil
+}
+
+func baseTemplate(cn string, ips, alternateDNS []any) (*x509.Certificate, error) {
+	ipAddresses, err := netIPs(ips)
+	if err != nil {
+		return nil, err
+	}
+	dnsNames, err := dnsStrs(alternateDNS)
+	if err != nil {
+		return nil, err
+	}
+	return &x509.Certificate{
+		Subject:               pkix.Name{CommonName: cn},
+		IPAddresses:           ipAddresses,
+		DNSNames:              dnsNames,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}, nil
+}
+
+func genCA(s *stream, cn string, days int) (certificate, error) {
+	tmpl, err := baseTemplate(cn, nil, nil)
+	if err != nil {
+		return certificate{}, err
+	}
+	tmpl.IsCA = true
+	tmpl.KeyUsage |= x509.KeyUsageCertSign
+	return issue(s, tmpl, nil, nil, days)
+}
+
+func genSelfSignedCert(s *stream, cn string, ips, alternateDNS []any, days int) (certificate, error) {
+	tmpl, err := baseTemplate(cn, ips, alternateDNS)
+	if err != nil {
+		return certificate{}, err
+	}
+	return issue(s, tmpl, nil, nil, days)
+}
+
+func genSignedCert(s *stream, cn string, ips, alternateDNS []any, days int, ca certificate) (certificate, error) {
+	parent, signerKey, err := parseCA(ca)
+	if err != nil {
+		return certificate{}, err
+	}
+	tmpl, err := baseTemplate(cn, ips, alternateDNS)
+	if err != nil {
+		return certificate{}, err
+	}
+	return issue(s, tmpl, parent, signerKey, days)
+}
+
+// parseCA decodes the CA certificate and key from a certificate produced by
+// genCA (or buildCustomCert). The key must be ed25519, which everything in this
+// package generates.
+func parseCA(ca certificate) (*x509.Certificate, ed25519.PrivateKey, error) {
+	certBlock, _ := pem.Decode([]byte(ca.Cert))
+	if certBlock == nil {
+		return nil, nil, errors.New("unable to decode CA certificate PEM")
+	}
+	parent, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing CA certificate: %w", err)
+	}
+	keyBlock, _ := pem.Decode([]byte(ca.Key))
+	if keyBlock == nil {
+		return nil, nil, errors.New("unable to decode CA key PEM")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing CA key: %w", err)
+	}
+	edKey, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("CA key is %T, want ed25519", key)
+	}
+	return parent, edKey, nil
+}
+
+func genPrivateKey(s *stream, typ string) string {
+	switch typ {
+	case "", "rsa", "ecdsa", "ed25519":
+		_, priv, err := ed25519.GenerateKey(s)
+		if err != nil {
+			return fmt.Sprintf("failed to generate private key: %s", err)
+		}
+		der, err := x509.MarshalPKCS8PrivateKey(priv)
+		if err != nil {
+			return fmt.Sprintf("failed to marshal private key: %s", err)
+		}
+		return string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	default:
+		return "Unknown type " + typ
+	}
+}
+
+// buildCustomCert decodes a base64 cert+key into a certificate. It is already
+// deterministic; it is overridden so its result is this package's certificate
+// type, letting a template feed it into genSignedCert without a type mismatch.
+func buildCustomCert(b64cert, b64key string) (certificate, error) {
+	cert, err := base64.StdEncoding.DecodeString(b64cert)
+	if err != nil {
+		return certificate{}, errors.New("unable to decode base64 certificate")
+	}
+	key, err := base64.StdEncoding.DecodeString(b64key)
+	if err != nil {
+		return certificate{}, errors.New("unable to decode base64 private key")
+	}
+	block, _ := pem.Decode(cert)
+	if block == nil {
+		return certificate{}, errors.New("unable to decode certificate")
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return certificate{}, fmt.Errorf("parsing certificate: %w", err)
+	}
+	return certificate{Cert: string(cert), Key: string(key)}, nil
+}
+
+func netIPs(ips []any) ([]net.IP, error) {
+	out := make([]net.IP, 0, len(ips))
+	for _, ip := range ips {
+		str, ok := ip.(string)
+		if !ok {
+			return nil, fmt.Errorf("ip %v is not a string", ip)
+		}
+		parsed := net.ParseIP(str)
+		if parsed == nil {
+			return nil, fmt.Errorf("invalid ip %q", str)
+		}
+		out = append(out, parsed)
+	}
+	return out, nil
+}
+
+func dnsStrs(names []any) ([]string, error) {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		str, ok := name.(string)
+		if !ok {
+			return nil, fmt.Errorf("dns name %v is not a string", name)
+		}
+		out = append(out, str)
+	}
+	return out, nil
+}

--- a/pkg/helm/deterministic/cert_test.go
+++ b/pkg/helm/deterministic/cert_test.go
@@ -1,0 +1,160 @@
+package deterministic
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+)
+
+func mustParseCert(t *testing.T, pemStr string) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		t.Fatalf("no PEM data in certificate:\n%s", pemStr)
+	}
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parsing certificate: %v", err)
+	}
+	return c
+}
+
+func mustParseEd25519Key(t *testing.T, pemStr string) ed25519.PrivateKey {
+	t.Helper()
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		t.Fatalf("no PEM data in key:\n%s", pemStr)
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parsing PKCS#8 key: %v", err)
+	}
+	ed, ok := k.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatalf("key is %T, want ed25519.PrivateKey", k)
+	}
+	return ed
+}
+
+func genCAFn(t *testing.T, fm map[string]any) func(string, int) (certificate, error) {
+	t.Helper()
+	fn, ok := fm["genCA"].(func(string, int) (certificate, error))
+	if !ok {
+		t.Fatalf("genCA override has unexpected type %T", fm["genCA"])
+	}
+	return fn
+}
+
+// TestCertFuncs_DeterministicAndValid pins the cert tier: a CA and a leaf signed
+// by it render byte-identically for a given seed, are valid ed25519 x509 with the
+// FixedTime window, and the leaf verifies against the CA — so caBundle/tls.crt
+// stop churning while staying internally consistent.
+func TestCertFuncs_DeterministicAndValid(t *testing.T) {
+	fm := Funcs(SeedFor("rel", "ns"))
+	ca, err := genCAFn(t, fm)("my-ca", 365)
+	if err != nil {
+		t.Fatalf("genCA: %v", err)
+	}
+
+	genSigned, ok := fm["genSignedCert"].(func(string, []any, []any, int, certificate) (certificate, error))
+	if !ok {
+		t.Fatalf("genSignedCert override has unexpected type %T", fm["genSignedCert"])
+	}
+	leaf, err := genSigned("leaf.example.com", []any{"10.0.0.1"}, []any{"leaf.example.com"}, 365, ca)
+	if err != nil {
+		t.Fatalf("genSignedCert: %v", err)
+	}
+
+	caCert := mustParseCert(t, ca.Cert)
+	if !caCert.IsCA {
+		t.Error("genCA cert is not marked IsCA")
+	}
+	if caCert.SignatureAlgorithm != x509.PureEd25519 {
+		t.Errorf("CA SignatureAlgorithm = %v, want PureEd25519 (a CustomReader-tainted algorithm would be nondeterministic)", caCert.SignatureAlgorithm)
+	}
+	if !caCert.NotBefore.Equal(FixedTime) {
+		t.Errorf("CA NotBefore = %v, want FixedTime %v", caCert.NotBefore, FixedTime)
+	}
+	if want := FixedTime.Add(365 * 24 * time.Hour); !caCert.NotAfter.Equal(want) {
+		t.Errorf("CA NotAfter = %v, want %v", caCert.NotAfter, want)
+	}
+
+	// Chain consistency: the leaf must be signed by the CA in caBundle.
+	leafCert := mustParseCert(t, leaf.Cert)
+	if err := leafCert.CheckSignatureFrom(caCert); err != nil {
+		t.Errorf("leaf is not signed by the generated CA: %v", err)
+	}
+
+	// Keys round-trip as ed25519.
+	mustParseEd25519Key(t, ca.Key)
+	mustParseEd25519Key(t, leaf.Key)
+
+	// Same seed → byte-identical CA; different seed → different.
+	again, err := genCAFn(t, Funcs(SeedFor("rel", "ns")))("my-ca", 365)
+	if err != nil {
+		t.Fatalf("genCA again: %v", err)
+	}
+	if again.Cert != ca.Cert || again.Key != ca.Key {
+		t.Error("same seed produced a different CA (genCA not deterministic)")
+	}
+	other, err := genCAFn(t, Funcs(SeedFor("other", "ns")))("my-ca", 365)
+	if err != nil {
+		t.Fatalf("genCA other: %v", err)
+	}
+	if other.Cert == ca.Cert {
+		t.Error("different seeds produced an identical CA")
+	}
+}
+
+// TestGenSignedCert_RejectsNonEd25519CA pins the WithKey/parseCA boundary: a CA
+// whose key is not ed25519 (everything this package generates is) is rejected
+// with a clear error rather than producing a nondeterministic signature.
+func TestGenSignedCert_RejectsNonEd25519CA(t *testing.T) {
+	// A valid ed25519 CA cert, but paired with an RSA key.
+	fm := Funcs(SeedFor("rel", "ns"))
+	ca, err := genCAFn(t, fm)("my-ca", 365)
+	if err != nil {
+		t.Fatalf("genCA: %v", err)
+	}
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(rsaKey)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8: %v", err)
+	}
+	ca.Key = string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+
+	genSigned := fm["genSignedCert"].(func(string, []any, []any, int, certificate) (certificate, error))
+	if _, err := genSigned("leaf", nil, nil, 365, ca); err == nil {
+		t.Error("genSignedCert accepted a non-ed25519 CA key; want an error")
+	}
+}
+
+// TestGenPrivateKey_ParsesPerType pins that every supported key type renders a
+// parseable deterministic ed25519 key. stdlib cannot make rsa/ecdsa keygen
+// deterministic, so those collapse to ed25519; "dsa" keeps sprig's message.
+func TestGenPrivateKey_ParsesPerType(t *testing.T) {
+	fm := Funcs(SeedFor("rel", "ns"))
+	gpk, ok := fm["genPrivateKey"].(func(string) string)
+	if !ok {
+		t.Fatalf("genPrivateKey override has unexpected type %T", fm["genPrivateKey"])
+	}
+	for _, typ := range []string{"", "rsa", "ecdsa", "ed25519"} {
+		mustParseEd25519Key(t, gpk(typ))
+	}
+	if got := gpk("dsa"); got != "Unknown type dsa" {
+		t.Errorf("genPrivateKey(\"dsa\") = %q, want unknown-type message", got)
+	}
+
+	a := Funcs(SeedFor("rel", "ns"))["genPrivateKey"].(func(string) string)("rsa")
+	b := Funcs(SeedFor("rel", "ns"))["genPrivateKey"].(func(string) string)("rsa")
+	if a != b {
+		t.Error("same seed produced different keys")
+	}
+}

--- a/pkg/helm/deterministic/doc.go
+++ b/pkg/helm/deterministic/doc.go
@@ -10,10 +10,11 @@
 // subcharts. pkg/helm assigns Funcs() to cfg.CustomTemplateFuncs once per
 // render.
 //
-// The replacements preserve Helm's output SHAPE (a real timestamp string,
-// a valid-length random string, a valid PEM certificate) while making the
-// VALUE reproducible. flate renders for offline review and diff and never
-// applies its output to a cluster, so a fixed clock — and, in later tiers,
-// a seeded randomness stream — is a safe deterministic stand-in for the
-// material the live controller draws freshly at apply time.
+// The replacements preserve Helm's output SHAPE (a real timestamp string, a
+// valid-length random string, a valid PEM certificate) while making the VALUE
+// reproducible: a fixed clock, a seeded ChaCha8 stream for the random funcs,
+// and seed-derived ed25519 keys/certs (ed25519 is the only key type Go's crypto
+// generates deterministically from a custom reader). flate renders for offline
+// review and diff and never applies its output, so these are safe deterministic
+// stand-ins for the material the live controller mints at apply time.
 package deterministic

--- a/pkg/helm/deterministic/funcs.go
+++ b/pkg/helm/deterministic/funcs.go
@@ -22,5 +22,6 @@ func Funcs(seed []byte) template.FuncMap {
 	fm := template.FuncMap{}
 	maps.Copy(fm, clockFuncs())
 	maps.Copy(fm, randFuncs(s))
+	maps.Copy(fm, certFuncs(s))
 	return fm
 }

--- a/pkg/helm/deterministic/rand.go
+++ b/pkg/helm/deterministic/rand.go
@@ -1,119 +1,89 @@
 package deterministic
 
 import (
-	"crypto/rand"
 	"encoding/base64"
 	"io"
-	"math"
-	"math/big"
+	"math/rand/v2"
 	"text/template"
-	"unicode"
 
 	"github.com/google/uuid"
 )
 
+const (
+	charsAlphaNum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	charsAlpha    = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	charsNumeric  = "0123456789"
+)
+
+// charsASCII is the printable ASCII range (bytes 32..126) — sprig's randAscii
+// character set.
+var charsASCII = func() string {
+	b := make([]byte, 0, 95)
+	for c := byte(32); c <= 126; c++ {
+		b = append(b, c)
+	}
+	return string(b)
+}()
+
 // randFuncs returns deterministic overrides for sprig's crypto/rand- and
 // math/rand-backed string/byte/int/uuid functions, all drawing from the
-// per-render stream instead of the process entropy source.
-//
-// The string generators are a faithful port of Masterminds/goutils
-// CryptoRandom (the consumer behind sprig's randAlpha* helpers) with its sole
-// randomness draw — getCryptoRandomInt = crypto/rand.Int(rand.Reader, …) —
-// swapped to read from the stream. Because crypto/rand.Int's reduction is
-// unchanged, output is byte-identical to goutils given the same stream bytes;
-// only the bytes' source is deterministic.
+// per-render stream. Output is not byte-identical to sprig — it only needs to be
+// deterministic and structurally valid (right length, right character class).
 func randFuncs(s *stream) template.FuncMap {
 	return template.FuncMap{
-		"randAlphaNum": func(n int) string { return cryptoRandom(s, n, 0, 0, true, true) },
-		"randAlpha":    func(n int) string { return cryptoRandom(s, n, 0, 0, true, false) },
-		"randNumeric":  func(n int) string { return cryptoRandom(s, n, 0, 0, false, true) },
-		"randAscii":    func(n int) string { return cryptoRandom(s, n, 32, 127, false, false) },
+		"randAlphaNum": func(n int) string { return randString(s, n, charsAlphaNum) },
+		"randAlpha":    func(n int) string { return randString(s, n, charsAlpha) },
+		"randNumeric":  func(n int) string { return randString(s, n, charsNumeric) },
+		"randAscii":    func(n int) string { return randString(s, n, charsASCII) },
 		"randBytes":    func(n int) (string, error) { return randBytes(s, n) },
-		"randInt":      func(minN, maxN int) int { return int(randomInt(s, maxN-minN)) + minN },
+		"randInt":      func(minN, maxN int) int { return randInt(s, minN, maxN) },
 		"uuidv4":       func() string { return uuidv4(s) },
 	}
 }
 
-// randomInt mirrors goutils.getCryptoRandomInt but reads from the stream.
-func randomInt(s *stream, n int) int64 {
-	v, err := rand.Int(s, big.NewInt(int64(n)))
-	if err != nil {
-		// crypto/rand.Int only errors on a non-positive bound; sprig's
-		// randInt(min,max) with max<=min and randAscii/etc. with count>0
-		// never reach it. Match math/rand.Intn's panic on a bad bound.
-		panic(err)
-	}
-	return v.Int64()
-}
-
-// cryptoRandom is a faithful port of Masterminds/goutils CryptoRandom (chars
-// always nil in sprig's usage) with its randomness draw replaced by the
-// stream. count<=0 yields "" — matching sprig, which swallows goutils' error.
-func cryptoRandom(s *stream, count, start, end int, letters, numbers bool) string {
-	if count <= 0 {
+// randString returns n characters, each one stream byte mapped into charset by
+// modulo. The bias from a charset length that doesn't divide 256 is irrelevant
+// for a render placeholder. n<=0 yields "".
+func randString(s *stream, n int, charset string) string {
+	if n <= 0 {
 		return ""
 	}
-	if start == 0 && end == 0 {
-		if !letters && !numbers {
-			end = math.MaxInt32
-		} else {
-			end = 'z' + 1
-			start = ' '
-		}
+	buf := make([]byte, n)
+	_, _ = io.ReadFull(s, buf)
+	for i, b := range buf {
+		buf[i] = charset[int(b)%len(charset)]
 	}
-	buffer := make([]rune, count)
-	gap := end - start
-	for count != 0 {
-		count--
-		//nolint:gosec // G115: randomInt(s,gap) ∈ [0,gap) so the sum is ≤ end ≤ MaxInt32 — always a valid rune.
-		ch := rune(randomInt(s, gap) + int64(start))
-		if letters && unicode.IsLetter(ch) || numbers && unicode.IsDigit(ch) || !letters && !numbers {
-			switch {
-			case ch >= 56320 && ch <= 57343: // low surrogate range
-				if count == 0 {
-					count++
-				} else {
-					buffer[count] = ch
-					count--
-					//nolint:gosec // G115: 55296+[0,128) is a valid surrogate-range rune.
-					buffer[count] = rune(55296 + randomInt(s, 128))
-				}
-			case ch >= 55296 && ch <= 56191: // high surrogate range (partial)
-				if count == 0 {
-					count++
-				} else {
-					//nolint:gosec // G115: 56320+[0,128) is a valid surrogate-range rune.
-					buffer[count] = rune(56320 + randomInt(s, 128))
-					count--
-					buffer[count] = ch
-				}
-			case ch >= 56192 && ch <= 56319: // private high surrogate, skip
-				count++
-			default:
-				buffer[count] = ch
-			}
-		} else {
-			count++
-		}
-	}
-	return string(buffer)
+	return string(buf)
 }
 
-// randBytes mirrors sprig.randBytes (base64 of count random bytes), reading
-// from the stream instead of crypto/rand.
-func randBytes(s *stream, count int) (string, error) {
-	buf := make([]byte, count)
+func randBytes(s *stream, n int) (string, error) {
+	if n < 0 {
+		return "", nil
+	}
+	buf := make([]byte, n)
 	if _, err := io.ReadFull(s, buf); err != nil {
 		return "", err
 	}
 	return base64.StdEncoding.EncodeToString(buf), nil
 }
 
-// uuidv4 mirrors sprig.uuidv4 (a v4 UUID) but draws its 16 bytes from the
-// stream, so the same seed yields the same UUID.
+// randInt mirrors sprig's randInt(min,max): an int in [min,max). A non-positive
+// span yields min (sprig would panic via math/rand.Intn; a renderer prefers a
+// benign value). The draw comes from the same ChaCha8 the stream wraps.
+func randInt(s *stream, minN, maxN int) int {
+	span := maxN - minN
+	if span <= 0 {
+		return minN
+	}
+	//nolint:gosec // G404: deterministic rendering deliberately draws from the seeded ChaCha8, not crypto/rand.
+	return minN + rand.New(s.c).IntN(span)
+}
+
 func uuidv4(s *stream) string {
 	u, err := uuid.NewRandomFromReader(s)
 	if err != nil {
+		// NewRandomFromReader only fails on a short read, which the stream
+		// (ChaCha8) never produces.
 		panic(err)
 	}
 	return u.String()

--- a/pkg/helm/deterministic_render_test.go
+++ b/pkg/helm/deterministic_render_test.go
@@ -95,3 +95,41 @@ func TestTemplate_DeterministicRandom(t *testing.T) {
 		t.Errorf("uncached renders differ — random funcs not deterministic:\n first=%q\nsecond=%q", first, second)
 	}
 }
+
+// TestTemplate_DeterministicCerts is the Tier 3 integration guard: a chart
+// that generates a CA and a leaf signed by it (the caBundle/tls.crt shape)
+// must render byte-identically across two UNCACHED renders. sprig draws cert
+// keys/serials from crypto/rand and validity from time.Now; the overrides seed
+// both, so the rendered cert material is reproducible.
+func TestTemplate_DeterministicCerts(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml",
+		"apiVersion: v2\nname: mychart\nversion: 0.1.0\ndescription: t\n")
+	testutil.WriteFile(t, dir, "mychart/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-ca\ndata:\n  {{- $ca := genCA \"my-ca\" 3650 }}\n  {{- $cert := genSignedCert \"svc\" nil (list \"svc.default.svc\") 365 $ca }}\n  ca.crt: {{ $ca.Cert | b64enc | quote }}\n  tls.crt: {{ $cert.Cert | b64enc | quote }}\n  tls.key: {{ $cert.Key | b64enc | quote }}\n")
+
+	cli, err := NewClientWithOptions(cacheroot.New(t.TempDir()), ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewClientWithOptions: %v", err)
+	}
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "chart-repo",
+			RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
+		},
+	}
+
+	first, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	second, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if first != second {
+		t.Errorf("uncached renders differ — cert funcs not deterministic:\n first=%q\nsecond=%q", first, second)
+	}
+}


### PR DESCRIPTION
## What

Completes the deterministic-render package (after the clock #667 and rand #668 tiers) and rewrites it to **minimal stdlib**, dropping the verbatim upstream ports the cert/random overrides had grown into.

**Why the old cert approach couldn't work:** `rsa`/`ecdsa.GenerateKey` and `rand.Prime` route through `crypto/internal/rand.CustomReader`, which — with the `cryptocustomrand` GODEBUG off (the default) — **discards a custom reader** and uses real entropy. So a seeded RSA/ECDSA key is impossible with stdlib, and the prior `cert.go` (a ~250-line port of sprig `crypto.go` + a `certReader` hack fighting `randutil.MaybeReadByte`) was both unmaintainable *and* non-deterministic. `ed25519.GenerateKey` reads the reader **directly** (`io.ReadFull` + `NewKeyFromSeed`), `crypto/rand.Int` reads it directly, and `x509.CreateCertificate` only touches `rand` for a nil serial — so **ed25519 + a stream-derived serial is deterministic with zero hand-rolled crypto**.

- **`cert.go`** (ed25519-only): one `issue()` helper generates an ed25519 key, stamps a stream-derived serial + `FixedTime` validity, signs, PEM-encodes. `genCA`/`genSelfSignedCert`/`genSignedCert`/`genPrivateKey`/`buildCustomCert` keep sprig-compatible signatures; `genSignedCert` re-decodes the CA from its arg so the leaf stays signed by exactly the CA in caBundle (chain verified by test). `genPrivateKey` returns a deterministic ed25519 key for every type; the `*WithKey` variants generate ed25519 (keeps output deterministic; avoids the nondeterministic-ECDSA-signer edge). **Deleted:** `certReader`, the MaybeReadByte narrative, all RSA/ECDSA/DSA branches, `pemBlockForKey`, the multi-type `parsePrivateKeyPEM`, `getPublicKey`, and the `WithKeyInternal`/`getCertAndKey`/`getBaseCertTemplate` scaffolding.
- **`rand.go`**: drops the Masterminds/goutils `CryptoRandom` port (incl. dead UTF-16 surrogate handling) for a charset mapper — output need not match sprig byte-for-byte, only be deterministic and the right length/class.

**Consequence:** `flate build` emits ed25519 caBundles/keys where real Helm emits random RSA-2048 — valid, deterministic, per-release-distinct, and immaterial for a render/diff tool (a caBundle never matches the live cluster regardless).

## Verification

- Unit: cert parses / IsCA / FixedTime window / `leaf.CheckSignatureFrom(ca)` / same-seed-identical / `SignatureAlgorithm==PureEd25519` / non-ed25519-CA rejected; rand class+length+determinism.
- Integration: uncached double-render of `now`/`randAlphaNum`/`genCA` chains is byte-identical.
- `gofmt`/`vet`/`golangci-lint` 0; `go test -race ./pkg/helm/...`; full `go test ./...`.
- **Run-to-run sweep over all 24 cross-repo paths renders every one BYTE-IDENTICAL** — Tiers 1+2+3 now cover caBundle + checksum + unlock/updatedAt. Line counts match the prior RSA-rendering sweeps (ed25519 certs are base64 single-lines → no structural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)