### PR TITLE
refactor(cli): make the status bar vanish completely when done

### DIFF
--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"io"
 	"os"
-	"strings"
 	"sync"
 )
 
@@ -89,16 +88,3 @@ func (r *stderrRouter) width() int { return terminalWidth(r.w) }
 
 // eraseLine returns the cursor to column 0 and clears to end of line.
 const eraseLine = "\r\x1b[K"
-
-// progressDetail reduces a status message to a one-line hint: first line only,
-// capped at 120 runes. Full failure detail belongs to the final report, not
-// the live ticker.
-func progressDetail(msg string) string {
-	if i := strings.IndexByte(msg, '\n'); i >= 0 {
-		msg = msg[:i]
-	}
-	if r := []rune(msg); len(r) > 120 {
-		return string(r[:119]) + "…"
-	}
-	return msg
-}

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 )
 
@@ -58,19 +57,6 @@ func TestStderrRouter_Stop(t *testing.T) {
 	_, _ = r.Write([]byte("after\n"))
 	if got := buf.String(); got != "after\n" {
 		t.Fatalf("post-Stop Write = %q, want bare line (bar forgotten)", got)
-	}
-}
-
-func TestProgressDetail_Truncation(t *testing.T) {
-	if got := progressDetail("short"); got != "short" {
-		t.Errorf("short passthrough = %q", got)
-	}
-	if got := progressDetail("first line\nsecond"); got != "first line" {
-		t.Errorf("multi-line not reduced to first line: %q", got)
-	}
-	long := strings.Repeat("x", 200)
-	if got := progressDetail(long); len([]rune(got)) != 120 || !strings.HasSuffix(got, "…") {
-		t.Errorf("long message not capped at 120 runes with ellipsis: len=%d", len([]rune(got)))
 	}
 }
 

--- a/internal/cli/statusbar.go
+++ b/internal/cli/statusbar.go
@@ -16,36 +16,32 @@ import (
 )
 
 // statusBar is the live, single-line progress indicator flate paints to
-// stderr during a run, replacing a wall of per-resource lines with one sticky
-// frame that repaints in place:
+// stderr during a run — one sticky frame that repaints in place:
 //
 //	⠹ [42/86] plex, factorio +3  12.3s
 //
 // A background ticker advances a braille spinner ~10×/s; the store's status
-// events drive the counters and the in-flight set. Only failures scroll into
-// permanent history (red ✗ lines above the bar) — successes and skips stay in
-// the counts, so the terminal reads as steady forward motion instead of spam.
-// A final summary replaces the bar when the run ends.
+// events drive the counters and the in-flight set. The bar is purely a
+// loading indicator: it prints nothing permanent and is erased without a
+// trace when the run ends (finish). Failures aren't surfaced here — flate's
+// own end-of-run report prints them once the bar is gone.
 //
 // The bar paints exclusively through a stderrRouter, which also carries slog
-// output, so log records and failure lines slot in cleanly above the bar
-// without ever corrupting it. stdout is untouched.
+// output, so log records slot in cleanly above the bar without ever
+// corrupting it. stdout is untouched.
 type statusBar struct {
 	r         *stderrRouter
 	color     bool
 	startedAt time.Time
 
 	mu sync.Mutex
-	// first records each id's first-seen time — drives in-flight ordering
-	// and per-resource elapsed on failure lines.
+	// first records each id's first-seen time — drives in-flight ordering.
 	first    map[manifest.NamedResource]time.Time
 	inflight map[manifest.NamedResource]struct{}
 	// printed records the last terminal status counted per id, so an
 	// idempotent re-write doesn't double-count and a genuine flip recounts.
 	printed map[manifest.NamedResource]store.Status
 	done    int // resources that reached a terminal status
-	failed  int
-	skipped int
 	total   int // every id seen so far (a live lower bound, grows with renders)
 
 	stop chan struct{}
@@ -72,6 +68,7 @@ func (b *statusBar) attach(s *store.Store) store.Unsubscribe {
 func (b *statusBar) onStatus(id manifest.NamedResource, info store.StatusInfo) {
 	now := time.Now()
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	if _, seen := b.first[id]; !seen {
 		b.first[id] = now
 		b.total++
@@ -80,33 +77,19 @@ func (b *statusBar) onStatus(id manifest.NamedResource, info store.StatusInfo) {
 		}
 	}
 	if info.Status != store.StatusReady && info.Status != store.StatusFailed {
-		b.mu.Unlock()
 		return
 	}
 	if b.printed[id] == info.Status {
-		b.mu.Unlock()
 		return
 	}
+	// Any terminal status (Ready, Failed, or a skipped/suspended/unchanged
+	// Ready) means the resource is done loading: count it and drop it from the
+	// in-flight set. The bar emits nothing here — it's a pure loading
+	// indicator; failures surface via flate's end-of-run report after the bar
+	// is erased.
 	b.printed[id] = info.Status
 	delete(b.inflight, id)
 	b.done++
-	var failLine string
-	switch {
-	case info.Status == store.StatusFailed:
-		b.failed++
-		failLine = fmt.Sprintf("%s %s (%s) — %s",
-			b.paint("✗", ansiRed), id, fmtElapsed(now.Sub(b.first[id])),
-			progressDetail(info.Message))
-	case store.IsSkipped(info), store.IsSuspended(info), store.IsUnchanged(info):
-		b.skipped++
-	}
-	b.mu.Unlock()
-	// Failures are the one terminal event worth keeping in scroll-back; the
-	// router slots the line above the bar. Best-effort: a stderr write error
-	// mid-run is unactionable.
-	if failLine != "" {
-		_, _ = io.WriteString(b.r, failLine+"\n")
-	}
 }
 
 // start launches the spinner ticker. It paints ~10×/s until stop is closed.
@@ -126,18 +109,15 @@ func (b *statusBar) start() {
 	})
 }
 
