### PR TITLE
refactor(source): unify error-prefix + slot-meta helpers across fetchers

### DIFF
--- a/pkg/source/bucket/auth.go
+++ b/pkg/source/bucket/auth.go
@@ -49,12 +49,11 @@ func (f *Fetcher) resolveCredentials(b *manifest.Bucket) (*credentials.Credentia
 		return credentials.NewStaticV4("", "", ""), nil
 	}
 	if f.Secrets == nil {
-		return nil, fmt.Errorf("bucket %s/%s references secretRef but no SecretGetter is wired",
-			b.Namespace, b.Name)
+		return nil, fmt.Errorf("%s references secretRef but no SecretGetter is wired", bucketID(b))
 	}
 	sec := f.Secrets(b.Namespace, b.SecretRef.Name)
 	if sec == nil {
-		return nil, source.MissingSecretErr("bucket", b.Namespace, b.Name, b.SecretRef.Name, "not found")
+		return nil, source.MissingSecretErr("Bucket", b.Namespace, b.Name, b.SecretRef.Name, "not found")
 	}
 	access := source.StringFromSecret(sec, "accesskey")
 	secret := source.StringFromSecret(sec, "secretkey")
@@ -62,7 +61,7 @@ func (f *Fetcher) resolveCredentials(b *manifest.Bucket) (*credentials.Credentia
 		// Empty covers both missing-key and PLACEHOLDER-wiped values
 		// (the ExternalSecret case). Same sentinel so
 		// --allow-missing-secrets covers both shapes.
-		return nil, source.MissingSecretErr("bucket", b.Namespace, b.Name, b.SecretRef.Name, "missing accesskey/secretkey")
+		return nil, source.MissingSecretErr("Bucket", b.Namespace, b.Name, b.SecretRef.Name, "missing accesskey/secretkey")
 	}
 	return credentials.NewStaticV4(access, secret, ""), nil
 }

--- a/pkg/source/bucket/fetcher.go
+++ b/pkg/source/bucket/fetcher.go
@@ -34,29 +34,9 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 			"S3-compatible")
 	}
 
-	creds, err := f.resolveCredentials(b)
+	client, endpoint, secure, err := f.newMinioClient(b)
 	if err != nil {
 		return nil, err
-	}
-
-	endpoint, secure, err := normalizeEndpoint(b.Endpoint, b.Insecure)
-	if err != nil {
-		return nil, err
-	}
-
-	transport, err := f.resolveTransport(b)
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := minio.New(endpoint, &minio.Options{
-		Creds:     creds,
-		Secure:    secure,
-		Region:    b.Region,
-		Transport: transport,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("bucket %s/%s: minio client: %w", b.Namespace, b.Name, err)
 	}
 
 	// Cache key: bucket+prefix. Unlike OCI / Git, the bucket fetcher
@@ -70,20 +50,20 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 	// slot on success.
 	slot, err := f.Cache.Slot(ctx, endpoint+"/"+b.BucketName, b.Prefix, authIdentity(b))
 	if err != nil {
-		return nil, fmt.Errorf("bucket %s/%s cache slot: %w", b.Namespace, b.Name, err)
+		return nil, fmt.Errorf("%s cache slot: %w", bucketID(b), err)
 	}
 	defer slot.Release()
 	if slot.Exists {
 		// Drop the prior committed slot and re-stage so the upcoming
 		// walk writes into an empty staging dir.
 		if err := slot.Refresh(); err != nil {
-			return nil, fmt.Errorf("bucket %s/%s refresh: %w", b.Namespace, b.Name, err)
+			return nil, fmt.Errorf("%s refresh: %w", bucketID(b), err)
 		}
 	}
 
 	keys, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot.Path)
 	if err != nil {
-		return nil, fmt.Errorf("bucket %s/%s walk: %w", b.Namespace, b.Name, err)
+		return nil, fmt.Errorf("%s walk: %w", bucketID(b), err)
 	}
 	// Bucket uses the no-defaults ignore variant — matches upstream
 	// source-controller's bucket_controller.go, which constructs an
