### PR TITLE
refactor(loader): typed decode + unified strategies in transformer_ns.go

### DIFF
--- a/pkg/loader/transformer_ns.go
+++ b/pkg/loader/transformer_ns.go
@@ -1,6 +1,9 @@
 package loader
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -111,12 +114,35 @@ func resolveOverlayInjectedNamespace(repoRoot, file string, cache map[string]nsR
 	return ""
 }
 
-// resolveTransformerTargetNamespace inspects the kustomization.yaml at
-// overlayDir. When it applies a `transformers:` entry whose subtree both
-// carries a `namespace:` directive and resolves to a builtin
-// NamespaceTransformer that sets Kustomization spec/targetNamespace, the
-// directive value is the namespace that transformer injects.
-func resolveTransformerTargetNamespace(repoRoot, overlayDir string) nsResolution {
+// nsInjectionStrategies are the supported overlay-namespace detectors, tried in
+// order: a builtin NamespaceTransformer (flatops), then a `replacements:` rule
+// (home-operations). Each reports the namespace the overlay at overlayDir
+// injects onto Flux Kustomization spec.targetNamespace, or the zero nsResolution
+// when it doesn't apply. Adding a third pattern is one entry here.
+var nsInjectionStrategies = []func(repoRoot, overlayDir string) nsResolution{
+	transformerInjectedNamespace,
+	replacementInjectedNamespace,
+}
+
+// resolveInjectedTargetNamespace returns the namespace the overlay at overlayDir
+// injects onto Flux Kustomizations via the first matching strategy. Strategies
+// key on the same overlay dir, so the caller's per-dir cache and
+// deepest-overlay-wins walk are unaffected.
+func resolveInjectedTargetNamespace(repoRoot, overlayDir string) nsResolution {
+	for _, strategy := range nsInjectionStrategies {
+		if r := strategy(repoRoot, overlayDir); r.ok {
+			return r
+		}
+	}
+	return nsResolution{}
+}
+
+// transformerInjectedNamespace inspects the kustomization.yaml at overlayDir.
+// When it applies a `transformers:` entry whose subtree both carries a
+// `namespace:` directive and resolves to a builtin NamespaceTransformer that
+// sets Kustomization spec/targetNamespace, the directive value is the namespace
+// that transformer injects.
+func transformerInjectedNamespace(repoRoot, overlayDir string) nsResolution {
 	d, ok := readKustomizeDirectives(repoRoot, overlayDir)
 	if !ok || len(d.Transformers) == 0 {
 		return nsResolution{}
@@ -130,124 +156,33 @@ func resolveTransformerTargetNamespace(repoRoot, overlayDir string) nsResolution
 		if !ok || td.Namespace == "" {
 			continue
 		}
-		if !subtreeHasNamespaceTransformer(repoRoot, transformerDir, map[string]struct{}{}, 0) {
-			continue
+		if subtreeHasNamespaceTransformer(repoRoot, transformerDir, map[string]struct{}{}, 0) {
+			return nsResolution{ns: td.Namespace, ok: true}
 		}
-		return nsResolution{ns: td.Namespace, ok: true}
 	}
 	return nsResolution{}
 }
 
-// resolveInjectedTargetNamespace resolves the namespace an enclosing
-// overlay injects onto Flux Kustomizations via EITHER supported pattern: a
-// builtin NamespaceTransformer (flatops) or a `replacements:` rule copying a
-// Namespace's name into spec.targetNamespace (home-operations). Transformer
-// first, then replacement; both key on the same overlay dir, so the caller's
-// per-dir cache and deepest-overlay-wins walk are unaffected.
-func resolveInjectedTargetNamespace(repoRoot, overlayDir string) nsResolution {
-	if r := resolveTransformerTargetNamespace(repoRoot, overlayDir); r.ok {
-		return r
-	}
-	return resolveReplacementTargetNamespace(repoRoot, overlayDir)
-}
-
-// resolveReplacementTargetNamespace inspects the kustomization.yaml at
-// overlayDir. When it carries BOTH a `namespace:` directive AND a
-// `replacements:` rule that copies a Namespace's metadata.name into
-// Kustomization spec.targetNamespace, the directive value is the namespace
-// that replacement injects — because the same `namespace:` directive renames
-// the source Namespace to that value before the copy runs. Requiring the
-// directive is conservative: an overlay with the rule but no directive (the
-// Namespace would keep a literal component name) is left unstamped rather
-// than guessed, and a bare `namespace:` directive with no targetNamespace
-// rule is owned by metadata.namespace inheritance, not us.
-func resolveReplacementTargetNamespace(repoRoot, overlayDir string) nsResolution {
+// replacementInjectedNamespace inspects the kustomization.yaml at overlayDir.
+// When it carries BOTH a `namespace:` directive AND a `replacements:` rule that
+// copies a Namespace's metadata.name into Kustomization spec.targetNamespace,
+// the directive value is the namespace that replacement injects — because the
+// same `namespace:` directive renames the source Namespace to that value before
+// the copy runs. Requiring the directive is conservative: an overlay with the
+// rule but no directive (the Namespace would keep a literal component name) is
+// left unstamped rather than guessed, and a bare `namespace:` directive with no
+// targetNamespace rule is owned by metadata.namespace inheritance, not us.
+func replacementInjectedNamespace(repoRoot, overlayDir string) nsResolution {
 	d, ok := readKustomizeDirectives(repoRoot, overlayDir)
 	if !ok || d.Namespace == "" || len(d.Replacements) == 0 {
 		return nsResolution{}
 	}
 	for _, r := range d.Replacements {
-		if replacementInjectsKustomizationTargetNamespace(repoRoot, overlayDir, r) {
+		if r.injectsKustomizationTargetNamespace(repoRoot, overlayDir) {
 			return nsResolution{ns: d.Namespace, ok: true}
 		}
 	}
 	return nsResolution{}
-}
-
-// replacementInjectsKustomizationTargetNamespace reports whether r is a
-// Namespace-name → Kustomization.spec.targetNamespace replacement, handling
-// both the inline (`{source, targets}`) and external (`{path: <file>}`)
-// forms. The path file is a YAML list of replacement objects.
-func replacementInjectsKustomizationTargetNamespace(repoRoot, overlayDir string, r replacementDirective) bool {
-	if r.Source != nil {
-		return docIsNamespaceNameReplacementForKustomization(r.Source, r.Targets)
-	}
-	if r.Path == "" {
-		return false
-	}
-	ref, ok := resolveRef(overlayDir, r.Path)
-	if !ok {
-		return false
-	}
-	data, err := os.ReadFile(filepath.Join(repoRoot, ref)) //nolint:gosec // path composed from known cluster layout
-	if err != nil {
-		return false
-	}
-	var rules []replacementDirective
-	if err := yaml.Unmarshal(data, &rules); err != nil {
-		return false
-	}
-	return slices.ContainsFunc(rules, func(rr replacementDirective) bool {
-		return docIsNamespaceNameReplacementForKustomization(rr.Source, rr.Targets)
-	})
-}
-
-// docIsNamespaceNameReplacementForKustomization reports whether a kustomize
-// replacement (source + targets) copies a Namespace's metadata.name into the
-// spec.targetNamespace of Flux Kustomizations — the precise shape
-// kubernetes/components/replacements/ks.yaml uses.
-func docIsNamespaceNameReplacementForKustomization(source map[string]any, targets []any) bool {
-	if source == nil {
-		return false
-	}
-	if kind, _ := source["kind"].(string); kind != "Namespace" {
-		return false
-	}
-	if !replacementFieldMatches(source, "metadata.name") {
-		return false
-	}
-	return slices.ContainsFunc(targets, func(raw any) bool {
-		t, ok := raw.(map[string]any)
-		if !ok {
-			return false
-		}
-		sel, _ := t["select"].(map[string]any)
-		if sel == nil {
-			return false
-		}
-		if kind, _ := sel["kind"].(string); kind != manifest.KindKustomization {
-			return false
-		}
-		if group, _ := sel["group"].(string); group != manifest.FluxKustomizeDomain {
-			return false
-		}
-		return replacementFieldMatches(t, "spec.targetNamespace")
-	})
-}
-
-// replacementFieldMatches reports whether m references the dotted path want
-// via either `fieldPath` (string — the canonical replacement-source form) or
-// `fieldPaths` (list — the target form). Accepting both on either side costs
-// nothing and tolerates hand-written variants.
-func replacementFieldMatches(m map[string]any, want string) bool {
-	if fp, ok := m["fieldPath"].(string); ok && fp == want {
-		return true
-	}
-	fps, _ := m["fieldPaths"].([]any)
-	return slices.ContainsFunc(fps, func(v any) bool {
-		s, _ := v.(string)
-		return s == want
-	})
 }
 
 // subtreeHasNamespaceTransformer reports whether the kustomize subtree
@@ -279,38 +214,57 @@ func subtreeHasNamespaceTransformer(repoRoot, dir string, visited map[string]str
 	})
 }
 
-// fileHasNamespaceTransformer reads target as a manifest file and
-// reports whether any document in it is a qualifying NamespaceTransformer.
-// Returns false when target is a directory or unreadable.
+// fileHasNamespaceTransformer reads target as a (possibly multi-document)
+// manifest file and reports whether any document is a qualifying
+// NamespaceTransformer. Returns false when target is a directory, unreadable, or
+// any document is malformed (all-or-nothing, matching a whole-file parse).
 func fileHasNamespaceTransformer(repoRoot, target string) bool {
 	data, err := os.ReadFile(filepath.Join(repoRoot, target)) //nolint:gosec // path composed from known cluster layout
 	if err != nil {
 		return false
 	}
-	docs, err := manifest.SplitDocs(data)
-	if err != nil {
-		return false
-	}
-	return slices.ContainsFunc(docs, docIsNamespaceTransformerForKustomization)
-}
-
-// docIsNamespaceTransformerForKustomization reports whether doc is a
-// builtin NamespaceTransformer with a fieldSpec that writes
-// spec/targetNamespace on Kustomizations — the precise shape that
-// injects a Flux KS's targetNamespace.
-func docIsNamespaceTransformerForKustomization(doc map[string]any) bool {
-	if manifest.DocKind(doc) != "NamespaceTransformer" {
-		return false
-	}
-	specs, _ := doc["fieldSpecs"].([]any)
-	return slices.ContainsFunc(specs, func(raw any) bool {
-		fs, ok := raw.(map[string]any)
-		if !ok {
+	// Decode every document up front and bail on any malformed one, matching
+	// the prior whole-file SplitDocs parse (all-or-nothing) exactly.
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	var docs []namespaceTransformerDoc
+	for {
+		var doc namespaceTransformerDoc
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
 			return false
 		}
-		kind, _ := fs["kind"].(string)
-		p, _ := fs["path"].(string)
-		return kind == manifest.KindKustomization && p == "spec/targetNamespace"
+		docs = append(docs, doc)
+	}
+	return slices.ContainsFunc(docs, namespaceTransformerDoc.injectsKustomizationTargetNamespace)
+}
+
+// namespaceTransformerDoc is the subset of a builtin NamespaceTransformer that
+// targetNamespace detection reads: a fieldSpec writing spec/targetNamespace on
+// Kustomizations is what injects a Flux KS's targetNamespace.
+type namespaceTransformerDoc struct {
+	Kind       string                 `yaml:"kind"`
+	FieldSpecs []transformerFieldSpec `yaml:"fieldSpecs"`
+}
+
+// transformerFieldSpec is one `fieldSpecs:` entry: the kind it applies to and
+// the object path it writes.
+type transformerFieldSpec struct {
+	Kind string `yaml:"kind"`
+	Path string `yaml:"path"`
+}
+
+// injectsKustomizationTargetNamespace reports whether doc is a builtin
+// NamespaceTransformer with a fieldSpec that writes spec/targetNamespace on
+// Kustomizations — the precise shape that injects a Flux KS's targetNamespace.
+func (d namespaceTransformerDoc) injectsKustomizationTargetNamespace() bool {
+	if d.Kind != "NamespaceTransformer" {
+		return false
+	}
+	return slices.ContainsFunc(d.FieldSpecs, func(fs transformerFieldSpec) bool {
+		return fs.Kind == manifest.KindKustomization && fs.Path == "spec/targetNamespace"
 	})
 }
 
@@ -340,21 +294,91 @@ type kustomizeDirectives struct {
 }
 
 // replacementDirective captures a single `replacements:` entry. kustomize
-// allows two shapes: an external file ref (`{path: <file>}`, where the file
-// is a YAML list of replacement objects) or an inline replacement object
-// (`{source, targets}`). Both decode into this one struct via plain
-// yaml.Unmarshal — the file form leaves Source/Targets nil, the inline form
-// leaves Path empty.
+// allows two shapes: an external file ref (`{path: <file>}`, where the file is a
+// YAML list of replacement objects) or an inline replacement (`{source,
+// targets}`). Both decode into this one struct: the file form leaves
+// Source/Targets nil, the inline form leaves Path empty.
 type replacementDirective struct {
-	Path    string         `yaml:"path"`
-	Source  map[string]any `yaml:"source"`
-	Targets []any          `yaml:"targets"`
+	Path    string              `yaml:"path"`
+	Source  *replacementSource  `yaml:"source"`
+	Targets []replacementTarget `yaml:"targets"`
+}
+
+// replacementSource / replacementTarget / replacementSelect model only the
+// fields targetNamespace detection reads. A replacement field path may be given
+// singular (`fieldPath`) or plural (`fieldPaths`); both are accepted on either
+// side. Selector keys beyond kind/group (version, name, namespace) are
+// intentionally ignored — same as the prior map-based check.
+type replacementSource struct {
+	Kind       string   `yaml:"kind"`
+	FieldPath  string   `yaml:"fieldPath"`
+	FieldPaths []string `yaml:"fieldPaths"`
+}
+
+type replacementTarget struct {
+	Select     replacementSelect `yaml:"select"`
+	FieldPath  string            `yaml:"fieldPath"`
+	FieldPaths []string          `yaml:"fieldPaths"`
+}
+
+type replacementSelect struct {
+	Kind  string `yaml:"kind"`
+	Group string `yaml:"group"`
+}
+
+// injectsKustomizationTargetNamespace reports whether r is a
+// Namespace-name → Kustomization.spec.targetNamespace replacement, resolving the
+// external `{path:}` form (a YAML list of replacement objects) against
+// overlayDir.
+func (r replacementDirective) injectsKustomizationTargetNamespace(repoRoot, overlayDir string) bool {
+	if r.Source != nil {
+		return r.copiesNamespaceNameToKustomizationTargetNamespace()
+	}
+	if r.Path == "" {
+		return false
+	}
+	ref, ok := resolveRef(overlayDir, r.Path)
+	if !ok {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(repoRoot, ref)) //nolint:gosec // path composed from known cluster layout
+	if err != nil {
+		return false
+	}
+	var rules []replacementDirective
+	if err := yaml.Unmarshal(data, &rules); err != nil {
+		return false
+	}
+	return slices.ContainsFunc(rules, replacementDirective.copiesNamespaceNameToKustomizationTargetNamespace)
+}
+
+// copiesNamespaceNameToKustomizationTargetNamespace reports whether r's inline
+// source/targets copy a Namespace's metadata.name into the spec.targetNamespace
+// of Flux Kustomizations — the precise shape
+// kubernetes/components/replacements/ks.yaml uses.
+func (r replacementDirective) copiesNamespaceNameToKustomizationTargetNamespace() bool {
+	if r.Source == nil || r.Source.Kind != "Namespace" ||
+		!fieldMatches(r.Source.FieldPath, r.Source.FieldPaths, "metadata.name") {
+		return false
+	}
+	return slices.ContainsFunc(r.Targets, func(t replacementTarget) bool {
+		return t.Select.Kind == manifest.KindKustomization &&
+			t.Select.Group == manifest.FluxKustomizeDomain &&
+			fieldMatches(t.FieldPath, t.FieldPaths, "spec.targetNamespace")
+	})
+}
+
+// fieldMatches reports whether a replacement field path equals want in either
+// the singular (`fieldPath`) or plural (`fieldPaths`) form. Accepting both on
+// either side costs nothing and tolerates hand-written variants.
+func fieldMatches(single string, plural []string, want string) bool {
+	return single == want || slices.Contains(plural, want)
 }
 
 // readKustomizeDirectives reads the kustomization file in dir (resolved
 // under repoRoot) and returns its namespace/resources/transformers/
-// components fields. ok is false when no kustomization file is present or
-// it can't be parsed — pure best-effort, same contract as
+// components/replacements fields. ok is false when no kustomization file is
+// present or it can't be parsed — pure best-effort, same contract as
 // readKustomizeNamespace.
 func readKustomizeDirectives(repoRoot, dir string) (kustomizeDirectives, bool) {
 	for _, name := range manifest.KustomizeBuilderFilenames {

--- a/pkg/loader/transformer_ns_test.go
+++ b/pkg/loader/transformer_ns_test.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"fmt"
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
@@ -374,6 +375,117 @@ resources:
 `)
 	if got.TargetNamespace != "storage" {
 		t.Errorf("TargetNamespace=%q want storage (plural source fieldPaths)", got.TargetNamespace)
+	}
+}
+
+// A target spelling the path singular (`fieldPath: spec.targetNamespace`)
+// rather than plural (`fieldPaths:`) must still match.
+func TestStampTransformerTargetNamespaces_ReplacementsTargetFieldPathSingular(t *testing.T) {
+	root := t.TempDir()
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - source:
+      kind: Namespace
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: Kustomization
+          group: kustomize.toolkit.fluxcd.io
+        fieldPath: spec.targetNamespace
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "storage" {
+		t.Errorf("TargetNamespace=%q want storage (singular target fieldPath)", got.TargetNamespace)
+	}
+}
+
+// A malformed overlay kustomization.yaml (namespace must be a scalar, not a
+// map) parses to ok=false and yields no stamp — best-effort, never a panic.
+func TestStampTransformerTargetNamespaces_MalformedOverlayIgnored(t *testing.T) {
+	root := t.TempDir()
+	got := stampReplacementsKS(t, root, "apps/storage", "namespace:\n  unexpected: map\nresources:\n  - ./app/ks.yaml\n")
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (malformed overlay)", got.TargetNamespace)
+	}
+}
+
+// A `replacements: {path:}` whose external file is malformed (a map where a
+// list of rules is expected) yields no stamp rather than a panic.
+func TestStampTransformerTargetNamespaces_MalformedReplacementsFileIgnored(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "components/replacements/ks.yaml", "this: is not a list\n")
+	got := stampReplacementsKS(t, root, "apps/storage", `namespace: storage
+replacements:
+  - path: ../../components/replacements/ks.yaml
+resources:
+  - ./app/ks.yaml
+`)
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (malformed replacements file)", got.TargetNamespace)
+	}
+}
+
+// A KS whose ancestor dirs carry no kustomization.yaml at all resolves to no
+// injected namespace (the walk terminates cleanly at the repo root).
+func TestStampTransformerTargetNamespaces_NoEnclosingOverlay(t *testing.T) {
+	root := t.TempDir()
+	s := store.New()
+	ks := leafKS("bare", "./apps/bare/app/workload")
+	s.AddObject(ks)
+	sourceFiles := map[manifest.NamedResource]string{ks.Named(): "apps/bare/app/ks.yaml"}
+	StampTransformerTargetNamespaces(s, sourceFiles, root)
+	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	if got.TargetNamespace != "" {
+		t.Errorf("TargetNamespace=%q want empty (no enclosing overlay)", got.TargetNamespace)
+	}
+}
+
+// TestResolveRef_Rejections locks the strict in-repo guard: remote, absolute,
+// repo-escaping, and empty refs are rejected; a normal relative ref resolves.
+func TestResolveRef_Rejections(t *testing.T) {
+	for _, tc := range []struct{ name, base, ref string }{
+		{"empty", "apps/x", ""},
+		{"remote scheme", "apps/x", "https://example.com/repo//base?ref=v1"},
+		{"absolute", "apps/x", "/etc/passwd"},
+		{"escapes repo root", "apps/x", "../../../../../../etc"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := resolveRef(tc.base, tc.ref); ok {
+				t.Errorf("resolveRef(%q,%q)=(%q,true), want rejected", tc.base, tc.ref, got)
+			}
+		})
+	}
+	if got, ok := resolveRef("apps/x", "../shared"); !ok || got != "apps/shared" {
+		t.Errorf("resolveRef(apps/x,../shared)=(%q,%v), want (apps/shared,true)", got, ok)
+	}
+}
+
+// TestSubtreeHasNamespaceTransformer_DepthCapAndCycle proves the recursive walk
+// is bounded: a NamespaceTransformer reachable only PAST transformerScanMaxDepth
+// is not found (the cap stops the descent), and a reference cycle terminates via
+// the visited set instead of looping.
+func TestSubtreeHasNamespaceTransformer_DepthCapAndCycle(t *testing.T) {
+	root := t.TempDir()
+	// A linear chain d0 → d1 → … each via `resources: - ../d{i+1}`, with the
+	// NamespaceTransformer only at the deepest dir — reached at a depth beyond
+	// the cap, so detection returns false.
+	const depth = transformerScanMaxDepth + 1
+	for i := range depth {
+		writeFile(t, root, fmt.Sprintf("d%d/kustomization.yaml", i),
+			fmt.Sprintf("resources:\n  - ../d%d\n", i+1))
+	}
+	writeFile(t, root, fmt.Sprintf("d%d/kustomization.yaml", depth), "resources:\n  - ./transformer.yaml\n")
+	writeFile(t, root, fmt.Sprintf("d%d/transformer.yaml", depth), namespaceTransformer)
+	if subtreeHasNamespaceTransformer(root, "d0", map[string]struct{}{}, 0) {
+		t.Error("want false: NamespaceTransformer sits past transformerScanMaxDepth")
+	}
+
+	// A reference cycle a → b → a must terminate (visited set) and return false.
+	writeFile(t, root, "cyc/a/kustomization.yaml", "resources:\n  - ../b\n")
+	writeFile(t, root, "cyc/b/kustomization.yaml", "resources:\n  - ../a\n")
+	if subtreeHasNamespaceTransformer(root, "cyc/a", map[string]struct{}{}, 0) {
+		t.Error("want false on a reference cycle (must not loop)")
 	}
 }
 


### PR DESCRIPTION
## Cleanup: pkg/loader/transformer_ns.go

`transformer_ns.go` stamps `spec.targetNamespace` onto namespace-less Flux Kustomizations from an enclosing kustomize overlay — a builtin `NamespaceTransformer` (flatops, #528) or a `replacements:` rule copying a Namespace's name into `spec.targetNamespace` (home-operations, #665). The detection read hand-shaped kustomize YAML through ~7 untyped `map[string]any` assertions and reached two near-parallel detectors via a chain of thin wrapper funcs — fragile and hard to follow.

### Changes (behavior-neutral)
- **Typed decode** — replacement rules now decode into `replacementSource`/`replacementTarget`/`replacementSelect`, and the NamespaceTransformer scan into a typed `namespaceTransformerDoc` (multi-doc `yaml.Decoder`, collect-all to match the prior `SplitDocs` whole-file parse exactly). All 7 untyped assertions are gone; matching is declarative field comparison + a 1-line `fieldMatches`.
- **Unified detectors** — the transformer + replacement detectors are an ordered `nsInjectionStrategies` slice behind `resolveInjectedTargetNamespace`; match logic moved onto `replacementDirective` methods.
- **Kept stable** — `StampTransformerTargetNamespaces` (discovery caller), `kustomizeDirectives` + `readKustomizeDirectives` (shared with `selfproduce.go`/`inherit.go`), `resolveRef`, the deepest-overlay walk + per-dir cache, and the bounded recursion (`transformerScanMaxDepth` + visited).
- **Guard tests added** — `resolveRef` rejections (scheme/abs/escape/empty), the depth-cap + reference-cycle bounds, malformed overlay / external replacements file, singular target `fieldPath`, and no-enclosing-overlay.

### Verification
- **24/24 byte-identical** to `main` across the regression sweep (independent per-binary caches).
- The 12 unchanged stamping tests (a base-vs-branch equivalence proof) + 6 new guards + the `TestOrchestrator_TransformerTargetNamespace` integration test all green; `go vet`, golangci-lint v2 (**0 issues**), full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
