### PR TITLE
refactor: drop unused speculative store.Mutate and cas.Stage adopted-bool

### DIFF
--- a/internal/cas/stage.go
+++ b/internal/cas/stage.go
@@ -29,19 +29,14 @@ import (
 //
 // The two prefixes let the caller keep its own error strings intact
 // (baseline passes "baseline staging"/"baseline finalize").
-//
-// adopted reports whether the returned slot came from adopting a peer's
-// finalized directory (false on the normal rename-wins path); callers
-// that distinguish "we built it" from "we adopted it" use it, others
-// ignore it.
-func Stage(parent, final, tmpPrefix, finalizePrefix string, build func(staging string) error, adopt func() bool) (adopted bool, err error) {
+func Stage(parent, final, tmpPrefix, finalizePrefix string, build func(staging string) error, adopt func() bool) error {
 	staging, err := os.MkdirTemp(parent, filepath.Base(final)+".tmp.*")
 	if err != nil {
-		return false, fmt.Errorf("%s: %w", tmpPrefix, err)
+		return fmt.Errorf("%s: %w", tmpPrefix, err)
 	}
 	if err := build(staging); err != nil {
 		_ = os.RemoveAll(staging)
-		return false, err
+		return err
 	}
 	if err := os.Rename(staging, final); err != nil {
 		_ = os.RemoveAll(staging)
@@ -50,9 +45,9 @@ func Stage(parent, final, tmpPrefix, finalizePrefix string, build func(staging s
 		// caller confirms the winner finalized, adopt it instead of
 		// re-materializing or surfacing the lost-race error.
 		if adopt() {
-			return true, nil
+			return nil
 		}
-		return false, fmt.Errorf("%s: %w", finalizePrefix, err)
+		return fmt.Errorf("%s: %w", finalizePrefix, err)
 	}
-	return false, nil
+	return nil
 }

--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -140,7 +140,7 @@ func materializeAt(repo *git.Repository, hash plumbing.Hash, layout cacheroot.La
 		// same commit will either share the finished slot or fall
 		// through to their own stage (one wins the rename, the rest
 		// see ErrExist, discard the temp, and adopt the winner's slot).
-		if _, err := cas.Stage(parent, slot, "baseline staging", "baseline finalize",
+		if err := cas.Stage(parent, slot, "baseline staging", "baseline finalize",
 			func(staging string) error { return materialize(repo, hash, staging) },
 			func() bool { return isDir(slot) },
 		); err != nil {

--- a/pkg/manifest/doc.go
+++ b/pkg/manifest/doc.go
@@ -29,8 +29,7 @@
 // Every concrete manifest type in this package is treated as
 // immutable once stored. Controllers and embedders that need to amend
 // a resource must Clone() it, mutate the clone, and AddObject the
-// result; the store helper pkg/store.Mutate[T] encodes that contract.
-// Mutating a *HelmRelease / *Kustomization / etc. in place after it
-// has been added to the store corrupts the canonical state that
-// other concurrent readers depend on.
+// result. Mutating a *HelmRelease / *Kustomization / etc. in place
+// after it has been added to the store corrupts the canonical state
+// that other concurrent readers depend on.
 package manifest

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -360,59 +360,6 @@ func (s *Store) Refire(id manifest.NamedResource) {
 	dispatchObj()
 }
 
-// Cloneable is satisfied by manifest types that can be shallowly
-// duplicated for safe mutation under the Store's immutability
-// contract. Kustomization, HelmRelease implement this; new types that
-// need post-load mutation should follow.
-type Cloneable[T any] interface {
-	Clone() T
-}
-
-// Mutate atomically replaces the store-owned object under id with the
-// result of mutating a fresh clone. Encodes the documented
-// immutability contract in one place: callers can't forget
-// clone-then-AddObject. Returns false when no object of type T is
-// stored under id (no-op).
-//
-// Use this for any post-load mutation such as namespace-inheritance
-// rewrites or alias seeding. Listeners fire as they would on a fresh
-// AddObject (intentionally — downstream controllers re-reconcile
-// against the mutated spec).
-func Mutate[T interface {
-	manifest.BaseManifest
-	Cloneable[T]
-}](s *Store, id manifest.NamedResource, mutate func(T)) bool {
-	// Hold sh.mu across the whole clone-mutate-write so a concurrent
-	// DeleteObject(id) or AddObject(newer) between Get and Add can't
-	// resurrect deleted state or clobber a newer write with the
-	// mutation of the previously-observed object.
-	sh := s.shardFor(id)
-	var dispatch func()
-	ok := func() bool {
-		sh.mu.Lock()
-		defer sh.mu.Unlock()
-		obj, isT := sh.objects[id].(T)
-		if !isT {
-			return false
-		}
-		cloned := obj.Clone()
-		mutate(cloned)
-		// Dedup parallel to AddObject — equal mutations no-op. obj is
-		// the value already read from sh.objects[id] under this lock, so
-		// compare against it directly rather than re-indexing the map.
-		if reflect.DeepEqual(obj, cloned) {
-			return true
-		}
-		sh.setLocked(id, cloned)
-		dispatch = s.fireUnderLock(EventObjectAdded, id, cloned)
-		return true
-	}()
-	if dispatch != nil {
-		dispatch()
-	}
-	return ok
-}
-
 // AddRendered records a manifest produced by helm/kustomize rendering.
 // Compared to AddObject it skips the reflect.DeepEqual dedup check —
 // rendered docs change on every render and the dedup would never hit.

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -215,46 +215,6 @@ func TestStore_SetCondition_IdenticalIsNoOp(t *testing.T) {
 	assert.Equal(t, statusEvents, 1) // identical SetCondition is a no-op
 }
 
-// Mutate encodes the clone-then-AddObject pattern. Verify it clones
-// (mutating the supplied pointer doesn't touch the canonical store),
-// fires EventObjectAdded (so dependent controllers re-reconcile), and
-// no-ops when the id isn't present.
-func TestStore_Mutate(t *testing.T) {
-	s := New()
-	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
-	orig := &manifest.Kustomization{
-		Name: "a", Namespace: "ns",
-		DependsOn: []manifest.DependencyRef{
-			{NamedResource: manifest.NamedResource{Kind: manifest.KindKustomization, Name: "x"}},
-		},
-	}
-	s.AddObject(orig)
-
-	fired := 0
-	s.AddListener(EventObjectAdded, func(_ manifest.NamedResource, _ any) { fired++ }, false)
-
-	ok := Mutate(s, id, func(k *manifest.Kustomization) { k.DependsOn = nil })
-	if !ok {
-		t.Fatalf("Mutate returned false on a present id")
-	}
-	assert.Equal(t, fired, 1) // EventObjectAdded fires once on Mutate
-	// Original pointer unchanged (clone semantics).
-	if len(orig.DependsOn) != 1 {
-		t.Errorf("original pointer was mutated; clone failed: %v", orig.DependsOn)
-	}
-	// Store now holds the mutated clone.
-	got, _ := s.GetObject(id).(*manifest.Kustomization)
-	if got == nil || len(got.DependsOn) != 0 {
-		t.Errorf("stored object not mutated: %v", got)
-	}
-
-	// Missing id is a no-op.
-	if Mutate(s, manifest.NamedResource{Kind: manifest.KindKustomization, Name: "absent"},
-		func(*manifest.Kustomization) {}) {
-		t.Errorf("Mutate returned true for absent id")
-	}
-}
-
 func TestStore_FailedResources(t *testing.T) {
 	s := New()
 	assert.Equal(t, len(s.FailedResources()), 0) // empty store

--- a/pkg/store/typed.go
+++ b/pkg/store/typed.go
@@ -14,8 +14,8 @@ import "github.com/home-operations/flate/pkg/manifest"
 //	// after
 //	ks, ok := store.Get[*manifest.Kustomization](s, id)
 //
-// The constraint on T is the same shape Mutate already uses, so
-// callers see a uniform interface for the two type-safe Store APIs.
+// The constraint on T is manifest.BaseManifest — any stored manifest
+// type — so Get and GetByName share one uniform, type-safe lookup.
 func Get[T manifest.BaseManifest](s *Store, id manifest.NamedResource) (T, bool) {
 	if s == nil {
 		var zero T


### PR DESCRIPTION
## What

Removes two pieces of speculative API surface kept for callers that never materialized. Found by an adversarially-verified discovery sweep across the codebase.

### `store.Mutate[T]` + `Cloneable[T]` (pkg/store)
Zero production callers since they were added (#149) — the only references were their own dedicated test and two doc comments. `Mutate` does **same-id in-place replacement** (`setLocked(id, cloned)`), but every real post-load mutation in the codebase is a **namespace-inheritance rewrite** (`pkg/loader/inherit.go`) that *changes the resource ID* and therefore must `DeleteObject(old)` + `AddObject(new)` — which `Mutate` structurally cannot express. So it could never have gained a caller. The immutability contract it claimed to "encode in one place" is already documented in prose on the `Store` type, so no documentation is lost (the two dangling references are reworded).

### `cas.Stage` `(adopted bool, error)` → `error` (internal/cas)
The first return value had no consumer: its sole caller (`pkg/baseline`) discarded it with `_`. Collapsed to a plain `error` and dropped the now-moot doc paragraph.

## Why
Both fit the same theme — unused speculative API for hypothetical future callers. Removing them is exactly the leanest-correct-code direction; `flate` is a single binary, not a published library, so there's no external-API-stability reason to keep dead exports.

## Safety
Pure dead-code removal, **no behavior change**:
- `gofmt` / `go build` / `go vet` clean
- `go test -race ./pkg/store/... ./internal/cas/... ./pkg/baseline/... ./pkg/manifest/...` pass
- `golangci-lint run ./...` → 0 issues
- full `go test ./...` passes
- **byte-identical render output across all 24 cross-repo paths** (base `2cbeb60` vs branch, render cache off): 24/24 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)