### PR TITLE
perf: persist HelmRepository index resolution to skip per-run index fetches

### DIFF
--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -9,6 +9,14 @@ import (
 	"github.com/home-operations/flate/pkg/source"
 )
 
+// helmRepoAuthIdentity is the cache auth tag for a HelmRepository's
+// resolve/blob slots: it folds the SecretRef (basic auth) and CertSecretRef
+// (TLS material) so a public-index resolution can't leak across a different-
+// auth repo that shares the URL. Mirrors oci.authIdentity.
+func helmRepoAuthIdentity(r *manifest.HelmRepository) string {
+	return source.AuthIdentityFromRefs(r.Namespace, r.SecretRef, r.CertSecretRef)
+}
+
 // helmRepoAuthOptions resolves SecretRef credentials for a HelmRepository
 // into helm getter options. Returns nil options when no SecretRef is set
 // (anonymous). Username/password basic auth + optional PassCredentials.

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -17,10 +17,11 @@ import (
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// fetchHTTPChart pulls a chart from a classic HTTP HelmRepository: download
-// index.yaml (cached per repo), pick the version, fetch the .tgz via helm's
-// getter, store it content-addressed, and return an artifact whose
-// LocalPath is the blob dir containing chart.tgz.
+// fetchHTTPChart pulls a chart from a classic HTTP HelmRepository: resolve the
+// chart name+version to a concrete (version, digest, URL), then fetch the .tgz
+// via helm's getter, store it content-addressed, and return an artifact whose
+// LocalPath is the blob dir containing chart.tgz. A warm run with a fresh
+// on-disk resolution and the blob already cached opens zero sockets.
 func (f *Fetcher) fetchHTTPChart(ctx context.Context, r *manifest.HelmRepository, chartName, version string) (*store.SourceArtifact, error) {
 	authOpts, err := f.helmRepoAuthOptions(r)
 	if err != nil {
@@ -33,51 +34,86 @@ func (f *Fetcher) fetchHTTPChart(ctx context.Context, r *manifest.HelmRepository
 	defer cleanup()
 	allOpts := slices.Concat(authOpts, tlsOpts)
 
-	indexURL := strings.TrimSuffix(r.URL, "/") + "/index.yaml"
-	idx, err := f.fetchIndex(ctx, r.Namespace+"/"+r.Name+"@"+indexURL, indexURL, allOpts)
-	if err != nil {
-		return nil, err
-	}
-	cv, err := idx.Get(chartName, version)
-	if err != nil {
-		return nil, fmt.Errorf("%w: chart %s@%s not found in %s: %v",
-			manifest.ErrObjectNotFound, chartName, version, r.URL, err)
-	}
-	if len(cv.URLs) == 0 {
-		return nil, fmt.Errorf("%w: chart %s@%s in %s has no URLs",
-			manifest.ErrObjectNotFound, chartName, version, r.URL)
-	}
-	chartURL, err := absChartURL(r.URL, cv.URLs[0])
+	res, err := f.resolveChart(ctx, r, chartName, version, allOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	wantDigest := normalizeChartDigest(cv.Digest)
-	if art, ok := f.chartArtifactByDigest(chartURL, cv.Version, wantDigest); ok {
+	if art, ok := f.chartArtifactByDigest(res.ChartURL, res.Version, res.Digest); ok {
 		return art, nil
 	}
-	release, err := f.downloadLocks.Acquire(ctx, chartDownloadKey(r, chartName, cv.Version, chartURL, wantDigest))
+	release, err := f.downloadLocks.Acquire(ctx, chartDownloadKey(r, chartName, res.Version, res.ChartURL, res.Digest))
 	if err != nil {
 		return nil, err
 	}
 	defer release()
-	if art, ok := f.chartArtifactByDigest(chartURL, cv.Version, wantDigest); ok {
+	if art, ok := f.chartArtifactByDigest(res.ChartURL, res.Version, res.Digest); ok {
 		return art, nil
 	}
 
-	buf, err := httpGet(chartURL, allOpts)
+	buf, err := httpGet(res.ChartURL, allOpts)
 	if err != nil {
-		return nil, fmt.Errorf("download %s: %w", chartURL, err)
+		return nil, fmt.Errorf("download %s: %w", res.ChartURL, err)
 	}
 	dir, digest, err := f.cache.PutBytes(ctx, buf.Bytes(), "chart.tgz")
 	if err != nil {
-		return nil, fmt.Errorf("store chart %s: %w", chartURL, err)
+		return nil, fmt.Errorf("store chart %s: %w", res.ChartURL, err)
 	}
-	if wantDigest != "" && digest != wantDigest {
+	if res.Digest != "" && digest != res.Digest {
 		return nil, fmt.Errorf("chart %s@%s digest mismatch: index has %s, downloaded %s",
-			chartName, cv.Version, wantDigest, digest)
+			chartName, res.Version, res.Digest, digest)
 	}
-	return httpChartArtifact(chartURL, dir, cv.Version, digest), nil
+	return httpChartArtifact(res.ChartURL, dir, res.Version, digest), nil
+}
+
+// resolveChart maps (chartName, requested version) to a concrete
+// (version, digest, URL) for an HTTP HelmRepository. Three tiers, cheapest
+// first: fetchIndex's in-process index memo (Tier 1), an on-disk resolve slot
+// fresh within spec.interval that skips the network entirely (Tier 2), then a
+// live index.yaml fetch whose result is persisted back to the slot (Tier 3).
+//
+// The slot key uses the RAW requested version, so a semver range and a pin
+// never share a slot — within one spec.interval window the cache deliberately
+// serves the same resolution a live fetch would have at populate time (the OCI
+// mutable-ref / resolve-marker contract, now applied to helm ranges). A pinned
+// exact version resolves identically regardless, so freshness only matters for
+// ranges. The chart .tgz stays content-addressed by digest, so this changes no
+// rendered output — only whether the index is fetched.
+func (f *Fetcher) resolveChart(ctx context.Context, r *manifest.HelmRepository, chartName, version string, opts []getter.Option) (chartResolution, error) {
+	slot, err := f.cache.Slot(ctx, r.URL, "helm-resolve:"+chartName+"@"+version, helmRepoAuthIdentity(r))
+	if err != nil {
+		return chartResolution{}, fmt.Errorf("helm resolve slot for %s: %w", r.URL, err)
+	}
+	defer slot.Release()
+	if slot.Exists {
+		if res, ok := readResolveFresh(slot.Path, r.Interval.Duration); ok {
+			return res, nil
+		}
+	}
+
+	indexURL := strings.TrimSuffix(r.URL, "/") + "/index.yaml"
+	idx, err := f.fetchIndex(ctx, r.Namespace+"/"+r.Name+"@"+indexURL, indexURL, opts)
+	if err != nil {
+		return chartResolution{}, err
+	}
+	cv, err := idx.Get(chartName, version)
+	if err != nil {
+		return chartResolution{}, fmt.Errorf("%w: chart %s@%s not found in %s: %v",
+			manifest.ErrObjectNotFound, chartName, version, r.URL, err)
+	}
+	if len(cv.URLs) == 0 {
+		return chartResolution{}, fmt.Errorf("%w: chart %s@%s in %s has no URLs",
+			manifest.ErrObjectNotFound, chartName, version, r.URL)
+	}
+	chartURL, err := absChartURL(r.URL, cv.URLs[0])
+	if err != nil {
+		return chartResolution{}, err
+	}
+	res := chartResolution{Version: cv.Version, Digest: normalizeChartDigest(cv.Digest), ChartURL: chartURL}
+	if err := persistResolve(slot, res); err != nil {
+		return chartResolution{}, err
+	}
+	return res, nil
 }
 
 // chartArtifactByDigest returns the cached chart artifact when the index

--- a/pkg/source/helmchart/resolve.go
+++ b/pkg/source/helmchart/resolve.go
@@ -1,0 +1,87 @@
+package helmchart
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/home-operations/flate/pkg/source"
+)
+
+// A HelmRepository HTTP chart resolution (the concrete version, tarball digest,
+// and absolute .tgz URL that index.yaml resolves a chart name+version to) is
+// persisted in a dedicated "helm-resolve:" slot's source.SlotMeta sidecar — the
+// same freshness-gated marker pattern the OCI fetcher uses for tag→digest
+// resolution (pkg/source/oci/marker.go). The chart .tgz itself stays in the
+// content-addressed blob store; this slot records only the small pointer, so a
+// warm run skips the live index.yaml fetch within spec.interval.
+
+// chartDigestRE matches a well-formed Helm chart tarball digest. Helm index
+// digests are bare hex (normalizeChartDigest strips any "sha256:" prefix), so —
+// unlike the OCI "<algo>:<hex>" digestRE — only the hex body is validated. A
+// malformed digest is treated as a missing marker so the resolution rebuilds.
+var chartDigestRE = regexp.MustCompile(`^[a-fA-F0-9]{32,}$`)
+
+// chartResolution is what the index supplies and the blob path consumes: the
+// concrete chart version, its tarball sha256 (bare hex; may be "" for a
+// digest-less mutable index entry), and the absolute .tgz URL.
+type chartResolution struct {
+	Version  string
+	Digest   string
+	ChartURL string
+}
+
+// valid reports whether r carries a usable resolution: a concrete version and
+// URL, plus either no digest (digest-less index) or a well-formed bare-hex one.
+func (r chartResolution) valid() bool {
+	if r.Version == "" || r.ChartURL == "" {
+		return false
+	}
+	return r.Digest == "" || chartDigestRE.MatchString(r.Digest)
+}
+
+// readResolveFresh returns the slot's recorded resolution only when the sidecar
+// was written within maxAge (spec.interval) and is well-formed. maxAge <= 0
+// disables the gate (always stale → re-fetch the index).
+func readResolveFresh(slotDir string, maxAge time.Duration) (chartResolution, bool) {
+	m, ok := source.ReadSlotMetaFresh(slotDir, maxAge)
+	if !ok {
+		return chartResolution{}, false
+	}
+	r := chartResolution{Version: m.ChartVersion, Digest: m.ChartDigest, ChartURL: m.ChartURL}
+	if !r.valid() {
+		return chartResolution{}, false
+	}
+	return r, true
+}
+
+// writeResolve records r in the slot's meta sidecar, preserving any other
+// fields (none today on a resolve slot — it carries only the Chart* triple).
+func writeResolve(slotDir string, r chartResolution) error {
+	m, _ := source.ReadSlotMeta(slotDir)
+	m.ChartVersion = r.Version
+	m.ChartDigest = r.Digest
+	m.ChartURL = r.ChartURL
+	return source.WriteSlotMeta(slotDir, m)
+}
+
+// persistResolve writes r into the resolve slot atomically (stage on a cache
+// hit, write, commit), mirroring oci.persistOCIResolve. A no-op when the
+// resolution is incomplete, so a failed resolve never poisons the slot.
+func persistResolve(slot *source.Slot, r chartResolution) error {
+	if slot == nil || !r.valid() {
+		return nil
+	}
+	if slot.Exists {
+		if err := slot.StageRefresh(); err != nil {
+			return fmt.Errorf("helm resolve stage: %w", err)
+		}
+	}
+	if err := writeResolve(slot.Path, r); err != nil {
+		return fmt.Errorf("helm resolve write: %w", err)
+	}
+	if err := slot.Commit(); err != nil {
+		return fmt.Errorf("helm resolve commit: %w", err)
+	}
+	return nil
+}

--- a/pkg/source/helmchart/resolve_test.go
+++ b/pkg/source/helmchart/resolve_test.go
@@ -1,0 +1,132 @@
+package helmchart
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
+	"github.com/home-operations/flate/pkg/source/cacheroot"
+)
+
+// startHelmRepoCounted is startHelmRepo with a SEPARATE index-fetch counter, so
+// a test can assert a warm run skips the live index.yaml fetch (not just the
+// chart download).
+func startHelmRepoCounted(t *testing.T, chartBytes []byte, indexDigest string) (srv *httptest.Server, indexHits, chartHits *int) {
+	t.Helper()
+	ih, ch := 0, 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/index.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		ih++
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(helmRepoIndex(indexDigest)))
+	})
+	mux.HandleFunc("/app-template-1.0.0.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		ch++
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(chartBytes)
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &ih, &ch
+}
+
+// fetcherWithCache builds a Fetcher over a caller-supplied cache+layout, so a
+// test can stand up two Fetchers sharing one on-disk cache — simulating two
+// separate `flate` invocations (each with a fresh in-process indexCache).
+func fetcherWithCache(t *testing.T, r *manifest.HelmRepository, cache *source.Cache, layout cacheroot.Layout) *Fetcher {
+	t.Helper()
+	f, err := New(nil, func(_, _ string) *manifest.HelmRepository { return r }, nil, cache, layout)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return f
+}
+
+// TestResolveChart_DiskCacheSkipsIndexWarm pins the fix for the warm==cold
+// regression: a SECOND Fetcher sharing the same on-disk source.Cache (its
+// in-process indexCache empty, as a fresh `flate` invocation has) resolves and
+// returns the chart with ZERO index.yaml and ZERO chart hits — the live index
+// fetch that made warm runs as slow as cold is gone.
+func TestResolveChart_DiskCacheSkipsIndexWarm(t *testing.T) {
+	chartBytes := buildChartTarGz(t, "app-template", "1.0.0")
+	srv, indexHits, chartHits := startHelmRepoCounted(t, chartBytes, chartDigest(chartBytes))
+	r := httpRepo(srv.URL)
+	r.Interval = metav1.Duration{Duration: time.Hour} // fresh window
+
+	layout := cacheroot.New(t.TempDir())
+	cache := source.NewCache(layout)
+
+	cold := fetcherWithCache(t, r, cache, layout)
+	if _, err := cold.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0")); err != nil {
+		t.Fatalf("cold Fetch: %v", err)
+	}
+	if *indexHits != 1 || *chartHits != 1 {
+		t.Fatalf("cold: indexHits=%d chartHits=%d, want 1/1", *indexHits, *chartHits)
+	}
+
+	warm := fetcherWithCache(t, r, cache, layout)
+	if _, err := warm.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0")); err != nil {
+		t.Fatalf("warm Fetch: %v", err)
+	}
+	if *indexHits != 1 {
+		t.Errorf("warm run re-fetched index.yaml: indexHits=%d, want 1 (disk resolve cache must skip it)", *indexHits)
+	}
+	if *chartHits != 1 {
+		t.Errorf("warm run re-downloaded chart: chartHits=%d, want 1 (blob CAS dedup)", *chartHits)
+	}
+}
+
+// TestResolveChart_StaleIntervalRefetches pins the freshness gate: a zero
+// spec.interval makes the on-disk resolution always stale, so each fresh
+// Fetcher re-fetches the index (the safe default for an interval-less repo).
+func TestResolveChart_StaleIntervalRefetches(t *testing.T) {
+	chartBytes := buildChartTarGz(t, "app-template", "1.0.0")
+	srv, indexHits, _ := startHelmRepoCounted(t, chartBytes, chartDigest(chartBytes))
+	r := httpRepo(srv.URL) // Interval == 0 → always stale
+
+	layout := cacheroot.New(t.TempDir())
+	cache := source.NewCache(layout)
+	for i := range 2 {
+		f := fetcherWithCache(t, r, cache, layout)
+		if _, err := f.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0")); err != nil {
+			t.Fatalf("Fetch %d: %v", i, err)
+		}
+	}
+	if *indexHits != 2 {
+		t.Errorf("zero-interval must re-fetch index each invocation: indexHits=%d, want 2", *indexHits)
+	}
+}
+
+// TestResolveChart_DigestlessWarmSkipsIndex pins the digest-less edge: a mutable
+// index entry (no digest) still skips the expensive index fetch on a warm run,
+// but the chart .tgz is re-downloaded (no digest → no content-addressed dedup),
+// which is the conservative, correct behavior.
+func TestResolveChart_DigestlessWarmSkipsIndex(t *testing.T) {
+	chartBytes := buildChartTarGz(t, "app-template", "1.0.0")
+	srv, indexHits, chartHits := startHelmRepoCounted(t, chartBytes, "") // digest-less index
+	r := httpRepo(srv.URL)
+	r.Interval = metav1.Duration{Duration: time.Hour}
+
+	layout := cacheroot.New(t.TempDir())
+	cache := source.NewCache(layout)
+	cold := fetcherWithCache(t, r, cache, layout)
+	if _, err := cold.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0")); err != nil {
+		t.Fatalf("cold Fetch: %v", err)
+	}
+	warm := fetcherWithCache(t, r, cache, layout)
+	if _, err := warm.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0")); err != nil {
+		t.Fatalf("warm Fetch: %v", err)
+	}
+	if *indexHits != 1 {
+		t.Errorf("digest-less warm re-fetched index: indexHits=%d, want 1", *indexHits)
+	}
+	if *chartHits != 2 {
+		t.Errorf("digest-less chart hits=%d, want 2 (no digest → no CAS dedup, re-download)", *chartHits)
+	}
+}