-// finish stops the ticker, erases the bar, and prints the run summary in its
-// place. Safe to call once after the attach unsubscribe has fired.
+// finish stops the ticker and erases the bar, leaving no trace — the bar
+// exists only during the loading phase. Safe to call once after the attach
+// unsubscribe has fired.
 func (b *statusBar) finish() {
 	if b.stop != nil {
 		close(b.stop)
 		b.wg.Wait()
 	}
 	b.r.Stop()
-	b.mu.Lock()
-	summary := b.summary(time.Since(b.startedAt))
-	b.mu.Unlock()
-	_, _ = io.WriteString(b.r, summary+"\n")
 }
 
 // repaint snapshots the live counts under the lock and paints one frame.
@@ -174,26 +154,6 @@ func (b *statusBar) inflightLabels() []string {
 	return names
 }
 
-// summary is the one-line report the bar leaves behind. Caller holds b.mu.
-func (b *statusBar) summary(elapsed time.Duration) string {
-	parts := []string{fmt.Sprintf("%s %d rendered", b.paint("✓", ansiGreen), b.done-b.failed-b.skipped)}
-	if b.failed > 0 {
-		parts = append(parts, fmt.Sprintf("%s %d failed", b.paint("✗", ansiRed), b.failed))
-	}
-	if b.skipped > 0 {
-		parts = append(parts, fmt.Sprintf("%s %d skipped", b.paint("–", ansiDim), b.skipped))
-	}
-	return fmt.Sprintf("flate: %s in %s", strings.Join(parts, ", "), fmtElapsed(elapsed))
-}
-
-// paint wraps s in an ANSI color when color is enabled, else returns it bare.
-func (b *statusBar) paint(s, code string) string {
-	if b.color {
-		return code + s + ansiReset
-	}
-	return s
-}
-
 // maxInflightNames caps how many in-flight resource names the bar lists before
 // collapsing the rest into a "+N" tail.
 const maxInflightNames = 2
@@ -206,8 +166,6 @@ const (
 	ansiReset = "\x1b[0m"
 	ansiBold  = "\x1b[1m"
 	ansiDim   = "\x1b[2m"
-	ansiRed   = "\x1b[31m"
-	ansiGreen = "\x1b[32m"
 	ansiCyan  = "\x1b[36m"
 )
 

--- a/internal/cli/statusbar_test.go
+++ b/internal/cli/statusbar_test.go
@@ -97,39 +97,30 @@ func TestFmtElapsed(t *testing.T) {
 }
 
 // TestStatusBar_CountsAndFailureLine drives onStatus through realistic events:
