### PR TITLE
feat(engine): re-entrant fixpoint scheduler behind --engine=dag

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -47,6 +47,10 @@ type commonFlags struct {
 	output              string
 	registryConfig      string
 	concurrency         int
+	// engine selects the reconcile engine: "event" (default — the blocking
+	// depwait + task-quiescence engine) or "dag" (the re-entrant fixpoint
+	// scheduler, pkg/schedule). Both produce byte-identical output.
+	engine string
 	// sourceRetry* tune the bounded retry applied uniformly to every source
 	// fetch on transient network errors. attempts is the total tries (first +
 	// retries); 1 disables. min/max bound the exponential backoff and jitter
@@ -123,6 +127,8 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 			"(Windows), falling back to $TMPDIR/flate-cache if those error.")
 	fs.IntVar(&f.concurrency, "concurrency", runtime.NumCPU()*4,
 		"max parallel reconcile bodies (0 = unbounded)")
+	fs.StringVar(&f.engine, "engine", "event",
+		"reconcile engine: event (blocking depwait + quiescence) or dag (re-entrant fixpoint scheduler)")
 	// Retry only kicks in for transient network failures (connection
 	// reset/refused, timeouts); a bad path / auth / not-found still fails
 	// on the first try. --source-retry-attempts=1 disables it entirely.
@@ -403,7 +409,18 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 		CacheDir:               c.resolveCacheRoot(),
 		HelmTemplateCacheBytes: int64(c.helmTemplateCacheMB) << 20,
 		HelmRenderCacheBytes:   int64(c.helmRenderCacheMB) << 20,
+		Engine:                 c.engine,
 	}
+}
+
+// validateEngine fails fast on an unknown --engine value so a typo surfaces
+// immediately rather than silently falling back to the event engine.
+func validateEngine(engine string) error {
+	switch engine {
+	case "", "event", "dag":
+		return nil
+	}
+	return fmt.Errorf("--engine %q: must be one of: event, dag", engine)
 }
 
 // resolveCacheRoot returns dir if non-empty, or the platform default.
