### PR TITLE
feat(cli): live per-resource progress on stderr

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -535,6 +535,12 @@ func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config) (*orchestr
 	if err != nil {
 		return nil, nil, err
 	}
+	// Live per-resource progress on stderr (TTY-gated via progressWriter).
+	// Registered before Render so terminal-status lines stream while the
+	// reconcile runs; stdout (the rendered output) is untouched.
+	if progressWriter != nil {
+		defer newProgressReporter(progressWriter).attach(o.Store())()
+	}
 	res, err := o.Render(ctx)
 	// Render nils the result only when Bootstrap fails (Run-time
 	// per-resource failures still produce a non-nil Result). Drop

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// progressWriter is the stderr sink live progress lines go to. Set by the
+// root command's PersistentPreRunE when stderr is a terminal and
+// --no-progress is unset; nil disables progress entirely (pipes, CI, the
+// in-process e2e harness). stdout is never written to — the rendered
+// output stays byte-deterministic.
+var progressWriter io.Writer
+
+// writerIsTTY reports whether w is a character device (an interactive
+// terminal). Buffers and pipes — CI, redirections, the e2e harness's
+// bytes.Buffer — are not, so progress stays off there without a flag.
+func writerIsTTY(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+// progressReporter prints one line per resource to stderr the moment it
+// reaches a terminal status, so a long first run (cold source fetches, big
+// renders) reads as live work instead of silence until the buffered render
+// is emitted. Lines look like:
+//
+//	[12/86] ✓ Kustomization/flux-system/apps (1.2s)
+//	[13/86] ✗ HelmRelease/media/plex (30s) — dependency not found
+//	[14/86] – Kustomization/games/factorio (0s) (suspended)
+//
+// done counts resources that reached a terminal status; the denominator is
+// every resource seen so far (including still-Pending ones), so it grows as
+// renders emit children — a live lower bound, not a fixed plan.
+type progressReporter struct {
+	w io.Writer
+
+	mu sync.Mutex
+	// first records each id's first status event (its Pending arrival) so
+	// the terminal line can show a per-resource elapsed time.
+	first map[manifest.NamedResource]time.Time
+	// printed records the last terminal status printed per id: idempotent
+	// terminal re-writes are suppressed, while a genuine flip (a Refire
+	// resurrection ending differently) prints a fresh line.
+	printed map[manifest.NamedResource]store.Status
+}
+
+func newProgressReporter(w io.Writer) *progressReporter {
+	return &progressReporter{
+		w:       w,
+		first:   map[manifest.NamedResource]time.Time{},
+		printed: map[manifest.NamedResource]store.Status{},
+	}
+}
+
+// attach subscribes the reporter to s's status events. Call before the
+// orchestrator runs (the store may still be empty); the returned
+// unsubscribe must be called once the run ends.
+func (p *progressReporter) attach(s *store.Store) store.Unsubscribe {
+	return s.OnStatus(p.onStatus, false)
+}
+
+func (p *progressReporter) onStatus(id manifest.NamedResource, info store.StatusInfo) {
+	now := time.Now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	started, seen := p.first[id]
+	if !seen {
+		p.first[id] = now
+		started = now
+	}
+	if info.Status != store.StatusReady && info.Status != store.StatusFailed {
+		return
+	}
+	if p.printed[id] == info.Status {
+		return
+	}
+	p.printed[id] = info.Status
+	mark, detail := "✓", ""
+	switch {
+	case info.Status == store.StatusFailed:
+		mark, detail = "✗", " — "+progressDetail(info.Message)
+	case store.IsSkipped(info), store.IsSuspended(info), store.IsUnchanged(info):
+		mark, detail = "–", " ("+progressDetail(info.Message)+")"
+	}
+	// A stderr write failure is unactionable mid-run; progress is best-effort.
+	_, _ = fmt.Fprintf(p.w, "[%d/%d] %s %s (%s)%s\n",
+		len(p.printed), len(p.first), mark, id,
+		now.Sub(started).Round(10*time.Millisecond), detail)
+}
+
+// progressDetail reduces a status message to a one-line hint: first line
+// only, capped at 120 runes. Full failure detail belongs to the final
+// report, not the live ticker.
+func progressDetail(msg string) string {
+	if i := strings.IndexByte(msg, '\n'); i >= 0 {
+		msg = msg[:i]
+	}
+	if r := []rune(msg); len(r) > 120 {
+		return string(r[:119]) + "…"
+	}
+	return msg
+}

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func progressID(name string) manifest.NamedResource {
+	return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
+}
+
+// TestProgressReporter_TerminalLines drives the reporter through the store's
+// real OnStatus path: Pending arrivals print nothing, terminal statuses print
+// exactly once each, and the [done/total] counters track unique ids.
+func TestProgressReporter_TerminalLines(t *testing.T) {
+	var buf bytes.Buffer
+	s := store.New()
+	defer newProgressReporter(&buf).attach(s)()
+
+	a, b := progressID("a"), progressID("b")
+	s.UpdateStatus(a, store.StatusPending, "resolving dependencies")
+	if buf.Len() != 0 {
+		t.Fatalf("Pending printed a line: %q", buf.String())
+	}
+	s.UpdateStatus(b, store.StatusPending, "rendering")
+	s.UpdateStatus(a, store.StatusReady, "")
+	s.UpdateStatus(b, store.StatusFailed, "boom: chart not found\nsecond line of detail")
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2:\n%s", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], "[1/2] ✓ Kustomization/ns/a") {
+		t.Errorf("ready line = %q, want [1/2] ✓ prefix", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "[2/2] ✗ Kustomization/ns/b") ||
+		!strings.Contains(lines[1], "boom: chart not found") {
+		t.Errorf("failed line = %q, want [2/2] ✗ with first-line reason", lines[1])
+	}
+	if strings.Contains(lines[1], "second line") {
+		t.Errorf("failed line leaked past the first message line: %q", lines[1])
+	}
+}
+
+// TestProgressReporter_DedupAndFlip: an idempotent terminal re-write is
+// suppressed; a genuine Ready→Failed flip prints a fresh line without
+// inflating the done counter.
+func TestProgressReporter_DedupAndFlip(t *testing.T) {
+	var buf bytes.Buffer
+	p := newProgressReporter(&buf)
+
+	id := progressID("a")
+	p.onStatus(id, store.StatusInfo{Status: store.StatusReady})
+	p.onStatus(id, store.StatusInfo{Status: store.StatusReady}) // duplicate — suppressed
+	if got := strings.Count(buf.String(), "\n"); got != 1 {
+		t.Fatalf("duplicate Ready printed %d lines, want 1:\n%s", got, buf.String())
+	}
+	p.onStatus(id, store.StatusInfo{Status: store.StatusFailed, Message: "late failure"})
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 || !strings.HasPrefix(lines[1], "[1/1] ✗") {
+		t.Fatalf("flip line = %v, want a second [1/1] ✗ line", lines)
+	}
+}
+
+// TestProgressReporter_SkippedVariants: suspended/unchanged/soft-skip Ready
+// statuses print the – mark with the message as the hint.
+func TestProgressReporter_SkippedVariants(t *testing.T) {
+	var buf bytes.Buffer
+	p := newProgressReporter(&buf)
+
+	p.onStatus(progressID("s"), store.StatusInfo{Status: store.StatusReady, Message: store.MsgSuspended})
+	p.onStatus(progressID("u"), store.StatusInfo{Status: store.StatusReady, Message: store.MsgUnchanged})
+	p.onStatus(progressID("k"), store.StatusInfo{Status: store.StatusReady, Message: store.SkippedPrefix + " missing secret"})
+
+	out := buf.String()
+	if got := strings.Count(out, "– "); got != 3 {
+		t.Fatalf("want 3 skipped marks, got %d:\n%s", got, out)
+	}
+	for _, want := range []string{"(suspended)", "(unchanged)", "(skipped: missing secret)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestProgressDetail_Truncation(t *testing.T) {
+	if got := progressDetail("short"); got != "short" {
+		t.Errorf("short passthrough = %q", got)
+	}
+	long := strings.Repeat("x", 200)
+	if got := progressDetail(long); len([]rune(got)) != 120 || !strings.HasSuffix(got, "…") {
+		t.Errorf("long message not capped at 120 runes with ellipsis: len=%d", len([]rune(got)))
+	}
+}
+
+// TestWriterIsTTY_NonFile: buffers (the e2e harness, pipes-as-buffers) are
+// never TTYs, so progress stays off without a flag.
+func TestWriterIsTTY_NonFile(t *testing.T) {
+	if writerIsTTY(&bytes.Buffer{}) {
+		t.Error("bytes.Buffer reported as a TTY")
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -37,12 +37,21 @@ func New(version string) *cobra.Command {
 		SilenceErrors: true,
 	}
 	root.PersistentFlags().String("log-level", "info", "log level (debug, info, warn, error)")
+	root.PersistentFlags().Bool("no-progress", false, "disable the live per-resource progress lines on stderr")
 	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
 		// Env binding runs first so FLATE_LOG_LEVEL is honored by the
 		// validation below, and downstream RunE bodies see flags that
 		// reflect the merged (CLI > env > default) view.
 		if err := applyEnvVars(cmd); err != nil {
 			return err
+		}
+		// Live progress goes to stderr only when it is an interactive
+		// terminal (pipes/CI/e2e buffers stay clean) and --no-progress is
+		// unset. Mirrors setLogLevel's package-global install below.
+		noProgress, _ := cmd.Flags().GetBool("no-progress")
+		progressWriter = nil
+		if errW := cmd.ErrOrStderr(); !noProgress && writerIsTTY(errW) {
+			progressWriter = errW
 		}
 		lvl, _ := cmd.Flags().GetString("log-level")
 		return setLogLevel(lvl, cmd.ErrOrStderr())


### PR DESCRIPTION
## Live per-resource progress on stderr

Long first runs read as a hang: all reconcile output is buffered and printed only after the full fixpoint, so a cold run spends tens of seconds silent while sources fetch and charts render (m00nwtchr's remaining ~39s cold floor is one upstream monorepo clone — now at least *visible*). This adds a live ticker on **stderr**; **stdout is never touched**, so rendered output stays byte-deterministic.

```
[12/86] ✓ Kustomization/flux-system/apps (1.2s)
[13/86] ✗ HelmRelease/media/plex (30s) — dependency not found
[14/86] – Kustomization/games/factorio (0s) (suspended)
```

- One line per resource at its terminal status (`✓` Ready, `✗` Failed + one-line reason hint, `–` suspended/unchanged/soft-skip via the existing `store.IsSkipped/IsUnchanged/IsSuspended` helpers). Per-resource elapsed from its first status event.
- `[done/total]` — done = unique terminal ids; total = ids seen so far, growing live as renders emit children.
- Dedup: idempotent terminal re-writes suppressed; a genuine `Ready→Failed` flip prints a fresh line.
- **Gating**: on only when stderr is an interactive terminal (char-device check, zero new deps) and `--no-progress` (new persistent flag) is unset — pipes, CI, and the e2e harness's buffers stay clean automatically.
- Wiring: subscribes via the existing `store.OnStatus(fn, replay=false)` seam in `runOrchestratorCfg` before `Render`, so all reconcile-running verbs (build/get/test/diff) get it uniformly.

### Verified
- Unit tests (incl. `-race`): terminal-line shape, dedup + flip, skipped variants, message truncation, non-TTY suppression.
- Live pty smoke (k8s-gitops): 174 streaming lines with the growing denominator; `--no-progress` → 0 lines; piped stderr → 0 lines.
- `gofmt` / `go vet` / golangci-lint v2 (**0 issues**) / full `go test ./...`; **24/24 byte-identical** sweep (stdout unchanged by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