--- a/pkg/source/meta.go
+++ b/pkg/source/meta.go
@@ -30,6 +30,17 @@ type SlotMeta struct {
 	// validated against; empty when verify is unconfigured. A mismatch on the
 	// next reconcile forces re-verify.
 	Verified string `json:"verified,omitempty"`
+
+	// ChartVersion, ChartDigest, ChartURL record a HelmRepository HTTP chart
+	// resolution (the concrete version, bare-hex tarball sha256, and absolute
+	// .tgz URL the repo's index.yaml resolved a chart name+version to). They
+	// live on a dedicated "helm-resolve:" slot so a warm run skips the live
+	// index.yaml fetch within spec.interval. Named distinctly from the OCI
+	// Digest so a slot never aliases the two. ChartDigest may be empty for a
+	// digest-less (mutable) index entry.
+	ChartVersion string `json:"chartVersion,omitempty"`
+	ChartDigest  string `json:"chartDigest,omitempty"`
+	ChartURL     string `json:"chartURL,omitempty"`
 }
 
 // WriteSlotMeta persists meta into slotDir atomically (temp file + fsync +


### PR DESCRIPTION
## What

A warm `flate build/test all` on a large repo was **as slow as cold** — the render cache gave no benefit — because every HTTP `HelmRepository`'s `index.yaml` was fetched **live on every invocation**.

