### PR TITLE
docs(cleanup): scrub dangling references to the deleted event engine

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -455,13 +455,9 @@ func RequireRefresh[T manifest.BaseManifest](
 // single-sourcing it keeps the failure shape consistent across controllers.
 func DepFailed(id manifest.NamedResource) func(depwait.Summary) error {
 	return func(sum depwait.Summary) error {
-		// Sort the failed-dep list so the rendered DependencyFailedError
-		// message is deterministic across runs AND identical between the two
-		// engines: the event engine's WaitAll collects failures in
-		// nondeterministic channel-receive order, while the dag engine collects
-		// them in dep-slice order. Sorting here normalizes both (and fixes a
-		// latent event-engine nondeterminism for multi-failed-dependency
-		// resources).
+		// Sort the failed-dep list so the rendered DependencyFailedError message
+		// lists dependencies in a canonical order — independent of dependsOn
+		// declaration order, and deterministic across runs.
 		slices.SortFunc(sum.Failed, func(a, b manifest.NamedResource) int { return a.Compare(b) })
 		return &manifest.DependencyFailedError{
 			Parent:  id,
@@ -523,9 +519,7 @@ func RunWithStatus[T manifest.BaseManifest](
 // terminalized (Ready / Skipped / Failed). It intercepts a *depwait.ErrBlocked
 // returned by the body BEFORE the generic Failed-status write, leaving the
 // Pending status the body's Require wrote — so a blocked node stays non-Ready
-// and re-runnable. Under the event engine the body never returns ErrBlocked, so
-// the returned slice is always nil and behavior is byte-identical to the prior
-// RunWithStatus.
+// and re-runnable.
 func RunWithStatusOutcome[T manifest.BaseManifest](
 	ctx context.Context,
 	s *store.Store,
@@ -546,11 +540,9 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 		return nil
 	}
 	if err := fn(ctx, obj); err != nil {
-		// dag-only: a dependency gate is unsatisfied. Surface the blocked deps
-		// WITHOUT writing Failed — the node keeps the Pending status Require
-		// wrote and stays parkable + re-runnable. Provably unreachable under the
-		// event engine (Await blocks instead of returning ErrBlocked), so the
-		// event path is byte-identical.
+		// A dependency gate is unsatisfied. Surface the blocked deps WITHOUT
+		// writing Failed — the node keeps the Pending status Require wrote and
+		// stays parkable + re-runnable.
 		var blocked *depwait.ErrBlocked
 		if errors.As(err, &blocked) {
 			return blocked.Deps

--- a/pkg/depwait/classify.go
+++ b/pkg/depwait/classify.go
@@ -22,7 +22,7 @@ const (
 	// ClassReady means the dependency is satisfied; the consumer may proceed.
 	ClassReady ClassKind = iota
 	// ClassFailed means the dependency is terminally unsatisfiable; Message
-	// carries the byte-exact reason the event engine would record.
+	// carries the canonical terminal reason for the failure.
 	ClassFailed
 	// ClassBlocked means the dependency is not yet satisfied but possibly
 	// producible; the scheduler parks the consumer keyed on it.
@@ -35,14 +35,13 @@ type Classification struct {
 	Message string // populated only for ClassFailed
 }
 
-// Classify resolves dep for the dag engine WITHOUT blocking, reusing the same
-// readiness predicates as the blocking Watch path (readyNow, depExists, the
-// ReadyExpr evaluator, Existence.Promote) so dag gate semantics are
-// byte-identical to the event engine's. drainLevel escalates how an unsatisfied
-// dependency is treated at the structural fixpoint and selects the canonical
-// terminal message — matching what the event engine produces at quiescence:
-// notFound ("dependency not found"), the raw stored Failed message, ErrQuiesced
-// ("not ready"), and the readyExpr strings.
+// Classify resolves dep for the dag engine WITHOUT blocking, reusing the shared
+// readiness predicates (readyNow, depExists, the ReadyExpr evaluator,
+// Existence.Promote). drainLevel escalates how an unsatisfied dependency is
+// treated at the structural fixpoint and selects the canonical terminal
+// message: notFound ("dependency not found"), the raw stored Failed message,
+// "not ready" (a present-Pending dep at the force level), and the readyExpr
+// strings.
 //
 // MUST run on a worker goroutine (it reads the store) — never under the
 // scheduler's mutex.
@@ -86,9 +85,8 @@ func (w *Waiter) Classify(dep manifest.DependencyRef, drainLevel int) Classifica
 		return Classification{Kind: ClassReady}
 	}
 
-	// 5. Present and Failed: cascade immediately with the raw stored message
-	//    (no FailedGrace under dag) — base.DepFailed wraps it into the same
-	//    DependencyFailedError the event engine builds.
+	// 5. Present and Failed: cascade immediately with the raw stored message —
+	//    base.DepFailed wraps it into a DependencyFailedError.
 	if info, ok := w.Store.GetStatus(id); ok && info.Status == store.StatusFailed {
 		return Classification{Kind: ClassFailed, Message: info.Message}
 	}
@@ -119,7 +117,7 @@ func (w *Waiter) Classify(dep manifest.DependencyRef, drainLevel int) Classifica
 			return Classification{Kind: ClassBlocked}
 		}
 		// Replace mode (the default): the CEL IS the readiness check, so at the
-		// fixpoint a never-true CEL is the event engine's "readyExpr timeout".
+		// fixpoint a never-true CEL fails with the canonical "readyExpr timeout".
 		if drainLevel >= drainCascade {
 			return Classification{Kind: ClassFailed, Message: "readyExpr timeout: context deadline exceeded"}
 		}
@@ -128,7 +126,7 @@ func (w *Waiter) Classify(dep manifest.DependencyRef, drainLevel int) Classifica
 
 	// 7. Present and Pending: block. A parked producer will terminalize and the
 	//    cascade carries its real message upward; only a cross-kind cycle
-	//    reaches drainForce, where it fails "not ready" (matches ErrQuiesced).
+	//    reaches drainForce, where it fails "not ready".
 	if drainLevel >= drainForce {
 		return Classification{Kind: ClassFailed, Message: "not ready"}
 	}

--- a/pkg/orchestrator/dagrun.go
+++ b/pkg/orchestrator/dagrun.go
@@ -48,8 +48,7 @@ func (o *Orchestrator) dagSchedulable(id manifest.NamedResource) bool {
 }
 
 // seedNodes returns every file-loaded reconcilable + source object currently in
-// the store — the scheduler's initial frontier, replacing the event engine's
-// flush=true listener replay.
+// the store — the scheduler's initial frontier.
 func (o *Orchestrator) seedNodes() []manifest.NamedResource {
 	var ids []manifest.NamedResource
 	for _, kind := range reconcilableKinds {

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -9,9 +9,9 @@
 // returns and before the scheduler decrements its in-flight count. Therefore
 // when no body is in flight and the runnable frontier is empty, no new object
 // can ever appear — so any still-parked node's dependencies are provably
-// unproducible. A draining sweep then terminalizes those nodes with the same
-// "dependency not found" / cascade / "not ready" statuses the event engine
-// produces at quiescence. There is no per-dependency timeout and no shared
+// unproducible. A draining sweep then terminalizes those nodes with the
+// canonical "dependency not found" / cascade / "not ready" statuses. There is
+// no per-dependency timeout and no shared
 // quiescence counter, so the #666 transient-drain false-drop cannot occur: a
 // parked node is never counted in flight, and nothing drops it except the
 // fixpoint, which only fires when nothing is running.
@@ -57,12 +57,12 @@ const (
 	// DrainCascade: an absent dependency (and a never-true ReadyExpr)
 	// terminalizes as a failure; a present-but-Pending dependency still
 	// parks, so a dangling chain fails leaf-first and each level cascades
-	// the child's real terminal message upward (matching the event engine).
+	// the child's real terminal message upward.
 	DrainCascade = 1
 	// DrainForce: a present-but-Pending dependency ALSO terminalizes ("not
 	// ready"). Reached only when a DrainCascade pass made no progress — i.e.
 	// a cross-kind structural cycle the same-kind preflight detector cannot
-	// represent. Breaks the cycle the way the event engine's quiescence does.
+	// represent; forcing the failure breaks it.
 	DrainForce = 2
 )
 


### PR DESCRIPTION
Pass 1 of a recurring cleanliness sweep (parallel per-package discovery agents → adversarial verify → main-agent review). The only genuine finding: comments across the engine-rewrite packages still reference symbols/concepts deleted with the legacy event engine (#679) — `ErrQuiesced`, `FailedGrace`, `WaitAll`, `Await`, "the event engine", "blocking Watch path", "at quiescence". A reader greps for them and finds nothing.

Reworded to describe the live behavior directly while preserving the rationale: the canonical terminal-message catalog in `Classify`, the `DepFailed` sort's determinism reason, and the `#666` fixpoint argument in the `pkg/schedule` package doc.

**Comment-only** across `pkg/depwait/classify.go`, `pkg/controllers/base/base.go`, `pkg/schedule/schedule.go`, `pkg/orchestrator/dagrun.go` (net −11 lines). No code changed — the `DepFailed` `slices.SortFunc` stays (only its comment), so rendered output is byte-identical by construction. `gofmt` / `go vet` / golangci-lint v2 (**0 issues**) / `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
