### PR TITLE
style: gofmt trailing newlines in substitute.go and constants.go

### DIFF
--- a/pkg/kustomize/substitute.go
+++ b/pkg/kustomize/substitute.go
@@ -33,4 +33,3 @@ func Substitute(data []byte, vars map[string]string) ([]byte, error) {
 	}
 	return []byte(out), nil
 }
-

--- a/pkg/manifest/constants.go
+++ b/pkg/manifest/constants.go
@@ -78,4 +78,3 @@ var KustomizeBuilderFilenames = []string{
 	"kustomization.yml",
 	"Kustomization",
 }
-


### PR DESCRIPTION
Two files failed `gofmt -l` on `main` with a trailing-blank-line-at-EOF — pre-existing, and missed by the golangci-lint v2 gate (so CI was green). `gofmt -w pkg/kustomize/substitute.go pkg/manifest/constants.go` removes the stray newline; `gofmt -l pkg internal cmd` is now empty. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