@@ -423,6 +440,9 @@ func (c *commonFlags) resolveCacheRoot() string {
 func runOrchestrator(ctx context.Context, c commonFlags, h helmFlags) (*orchestrator.Orchestrator, *orchestrator.Result, error) {
 	if c.path == "" {
 		return nil, nil, errors.New("path is required")
+	}
+	if err := validateEngine(c.engine); err != nil {
+		return nil, nil, err
 	}
 	if err := validatePathFlag("--path", c.path); err != nil {
 		return nil, nil, err

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -96,6 +97,11 @@ type Controller struct {
 	renders   depwait.RenderInflight
 	preflight func(manifest.NamedResource) (string, bool)
 	parentOf  func(manifest.NamedResource) (manifest.NamedResource, bool)
+
+	// engine selects the dependency-gating strategy Require uses. The zero
+	// value (EngineEvent) is the blocking event engine — today's default; the
+	// orchestrator flips it to EngineDAG via SetEngine when --engine=dag.
+	engine EngineMode
 
 	// renderTracker receives every reconcilable/source child a render
 	// emits. Set via SetRenderTracker before Start; read-only after.
@@ -475,21 +481,65 @@ func AwaitRefresh[T manifest.BaseManifest](
 	return obj, ok, nil
 }
 
-// Require is the engine-agnostic dependency gate the reconcile bodies
-// call. It owns Waiter construction (built from id + timeout) so call
-// sites no longer thread a *depwait.Waiter, and is the single seam where
-// the two engines diverge:
+// EngineMode selects how Require gates on dependencies.
+type EngineMode uint8
+
+const (
+	// EngineEvent is the blocking event engine (depwait + task quiescence) —
+	// the zero value and current default.
+	EngineEvent EngineMode = iota
+	// EngineDAG is the re-entrant fixpoint scheduler: Require returns a
+	// *depwait.ErrBlocked sentinel instead of blocking, so the scheduler parks
+	// the node and re-runs it when a dependency advances.
+	EngineDAG
+)
+
+// SetEngine selects the dependency-gating engine. Panics after Start —
+// reconcile-shaping config is frozen once dispatch begins.
+func (c *Controller) SetEngine(m EngineMode) {
+	c.requireNotStarted("SetEngine")
+	c.engine = m
+}
+
+// DAGEngine reports whether the dag scheduler owns dispatch. Concrete
+// controllers use it to skip registering their event-driven OnReconcile
+// dispatch listener in Start — under dag the scheduler invokes ReconcileNode
+// directly. Other listeners (HR's producer index) stay registered.
+func (c *Controller) DAGEngine() bool { return c.engine == EngineDAG }
+
+type drainLevelKey struct{}
+
+// WithDrainLevel stamps the dag scheduler's current drain level onto ctx so
+// the body's Require calls reach Classify with it. The orchestrator's
+// Dispatcher sets it per-dispatch; absent ⇒ DrainNone (0).
+func WithDrainLevel(ctx context.Context, level int) context.Context {
+	return context.WithValue(ctx, drainLevelKey{}, level)
+}
+
+func drainLevel(ctx context.Context) int {
+	v, _ := ctx.Value(drainLevelKey{}).(int)
+	return v
+}
+
+// Require gates the caller on deps. Under the event engine it blocks (Await);
+// under the dag engine it classifies each dep WITHOUT blocking and returns
+// one of:
+//   - nil — every dep satisfied; the body proceeds.
+//   - onFail(sum) (a *manifest.DependencyFailedError) — a dep is terminally
+//     Failed and none is still blockable; instant cascade, no FailedGrace.
+//   - *depwait.ErrBlocked — at least one dep is absent/Pending/ReadyExpr-pending;
+//     the body returns and the scheduler parks the node on those deps.
 //
-//   - event engine (current default): blocks via Await — identical
-//     behavior to the pre-seam call sites.
-//   - dag engine (Phase 1): performs a NON-blocking check and returns an
-//     ErrBlocked sentinel when a dep is absent / not-yet-Ready, so the
-//     scheduler can park the node and re-run the body once the dep
-//     advances — no goroutine or active-count is held across the wait.
+// Blocked WINS over failed: if any dep is still producible (ClassBlocked) we
+// park even when another dep already failed, discarding sum — the re-run
+// re-derives the failure on a later pass once nothing is blocked. This matches
+// the event engine, where a producible dep keeps the wait alive while a
+// failed-omittable ref is handled by the caller's onFail only once it is the
+// sole remaining signal (see resolvePreRenderValuesFrom).
 //
-// Both engines return a *manifest.DependencyFailedError (via onFail) when
-// a dep is terminally Failed, and nil when every dep is satisfied. Phase 0
-// wires only the event branch; the result is byte-identical to Await.
+// The pendingMsg status write mirrors Await exactly (unconditional Pending when
+// non-empty, nothing when empty) so a dependent observing this node mid-gate
+// sees the identical status under both engines.
 func (c *Controller) Require(
 	ctx context.Context,
 	id manifest.NamedResource,
@@ -498,7 +548,33 @@ func (c *Controller) Require(
 	pendingMsg string,
 	onFail func(depwait.Summary) error,
 ) error {
-	return c.Await(ctx, id, c.NewWaiter(id, timeout), deps, pendingMsg, onFail)
+	if c.engine != EngineDAG {
+		return c.Await(ctx, id, c.NewWaiter(id, timeout), deps, pendingMsg, onFail)
+	}
+	if pendingMsg != "" {
+		c.Store.UpdateStatus(id, store.StatusPending, pendingMsg)
+	}
+	level := drainLevel(ctx)
+	w := c.NewWaiter(id, timeout)
+	var blocked []manifest.NamedResource
+	sum := depwait.Summary{Messages: map[manifest.NamedResource]string{}}
+	for _, dep := range deps {
+		switch cl := w.Classify(dep, level); cl.Kind {
+		case depwait.ClassReady:
+		case depwait.ClassFailed:
+			sum.Failed = append(sum.Failed, dep.NamedResource)
+			sum.Messages[dep.NamedResource] = cl.Message
+		case depwait.ClassBlocked:
+			blocked = append(blocked, dep.NamedResource)
+		}
+	}
+	if len(blocked) > 0 {
+		return &depwait.ErrBlocked{Deps: blocked}
+	}
+	if sum.AnyFailed() {
+		return onFail(sum)
+	}
+	return nil
 }
 
 // RequireRefresh fuses Require with the load-bearing store re-read every
@@ -530,6 +606,14 @@ func RequireRefresh[T manifest.BaseManifest](
 // single-sourcing it keeps the failure shape consistent across controllers.
 func DepFailed(id manifest.NamedResource) func(depwait.Summary) error {
 	return func(sum depwait.Summary) error {
+		// Sort the failed-dep list so the rendered DependencyFailedError
+		// message is deterministic across runs AND identical between the two
+		// engines: the event engine's WaitAll collects failures in
+		// nondeterministic channel-receive order, while the dag engine collects
+		// them in dep-slice order. Sorting here normalizes both (and fixes a
+		// latent event-engine nondeterminism for multi-failed-dependency
+		// resources).
+		slices.SortFunc(sum.Failed, func(a, b manifest.NamedResource) int { return a.Compare(b) })
 		return &manifest.DependencyFailedError{
 			Parent:  id,
 			Failed:  sum.Failed,
@@ -582,47 +666,112 @@ func RunWithStatus[T manifest.BaseManifest](
 	logKind string,
 	fn func(context.Context, T) error,
 ) {
+	_ = RunWithStatusOutcome[T](ctx, s, id, logKind, fn)
+}
+
+// RunWithStatusOutcome is RunWithStatus that additionally reports the dag
+// scheduler's outcome: the blocked dependency set, or nil when the body
+// terminalized (Ready / Skipped / Failed). It intercepts a *depwait.ErrBlocked
+// returned by the body BEFORE the generic Failed-status write, leaving the
+// Pending status the body's Require wrote — so a blocked node stays non-Ready
+// and re-runnable. Under the event engine the body never returns ErrBlocked, so
+// the returned slice is always nil and behavior is byte-identical to the prior
+// RunWithStatus.
+func RunWithStatusOutcome[T manifest.BaseManifest](
+	ctx context.Context,
+	s *store.Store,
+	id manifest.NamedResource,
+	logKind string,
+	fn func(context.Context, T) error,
+) []manifest.NamedResource {
 	defer Recover(s, id, logKind)
 	obj, ok := store.Get[T](s, id)
 	if !ok {
-		// Object deleted (or wrong type) between coalescer enqueue and
-		// run. A Refire-driven re-run that previously wrote
-		// StatusPending/MsgRefetching would otherwise stick at Pending
-		// forever — every depwait blocking on this id rides its full
-		// per-dep timeout. Write a terminal Ready with a brief reason
-		// so dep checks unblock and the testrunner reports cleanly.
-		// Use Ready (not Failed) because a vanished resource is the
-		// same outcome real Flux would see when the CR is deleted.
+		// Object deleted (or wrong type) between discovery/enqueue and run.
+		// Write a terminal Ready with a brief reason so dependents unblock and
+		// the testrunner reports cleanly — a vanished resource is the same
+		// outcome real Flux sees when the CR is deleted.
 		if info, has := s.GetStatus(id); has && info.Status != store.StatusReady {
 			s.UpdateStatus(id, store.StatusReady, "skipped: object not in store at reconcile time")
 		}
-		return
+		return nil
 	}
 	if err := fn(ctx, obj); err != nil {
-		// ErrSourceSkipped propagates a soft-skip from a referenced
-		// source (e.g. --allow-missing-secrets on its auth secret) up
-		// to this consumer. Mark Ready with a "skipped:" message
-		// rather than Failed so depwait treats us as ready and the
-		// test runner reports SKIPPED, matching the source's outcome.
+		// dag-only: a dependency gate is unsatisfied. Surface the blocked deps
+		// WITHOUT writing Failed — the node keeps the Pending status Require
+		// wrote and stays parkable + re-runnable. Provably unreachable under the
+		// event engine (Await blocks instead of returning ErrBlocked), so the
+		// event path is byte-identical.
+		var blocked *depwait.ErrBlocked
+		if errors.As(err, &blocked) {
+			return blocked.Deps
+		}
+		// ErrSourceSkipped propagates a soft-skip from a referenced source
+		// (--allow-missing-secrets on its auth secret). Mark Ready+"skipped:"
+		// rather than Failed so dependents treat us as ready and the runner
+		// reports SKIPPED, matching the source's outcome.
 		if errors.Is(err, manifest.ErrSourceSkipped) {
 			s.UpdateStatus(id, store.StatusReady,
 				store.SkippedPrefix+" "+manifest.TrimSentinelPrefix(err.Error()))
-			return
+			return nil
 		}
 		s.UpdateStatus(id, store.StatusFailed, err.Error())
-		return
+		return nil
 	}
 	if existing, ok := s.GetStatus(id); ok {
 		if existing.Status == store.StatusFailed {
-			return
+			return nil
 		}
 		if existing.Status == store.StatusReady && existing.Message != "" {
-			// Existing Ready message is informative (skipped:, unchanged,
-			// suspended, or any future Ready sub-state) — don't clobber.
-			return
+			// Informative Ready message (skipped:, unchanged, suspended) —
+			// don't clobber.
+			return nil
 		}
 	}
 	s.UpdateStatus(id, store.StatusReady, "")
+	return nil
+}
+
+// statusReady reports whether id's current store status is Ready — the dag
+// scheduler's "this terminal node satisfies a dependency" signal.
+func (c *Controller) statusReady(id manifest.NamedResource) bool {
+	info, ok := c.Store.GetStatus(id)
+	return ok && info.Status == store.StatusReady
+}
+
+// DispatchNode runs id's reconcile body under the dag engine and reports what
+// the scheduler needs: the blocked dependency set (nil = terminalized) and
+// whether id's final store status is Ready. It performs the same PreGate /
+// preflight pre-checks the event listener (OnReconcile) does, then
+// RunWithStatusOutcome. drainLevel threads the scheduler's fixpoint level into
+// Require via ctx. The orchestrator's Dispatcher calls this, routing by Kind, so
+// no per-kind match check is needed here.
+func DispatchNode[T manifest.BaseManifest](
+	ctx context.Context,
+	c *Controller,
+	id manifest.NamedResource,
+	drainLevel int,
+	suspended func(T) bool,
+	logKind string,
+	reconcile func(context.Context, T) error,
+) (blocked []manifest.NamedResource, ready bool) {
+	ctx = WithDrainLevel(ctx, drainLevel)
+	obj, ok := store.Get[T](c.Store, id)
+	if !ok {
+		// Vanished — RunWithStatusOutcome's vanished branch records a terminal
+		// status; report it.
+		blocked = RunWithStatusOutcome[T](ctx, c.Store, id, logKind, reconcile)
+		return blocked, c.statusReady(id)
+	}
+	if c.PreGate(id, suspended(obj)) {
+		return nil, c.statusReady(id) // gated out: Ready (suspended/unchanged)
+	}
+	if msg, failed := c.PreflightFailure(id); failed {
+		c.Store.UpdateStatus(id, store.StatusFailed, msg)
+		return nil, false
+	}
+	blocked = RunWithStatusOutcome[T](ctx, c.Store, id, logKind, reconcile)
+	return blocked, c.statusReady(id)
 }
 
 // OnReconcile builds the EventObjectAdded listener every controller registers

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -75,6 +75,9 @@ type Controller struct {
 // cluster KS level, post-build substitutions, kustomize replacements)
 // land before the first helm.Template call.
 type ReconcileOptions struct {
+	// Engine selects the dependency-gating engine (event vs dag); forwarded to
+	// base.Controller via SetEngine in Configure.
+	Engine   base.EngineMode
 	Filter   *change.Filter
 	ParentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
 	// RenderTracker receives every source-kind child emitted during HR
@@ -118,6 +121,7 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once dispatch begins.
 func (c *Controller) Configure(opts ReconcileOptions) {
+	c.SetEngine(opts.Engine)
 	c.SetFilter(opts.Filter)
 	c.SetDepwait(opts.Existence, opts.Renders)
 	c.SetPreflight(opts.PreflightFailure)
@@ -134,11 +138,27 @@ func (c *Controller) Configure(opts ReconcileOptions) {
 // the canonical Store. One fewer push-registry to keep in sync.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("helmrelease")
+	// The producer index stays wired under BOTH engines — it is read by the
+	// reconcile body (generatedValuesProducer), not a dispatch trigger.
 	c.AddListener(store.EventObjectAdded, c.onRawProducerAdded())
+	// Under the dag engine the scheduler owns dispatch (via ReconcileNode), so
+	// the event-driven OnReconcile dispatch listener is not registered.
+	if c.DAGEngine() {
+		return
+	}
 	c.AddListener(store.EventObjectAdded, base.OnReconcile(ctx, c.Controller,
 		func(id manifest.NamedResource) bool { return id.Kind == manifest.KindHelmRelease },
 		func(hr *manifest.HelmRelease) bool { return hr.Suspend },
 		"helmrelease", c.reconcile))
+}
+
+// ReconcileNode runs id's reconcile under the dag engine, returning the blocked
+// dependency set (nil = terminalized) and whether id ended Ready. The
+// orchestrator's scheduler Dispatcher calls this for HelmRelease nodes.
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+		func(hr *manifest.HelmRelease) bool { return hr.Suspend },
+		"helmrelease", c.reconcile)
 }
 
 // onRawProducerAdded returns a listener that indexes RawObject producers

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -54,6 +54,9 @@ type Controller struct {
 // parent-enforcement, matching pre-#102 behavior. RenderTracker
 // receives every reconcilable child this KS emits during render.
 type Options struct {
+	// Engine selects the dependency-gating engine (event vs dag); forwarded to
+	// base.Controller via SetEngine in Configure.
+	Engine        base.EngineMode
 	Filter        *change.Filter
 	ParentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
 	RenderTracker base.RenderTracker
@@ -97,6 +100,7 @@ func New(s *store.Store, t *task.Service, trees *kustomize.TreeCache, wipeSecret
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once the controller is dispatching.
 func (c *Controller) Configure(opts Options) {
+	c.SetEngine(opts.Engine)
 	c.SetFilter(opts.Filter)
 	c.SetDepwait(opts.Existence, opts.Renders)
 	c.SetPreflight(opts.PreflightFailure)
@@ -105,13 +109,28 @@ func (c *Controller) Configure(opts Options) {
 	c.selfProduces = opts.SelfProduces
 }
 
-// Start registers the listener that drives reconciliation.
+// Start registers the listener that drives reconciliation. Under the dag
+// engine the scheduler owns dispatch (via ReconcileNode), so the event-driven
+// OnReconcile dispatch listener is NOT registered — the orchestrator's dagrun
+// wires its own discovery/wake listeners instead.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("kustomization")
+	if c.DAGEngine() {
+		return
+	}
 	c.AddListener(store.EventObjectAdded, base.OnReconcile(ctx, c.Controller,
 		func(id manifest.NamedResource) bool { return id.Kind == manifest.KindKustomization },
 		func(ks *manifest.Kustomization) bool { return ks.Suspend },
 		"kustomization", c.reconcile))
+}
+
+// ReconcileNode runs id's reconcile under the dag engine, returning the blocked
+// dependency set (nil = terminalized) and whether id ended Ready. The
+// orchestrator's scheduler Dispatcher calls this for Kustomization nodes.
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+		func(ks *manifest.Kustomization) bool { return ks.Suspend },
+		"kustomization", c.reconcile)
 }
 
 func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) error {

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -46,6 +46,9 @@ type Controller struct {
 // onto the controller. Filter narrows fetches to sources referenced by
 // changed resources in changed-only mode.
 type FetchOptions struct {
+	// Engine selects the dependency-gating engine (event vs dag); forwarded to
+	// base.Controller via SetEngine in Configure.
+	Engine              base.EngineMode
 	Filter              *change.Filter
 	AllowMissingSecrets bool
 }
@@ -62,6 +65,7 @@ func New(s *store.Store, t *task.Service) *Controller {
 // Configure installs the post-bootstrap state. Panics if called after
 // Start.
 func (c *Controller) Configure(opts FetchOptions) {
+	c.SetEngine(opts.Engine)
 	c.SetFilter(opts.Filter)
 	c.allowMissingSecrets = opts.AllowMissingSecrets
 }
@@ -70,6 +74,11 @@ func (c *Controller) Configure(opts FetchOptions) {
 // Close is called.
 func (c *Controller) Start(ctx context.Context) {
 	c.StartLifecycle("source")
+	// Under the dag engine the scheduler owns dispatch (via ReconcileNode), so
+	// the event-driven OnReconcile dispatch listener is not registered.
+	if c.DAGEngine() {
+		return
+	}
 	// Match any kind with a registered fetcher (not a single kind like KS/HR),
 	// and read Suspend via the Suspendable interface. Coalescing in Submit
 	// means a duplicate AddObject for the same source (e.g. a parent KS
@@ -78,8 +87,31 @@ func (c *Controller) Start(ctx context.Context) {
 	// OnReconcile's PreflightFailure check is a no-op here.
 	c.AddListener(store.EventObjectAdded, base.OnReconcile(ctx, c.Controller,
 		func(id manifest.NamedResource) bool { _, ok := c.Fetchers[id.Kind]; return ok },
-		func(obj manifest.BaseManifest) bool { s, _ := obj.(src.Suspendable); return s != nil && s.Suspended() },
+		suspendedSource,
 		"source", c.reconcile))
+}
+
+// suspendedSource reports whether a source object is suspended, via the
+// optional Suspendable interface.
+func suspendedSource(obj manifest.BaseManifest) bool {
+	s, _ := obj.(src.Suspendable)
+	return s != nil && s.Suspended()
+}
+
+// HasFetcher reports whether a fetcher is registered for kind — the dag
+// Dispatcher uses it to route source-kind nodes to ReconcileNode.
+func (c *Controller) HasFetcher(kind string) bool {
+	_, ok := c.Fetchers[kind]
+	return ok
+}
+
+// ReconcileNode runs id's source fetch under the dag engine, returning the
+// blocked dependency set (always nil — sources have no depwait gates) and
+// whether id ended Ready. The orchestrator's scheduler Dispatcher calls this
+// for source-kind nodes.
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+		suspendedSource, "source", c.reconcile)
 }
 
 // reconcile fetches the source artifact via the registered Fetcher and

--- a/pkg/depwait/blocked.go
+++ b/pkg/depwait/blocked.go
@@ -1,0 +1,29 @@
+package depwait
+
+import "github.com/home-operations/flate/pkg/manifest"
+
+// ErrBlocked is the control-flow sentinel a dag-engine Require returns when a
+// reconcile body cannot proceed because one or more dependencies are not yet
+// satisfied — absent (not in the store), present-but-not-Ready, or carrying a
+// ReadyExpr that has not yet evaluated true — AND none is terminally Failed.
+// The scheduler parks the node keyed on Deps and re-runs the body when any of
+// them advances; at the structural fixpoint a draining re-run terminalizes the
+// node with the canonical failure status.
+//
+// It deliberately has NO Unwrap and wraps no sentinel: it must never satisfy an
+// errors.Is chain for a user-facing failure (manifest.ErrInput / ErrFlux /
+// ErrObjectNotFound) or be mistaken for a reconcile error. RunWithStatusOutcome
+// intercepts it via errors.As before the generic Failed-status write, so a
+// blocked node keeps the Pending status its Require wrote and stays re-runnable.
+//
+// Deps carries only the dependency identities, not a per-dep reason: the
+// terminal failure message for a dependency that never becomes producible is
+// re-derived structurally at the draining sweep (classifyDep re-reads the final
+// store state), exactly as the event engine's WatchReady / waitRenderEmission
+// re-check their dep at quiescence — so a stale park-time reason would be both
+// redundant and, if the dep's state changed, wrong.
+type ErrBlocked struct {
+	Deps []manifest.NamedResource
+}
+
+func (e *ErrBlocked) Error() string { return "blocked on dependencies" }

--- a/pkg/depwait/classify.go
+++ b/pkg/depwait/classify.go
@@ -94,10 +94,34 @@ func (w *Waiter) Classify(dep manifest.DependencyRef, drainLevel int) Classifica
 		return Classification{Kind: ClassFailed, Message: info.Message}
 	}
 
-	// 6. Present, Ready (or Pending) but a ReadyExpr that is not yet true. At
-	//    the fixpoint the dependency is as ready as it will get and the CEL
-	//    still fails → the event engine's "readyExpr timeout".
+	// 6. Present with a ReadyExpr that readyNow rejected.
 	if dep.ReadyExpr != "" {
+		// Additive mode (Flux AdditiveCELDependencyCheck=true): the built-in
+		// Ready check AND the CEL must both hold — mirroring watchOne's
+		// post-WatchReady additive evaluation. When the built-in status is
+		// already Ready, the CEL is the blocker, so evaluate it now and return
+		// the byte-exact event-engine result rather than blocking/timing out.
+		// (Unreachable today: NewWaiter never sets AdditiveReadyExpr; kept so
+		// the dag engine stays byte-equivalent if that feature gate is wired.)
+		if w.AdditiveReadyExpr {
+			if info, ok := w.Store.GetStatus(id); ok && info.Status == store.StatusReady {
+				okExpr, evalErr := evaluateReadyExpr(dep.ReadyExpr, w.Store, w.Parent, id)
+				if evalErr != nil {
+					return Classification{Kind: ClassFailed, Message: "readyExpr: " + evalErr.Error()}
+				}
+				if !okExpr {
+					return Classification{Kind: ClassFailed, Message: "readyExpr returned false"}
+				}
+				return Classification{Kind: ClassReady}
+			}
+			// Built-in not yet Ready: treat like a plain present-Pending dep.
+			if drainLevel >= drainForce {
+				return Classification{Kind: ClassFailed, Message: "not ready"}
+			}
+			return Classification{Kind: ClassBlocked}
+		}
+		// Replace mode (the default): the CEL IS the readiness check, so at the
+		// fixpoint a never-true CEL is the event engine's "readyExpr timeout".
 		if drainLevel >= drainCascade {
 			return Classification{Kind: ClassFailed, Message: "readyExpr timeout: context deadline exceeded"}
 		}

--- a/pkg/depwait/classify.go
+++ b/pkg/depwait/classify.go
@@ -1,0 +1,114 @@
+package depwait
+
+import (
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// Drain levels for Classify, mirroring pkg/schedule's Drain* constants — a
+// small shared int contract: the scheduler picks the level and threads it
+// through the controller's Require into Classify. Defined here (not imported
+// from schedule) so depwait stays free of a schedule dependency.
+const (
+	drainNone    = 0 // an unsatisfied dep blocks (the node parks)
+	drainCascade = 1 // an absent dep / never-true ReadyExpr fails; present-Pending still blocks
+	drainForce   = 2 // a present-Pending dep ALSO fails ("not ready") — breaks a cross-kind cycle
+)
+
+// ClassKind is the non-blocking resolution of one dependency for the dag engine.
+type ClassKind int
+
+const (
+	// ClassReady means the dependency is satisfied; the consumer may proceed.
+	ClassReady ClassKind = iota
+	// ClassFailed means the dependency is terminally unsatisfiable; Message
+	// carries the byte-exact reason the event engine would record.
+	ClassFailed
+	// ClassBlocked means the dependency is not yet satisfied but possibly
+	// producible; the scheduler parks the consumer keyed on it.
+	ClassBlocked
+)
+
+// Classification is the result of Classify.
+type Classification struct {
+	Kind    ClassKind
+	Message string // populated only for ClassFailed
+}
+
+// Classify resolves dep for the dag engine WITHOUT blocking, reusing the same
+// readiness predicates as the blocking Watch path (readyNow, depExists, the
+// ReadyExpr evaluator, Existence.Promote) so dag gate semantics are
+// byte-identical to the event engine's. drainLevel escalates how an unsatisfied
+// dependency is treated at the structural fixpoint and selects the canonical
+// terminal message — matching what the event engine produces at quiescence:
+// notFound ("dependency not found"), the raw stored Failed message, ErrQuiesced
+// ("not ready"), and the readyExpr strings.
+//
+// MUST run on a worker goroutine (it reads the store) — never under the
+// scheduler's mutex.
+func (w *Waiter) Classify(dep manifest.DependencyRef, drainLevel int) Classification {
+	id := dep.NamedResource
+
+	// 1. Already satisfied: status Ready, a status-less kind that exists, or a
+	//    satisfied ReadyExpr (replace or additive). Same predicate as the
+	//    blocking ReadyNow fast path.
+	if w.readyNow(dep) {
+		return Classification{Kind: ClassReady}
+	}
+
+	// 2. A ReadyExpr that COMPILE-fails is permanently unsatisfiable regardless
+	//    of dependency state or drain level (matches watchReadyExpr's immediate
+	//    compile-error return). A transient eval error (missing attribute)
+	//    returns done=false and falls through.
+	if dep.ReadyExpr != "" {
+		if ev, done := w.tryReadyExpr(dep.ReadyExpr, id); done && ev.Status == DepFailed {
+			return Classification{Kind: ClassFailed, Message: ev.Reason}
+		}
+	}
+
+	// 3. Absent: try a lazy promote from the file-existence index (the bjw-s
+	//    same-path substituteFrom-CM pattern), else block — or fail
+	//    "dependency not found" once draining, since an absent dep with no
+	//    in-flight producer can never appear.
+	if !w.depExists(id) {
+		if w.Existence != nil && w.Existence.Promote(id) && w.readyNow(dep) {
+			return Classification{Kind: ClassReady}
+		}
+		if !w.depExists(id) {
+			if drainLevel >= drainCascade {
+				return Classification{Kind: ClassFailed, Message: "dependency not found"}
+			}
+			return Classification{Kind: ClassBlocked}
+		}
+	}
+
+	// 4. Present, status-less kind (ConfigMap/Secret): existence is readiness.
+	if !store.SupportsStatus(id.Kind) {
+		return Classification{Kind: ClassReady}
+	}
+
+	// 5. Present and Failed: cascade immediately with the raw stored message
+	//    (no FailedGrace under dag) — base.DepFailed wraps it into the same
+	//    DependencyFailedError the event engine builds.
+	if info, ok := w.Store.GetStatus(id); ok && info.Status == store.StatusFailed {
+		return Classification{Kind: ClassFailed, Message: info.Message}
+	}
+
+	// 6. Present, Ready (or Pending) but a ReadyExpr that is not yet true. At
+	//    the fixpoint the dependency is as ready as it will get and the CEL
+	//    still fails → the event engine's "readyExpr timeout".
+	if dep.ReadyExpr != "" {
+		if drainLevel >= drainCascade {
+			return Classification{Kind: ClassFailed, Message: "readyExpr timeout: context deadline exceeded"}
+		}
+		return Classification{Kind: ClassBlocked}
+	}
+
+	// 7. Present and Pending: block. A parked producer will terminalize and the
+	//    cascade carries its real message upward; only a cross-kind cycle
+	//    reaches drainForce, where it fails "not ready" (matches ErrQuiesced).
+	if drainLevel >= drainForce {
+		return Classification{Kind: ClassFailed, Message: "not ready"}
+	}
+	return Classification{Kind: ClassBlocked}
+}

--- a/pkg/depwait/classify_test.go
+++ b/pkg/depwait/classify_test.go
@@ -1,0 +1,107 @@
+package depwait
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func classifyDep(t *testing.T, w *Waiter, ref manifest.DependencyRef, drain int) Classification {
+	t.Helper()
+	return w.Classify(ref, drain)
+}
+
+func ksDep(name string) manifest.DependencyRef {
+	return manifest.DependencyRef{NamedResource: manifest.NamedResource{
+		Kind: manifest.KindKustomization, Namespace: "ns", Name: name,
+	}}
+}
+
+// TestClassify_CoreStates exercises the non-ReadyExpr branches that drive the
+// dag engine's gate, asserting the canonical event-engine messages per drain
+// level.
+func TestClassify_CoreStates(t *testing.T) {
+	s := store.New()
+	ready := ksDep("ready")
+	failed := ksDep("failed")
+	pending := ksDep("pending")
+	absent := ksDep("absent")
+	s.UpdateStatus(ready.NamedResource, store.StatusReady, "")
+	s.UpdateStatus(failed.NamedResource, store.StatusFailed, "boom")
+	s.UpdateStatus(pending.NamedResource, store.StatusPending, "working")
+
+	w := &Waiter{Store: s}
+
+	if got := classifyDep(t, w, ready, drainNone); got.Kind != ClassReady {
+		t.Errorf("ready: got %+v, want ClassReady", got)
+	}
+	if got := classifyDep(t, w, failed, drainNone); got.Kind != ClassFailed || got.Message != "boom" {
+		t.Errorf("failed: got %+v, want ClassFailed 'boom'", got)
+	}
+	// Present-Pending: blocks at none/cascade, fails "not ready" only at force.
+	if got := classifyDep(t, w, pending, drainNone); got.Kind != ClassBlocked {
+		t.Errorf("pending@none: got %+v, want ClassBlocked", got)
+	}
+	if got := classifyDep(t, w, pending, drainCascade); got.Kind != ClassBlocked {
+		t.Errorf("pending@cascade: got %+v, want ClassBlocked (cascade keeps Pending blocked)", got)
+	}
+	if got := classifyDep(t, w, pending, drainForce); got.Kind != ClassFailed || got.Message != "not ready" {
+		t.Errorf("pending@force: got %+v, want ClassFailed 'not ready'", got)
+	}
+	// Absent: blocks at none, fails "dependency not found" once draining.
+	if got := classifyDep(t, w, absent, drainNone); got.Kind != ClassBlocked {
+		t.Errorf("absent@none: got %+v, want ClassBlocked", got)
+	}
+	if got := classifyDep(t, w, absent, drainCascade); got.Kind != ClassFailed || got.Message != "dependency not found" {
+		t.Errorf("absent@cascade: got %+v, want ClassFailed 'dependency not found'", got)
+	}
+}
+
+// TestClassify_ReplaceReadyExpr: in the default (replace) mode the CEL is the
+// readiness check; a never-true CEL blocks until the fixpoint, then fails with
+// the event engine's "readyExpr timeout" string.
+func TestClassify_ReplaceReadyExpr(t *testing.T) {
+	s := store.New()
+	dep := ksDep("infra")
+	s.UpdateStatus(dep.NamedResource, store.StatusReady, "")
+	dep.ReadyExpr = `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")` // not satisfied
+
+	w := &Waiter{Store: s} // AdditiveReadyExpr=false (default/reachable mode)
+	if got := classifyDep(t, w, dep, drainNone); got.Kind != ClassBlocked {
+		t.Errorf("replace ReadyExpr false@none: got %+v, want ClassBlocked", got)
+	}
+	if got := classifyDep(t, w, dep, drainCascade); got.Kind != ClassFailed ||
+		got.Message != "readyExpr timeout: context deadline exceeded" {
+		t.Errorf("replace ReadyExpr false@cascade: got %+v, want ClassFailed 'readyExpr timeout: context deadline exceeded'", got)
+	}
+}
+
+// TestClassify_AdditiveReadyExpr is the defensive byte-equivalence guard: in
+// additive mode (currently unreachable — no production Waiter sets it) Classify
+// must match watchOne, failing a present-Ready dep immediately with
+// "readyExpr returned false" on a clean-false CEL rather than blocking/timing
+// out. Locks the fix so the divergence cannot return if the feature gate is
+// ever wired.
+func TestClassify_AdditiveReadyExpr(t *testing.T) {
+	s := store.New()
+	dep := ksDep("infra")
+	s.UpdateStatus(dep.NamedResource, store.StatusReady, "") // built-in Ready holds
+	dep.ReadyExpr = `dep.status.conditions.exists(c, c.type == "Healthy" && c.status == "True")`
+
+	w := &Waiter{Store: s, AdditiveReadyExpr: true}
+	// CEL is clean-false (no Healthy condition) → immediate fail, any drain level.
+	for _, drain := range []int{drainNone, drainCascade, drainForce} {
+		got := classifyDep(t, w, dep, drain)
+		if got.Kind != ClassFailed || got.Message != "readyExpr returned false" {
+			t.Errorf("additive clean-false@%d: got %+v, want ClassFailed 'readyExpr returned false'", drain, got)
+		}
+	}
+	// Now satisfy the CEL: built-in Ready AND CEL true → ClassReady.
+	s.SetCondition(dep.NamedResource, store.Condition{Type: "Healthy", Status: metav1.ConditionTrue})
+	if got := classifyDep(t, w, dep, drainNone); got.Kind != ClassReady {
+		t.Errorf("additive both-true: got %+v, want ClassReady", got)
+	}
+}

--- a/pkg/orchestrator/dagrun.go
+++ b/pkg/orchestrator/dagrun.go
@@ -1,0 +1,117 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/schedule"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// dagDispatcher implements schedule.Dispatcher: it routes a node by Kind to the
+// owning controller's ReconcileNode and maps the (blocked, ready) result into a
+// scheduler Outcome. This is the single composition point where the scheduler,
+// the controllers, and the store meet — pkg/schedule itself imports none of
+// them. NodeID is manifest.NamedResource, so the blocked slice flows through
+// untranslated.
+type dagDispatcher struct{ o *Orchestrator }
+
+func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLevel int) (schedule.Outcome, []schedule.NodeID, bool) {
+	o := d.o
+	var (
+		blocked []manifest.NamedResource
+		ready   bool
+	)
+	switch {
+	case id.Kind == manifest.KindKustomization:
+		blocked, ready = o.ksc.ReconcileNode(ctx, id, drainLevel)
+	case id.Kind == manifest.KindHelmRelease:
+		blocked, ready = o.hrc.ReconcileNode(ctx, id, drainLevel)
+	case o.src.HasFetcher(id.Kind):
+		blocked, ready = o.src.ReconcileNode(ctx, id, drainLevel)
+	default:
+		// Not a schedulable kind (should never be dispatched) — terminal no-op.
+		return schedule.OutcomeTerminal, nil, true
+	}
+	if len(blocked) > 0 {
+		return schedule.OutcomeBlocked, blocked, false
+	}
+	return schedule.OutcomeTerminal, nil, ready
+}
+
+// dagSchedulable reports whether id is a node the scheduler runs
+// (Kustomization/HelmRelease/source) versus pure data (ConfigMap/Secret) that
+// only WAKES nodes parked on it.
+func (o *Orchestrator) dagSchedulable(id manifest.NamedResource) bool {
+	return isReconcilableKind(id.Kind) || o.src.HasFetcher(id.Kind)
+}
+
+// seedNodes returns every file-loaded reconcilable + source object currently in
+// the store — the scheduler's initial frontier, replacing the event engine's
+// flush=true listener replay.
+func (o *Orchestrator) seedNodes() []manifest.NamedResource {
+	var ids []manifest.NamedResource
+	for _, kind := range reconcilableKinds {
+		for _, obj := range o.store.ListObjects(kind) {
+			ids = append(ids, obj.Named())
+		}
+	}
+	for kind := range o.src.Fetchers {
+		for _, obj := range o.store.ListObjects(kind) {
+			ids = append(ids, obj.Named())
+		}
+	}
+	return ids
+}
+
+// runDAG drives reconciliation with the re-entrant fixpoint scheduler instead
+// of the event-driven dispatch loop. The cycle-detect listener is already
+// registered by Run (shared with the event path), so preflight cycle failures
+// are recorded before any node runs.
+func (o *Orchestrator) runDAG(ctx context.Context) error {
+	defer o.Stop()
+	sched := schedule.New(o.tasks, dagDispatcher{o})
+
+	// Start the controllers. Under dag this registers lifecycle state + the HR
+	// producer index (flush=true replay), but NOT the OnReconcile dispatch
+	// listeners (the scheduler owns dispatch). No render runs here, so no
+	// children are emitted before the wake adapters below are registered.
+	o.src.Start(ctx)
+	o.ksc.Start(ctx)
+	o.hrc.Start(ctx)
+
+	// Store → scheduler adapters (fire-only, flush=false), registered AFTER the
+	// shared cycle-detect listener so cycle preflight runs first.
+	//
+	//   EventObjectAdded: discover render-emitted nodes, wake nodes parked on
+	//   an arriving dep (source/CM/KS), and re-dispatch a terminal producer
+	//   whose Refire status-reset re-arrival signals a changed-only
+	//   resurrection. The listener runs OUTSIDE the store shard lock (AddObject
+	//   fires it post-unlock), and dagStatusReady's read completes before
+	//   sched.OnArrival takes sched.mu — so there is no store-lock ↔ sched.mu
+	//   inversion.
+	unsubAdd := o.store.AddListener(store.EventObjectAdded, func(id manifest.NamedResource, _ any) {
+		sched.OnArrival(id, o.dagSchedulable(id))
+	}, false)
+	defer unsubAdd()
+	//   EventStatusUpdated: wake nodes parked on a dep that reached a terminal
+	//   status. Terminal-gated inside OnStatusWake (Pending writes are ignored).
+	unsubStatus := o.store.AddListener(store.EventStatusUpdated, func(id manifest.NamedResource, payload any) {
+		info, ok := payload.(store.StatusInfo)
+		if !ok {
+			return
+		}
+		sched.OnStatusWake(id, info.Status == store.StatusReady, info.Status == store.StatusFailed)
+	}, false)
+	defer unsubStatus()
+
+	// Pre-warm git mirrors so the scheduler's source fetches see warm mirrors
+	// (the per-URL mirror lock serializes against the fetches themselves).
+	o.prewarmGitMirrors(ctx)
+
+	sched.Seed(o.seedNodes())
+	sched.Run(ctx)
+
+	return errors.Join(o.finalize(), ctx.Err())
+}

--- a/pkg/orchestrator/dagrun_test.go
+++ b/pkg/orchestrator/dagrun_test.go
@@ -1,0 +1,174 @@
+package orchestrator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// ksYAML is a minimal Kustomization manifest for the dag tests.
+func ksYAML(name, path, dependsOn string) string {
+	dep := ""
+	if dependsOn != "" {
+		dep = "  dependsOn:\n    - name: " + dependsOn + "\n"
+	}
+	return "apiVersion: kustomize.toolkit.fluxcd.io/v1\n" +
+		"kind: Kustomization\n" +
+		"metadata:\n  name: " + name + "\n  namespace: flux-system\n" +
+		"spec:\n  path: ./" + path + "\n" + dep +
+		"  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}\n"
+}
+
+func ksID(name string) manifest.NamedResource {
+	return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+}
+
+// TestDAG_RenderEmittedDependencyResolves is the KS-A2 scenario: a consumer
+// dependsOn a Kustomization that does not exist on disk but is emitted by
+// another KS's render of a REMOTE resources: URL. The dag scheduler must
+// discover the render-emitted dependency and resolve the consumer Ready —
+// exactly the case a static dangling-dep oracle could not see.
+func TestDAG_RenderEmittedDependencyResolves(t *testing.T) {
+	dir := t.TempDir()
+	produced := ksYAML("produced", "produced", "")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(produced))
+	}))
+	t.Cleanup(srv.Close)
+	testutil.WriteFile(t, dir, "flux/producer.yaml", ksYAML("producer", "producer", ""))
+	testutil.WriteFile(t, dir, "flux/consumer.yaml", ksYAML("consumer", "consumer", "produced"))
+	testutil.WriteFile(t, dir, "producer/kustomization.yaml", "resources:\n- "+srv.URL+"/produced.yaml\n")
+	testutil.WriteFile(t, dir, "consumer/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "consumer/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: consumer}\ndata: {k: v}\n")
+	testutil.WriteFile(t, dir, "produced/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "produced/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: produced}\ndata: {k: v}\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4, Engine: "dag"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := o.Bootstrap(context.Background()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	if err := o.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, name := range []string{"produced", "consumer", "producer"} {
+		info, ok := o.Store().GetStatus(ksID(name))
+		if !ok || info.Status != store.StatusReady {
+			t.Fatalf("%s status = (%+v, %v), want Ready under dag", name, info, ok)
+		}
+	}
+}
+
+// TestDAG_DanglingDependencyCascadesAndTerminates verifies the structural
+// fixpoint terminator: a chain leaf→(absent) fails "dependency not found" and
+// its consumer cascades with the leaf's terminal message — without riding any
+// timeout. The bounded context proves termination is structural, not timed.
+func TestDAG_DanglingDependencyCascadesAndTerminates(t *testing.T) {
+	dir := t.TempDir()
+	// leaf dependsOn a Kustomization that is never defined or emitted; mid
+	// dependsOn leaf.
+	testutil.WriteFile(t, dir, "flux/leaf.yaml", ksYAML("leaf", "leaf", "ghost"))
+	testutil.WriteFile(t, dir, "flux/mid.yaml", ksYAML("mid", "mid", "leaf"))
+	testutil.WriteFile(t, dir, "leaf/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "leaf/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: leaf}\ndata: {k: v}\n")
+	testutil.WriteFile(t, dir, "mid/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "mid/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: mid}\ndata: {k: v}\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4, Engine: "dag"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// A short bounded context: the structural fixpoint must terminate well
+	// within it (no per-dep timeout cap). A regression that reintroduces a
+	// blocking wait would hit this deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 20_000_000_000) // 20s ceiling
+	defer cancel()
+	res, _ := o.Render(ctx)
+	if res == nil {
+		t.Fatal("Render returned nil result")
+	}
+	leafInfo, ok := res.Failed[ksID("leaf")]
+	if !ok || !strings.Contains(leafInfo.Message, "dependency not found") {
+		t.Fatalf("leaf: want FAILED 'dependency not found', got %+v (ok=%v)", leafInfo, ok)
+	}
+	midInfo, ok := res.Failed[ksID("mid")]
+	if !ok || !strings.Contains(midInfo.Message, "leaf") {
+		t.Fatalf("mid: want FAILED cascading leaf's failure, got %+v (ok=%v)", midInfo, ok)
+	}
+}
+
+// TestDAG_StatusParityWithEvent runs the same multi-resource fixture under both
+// engines and asserts an identical Ready set and identical Failed id→message
+// map — the end-to-end byte-equivalence contract, in miniature.
+func TestDAG_StatusParityWithEvent(t *testing.T) {
+	build := func() string {
+		dir := t.TempDir()
+		// A clean root KS, a dependsOn chain (b -> a), and a dangling one.
+		testutil.WriteFile(t, dir, "flux/a.yaml", ksYAML("a", "a", ""))
+		testutil.WriteFile(t, dir, "flux/b.yaml", ksYAML("b", "b", "a"))
+		testutil.WriteFile(t, dir, "flux/c.yaml", ksYAML("c", "c", "nonexistent"))
+		for _, n := range []string{"a", "b", "c"} {
+			testutil.WriteFile(t, dir, n+"/kustomization.yaml", "resources:\n- cm.yaml\n")
+			testutil.WriteFile(t, dir, n+"/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: "+n+"}\ndata: {k: v}\n")
+		}
+		return dir
+	}
+	statuses := func(engine string) (ready []string, failed map[string]string) {
+		dir := build()
+		o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4, Engine: engine})
+		if err != nil {
+			t.Fatalf("New(%s): %v", engine, err)
+		}
+		res, _ := o.Render(context.Background())
+		if res == nil {
+			t.Fatalf("Render(%s) returned nil", engine)
+		}
+		failed = map[string]string{}
+		for id, info := range res.Failed {
+			failed[id.String()] = info.Message
+		}
+		for _, kind := range reconcilableKinds {
+			for _, obj := range o.Store().ListObjects(kind) {
+				id := obj.Named()
+				if info, ok := o.Store().GetStatus(id); ok && info.Status == store.StatusReady {
+					ready = append(ready, id.String())
+				}
+			}
+		}
+		return ready, failed
+	}
+	evReady, evFailed := statuses("event")
+	dagReady, dagFailed := statuses("dag")
+
+	if strings.Join(sortedCopy(evReady), ",") != strings.Join(sortedCopy(dagReady), ",") {
+		t.Fatalf("Ready set differs:\n event=%v\n dag=%v", sortedCopy(evReady), sortedCopy(dagReady))
+	}
+	if len(evFailed) != len(dagFailed) {
+		t.Fatalf("Failed count differs: event=%d dag=%d (%v vs %v)", len(evFailed), len(dagFailed), evFailed, dagFailed)
+	}
+	for id, evMsg := range evFailed {
+		if dagMsg, ok := dagFailed[id]; !ok || dagMsg != evMsg {
+			t.Fatalf("Failed[%s] differs:\n event=%q\n dag=%q (ok=%v)", id, evMsg, dagMsg, ok)
+		}
+	}
+}
+
+func sortedCopy(s []string) []string {
+	c := append([]string(nil), s...)
+	for i := range c {
+		for j := i + 1; j < len(c); j++ {
+			if c[j] < c[i] {
+				c[i], c[j] = c[j], c[i]
+			}
+		}
+	}
+	return c
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -137,6 +137,12 @@ type Config struct {
 	// The CLI flag `--helm-render-cache-mb` exposes this in MB
 	// units; embedders pass bytes directly.
 	HelmRenderCacheBytes int64
+
+	// Engine selects the reconcile engine: "" / "event" is the blocking
+	// event engine (depwait + task quiescence — the default); "dag" is the
+	// re-entrant fixpoint scheduler (pkg/schedule). Exposed via the CLI
+	// `--engine` flag; both produce byte-identical output.
+	Engine string
 }
 
 // Orchestrator wires controllers and drives reconciliation.

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/controllers/helmrelease"
 	"github.com/home-operations/flate/pkg/controllers/kustomization"
 	sourcectrl "github.com/home-operations/flate/pkg/controllers/source"
@@ -89,6 +90,13 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	}, false)
 	defer unsubCycles()
 
+	// Dag engine: the re-entrant fixpoint scheduler owns dispatch. The
+	// cycle-detect listener above stays registered in BOTH paths so preflight
+	// failures are recorded before any node runs.
+	if o.cfg.Engine == "dag" {
+		return o.runDAG(ctx)
+	}
+
 	// Keep depwait's render-quiescence signal open while listener
 	// flushes submit the bootstrap objects. Without this marker, a
 	// Kustomization can start waiting on a render-emitted dependency
@@ -157,7 +165,12 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 // controller Start, since Configure panics if invoked after dispatch
 // begins.
 func (o *Orchestrator) configureControllers() {
+	engineMode := base.EngineEvent
+	if o.cfg.Engine == "dag" {
+		engineMode = base.EngineDAG
+	}
 	o.src.Configure(sourcectrl.FetchOptions{
+		Engine:              engineMode,
 		Filter:              o.filter,
 		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
 	})
@@ -197,6 +210,7 @@ func (o *Orchestrator) configureControllers() {
 		return slices.Contains(o.selfProduce.ProducedBy(cm), consumer)
 	}
 	o.ksc.Configure(kustomization.Options{
+		Engine:           engineMode,
 		Filter:           o.filter,
 		ParentOf:         parentResolver,
 		RenderTracker:    o.rendered,
@@ -206,6 +220,7 @@ func (o *Orchestrator) configureControllers() {
 		SelfProduces:     selfProduces,
 	})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
+		Engine:              engineMode,
 		Filter:              o.filter,
 		ParentOf:            parentResolver,
 		RenderTracker:       o.rendered,

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -1,0 +1,442 @@
+// Package schedule provides flate's dependency-driven reconcile scheduler:
+// a re-entrant fixpoint engine that runs each node's reconcile body on a
+// bounded task pool, parks a body that reports unsatisfied dependencies
+// (Dispatcher OutcomeBlocked), and re-runs it when any of those dependencies
+// advances.
+//
+// Termination is STRUCTURAL, not timed. Every render emission is a synchronous
+// store write on the body's own task goroutine, completing before the body
+// returns and before the scheduler decrements its in-flight count. Therefore
+// when no body is in flight and the runnable frontier is empty, no new object
+// can ever appear — so any still-parked node's dependencies are provably
+// unproducible. A draining sweep then terminalizes those nodes with the same
+// "dependency not found" / cascade / "not ready" statuses the event engine
+// produces at quiescence. There is no per-dependency timeout and no shared
+// quiescence counter, so the #666 transient-drain false-drop cannot occur: a
+// parked node is never counted in flight, and nothing drops it except the
+// fixpoint, which only fires when nothing is running.
+//
+// The package depends only on pkg/manifest and pkg/task; all store and
+// controller interaction is behind the Dispatcher seam, so the scheduler is
+// unit-testable against a fake Dispatcher with no store or controllers.
+package schedule
+
+import (
+	"context"
+	"slices"
+	"sync"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+// NodeID identifies a schedulable node — a Kustomization, HelmRelease, or
+// source CR — by its store identity.
+type NodeID = manifest.NamedResource
+
+// Outcome is what one reconcile-body invocation reported via the Dispatcher.
+type Outcome int
+
+const (
+	// OutcomeTerminal means the body wrote a terminal store status
+	// (Ready/Skipped/Failed); the node is done unless a later store event
+	// re-emits or resets it.
+	OutcomeTerminal Outcome = iota
+	// OutcomeBlocked means the body could not proceed because one or more
+	// dependencies are unsatisfied; the scheduler parks the node keyed on the
+	// returned ids and re-runs it when any advances.
+	OutcomeBlocked
+)
+
+// Drain levels passed to Dispatcher.Dispatch. 0 is normal operation; the
+// scheduler escalates only at the structural fixpoint (nothing in flight,
+// nodes still parked).
+const (
+	// DrainNone: normal operation — an unsatisfiable dependency parks.
+	DrainNone = 0
+	// DrainCascade: an absent dependency (and a never-true ReadyExpr)
+	// terminalizes as a failure; a present-but-Pending dependency still
+	// parks, so a dangling chain fails leaf-first and each level cascades
+	// the child's real terminal message upward (matching the event engine).
+	DrainCascade = 1
+	// DrainForce: a present-but-Pending dependency ALSO terminalizes ("not
+	// ready"). Reached only when a DrainCascade pass made no progress — i.e.
+	// a cross-kind structural cycle the same-kind preflight detector cannot
+	// represent. Breaks the cycle the way the event engine's quiescence does.
+	DrainForce = 2
+)
+
+// Dispatcher runs a node's reconcile body. The orchestrator supplies the
+// concrete implementation, closing over the store and the three controllers;
+// the scheduler never sees a store or controller type.
+type Dispatcher interface {
+	// Dispatch invokes id's reconcile body synchronously on the calling
+	// goroutine (a task.Service worker) and reports back:
+	//   - out: OutcomeTerminal or OutcomeBlocked.
+	//   - blocked: unsatisfied dependency ids (non-nil only when Blocked).
+	//   - ready: whether id's final store status is Ready (meaningful only
+	//     when Terminal) — the scheduler records it so a node parking on id
+	//     can tell, without reading the store, whether id is satisfied.
+	// drainLevel is one of DrainNone/DrainCascade/DrainForce.
+	Dispatch(ctx context.Context, id NodeID, drainLevel int) (out Outcome, blocked []NodeID, ready bool)
+}
+
+type nodeState uint8
+
+const (
+	stateRunnable nodeState = iota
+	stateRunning
+	stateParked
+	stateTerminal
+)
+
+type node struct {
+	id        NodeID
+	state     nodeState
+	ready     bool     // for stateTerminal: did it end Ready (vs Failed)?
+	blockedOn []NodeID // deps recorded at the last OutcomeBlocked
+	// rerunRequested is set when a wake arrives while the node is running, so
+	// complete() re-queues it once instead of dropping the wake (the re-run
+	// re-reads the store and re-evaluates its gate against current state).
+	rerunRequested bool
+}
+
+// Scheduler is a re-entrant fixpoint reconcile driver. Construct with New,
+// Seed the initial node set, wire store events to OnArrival/OnStatusWake/
+// OnDelete, then call Run.
+type Scheduler struct {
+	tasks *task.Service
+	disp  Dispatcher
+
+	mu        sync.Mutex
+	cond      *sync.Cond
+	nodes     map[NodeID]*node
+	runq      []NodeID
+	parkedIdx map[NodeID]map[NodeID]struct{} // dep id -> set of nodes parked on it
+	inFlight  int                            // count of stateRunning nodes (EXCLUDES parked)
+	draining  int                            // DrainNone/DrainCascade/DrainForce
+	canceled  bool
+}
+
+// New constructs a Scheduler that runs bodies on tasks via disp.
+func New(tasks *task.Service, disp Dispatcher) *Scheduler {
+	s := &Scheduler{
+		tasks:     tasks,
+		disp:      disp,
+		nodes:     map[NodeID]*node{},
+		parkedIdx: map[NodeID]map[NodeID]struct{}{},
+	}
+	s.cond = sync.NewCond(&s.mu)
+	return s
+}
+
+// Seed registers the initial node set (file-loaded Kustomizations,
+// HelmReleases, and source CRs from Bootstrap) as runnable, in deterministic
+// id order. Duplicates and already-known ids are ignored.
+func (s *Scheduler) Seed(ids []NodeID) {
+	ordered := slices.Clone(ids)
+	slices.SortFunc(ordered, func(a, b NodeID) int { return a.Compare(b) })
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range ordered {
+		if _, ok := s.nodes[id]; ok {
+			continue
+		}
+		s.nodes[id] = &node{id: id, state: stateRunnable}
+		s.runq = append(s.runq, id)
+	}
+}
+
+// Run drives the scheduler to a fixpoint, returning when every node is
+// terminal (or ctx is canceled) after the in-flight bodies drain.
+func (s *Scheduler) Run(ctx context.Context) {
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.mu.Lock()
+			s.canceled = true
+			s.cond.Broadcast()
+			s.mu.Unlock()
+		case <-stop:
+		}
+	}()
+
+	s.mu.Lock()
+	for !s.canceled {
+		// 1. Dispatch the runnable frontier onto the bounded pool.
+		for len(s.runq) > 0 && !s.canceled {
+			id := s.runq[0]
+			s.runq = s.runq[1:]
+			n := s.nodes[id]
+			if n == nil || n.state != stateRunnable {
+				continue
+			}
+			n.state = stateRunning
+			n.rerunRequested = false
+			n.blockedOn = nil
+			s.inFlight++
+			level := s.draining
+			s.mu.Unlock()
+			s.tasks.Go(ctx, "schedule/"+id.String(), func(ctx context.Context) {
+				out, blocked, ready := s.disp.Dispatch(ctx, id, level)
+				s.complete(id, out, blocked, ready)
+			})
+			s.mu.Lock()
+		}
+		// 2. Frontier empty. If nothing is in flight, we are at a fixpoint:
+		//    either done, or the remaining parked nodes are unproducible and
+		//    must be drained.
+		if s.inFlight == 0 {
+			if !s.hasParkedLocked() {
+				break // clean fixpoint: every node terminal
+			}
+			// Parked nodes remain with nothing in flight. Escalate the drain
+			// level and re-queue all parked once. WITHIN a level the cascade
+			// propagates via complete() wakes — inFlight never settles to 0
+			// mid-cascade, because a terminalize that wakes a waiter pushes it
+			// to runq before the loop re-checks inFlight — so reaching here
+			// again means the level made no progress: a cross-kind structural
+			// cycle (same-kind cycles fail earlier at preflight). DrainForce
+			// fails present-Pending deps, breaking the cycle the way the event
+			// engine's quiescence does; finalSweep is the last-resort backstop.
+			if s.draining >= DrainForce {
+				break
+			}
+			s.draining++
+			s.requeueAllParkedLocked()
+			continue
+		}
+		// 3. Work in flight, frontier empty: wait for a completion or arrival.
+		s.cond.Wait()
+	}
+	if !s.canceled {
+		s.finalSweepLocked()
+	}
+	s.mu.Unlock()
+	s.tasks.BlockTillDone()
+}
+
+// complete records the result of one Dispatch. Runs on the worker goroutine;
+// acquires mu. Touches ONLY scheduler state — never the store or the pool.
+func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready bool) {
+	s.mu.Lock()
+	// Broadcast on EVERY path (terminalize, park, re-queue) so the Run loop
+	// re-evaluates inFlight/runq after any transition — a terminalize that
+	// drops inFlight to 0 with the loop in cond.Wait MUST wake it. Deferred
+	// after Unlock so (LIFO) it runs first, still under mu.
+	defer s.mu.Unlock()
+	defer s.cond.Broadcast()
+	n := s.nodes[id]
+	s.inFlight--
+
+	// A wake landed while this body was running: honor it exactly once by
+	// re-queuing, regardless of the outcome just reported. The re-run
+	// re-reads the store and re-evaluates against the now-current state
+	// (covers a dep that advanced mid-run, and the #102 parent-mutated-spec
+	// re-emit). We do NOT mark it terminal, so a parker never sees a stale
+	// terminal here.
+	if n.rerunRequested {
+		n.rerunRequested = false
+		n.state = stateRunnable
+		n.blockedOn = nil
+		s.runq = append(s.runq, id)
+		return
+	}
+
+	switch out {
+	case OutcomeTerminal:
+		n.state = stateTerminal
+		n.ready = ready
+		n.blockedOn = nil
+		s.wakeWaitersLocked(id)
+	case OutcomeBlocked:
+		// Lost-wakeup re-check using ONLY scheduler state (never the store —
+		// reading the store under mu would invert lock order against an
+		// emitting worker that wants mu via OnArrival). If ANY blocked dep is
+		// already terminal in our node map it will deliver no further
+		// terminalize-wake, so parking risks hanging until draining; re-run now
+		// instead (the re-run re-classifies: a terminal-Ready dep is satisfied,
+		// a terminal-Failed dep cascades).
+		for _, dep := range blocked {
+			if d := s.nodes[dep]; d != nil && d.state == stateTerminal {
+				n.state = stateRunnable
+				s.runq = append(s.runq, id)
+				return
+			}
+		}
+		// Park: every blocked dep is live (a non-terminal node that will
+		// terminalize and wake us) or has no scheduler node (an absent dep,
+		// woken by a future OnArrival or terminalized by the draining sweep).
+		n.state = stateParked
+		n.blockedOn = blocked
+		for _, dep := range blocked {
+			set := s.parkedIdx[dep]
+			if set == nil {
+				set = map[NodeID]struct{}{}
+				s.parkedIdx[dep] = set
+			}
+			set[id] = struct{}{}
+		}
+	}
+}
+
+// wakeWaitersLocked re-queues every node parked on depID (because depID
+// terminalized, arrived, or reached a terminal status). Caller holds mu.
+func (s *Scheduler) wakeWaitersLocked(depID NodeID) {
+	set := s.parkedIdx[depID]
+	if len(set) == 0 {
+		return
+	}
+	waiters := make([]NodeID, 0, len(set))
+	for w := range set {
+		waiters = append(waiters, w)
+	}
+	for _, w := range waiters {
+		n := s.nodes[w]
+		if n == nil {
+			continue
+		}
+		switch n.state {
+		case stateParked:
+			s.unparkLocked(n)
+		case stateRunning:
+			n.rerunRequested = true
+		}
+	}
+}
+
+// unparkLocked moves a parked node to runnable and removes it from every
+// parkedIdx set it was registered in. Caller holds mu.
+func (s *Scheduler) unparkLocked(n *node) {
+	for _, dep := range n.blockedOn {
+		if set := s.parkedIdx[dep]; set != nil {
+			delete(set, n.id)
+			if len(set) == 0 {
+				delete(s.parkedIdx, dep)
+			}
+		}
+	}
+	n.blockedOn = nil
+	n.state = stateRunnable
+	s.runq = append(s.runq, n.id)
+}
+
+// OnArrival is called from the store's EventObjectAdded subscription (which
+// fires only when an object's content actually changed — including a Refire's
+// status reset). schedulable reports whether id is a node the scheduler runs (a
+// Kustomization/HelmRelease/source) versus pure data (a ConfigMap/Secret): a
+// data arrival must WAKE nodes parked on it (a KS waiting on a substituteFrom
+// CM) but is never registered as a runnable node. A content-changed arrival of
+// a terminal node re-dispatches it (the re-run re-reads and is idempotent via
+// fingerprint dedup), which is what restores a Refired producer/source.
+func (s *Scheduler) OnArrival(id NodeID, schedulable bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n := s.nodes[id]; n == nil {
+		if schedulable {
+			// Render-discovered node: register and queue it.
+			s.nodes[id] = &node{id: id, state: stateRunnable}
+			s.runq = append(s.runq, id)
+		}
+		// Non-schedulable unknown id (ConfigMap/Secret): fall through to wake
+		// nodes parked on it, but do not register it.
+	} else {
+		switch n.state {
+		case stateTerminal:
+			// Content changed (Refire reset, or a parent re-emitted a mutated
+			// spec): re-run so the new content is reconciled.
+			n.state = stateRunnable
+			n.ready = false
+			s.runq = append(s.runq, id)
+		case stateRunning:
+			n.rerunRequested = true
+		}
+	}
+	// Always wake nodes parked ON id — a node parked on its own emitted child
+	// (HR -> synthetic HelmChart), or on a dep (CM/source/KS) that just arrived.
+	s.wakeWaitersLocked(id)
+	s.cond.Broadcast()
+}
+
+// OnStatusWake is called from the store's EventStatusUpdated subscription. It
+// acts only on a TERMINAL store status (Ready or Failed): a parked node gates
+// on Ready/Failed, so intermediate Pending progress writes never change its
+// gate answer and waking on them is pure churn that also widens race windows.
+func (s *Scheduler) OnStatusWake(id NodeID, ready, failed bool) {
+	if !ready && !failed {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.wakeWaitersLocked(id)
+	s.cond.Broadcast()
+}
+
+// OnDelete is called when a render-discovered node is removed from the store
+// mid-run. It terminalizes the node in the scheduler and wakes its waiters,
+// which re-Require and route through the absent-dep path.
+func (s *Scheduler) OnDelete(id NodeID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n := s.nodes[id]; n != nil && n.state != stateRunning {
+		n.state = stateTerminal
+		n.ready = false
+		s.unparkSelfLocked(n)
+	}
+	s.wakeWaitersLocked(id)
+	s.cond.Broadcast()
+}
+
+// unparkSelfLocked removes n from every parkedIdx set without queuing it (used
+// when forcibly terminalizing a parked node). Caller holds mu.
+func (s *Scheduler) unparkSelfLocked(n *node) {
+	for _, dep := range n.blockedOn {
+		if set := s.parkedIdx[dep]; set != nil {
+			delete(set, n.id)
+			if len(set) == 0 {
+				delete(s.parkedIdx, dep)
+			}
+		}
+	}
+	n.blockedOn = nil
+}
+
+func (s *Scheduler) hasParkedLocked() bool {
+	for _, n := range s.nodes {
+		if n.state == stateParked {
+			return true
+		}
+	}
+	return false
+}
+
+// requeueAllParkedLocked moves every parked node back to runnable, in id
+// order, so the draining sweep re-runs them leaf-first. Caller holds mu.
+func (s *Scheduler) requeueAllParkedLocked() {
+	var parked []*node
+	for _, n := range s.nodes {
+		if n.state == stateParked {
+			parked = append(parked, n)
+		}
+	}
+	slices.SortFunc(parked, func(a, b *node) int { return a.id.Compare(b.id) })
+	for _, n := range parked {
+		s.unparkLocked(n)
+	}
+}
+
+// finalSweepLocked is a defensive backstop: after DrainForce every parked node
+// should have terminalized (DrainForce fails present-Pending deps), so nothing
+// should remain parked. If a node somehow does, force it terminal so a parked
+// node can never masquerade as a clean run. Caller holds mu.
+func (s *Scheduler) finalSweepLocked() {
+	for _, n := range s.nodes {
+		if n.state == stateParked {
+			n.state = stateTerminal
+			n.ready = false
+			s.unparkSelfLocked(n)
+		}
+	}
+}

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -1,0 +1,323 @@
+package schedule
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/task"
+)
+
+// id builds a Kustomization-kind NodeID for tests.
+func id(name string) NodeID {
+	return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
+}
+
+// fakeDisp is a store-free, controller-free Dispatcher driven by a fixed
+// dependency graph. It mimics classifyDep semantics exactly:
+//   - a dep present-and-Ready              -> satisfied
+//   - a dep present-and-Failed             -> cascade-fail this node
+//   - a dep absent (no graph node):
+//     DrainNone           -> block
+//     DrainCascade/Force  -> fail ("dependency not found")
+//   - a dep present-but-Pending (a graph node not yet terminal):
+//     DrainNone/Cascade   -> block
+//     DrainForce          -> fail ("not ready")
+//
+// A "failing leaf" is modeled as a node depending on an id absent from the
+// graph. The fake records terminal state + per-node dispatch counts + the max
+// drain level it observed, all under its own mutex.
+type fakeDisp struct {
+	graph map[NodeID][]NodeID // node -> deps
+
+	// gate, if set for an id, blocks that id's Dispatch until the channel is
+	// closed — used to force interleavings (e.g. the lost-wakeup race).
+	gate map[NodeID]chan struct{}
+
+	mu        sync.Mutex
+	termReady map[NodeID]bool
+	termAny   map[NodeID]bool
+	runs      map[NodeID]int
+	maxDrain  int
+}
+
+func newFake(graph map[NodeID][]NodeID) *fakeDisp {
+	return &fakeDisp{
+		graph:     graph,
+		gate:      map[NodeID]chan struct{}{},
+		termReady: map[NodeID]bool{},
+		termAny:   map[NodeID]bool{},
+		runs:      map[NodeID]int{},
+	}
+}
+
+func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outcome, []NodeID, bool) {
+	f.mu.Lock()
+	g := f.gate[nid]
+	f.mu.Unlock()
+	if g != nil {
+		<-g // block until the test releases this node
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.runs[nid]++
+	if drainLevel > f.maxDrain {
+		f.maxDrain = drainLevel
+	}
+	deps := f.graph[nid]
+	var blocked []NodeID
+	failed := false
+	for _, d := range deps {
+		if f.termAny[d] {
+			if !f.termReady[d] {
+				failed = true
+			}
+			continue // terminal-ready -> satisfied
+		}
+		if _, isNode := f.graph[d]; !isNode {
+			// absent dep
+			if drainLevel >= DrainCascade {
+				failed = true
+				continue
+			}
+			blocked = append(blocked, d)
+			continue
+		}
+		// present but not yet terminal (pending)
+		if drainLevel >= DrainForce {
+			failed = true
+			continue
+		}
+		blocked = append(blocked, d)
+	}
+	switch {
+	case failed:
+		f.termAny[nid] = true
+		f.termReady[nid] = false
+		return OutcomeTerminal, nil, false
+	case len(blocked) > 0:
+		return OutcomeBlocked, blocked, false
+	default:
+		f.termAny[nid] = true
+		f.termReady[nid] = true
+		return OutcomeTerminal, nil, true
+	}
+}
+
+func (f *fakeDisp) state(nid NodeID) (terminal, ready bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.termAny[nid], f.termReady[nid]
+}
+
+func (f *fakeDisp) runCount(nid NodeID) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.runs[nid]
+}
+
+func (f *fakeDisp) maxDrainLevel() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.maxDrain
+}
+
+// run seeds the graph keys and runs the scheduler to a fixpoint on a pool of
+// the given width.
+func run(t *testing.T, f *fakeDisp, workers int) *Scheduler {
+	t.Helper()
+	ts := task.NewBounded(workers)
+	s := New(ts, f)
+	seeds := make([]NodeID, 0, len(f.graph))
+	for k := range f.graph {
+		seeds = append(seeds, k)
+	}
+	s.Seed(seeds)
+	s.Run(context.Background())
+	return s
+}
+
+func assertReady(t *testing.T, f *fakeDisp, name string) {
+	t.Helper()
+	term, ready := f.state(id(name))
+	if !term || !ready {
+		t.Fatalf("%s: want terminal-Ready, got terminal=%v ready=%v", name, term, ready)
+	}
+}
+
+func assertFailed(t *testing.T, f *fakeDisp, name string) {
+	t.Helper()
+	term, ready := f.state(id(name))
+	if !term || ready {
+		t.Fatalf("%s: want terminal-Failed, got terminal=%v ready=%v", name, term, ready)
+	}
+}
+
+func TestLinearChainReadyPropagation(t *testing.T) {
+	// a -> b -> c (c is a ready leaf).
+	f := newFake(map[NodeID][]NodeID{
+		id("a"): {id("b")},
+		id("b"): {id("c")},
+		id("c"): nil,
+	})
+	run(t, f, 8)
+	assertReady(t, f, "a")
+	assertReady(t, f, "b")
+	assertReady(t, f, "c")
+	if f.maxDrainLevel() != DrainNone {
+		t.Fatalf("a healthy chain must resolve without draining; maxDrain=%d", f.maxDrainLevel())
+	}
+}
+
+func TestDiamondReadyPropagation(t *testing.T) {
+	// d -> {b, c}; b -> a; c -> a; a ready leaf.
+	f := newFake(map[NodeID][]NodeID{
+		id("d"): {id("b"), id("c")},
+		id("b"): {id("a")},
+		id("c"): {id("a")},
+		id("a"): nil,
+	})
+	run(t, f, 8)
+	for _, n := range []string{"a", "b", "c", "d"} {
+		assertReady(t, f, n)
+	}
+}
+
+func TestDanglingChainCascadeFails(t *testing.T) {
+	// a -> b -> (absent X). Both must fail; the leaf's "dependency not found"
+	// cascades up. DrainCascade suffices (no DrainForce needed for a chain).
+	f := newFake(map[NodeID][]NodeID{
+		id("a"): {id("b")},
+		id("b"): {id("missing")}, // "missing" is absent from the graph
+	})
+	run(t, f, 8)
+	assertFailed(t, f, "a")
+	assertFailed(t, f, "b")
+	if f.maxDrainLevel() != DrainCascade {
+		t.Fatalf("a dangling chain should drain at DrainCascade, not DrainForce; maxDrain=%d", f.maxDrainLevel())
+	}
+}
+
+func TestParkThenArrivalWake(t *testing.T) {
+	// a -> x, but x is NOT seeded; it must arrive via OnArrival (render
+	// discovery) and wake the parked a. A gated "keepalive" node holds the pool
+	// non-idle so the scheduler cannot reach the fixpoint and drain a before x
+	// arrives — forcing the genuine park-then-wake path deterministically.
+	f := newFake(map[NodeID][]NodeID{
+		id("a"):         {id("x")},
+		id("x"):         nil, // x is a ready leaf once known
+		id("keepalive"): nil,
+	})
+	gate := make(chan struct{})
+	f.gate[id("keepalive")] = gate
+	ts := task.NewBounded(8)
+	s := New(ts, f)
+	s.Seed([]NodeID{id("a"), id("keepalive")}) // x absent at start
+	done := make(chan struct{})
+	go func() { s.Run(context.Background()); close(done) }()
+
+	// Wait until a has actually parked (its first Dispatch ran and reported
+	// Blocked) before introducing x, so we exercise park-then-wake.
+	waitUntil(t, func() bool { return f.runCount(id("a")) >= 1 })
+	s.OnArrival(id("x"), true) // x appears (render-discovered) -> wakes a
+	waitUntil(t, func() bool { term, _ := f.state(id("a")); return term })
+	close(gate) // let keepalive finish so Run can reach the fixpoint
+	<-done
+	assertReady(t, f, "a")
+	assertReady(t, f, "x")
+}
+
+// waitUntil polls cond until true or the test times out.
+func waitUntil(t *testing.T, cond func() bool) {
+	t.Helper()
+	for range 5_000_000 {
+		if cond() {
+			return
+		}
+		runtime.Gosched()
+	}
+	t.Fatal("waitUntil: condition not met")
+}
+
+func TestLostWakeupRecheck(t *testing.T) {
+	// Force the race: a's Dispatch returns OutcomeBlocked on b only AFTER b has
+	// already terminalized. complete(a)'s scheduler-state re-check must see b
+	// terminal and re-queue a (not park it on an already-fired wake). a must
+	// resolve Ready WITHOUT entering draining — proving the re-check, not the
+	// draining backstop, recovered it.
+	f := newFake(map[NodeID][]NodeID{
+		id("a"): {id("b")},
+		id("b"): nil,
+	})
+	gate := make(chan struct{})
+	f.gate[id("a")] = gate
+	// Release a's Dispatch once b is terminal.
+	go func() {
+		for {
+			if term, _ := f.state(id("b")); term {
+				close(gate)
+				return
+			}
+		}
+	}()
+	run(t, f, 8)
+	assertReady(t, f, "a")
+	assertReady(t, f, "b")
+	if f.maxDrainLevel() != DrainNone {
+		t.Fatalf("lost-wakeup re-check should recover at DrainNone, not via draining; maxDrain=%d", f.maxDrainLevel())
+	}
+}
+
+func TestTransitiveBlockCompareOrderCascades(t *testing.T) {
+	// Names chosen so the CONSUMER sorts before its blocker in requeue order
+	// ("a-top" < "z-leaf"), forcing the draining sweep to re-run the consumer
+	// first; the complete() wake must still cascade the leaf's failure upward.
+	f := newFake(map[NodeID][]NodeID{
+		id("a-top"):  {id("z-leaf")},
+		id("z-leaf"): {id("absent")},
+	})
+	run(t, f, 8)
+	assertFailed(t, f, "a-top")
+	assertFailed(t, f, "z-leaf")
+}
+
+func TestCrossKindCycleForceDrains(t *testing.T) {
+	// a <-> b mutual dependency (no same-kind preflight here): DrainCascade
+	// cannot break it (each sees the other present-Pending and re-parks), so
+	// the scheduler must escalate to DrainForce and fail both.
+	f := newFake(map[NodeID][]NodeID{
+		id("a"): {id("b")},
+		id("b"): {id("a")},
+	})
+	run(t, f, 8)
+	assertFailed(t, f, "a")
+	assertFailed(t, f, "b")
+	if f.maxDrainLevel() != DrainForce {
+		t.Fatalf("a cycle must escalate to DrainForce; maxDrain=%d", f.maxDrainLevel())
+	}
+}
+
+func TestDanglingChainRunCountBounded(t *testing.T) {
+	// A depth-5 dangling chain must terminalize with a bounded number of
+	// re-runs per node (no exponential blowup / no infinite re-park loop).
+	g := map[NodeID][]NodeID{}
+	names := []string{"n0", "n1", "n2", "n3", "n4"}
+	for i, n := range names {
+		if i+1 < len(names) {
+			g[id(n)] = []NodeID{id(names[i+1])}
+		} else {
+			g[id(n)] = []NodeID{id("absent")} // leaf blocks on absent
+		}
+	}
+	f := newFake(g)
+	run(t, f, 8)
+	for _, n := range names {
+		assertFailed(t, f, n)
+		if rc := f.runCount(id(n)); rc > 6 {
+			t.Fatalf("%s ran %d times; expected a small bounded count", n, rc)
+		}
+	}
+}


### PR DESCRIPTION
## What

Phase 1 of the engine rewrite ([plan](https://github.com/home-operations/flate)). Adds **`pkg/schedule`** — a re-entrant fixpoint reconcile scheduler that replaces depwait's blocking-wait + task-quiescence model with **structural termination**, behind a new `--engine=dag` flag. `--engine=event` (depwait + quiescence) stays the **default and unchanged**; dag is opt-in and gated.

A reconcile body never blocks: instead of `base.Await` it calls `Require`, which under dag classifies each dependency *without blocking* and returns `nil` / `*manifest.DependencyFailedError` / `*depwait.ErrBlocked`. The scheduler parks a blocked node and re-runs it when a dependency advances. At the fixpoint (nothing in flight, frontier empty) any still-parked node's deps are **provably unproducible** (every render emission is a synchronous store write within the body), so they're terminalized with the canonical failure status — **no per-dep timeout, no shared quiescence signal**, so the #666 transient-drain false-drop class cannot occur by construction.

## Why

The ~16s dependency-wait stall on repos with dangling `dependsOn` (measured: Biohazard whole-cluster warm = 23s, of which only ~7s is real work) is undecidable to fix safely in the event engine — it's the cost of using timeouts as a proxy for "this dep will never arrive." The scheduler decides danglement structurally instead.

## Components

- **`pkg/schedule`** — single-mutex scheduler (`Seed`/`Run`/`complete`/`OnArrival`/`OnStatusWake`/`OnDelete`), a `Dispatcher` seam, and an escalating drain fixpoint (cascade → force) that reproduces the event engine's leaf-first cascade messages and cross-kind-cycle handling. Imports only `manifest` + `task`; unit-tested against a fake Dispatcher at `-race -count=300` (lost-wakeup re-check, cascade, force-drain, park-then-wake).
- **`pkg/depwait`** — `ErrBlocked` sentinel + `Classify` (non-blocking per-dep classifier reusing `readyNow`/ReadyExpr/`Promote`, so dag gate semantics are byte-identical to the event engine).
- **`base.Controller`** — `EngineMode`, the `Require` dag branch, `RunWithStatusOutcome` (intercepts `ErrBlocked` *before* the Failed-status write so a parked node stays non-Ready + re-runnable), `DispatchNode`. `DepFailed` now sorts the failed-dep list — making **both** engines deterministic for multi-failed-dependency messages (fixes a latent event-engine nondeterminism).
- **controllers** — per-controller `ReconcileNode`; dag skips the `OnReconcile` dispatch listener (the scheduler owns dispatch; the HR producer index stays wired).
- **orchestrator** — `Config.Engine` + `runDAG` (`dagrun.go`) wiring the scheduler to the store via `OnArrival`/`OnStatusWake` adapters, with no store read under the scheduler mutex (no lock-order inversion).
- **CLI** — `--engine` flag (`event`|`dag`, default `event`).

## Verification

- `gofmt` / `go vet` / `golangci-lint` clean; full `go test ./...` passes; scheduler `-race -count=300` green.
- New orchestrator dag integration tests: render-emitted dependency resolves (the case a static oracle can't see), dangling chain cascades + terminates structurally, and event-vs-dag status parity.
- **24/24 byte-identical** `build all` output between `--engine=event` and `--engine=dag` across the regression repos (shared cache isolating engine behavior).
- Biohazard whole-cluster `test all`: **23.2s (event) → 6.0s (dag)**, identical pass/fail set (370/16) and identical reasons — the only delta is helm's own schema-validation error ordering, which varies run-to-run under **both** engines (pre-existing, engine-independent).

Staged per the plan: this lands the scheduler behind the flag. A later PR flips the default and deletes the depwait/quiescence machinery once the gate has held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)