-// counters track unique terminal ids, only the failure scrolls a permanent
-// line, and the summary reflects rendered/failed/skipped.
-func TestStatusBar_CountsAndFailureLine(t *testing.T) {
+// counters track unique terminal ids, but the bar writes nothing permanent —
+// it is a pure loading indicator.
+func TestStatusBar_CountsNoPermanentOutput(t *testing.T) {
 	var buf bytes.Buffer
 	bar := newStatusBar(newStderrRouter(&buf))
-	bar.color = false // deterministic assertions
+	bar.color = false
 
 	a, b, s := barID("a"), barID("b"), barID("suspended")
 	bar.onStatus(a, store.StatusInfo{Status: store.StatusPending})
 	bar.onStatus(b, store.StatusInfo{Status: store.StatusPending})
-	if buf.Len() != 0 {
-		t.Fatalf("pending events scrolled output: %q", buf.String())
-	}
 	bar.onStatus(a, store.StatusInfo{Status: store.StatusReady})
-	bar.onStatus(b, store.StatusInfo{Status: store.StatusFailed, Message: "boom: chart not found\ndetail"})
+	bar.onStatus(b, store.StatusInfo{Status: store.StatusFailed, Message: "boom: chart not found"})
 	bar.onStatus(s, store.StatusInfo{Status: store.StatusReady, Message: store.MsgSuspended})
 
-	// Only the failure leaves a permanent line.
-	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
-	if len(lines) != 1 || !strings.HasPrefix(lines[0], "✗ Kustomization/ns/b") {
-		t.Fatalf("scroll-back = %v, want a single ✗ line for b", lines)
+	// Ready, Failed, and skipped all count as "done loading" — and none of
+	// them write a permanent line.
+	if buf.Len() != 0 {
+		t.Fatalf("bar wrote permanent output (it must stay silent): %q", buf.String())
 	}
-	if !strings.Contains(lines[0], "boom: chart not found") || strings.Contains(lines[0], "detail") {
-		t.Errorf("failure line should carry only the first message line: %q", lines[0])
+	if bar.done != 3 || bar.total != 3 {
+		t.Errorf("counts: done=%d total=%d; want 3/3", bar.done, bar.total)
 	}
-
-	if bar.done != 3 || bar.failed != 1 || bar.skipped != 1 || bar.total != 3 {
-		t.Errorf("counts: done=%d failed=%d skipped=%d total=%d; want 3/1/1/3",
-			bar.done, bar.failed, bar.skipped, bar.total)
-	}
-	if got := bar.summary(time.Second); !strings.Contains(got, "1 rendered") ||
-		!strings.Contains(got, "1 failed") || !strings.Contains(got, "1 skipped") {
-		t.Errorf("summary = %q, want 1 rendered / 1 failed / 1 skipped", got)
+	if got := bar.inflightLabels(); len(got) != 0 {
+		t.Errorf("all resources terminal but still in-flight: %v", got)
 	}
 }
 
@@ -156,8 +147,8 @@ func TestStatusBar_DedupAndInflight(t *testing.T) {
 }
 
 // TestStatusBar_StartFinish: the live lifecycle paints at least one frame and
-// leaves a clean summary line behind (exercises the ticker + router under the
-// race detector).
+// then vanishes completely — finish erases the bar and leaves no trace
+// (exercises the ticker + router under the race detector).
 func TestStatusBar_StartFinish(t *testing.T) {
 	var buf bytes.Buffer
 	bar := newStatusBar(newStderrRouter(&buf))
@@ -173,11 +164,12 @@ func TestStatusBar_StartFinish(t *testing.T) {
 	if !strings.Contains(out, eraseLine) {
 		t.Errorf("no in-place repaint observed: %q", out)
 	}
-	// The summary is the final, bar-free output and ends the stream.
-	if !strings.Contains(out, "flate: ✓ 1 rendered in ") {
-		t.Errorf("missing final summary line: %q", out)
+	// Pure loading indicator: nothing permanent survives the run.
+	if strings.Contains(out, "flate:") {
+		t.Errorf("bar left a summary/trace behind; it must vanish: %q", out)
 	}
-	if !strings.HasSuffix(out, "\n") {
-		t.Errorf("output should end on a clean newline (bar erased): %q", out)
+	// finish ends with a bare erase, leaving the cursor on a clean empty line.
+	if !strings.HasSuffix(out, eraseLine) {
+		t.Errorf("bar not erased on finish; want trailing erase: %q", out)
 	}
 }


### PR DESCRIPTION
## What

The live status bar (#686) is purely a **loading indicator** — once everything has rendered, it should leave no trace. This makes it ephemeral:

- **`finish()`** erases the bar and prints **nothing** (previously it left a `flate: ✓ N rendered, …` summary line).
- **`onStatus()`** no longer prints per-resource `✗` failure lines. Terminal statuses (Ready / Failed / skipped) only advance the `[done/total]` counter and drop the resource from the in-flight set.

The bar now exists only during the loading phase and disappears completely when the run ends, leaving a clean terminal.

## Failures aren't lost

flate already prints its own end-of-run failure report to stderr (via `emitResult`), which runs **after** the bar is erased. So removing the bar's `✗` lines and summary loses no information — failures still surface, just from flate's normal reporting once the loading indicator is gone.

## Cleanup

Drops the now-dead `summary()` / `paint()` helpers, the `failed`/`skipped` counters, the `ansiRed`/`ansiGreen` codes, and `progressDetail()` — **net −78 lines**.

## Verification

- `gofmt` clean · `go vet` ok · `golangci-lint run ./...` → 0 issues · `go test ./...` ok · `go test -race ./internal/cli/` ok.
- Tests updated: the bar writes nothing permanent for Ready/Failed/skipped (counts still track), and the start→finish lifecycle now asserts the bar **vanishes with no trace** (ends on a bare erase, no `flate:` summary) — exercised under `-race`.
- Piped (non-TTY) behavior unchanged: stdout renders identically (67542 lines on k8s-gitops flux), stderr carries no bar residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)