### PR TITLE
perf: read only the referenced key in valuesFrom lookups

### DIFF
--- a/pkg/values/bench_test.go
+++ b/pkg/values/bench_test.go
@@ -110,6 +110,39 @@ counts:
 	}
 }
 
+// BenchmarkExpandValueReferences_ManyKeyCM is the gate for the single-key
+// valuesFrom lookup. An HR references ONE key of a ConfigMap whose data bag
+// carries many keys (the shared-settings / shared-secret shape). The values
+// Cache memoizes the yaml.Unmarshal of the referenced key after the first
+// iteration, but it is keyed on the *extracted* string, so the bag access in
+// lookupValueRef runs every iteration: the old path normalized (and, for a
+// Secret, base64-decoded) all 30 keys to return one; the single-key path reads
+// only the referenced key. The per-iteration delta is that wasted full-bag
+// decode.
+func BenchmarkExpandValueReferences_ManyKeyCM(b *testing.B) {
+	data := make(map[string]any, 30)
+	data["values.yaml"] = "replicaCount: 3\n"
+	for i := range 29 {
+		data[fmt.Sprintf("sibling-%d.yaml", i)] = fmt.Sprintf("key%d: value-%d\n", i, i)
+	}
+	cm := &manifest.ConfigMap{Name: "shared", Namespace: "default", Data: data}
+	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
+	ref := manifest.ValuesReference{Kind: "ConfigMap", Name: "shared", ValuesKey: "values.yaml"}
+	cache := NewCache()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		hr := &manifest.HelmRelease{
+			Name: "app", Namespace: "default",
+			HelmReleaseSpec: helmv2.HelmReleaseSpec{ValuesFrom: []manifest.ValuesReference{ref}},
+		}
+		if err := ExpandValueReferences(hr, provider, cache); err != nil {
+			b.Fatalf("ExpandValueReferences: %v", err)
+		}
+	}
+}
+
 // BenchmarkExpandPostBuildSubstituteReference_SharedCM measures the
 // per-KS cost of the kustomize substitute path against a large shared
 // cluster-settings ConfigMap (50 flat vars) — the bjw-s/onedr0p pattern

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -314,21 +314,93 @@ func ExpandValueReferences(hr *manifest.HelmRelease, provider Provider, cache *C
 	return nil
 }
 
