### PR TITLE
refactor(controllers): add engine-agnostic Require dependency seam

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -475,6 +475,55 @@ func AwaitRefresh[T manifest.BaseManifest](
 	return obj, ok, nil
 }
 
+// Require is the engine-agnostic dependency gate the reconcile bodies
+// call. It owns Waiter construction (built from id + timeout) so call
+// sites no longer thread a *depwait.Waiter, and is the single seam where
+// the two engines diverge:
+//
+//   - event engine (current default): blocks via Await — identical
+//     behavior to the pre-seam call sites.
+//   - dag engine (Phase 1): performs a NON-blocking check and returns an
+//     ErrBlocked sentinel when a dep is absent / not-yet-Ready, so the
+//     scheduler can park the node and re-run the body once the dep
+//     advances — no goroutine or active-count is held across the wait.
+//
+// Both engines return a *manifest.DependencyFailedError (via onFail) when
+// a dep is terminally Failed, and nil when every dep is satisfied. Phase 0
+// wires only the event branch; the result is byte-identical to Await.
+func (c *Controller) Require(
+	ctx context.Context,
+	id manifest.NamedResource,
+	timeout *metav1.Duration,
+	deps []manifest.DependencyRef,
+	pendingMsg string,
+	onFail func(depwait.Summary) error,
+) error {
+	return c.Await(ctx, id, c.NewWaiter(id, timeout), deps, pendingMsg, onFail)
+}
+
+// RequireRefresh fuses Require with the load-bearing store re-read every
+// dependency gate performs on success — the Require counterpart of
+// AwaitRefresh (see its doc for the #102 re-read rationale). Call sites use
+// this instead of AwaitRefresh so the engine seam (Require) is the only
+// thing they depend on; the dag engine re-reads identically after a
+// satisfied gate.
+func RequireRefresh[T manifest.BaseManifest](
+	ctx context.Context,
+	c *Controller,
+	id manifest.NamedResource,
+	timeout *metav1.Duration,
+	deps []manifest.DependencyRef,
+	pendingMsg string,
+	onFail func(depwait.Summary) error,
+) (T, bool, error) {
+	if err := c.Require(ctx, id, timeout, deps, pendingMsg, onFail); err != nil {
+		var zero T
+		return zero, false, err
+	}
+	obj, ok := store.Get[T](c.Store, id)
+	return obj, ok, nil
+}
+
 // DepFailed returns the canonical onFail closure that reports a
 // dependency-wait failure as a *manifest.DependencyFailedError for id.
 // The identical literal was rebuilt at every dependsOn/pre-render wait;

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -209,7 +209,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// driftDetection / install.crds / upgrade strategy / rollback to
 	// every HR, so all of them were hit by this).
 	if parent, ok := c.LookupParent(id); ok {
-		err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout),
+		err := c.Require(ctx, id, hr.Timeout,
 			[]manifest.DependencyRef{{NamedResource: parent}},
 			"waiting for parent KS",
 			func(sum depwait.Summary) error {
@@ -241,8 +241,8 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		// with explicit spec.dependsOn but no structural parent — or one
 		// whose parent re-emitted us after the parent-gate cleared — keeps
 		// the pre-mutation snapshot through chart resolution.
-		fresh, ok, err := base.AwaitRefresh[*manifest.HelmRelease](
-			ctx, c.Controller, id, c.NewWaiter(id, hr.Timeout), deps,
+		fresh, ok, err := base.RequireRefresh[*manifest.HelmRelease](
+			ctx, c.Controller, id, hr.Timeout, deps,
 			"resolving dependencies", base.DepFailed(id))
 		if err != nil {
 			return err
@@ -373,7 +373,7 @@ func chartSourceID(hr *manifest.HelmRelease) manifest.NamedResource {
 // OUTCOME instead of dropped nondeterministically. See depwait.Waiter.watchOne.
 func (c *Controller) awaitChartSource(ctx context.Context, id manifest.NamedResource, hr *manifest.HelmRelease) error {
 	srcID := chartSourceID(hr)
-	if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout),
+	if err := c.Require(ctx, id, hr.Timeout,
 		[]manifest.DependencyRef{{NamedResource: srcID}},
 		"", // status already set by the caller
 		func(sum depwait.Summary) error {

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -46,7 +46,7 @@ func (c *Controller) resolvePreRenderValuesFrom(ctx context.Context, id manifest
 			break
 		}
 		var preSum depwait.Summary
-		if err := c.Await(ctx, id, c.NewWaiter(id, hr.Timeout), preDeps,
+		if err := c.Require(ctx, id, hr.Timeout, preDeps,
 			"awaiting pre-render references",
 			func(sum depwait.Summary) error {
 				preSum = sum

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -138,8 +138,8 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// stale-spec snapshot captured by RunWithStatus, producing
 		// duplicate renders that linger in the store with the wrong
 		// namespace. See #102.
-		fresh, ok, err := base.AwaitRefresh[*manifest.Kustomization](
-			ctx, c.Controller, id, c.NewWaiter(id, ks.Timeout), deps,
+		fresh, ok, err := base.RequireRefresh[*manifest.Kustomization](
+			ctx, c.Controller, id, ks.Timeout, deps,
 			"", base.DepFailed(id)) // empty pendingMsg: status set above (kept Ready on a no-op re-run)
 		if err != nil {
 			return err


### PR DESCRIPTION
## What

Introduce `base.Controller.Require` + `base.RequireRefresh[T]` — the single point where reconcile bodies gate on dependencies. They own `Waiter` construction, so call sites no longer thread a `*depwait.Waiter`. Under the current (event) engine they delegate to `Await`/`AwaitRefresh`, so behavior is **byte-identical**.

This is Phase 0 of a staged engine rewrite ([plan](https://github.com/home-operations/flate)): the seam where a future fixpoint scheduler will diverge — returning a *blocked* sentinel instead of blocking, so the scheduler can park and re-run a node rather than hold a goroutine + active count across the wait. Isolating the call-site churn here keeps the later engine swap reviewable on its own.

## Changes

Migrates all five wait call sites to the seam:
- KS `dependsOn`/source/parent/substituteFrom (`kustomization/controller.go`)
- HR parent-gate, HR `dependsOn`, `awaitChartSource`, `preparePrereqs` pre-await (`helmrelease/controller.go`, `valuesfrom.go`)

No behavioral change — `Require` is a thin wrapper over `Await`.

## Verification

- `gofmt` / `go vet` / `golangci-lint` clean.
- `go test -race` green across controllers / depwait / task / store / change — including the #666 `transient_quiescence_test.go` (which still exercises `Await` directly).
- Full `go test ./...` passes.
- **Byte-equivalence**: base-vs-branch `build all` across the 24-repo sweep (independent per-binary caches). 22/24 byte-identical; the 2 deltas (`bo0tzz/kube/flux-system`, `m00nwtchr` flux) are transient upstream-fetch variance — opposite directions, whole-chart presence/absence — and are **byte-identical under a shared warm cache**, proving the seam changes nothing about output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)