@@ -91,10 +71,10 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 	// object stores with no VCS semantics; .jpg / .flux.yaml / etc.
 	// are legitimate content and must reach the artifact.
 	if err := source.ApplyIgnoreNoDefaults(slot.Path, b.Ignore); err != nil {
-		return nil, fmt.Errorf("bucket %s/%s: %w", b.Namespace, b.Name, err)
+		return nil, fmt.Errorf("%s: %w", bucketID(b), err)
 	}
 	if err := slot.Commit(); err != nil {
-		return nil, fmt.Errorf("bucket %s/%s: commit slot: %w", b.Namespace, b.Name, err)
+		return nil, fmt.Errorf("%s: commit slot: %w", bucketID(b), err)
 	}
 
 	return &store.SourceArtifact{
@@ -106,6 +86,40 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 			"objectCount": strconv.Itoa(len(keys)),
 		},
 	}, nil
+}
+
+// newMinioClient resolves credentials, endpoint, and TLS/proxy transport for b
+// and constructs the minio client. Returns the resolved endpoint + secure flag
+// too, since the slot key and artifact URL both need them.
+func (f *Fetcher) newMinioClient(b *manifest.Bucket) (client *minio.Client, endpoint string, secure bool, err error) {
+	creds, err := f.resolveCredentials(b)
+	if err != nil {
+		return nil, "", false, err
+	}
+	endpoint, secure, err = normalizeEndpoint(b.Endpoint, b.Insecure)
+	if err != nil {
+		return nil, "", false, err
+	}
+	transport, err := f.resolveTransport(b)
+	if err != nil {
+		return nil, "", false, err
+	}
+	client, err = minio.New(endpoint, &minio.Options{
+		Creds:     creds,
+		Secure:    secure,
+		Region:    b.Region,
+		Transport: transport,
+	})
+	if err != nil {
+		return nil, "", false, fmt.Errorf("%s: minio client: %w", bucketID(b), err)
+	}
+	return client, endpoint, secure, nil
+}
+
+// bucketID is the "Bucket <namespace>/<name>" error prefix, via the shared
+// source.QualifiedName so every fetcher formats kind/ns/name identically.
+func bucketID(b *manifest.Bucket) string {
+	return source.QualifiedName("Bucket", b.Namespace, b.Name)
 }
 
 // authIdentity returns the cache-key auth tag for a Bucket. Combines