-// lookupValueRef returns the raw string value referenced by ref.
+// lookupValueRef returns the raw string value referenced by ref. It reads
+// only the single key the ref names (ref.GetValuesKey()), mirroring upstream
+// Flux's chartutil.ChartValuesFromReferences, which indexes
+// typedRes.Data[valuesKey] directly. This is the steady-state per-HelmRelease
+// path; reading one key avoids decodeBag's full-bag normalization, which
+// base64-decodes and coerces every sibling entry only to discard all but one
+// (decodeBag was ~25% of alloc_space in BenchmarkExpandValueReferences_*).
+//
+// Consequence — a deliberate, Flux-aligning narrowing of the error surface:
+// the old full-bag decode failed the ref if ANY sibling key was malformed,
+// whereas this validates only the requested key (as Flux does). Output for
+// every input that renders today is unchanged; only pathological inputs with a
+// valid requested key beside a malformed sibling stop erroring. The
+// substituteFrom/postBuild path (which legitimately consumes the whole bag)
+// keeps using lookupResourceData/decodeBag.
 func lookupValueRef(ref manifest.ValuesReference, namespace string, p Provider) (string, error) {
-	data, err := lookupResourceData(ref.Kind, namespace, ref.Name, p)
+	stringData, binaryData, found, err := resourceBag(ref.Kind, namespace, ref.Name, p)
 	if err != nil {
 		return "", err
 	}
-	if data == nil {
+	// An absent resource and a present-but-empty bag both surface as
+	// "resource not found": decodeBag returned nil for an empty bag, which the
+	// previous data==nil branch mapped to ErrObjectNotFound. Preserve that so
+	// error identity (and Optional handling) is unchanged.
+	if !found || (len(stringData) == 0 && len(binaryData) == 0) {
 		return "", &missingValueRefError{kind: ref.Kind, namespace: namespace, name: ref.Name}
 	}
 	key := ref.GetValuesKey()
-	val, ok := data[key]
+	val, ok, err := lookupBagKey(stringData, binaryData, key)
+	if err != nil {
+		return "", err
+	}
 	if !ok {
 		return "", &missingValueRefError{kind: ref.Kind, namespace: namespace, name: ref.Name, key: key}
 	}
 	return val, nil
+}
+
+// resourceBag returns the raw (stringData, binaryData) maps backing a
+// ConfigMap or Secret values reference, without decoding the whole bag. found
+// is false when the resource is absent (no error). ConfigMap binaryData is
+// intentionally nil: valuesFrom reads only ConfigMap.data, matching upstream
+// fluxcd ChartValuesFromReferences (see lookupResourceData).
+func resourceBag(kind, namespace, name string, p Provider) (stringData, binaryData map[string]any, found bool, err error) {
+	switch kind {
+	case manifest.KindSecret:
+		if s := p.Secret(namespace, name); s != nil {
+			return s.StringData, s.Data, true, nil
+		}
+		return nil, nil, false, nil
+	case manifest.KindConfigMap:
+		if c := p.ConfigMap(namespace, name); c != nil {
+			return c.Data, nil, true, nil
+		}
+		return nil, nil, false, nil
+	default:
+		return nil, nil, false, fmt.Errorf("%w: unsupported kind %s", manifest.ErrInvalidValuesReference, kind)
+	}
+}
+
+// lookupBagKey returns the value at key from a ConfigMap/Secret data bag,
+// applying decodeBag's coercion and precedence — binaryData wins over
+// stringData on collision (decodeBag writes stringData first, then binaryData
+// overwrites) — but reading ONLY key and leaving sibling entries untouched. ok
+// is false when key is absent. An error surfaces only when the requested key
+// itself is malformed; the error strings match decodeBag's so a malformed
+// requested key reports identically.
+func lookupBagKey(stringData, binaryData map[string]any, key string) (string, bool, error) {
+	if v, ok := binaryData[key]; ok {
+		s, err := bagValueAsString(v)
+		if err != nil {
+			return "", false, fmt.Errorf("binaryData[%s]: %w", key, err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return "", false, fmt.Errorf("decode binaryData[%s]: %w", key, err)
+		}
+		return string(decoded), true, nil
+	}
+	if v, ok := stringData[key]; ok {
+		s, err := bagValueAsString(v)
+		if err != nil {
+			return "", false, fmt.Errorf("stringData[%s]: %w", key, err)
+		}
+		return s, true, nil
+	}
+	return "", false, nil
 }
 
 // lookupResourceData fetches and decodes the data bag for a ConfigMap or

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -2,6 +2,7 @@ package values
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -127,6 +128,61 @@ func TestExpandValueReferences_IgnoresConfigMapBinaryData(t *testing.T) {
 	}
 	if _, leaked := hr.Values["fromBinary"]; leaked {
 		t.Errorf("binaryData key leaked into hr.Values: %+v", hr.Values)
+	}
+}
+
+// TestExpandValueReferences_MalformedSiblingTolerated documents the
+// deliberate, Flux-aligning narrowing of the valuesFrom error surface in
+// lookupValueRef: it decodes only the referenced key, so a malformed SIBLING
+// key no longer fails the ref. Upstream Flux (chartutil.ChartValuesFromReferences)
+// likewise indexes typedRes.Data[valuesKey] and never validates siblings. The
+// old full-bag decode (still used by substituteFrom, which legitimately
+// consumes every key) errored the whole ref on the broken sibling here.
+func TestExpandValueReferences_MalformedSiblingTolerated(t *testing.T) {
+	cm := &manifest.ConfigMap{
+		Name: "extra", Namespace: "default",
+		Data: map[string]any{
+			"values.yaml": "replicaCount: 3\n",
+			// A non-scalar value bagValueAsString cannot coerce. decodeBag
+			// would error on this sibling regardless of map iteration order;
+			// the single-key path never reads it.
+			"broken": map[string]any{"nested": true},
+		},
+	}
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
+		},
+	}
+	if err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}, nil); err != nil {
+		t.Fatalf("malformed sibling must not fail the ref (Flux reads only the named key): %v", err)
+	}
+	if got := hr.Values["replicaCount"]; fmt.Sprint(got) != "3" {
+		t.Errorf("replicaCount = %v, want 3 (values.yaml read despite broken sibling)", got)
+	}
+}
+
+// TestExpandValueReferences_MalformedRequestedKeyStillFails pins that the
+// error surface narrows ONLY for siblings: a malformed value at the REQUESTED
+// key still fails the ref, with decodeBag's original "stringData[key]" wording.
+func TestExpandValueReferences_MalformedRequestedKeyStillFails(t *testing.T) {
+	cm := &manifest.ConfigMap{
+		Name: "extra", Namespace: "default",
+		Data: map[string]any{"values.yaml": []any{"not", "a", "scalar"}},
+	}
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
+		},
+	}
+	err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}, nil)
+	if err == nil {
+		t.Fatal("malformed requested key must still fail the ref")
+	}
+	if !strings.Contains(err.Error(), "stringData[values.yaml]") {
+		t.Errorf("error should name the requested key as decodeBag did: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

`lookupValueRef` decoded the **entire** ConfigMap/Secret data bag — base64-decoding and coercing every key — just to return the single key the ref names. `decodeBag` was **~25% of alloc_space** in `BenchmarkExpandValueReferences_*` and runs per-HelmRelease on the render path (it's not cache-gated; the values cache is keyed on the *extracted* string).

This reads only the requested key (`resourceBag` + `lookupBagKey`), preserving `decodeBag`'s exact coercion and precedence (binaryData wins over stringData on collision). The `substituteFrom`/postBuild path, which legitimately consumes the whole bag, keeps using `lookupResourceData`/`decodeBag`.

Found by a profile-grounded perf pass (CPU + heap profiles on onedr0p/drag0n141); the other investigated areas — YAML emit, source-I/O, manifest decode, deep-merge — are at the floor (costs are dep-internal Helm/kustomize/yaml that flate already caches around).

## Flux fidelity (the one behavior change)

The win is inseparable from a deliberate, **Flux-aligning** narrowing of the error surface: the old full-bag decode failed the ref if **any** sibling key was malformed, whereas upstream Flux (`chartutil.ChartValuesFromReferences`) indexes `typedRes.Data[valuesKey]` and never validates siblings. So flate now matches Flux:
- **Output for every input that renders today is unchanged** (proven: 24/24 cross-repo byte-identical).
- Only pathological inputs with a *valid* requested key beside a *malformed sibling* stop erroring.
- Absent-resource, empty-bag, and unsupported-kind error identities are preserved exactly; a malformed **requested** key still errors with the same `stringData[key]` wording.

Two documenting tests pin both halves (`MalformedSiblingTolerated`, `MalformedRequestedKeyStillFails`).

## Benchmarks

`benchstat` (count=8, M4 Max):
```
                          sec/op        B/op          allocs/op
ManyKeyCM (gate)          -80.19%       -84.94%       -50.00%
ManyFromRefs              -17.01%       -28.55%       -25.32%
SharedLargeCM              ~ (p=0.065)   -6.35%       -13.33%
geomean                   -44.45%       -53.47%       -31.34%
```

## Verification
- `gofmt` / `go build` / `go vet` clean
- `golangci-lint run` → 0 issues
- `go test -race ./pkg/values/... ./pkg/helm/... ./pkg/controllers/...` pass
- full `go test ./...` passes
- **byte-identical render output across all 24 cross-repo paths** (main `c18dd0c` vs branch, render cache off): 24/24 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)