`fetchHTTPChart` resolves a chart name+version → `(version, digest, URL)` via the index *before* the content-addressed chart-blob check (the blob is keyed by the digest the index supplies), and the parsed index was memoized **only in an in-process `sync.Map`**. On a repo with 100+ HelmRepositories (some indexes >1 MB) that's seconds of avoidable network every run — and an apparent **hang** when a repo is slow/black-holed (each fetch has a 120s timeout).

## Fix

Persist the small resolution triple `(ChartVersion, ChartDigest, ChartURL)` to a dedicated `helm-resolve:` cache slot's `.flate-meta.json` sidecar, **freshness-gated by `spec.interval`** — exactly the OCI resolve-marker pattern (`pkg/source/oci/marker.go`). `resolveChart` now checks three tiers, cheapest first:
1. in-process index memo,
2. **on-disk resolve slot fresh within `spec.interval` → no network**,
3. live `index.yaml` fetch, persisted back to the slot.

With a fresh resolution and the chart blob already cached, a warm run opens **zero sockets**.

## Determinism (preserved)

The slot key includes the **raw requested version**, so a semver range and a pin never share a slot; within one `spec.interval` window the cache serves the same resolution a live fetch would have at populate time (the OCI mutable-ref contract, now applied to helm ranges). The chart `.tgz` stays content-addressed by digest and the post-download digest guard still fires → **no rendered output changes, only avoided network**. A digest-less (mutable) index entry still skips the index fetch and re-downloads the tgz conservatively. A `HelmRepository` with no `spec.interval` gets the safe always-stale default.

## Verification

- `gofmt` / `go build` / `go vet` clean; `golangci-lint run ./pkg/source/...` → 0 issues
- `go test -race ./pkg/source/...` + full `go test ./...` pass
- New tests (`resolve_test.go`): a second `Fetcher` sharing one on-disk cache (fresh in-process memo, as a new invocation has) fetches the chart with **0 index + 0 chart** hits; zero-interval re-fetches; digest-less still skips the index.
- **Byte-identical render output across all 24 cross-repo paths** (independent per-binary caches; main `6572914` vs branch).
- **Warm run on JJGadgets/Biohazard `kube`: index.yaml fetches 15 → 0.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)