--- a/pkg/source/git/auth.go
+++ b/pkg/source/git/auth.go
@@ -22,8 +22,7 @@ func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMetho
 		return nil, nil
 	}
 	if f.Secrets == nil {
-		return nil, fmt.Errorf("GitRepository %s/%s references secretRef but no SecretGetter is wired",
-			repo.Namespace, repo.Name)
+		return nil, fmt.Errorf("%s references secretRef but no SecretGetter is wired", gitID(repo))
 	}
 	sec := f.Secrets(repo.Namespace, repo.SecretRef.Name)
 	if sec == nil {
@@ -41,8 +40,7 @@ func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMetho
 		user := sshUserFromURL(repo.URL)
 		auth, err := gitssh.NewPublicKeys(user, []byte(identity), password)
 		if err != nil {
-			return nil, fmt.Errorf("GitRepository %s/%s: parse SSH identity: %w",
-				repo.Namespace, repo.Name, err)
+			return nil, fmt.Errorf("%s: parse SSH identity: %w", gitID(repo), err)
 		}
 		// Flate has no central known_hosts. If the secret carries one,
 		// enforce strict host-key checking; otherwise skip (offline
@@ -51,8 +49,7 @@ func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMetho
 		if kh := source.StringFromSecret(sec, "known_hosts"); kh != "" {
 			cb, herr := knownHostsCallback([]byte(kh))
 			if herr != nil {
-				return nil, fmt.Errorf("GitRepository %s/%s: parse known_hosts: %w",
-					repo.Namespace, repo.Name, herr)
+				return nil, fmt.Errorf("%s: parse known_hosts: %w", gitID(repo), herr)
 			}
 			auth.HostKeyCallback = cb
 		} else {

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -166,7 +166,15 @@ func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth 
 	if f.canUseMirror(repo) {
 		return f.fetchViaMirror(ctx, repo, refLabel, slot, auth, proxy)
 	}
+	return f.cloneIntoSlot(ctx, repo, refLabel, slot, auth, proxy)
+}
 
+// cloneIntoSlot runs the legacy full-clone path into the slot's staging dir:
+// PlainClone (with optional shallow/submodule), fetch any explicit named ref,
+// checkout the requested ref (honoring sparse paths), recurse submodules, then
+// finalize (verify + ignore + marker) and commit. The mirror-path counterpart
+// is fetchViaMirror; fetch() picks between them via canUseMirror.
+func (f *Fetcher) cloneIntoSlot(ctx context.Context, repo *manifest.GitRepository, refLabel string, slot *source.Slot, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
 	url := repo.URL
 	// file:// URLs are accepted by go-git as bare filesystem paths.
 	if rest, ok := strings.CutPrefix(url, "file://"); ok {
@@ -225,7 +233,7 @@ func validateRepo(repo *manifest.GitRepository) error {
 		return errors.New("git repository is nil")
 	}
 	if repo.URL == "" {
-		return fmt.Errorf("%w: GitRepository %s missing url", manifest.ErrInput, repo.RepoName())
+		return fmt.Errorf("%w: %s missing url", manifest.ErrInput, gitID(repo))
 	}
 	return nil
 }
@@ -336,7 +344,7 @@ func (f *Fetcher) finalize(repo *manifest.GitRepository, art *store.SourceArtifa
 // .git/ was wiped by the ignore step.
 func applyIgnoreAndMark(repo *manifest.GitRepository, art *store.SourceArtifact) error {
 	if err := source.ApplyIgnore(art.LocalPath, repo.Ignore); err != nil {
-		return fmt.Errorf("GitRepository %s/%s: %w", repo.Namespace, repo.Name, err)
+		return fmt.Errorf("%s: %w", gitID(repo), err)
 	}
 	if art.Revision != "" {
 		_ = writeCachedRevision(art.LocalPath, art.Revision)
@@ -389,7 +397,7 @@ func (f *Fetcher) fetchViaMirror(ctx context.Context, repo *manifest.GitReposito
 	}
 	hash, err := resolveRefHash(mirrorRepo, repo.Reference)
 	if err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s ref %q: %w", repo.Namespace, repo.Name, refStr, err)
+		return nil, fmt.Errorf("%s ref %q: %w", gitID(repo), refStr, err)
 	}
 	// Walk the tree at hash and write every blob into the slot's staging
 	// dir via the shared gittree.Materialize helper. Submodule entries
@@ -472,6 +480,12 @@ func singleMirrorRefSpec(src string) mirror.FetchPlan {
 	return mirror.FetchPlan{RefSpecs: []config.RefSpec{config.RefSpec("+" + src + ":" + src)}}
 }
 
+// gitID is the "GitRepository <namespace>/<name>" error prefix, via the shared
+// source.QualifiedName so every fetcher formats kind/ns/name identically.
+func gitID(repo *manifest.GitRepository) string {
+	return source.QualifiedName("GitRepository", repo.Namespace, repo.Name)
+}
+
 // authIdentity returns the cache-key auth tag for a GitRepository.
 // Combines the SecretRef (HTTPS / SSH creds) and ProxySecretRef the
 // fetcher binds. Returns "" for anonymous clones so they share slots
@@ -497,7 +511,7 @@ func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
 // which finalize the slot identically once materialization is done.
 func commitArtifact(repo *manifest.GitRepository, slot *source.Slot, art *store.SourceArtifact) (*store.SourceArtifact, error) {
 	if err := slot.Commit(); err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: commit slot: %w", repo.Namespace, repo.Name, err)
+		return nil, fmt.Errorf("%s: commit slot: %w", gitID(repo), err)
 	}
 	art.LocalPath = slot.Path
 	return art, nil

--- a/pkg/source/git/marker.go
+++ b/pkg/source/git/marker.go
@@ -13,9 +13,10 @@ import (
 // the caller's ApplyIgnore wipes .git/, so a cache-hit check can validate the
 // slot without re-running git.PlainOpen on a tree whose .git/ is gone.
 
-// writeCachedRevision records rev in the slot's meta sidecar (atomic).
+// writeCachedRevision records rev in the slot's meta sidecar (atomic),
+// preserving any other fields.
 func writeCachedRevision(slot, rev string) error {
-	return source.WriteSlotMeta(slot, source.SlotMeta{Revision: rev})
+	return source.UpdateSlotMeta(slot, func(m *source.SlotMeta) { m.Revision = rev })
 }
 
 // readCachedRevision returns the slot's recorded commit SHA, or "" when the

--- a/pkg/source/git/tls.go
+++ b/pkg/source/git/tls.go
@@ -50,8 +50,8 @@ func (f *Fetcher) resolveTLS(repo *manifest.GitRepository) (*tls.Config, error) 
 	}
 	cfg, err := source.BuildTLSConfig(crt, key, ca)
 	if err != nil {
-		return nil, fmt.Errorf("GitRepository %s/%s: secretRef %s/%s: %w",
-			repo.Namespace, repo.Name, repo.Namespace, repo.SecretRef.Name, err)
+		return nil, fmt.Errorf("%s: secretRef %s/%s: %w",
+			gitID(repo), repo.Namespace, repo.SecretRef.Name, err)
 	}
 	return cfg, nil
 }

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -27,8 +27,8 @@ func (f *Fetcher) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Opti
 	if f.secrets == nil {
 		// Same sentinel as "secret not found" so --allow-missing-secrets
 		// covers both shapes — the dependency is equally unresolved.
-		return nil, fmt.Errorf("%w: HelmRepository %s/%s references secretRef but no SecretGetter is wired",
-			manifest.ErrMissingSecret, r.Namespace, r.Name)
+		return nil, fmt.Errorf("%w: %s references secretRef but no SecretGetter is wired",
+			manifest.ErrMissingSecret, helmID(r))
 	}
 	sec := f.secrets(r.Namespace, r.SecretRef.Name)
 	if sec == nil {
@@ -63,8 +63,7 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		// ErrMissingSecret wrap, which --allow-missing-secrets would soft-skip):
 		// silently dropping TLS material is a security downgrade. Mirrors
 		// source.ResolveCertSecret, the canonical cross-kind cert helper.
-		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s references certSecretRef but no SecretGetter is wired",
-			r.Namespace, r.Name)
+		return nil, noCleanup, fmt.Errorf("%s references certSecretRef but no SecretGetter is wired", helmID(r))
 	}
 	sec := f.secrets(r.Namespace, r.CertSecretRef.Name)
 	if sec == nil {
@@ -95,8 +94,8 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		cleanup()
 		// A secret present but carrying none of the TLS keys is malformed
 		// config — fail loud (no ErrMissingSecret wrap), like BuildTLSConfig.
-		return nil, noCleanup, fmt.Errorf("HelmRepository %s/%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
-			r.Namespace, r.Name, r.Namespace, r.CertSecretRef.Name)
+		return nil, noCleanup, fmt.Errorf("%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			helmID(r), r.Namespace, r.CertSecretRef.Name)
 	}
 	return []getter.Option{getter.WithTLSClientConfig(paths[0], paths[1], paths[2])}, cleanup, nil
 }

--- a/pkg/source/helmchart/fetcher.go
+++ b/pkg/source/helmchart/fetcher.go
@@ -85,8 +85,8 @@ func (f *Fetcher) Fetch(ctx context.Context, hc *manifest.HelmChartSource) (*sto
 	}
 	r := f.repos(hc.Namespace, hc.SourceRef.Name)
 	if r == nil {
-		return nil, fmt.Errorf("%w: HelmRepository %s/%s backing HelmChart %s",
-			manifest.ErrObjectNotFound, hc.Namespace, hc.SourceRef.Name, hc.Named().String())
+		return nil, fmt.Errorf("%w: %s backing HelmChart %s", manifest.ErrObjectNotFound,
+			source.QualifiedName("HelmRepository", hc.Namespace, hc.SourceRef.Name), hc.Named().String())
 	}
 	if isOCIHelmRepo(r) {
 		// Delegate to the OCI fetcher via a synthesized OCIRepository. The
@@ -104,6 +104,12 @@ func (f *Fetcher) Fetch(ctx context.Context, hc *manifest.HelmChartSource) (*sto
 		return art, nil
 	}
 	return f.fetchHTTPChart(ctx, r, hc.Chart, hc.Version)
+}
+
+// helmID is the "HelmRepository <namespace>/<name>" error prefix, via the
+// shared source.QualifiedName so every fetcher formats kind/ns/name identically.
+func helmID(r *manifest.HelmRepository) string {
+	return source.QualifiedName("HelmRepository", r.Namespace, r.Name)
 }
 
 // Synthesize builds an in-memory HelmChart for a single chart served by a

--- a/pkg/source/helmchart/resolve.go
+++ b/pkg/source/helmchart/resolve.go
@@ -58,11 +58,11 @@ func readResolveFresh(slotDir string, maxAge time.Duration) (chartResolution, bo
 // writeResolve records r in the slot's meta sidecar, preserving any other
 // fields (none today on a resolve slot — it carries only the Chart* triple).
 func writeResolve(slotDir string, r chartResolution) error {
-	m, _ := source.ReadSlotMeta(slotDir)
-	m.ChartVersion = r.Version
-	m.ChartDigest = r.Digest
-	m.ChartURL = r.ChartURL
-	return source.WriteSlotMeta(slotDir, m)
+	return source.UpdateSlotMeta(slotDir, func(m *source.SlotMeta) {
+		m.ChartVersion = r.Version
+		m.ChartDigest = r.Digest
+		m.ChartURL = r.ChartURL
+	})
 }
 
 // persistResolve writes r into the resolve slot atomically (stage on a cache

--- a/pkg/source/meta.go
+++ b/pkg/source/meta.go
@@ -54,6 +54,18 @@ func WriteSlotMeta(slotDir string, meta SlotMeta) error {
 	return atomic.WriteFile(filepath.Join(slotDir, SlotMetaFile), b, 0o600, true)
 }
 
+// UpdateSlotMeta read-modify-writes the slot's sidecar: read the current
+// SlotMeta (preserving fields the caller leaves alone), apply mutate, write it
+// back. Marker writers run under the slot lock (cache.Slot serializes per key),
+// so the RMW has a single writer. Shared by the per-kind fetchers (oci digest +
+// verify fingerprint, helmchart chart resolution, git revision) so each records
+// its facts without clobbering the others.
+func UpdateSlotMeta(slotDir string, mutate func(*SlotMeta)) error {
+	m, _ := ReadSlotMeta(slotDir)
+	mutate(&m)
+	return WriteSlotMeta(slotDir, m)
+}
+
 // ReadSlotMeta returns the slot's sidecar. A missing, unreadable, or unparseable
 // sidecar yields ok=false — all three mean "no usable marker", so the caller
 // rebuilds. Atomic writes guarantee the file is either absent or complete, so a

--- a/pkg/source/oci/fetcher.go
+++ b/pkg/source/oci/fetcher.go
@@ -69,10 +69,10 @@ func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.OCIRepository) (*sto
 }
 
 // ociID is the "OCIRepository <namespace>/<name>" prefix shared by this
-// package's error messages — one helper so the prefix can't drift across the
-// ~dozen wrap sites. RepoName already yields "<namespace>/<name>".
+// package's error messages — wraps source.QualifiedName so every fetcher
+// formats its kind/ns/name identically.
 func ociID(repo *manifest.OCIRepository) string {
-	return "OCIRepository " + repo.RepoName()
+	return source.QualifiedName("OCIRepository", repo.Namespace, repo.Name)
 }
 
 // authIdentity returns the cache-key auth tag for an OCIRepository.

--- a/pkg/source/oci/marker.go
+++ b/pkg/source/oci/marker.go
@@ -23,20 +23,10 @@ import (
 // cosign.
 var digestRE = regexp.MustCompile(`^[a-z0-9]+:[a-fA-F0-9]{32,}$`)
 
-// updateSlotMeta read-modify-writes the slot's meta sidecar: read the current
-// SlotMeta (preserving fields the caller leaves alone), apply mutate, write it
-// back. Both marker writers run under the slot lock (cache.Slot serializes per
-// key), so the RMW has a single writer.
-func updateSlotMeta(slot string, mutate func(*source.SlotMeta)) error {
-	m, _ := source.ReadSlotMeta(slot)
-	mutate(&m)
-	return source.WriteSlotMeta(slot, m)
-}
-
 // writeCachedDigest records digest in the slot's meta sidecar, preserving any
 // existing verify fingerprint.
 func writeCachedDigest(slot, digest string) error {
-	return updateSlotMeta(slot, func(m *source.SlotMeta) { m.Digest = digest })
+	return source.UpdateSlotMeta(slot, func(m *source.SlotMeta) { m.Digest = digest })
 }
 
 // readCachedDigest returns the slot's recorded digest only when it is
@@ -79,7 +69,7 @@ func verifyFingerprint(v *manifest.OCIRepositoryVerify) string {
 // writeVerifyMarker records the verify-policy fingerprint in the slot's meta
 // sidecar, preserving the digest. Called only after a successful verification.
 func writeVerifyMarker(slot, fingerprint string) error {
-	return updateSlotMeta(slot, func(m *source.SlotMeta) { m.Verified = fingerprint })
+	return source.UpdateSlotMeta(slot, func(m *source.SlotMeta) { m.Verified = fingerprint })
 }
 
 // readVerifyMarker returns the slot's recorded verify fingerprint, or "" when

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -97,8 +97,18 @@ func (ExistenceFetcher) Fetch(_ context.Context, _ manifest.BaseManifest) (*stor
 // hint is a short parenthetical that names what the supported provider
 // expects (e.g. "SecretRef-based credentials" or "S3-compatible").
 func ErrUnsupportedProvider(kind, namespace, name, got, want, hint string) error {
-	return fmt.Errorf("%s %s/%s provider %q is not implemented; flate currently supports only %q (%s)",
-		kind, namespace, name, got, want, hint)
+	return fmt.Errorf("%s provider %q is not implemented; flate currently supports only %q (%s)",
+		QualifiedName(kind, namespace, name), got, want, hint)
+}
+
+// QualifiedName is the canonical "<Kind> <namespace>/<name>" identifier the
+// per-kind fetchers prefix their error messages with — one helper so the
+// "Kind ns/name" shape can't drift across fetchers (git, oci, bucket, and
+// helmchart each wrap it as gitID/ociID/…). This is the slash form for
+// human-readable errors, distinct from RepoName()'s "ns-name" Flux resource
+// identifier used for cache slots and auth scopes.
+func QualifiedName(kind, namespace, name string) string {
+	return kind + " " + namespace + "/" + name
 }
 
 // CacheKeyHash marshals v to JSON, sha256-hashes the bytes, and returns


### PR DESCRIPTION
## What

Extends the oci cohesion pass to the rest of the source fetchers and hoists the two bits the audit found genuinely duplicated. The fetcher file split and the secret/TLS/proxy/transport/auth-identity/slot-lifecycle/ignore/temp-file helpers were **already** shared via `pkg/source`, so this is targeted dedup + light cohesion — **pure refactor, behavior-preserving, byte-identical (24/24), no public API change.**

## Shared (`pkg/source`)

- **`source.QualifiedName(kind, ns, name)`** — one helper for the `"<Kind> ns/name"` error prefix every fetcher hand-formatted (and `ErrUnsupportedProvider` now uses it). Each package keeps a one-line wrapper (`gitID`/`bucketID`/`helmID`/`ociID`). Standardizes all prefixes on the conventional slash form — which also **corrects a `ns-name` drift** the oci PR's `ociID` introduced. (Error text isn't rendered output, so byte-equivalence is unaffected.)
- **`source.UpdateSlotMeta(slot, mutate)`** — read-modify-write of the `SlotMeta` sidecar, hoisted from oci's local `updateSlotMeta`. oci, git, and helmchart now share one RMW instead of three copies.

## Per-package cohesion

- **git**: extract `cloneIntoSlot` so the legacy-clone and mirror paths are symmetric — `fetch()` now reads validate → slot → cache-hit → `mirror | clone`. `gitID` for the ~7 error sites; marker write onto the shared RMW. (Transport install/restore ordering, `canUseMirror` guard, `effectiveDepth`, slot transaction — unchanged.)
- **bucket**: extract `newMinioClient` from `Fetch` (resolve creds/endpoint/TLS + construct); `bucketID` (normalizing the stray lowercase `"bucket"` prefix to the Flux `Bucket` kind); `Fetch` reads resolve → client → slot → walk → ignore → commit. (Flux digest format, `ApplyIgnoreNoDefaults`, write-only cache — unchanged.)
- **helmchart**: `helmID` for the prefixes; `writeResolve` onto the shared RMW. (Three-tier resolve cache, download coalescing, digest-mismatch hard error — untouched.)
- **blob / gittree / external**: reviewed — already cohesive, no god-functions, and the shared helpers don't apply (blob uses its own refs store; gittree/external don't touch slots). Left unchanged rather than churn cosmetics.

## Verification

- `gofmt`/`go vet`/`golangci-lint run ./...` (0 issues) · `go test ./...` · `go test -race ./pkg/source/...` — all green.
- Each fetcher's existing suite (git/bucket/helmchart/oci + shared) is the behavior gate.
- **24-repo cross-cluster byte-equivalence sweep: 24/24 identical to `main`** (pure refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)