### PR TITLE
fix(cli): count only declared resources in the status bar

### DIFF
--- a/internal/cli/statusbar.go
+++ b/internal/cli/statusbar.go
@@ -41,8 +41,12 @@ type statusBar struct {
 	// printed records the last terminal status counted per id, so an
 	// idempotent re-write doesn't double-count and a genuine flip recounts.
 	printed map[manifest.NamedResource]store.Status
-	done    int // resources that reached a terminal status
-	total   int // every id seen so far (a live lower bound, grows with renders)
+	done    int // declared resources that reached a terminal status
+	// total counts every declared id seen so far — a live lower bound that grows
+	// as discovery and renders surface more resources. Synthetic/internal ids
+	// (the bootstrap source, synthesized HelmCharts) are excluded via barExcluded
+	// so the denominator matches flate's own report rather than overshooting it.
+	total int
 
 	stop chan struct{}
 	wg   sync.WaitGroup
@@ -65,7 +69,23 @@ func (b *statusBar) attach(s *store.Store) store.Unsubscribe {
 	return s.OnStatus(b.onStatus, false)
 }
 
+// barExcluded reports ids the bar must neither count nor name: the synthetic
+// bootstrap GitRepository and any HelmChart (always internally synthesized for a
+// HelmRepository-backed HelmRelease — see helmrelease.materializeHelmChartSource).
+// Neither is a resource the user declared, and neither appears in flate's own
+// report: `flate test` skips the bootstrap id and its kind set omits HelmChart.
+// Counting them made the bar's [done/total] overshoot every report (e.g. 175 vs
+// 174 when only the bootstrap leaks; +1 per HelmRepository-backed HelmRelease on
+// top). Excluding the same two id-classes aligns the bar's population exactly
+// with `flate test all`'s "collected N".
+func barExcluded(id manifest.NamedResource) bool {
+	return id == manifest.BootstrapSourceID || id.Kind == manifest.KindHelmChart
+}
+
 func (b *statusBar) onStatus(id manifest.NamedResource, info store.StatusInfo) {
+	if barExcluded(id) {
+		return
+	}
 	now := time.Now()
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/cli/statusbar_test.go
+++ b/internal/cli/statusbar_test.go
@@ -146,6 +146,42 @@ func TestStatusBar_DedupAndInflight(t *testing.T) {
 	}
 }
 
+// TestStatusBar_ExcludesSyntheticIDs: the synthetic bootstrap GitRepository and
+// internally-synthesized HelmCharts are reconciled internally but appear in no
+// `flate test`/`build` report, so the bar must neither count them nor list them
+// in-flight — otherwise its [done/total] overshoots every report (the 175-vs-174
+// gap). A normal declared resource alongside them still counts and names.
+func TestStatusBar_ExcludesSyntheticIDs(t *testing.T) {
+	bar := newStatusBar(newStderrRouter(&bytes.Buffer{}))
+	bar.color = false
+
+	boot := manifest.BootstrapSourceID
+	chart := manifest.NamedResource{Kind: manifest.KindHelmChart, Namespace: "ns", Name: "repo-app-abc1234"}
+	declared := barID("declared")
+
+	// Drive each excluded id through a full Pending→terminal lifecycle, and the
+	// declared one too.
+	for _, id := range []manifest.NamedResource{boot, chart, declared} {
+		bar.onStatus(id, store.StatusInfo{Status: store.StatusPending})
+	}
+	for _, id := range []manifest.NamedResource{boot, chart, declared} {
+		bar.onStatus(id, store.StatusInfo{Status: store.StatusReady})
+	}
+
+	// Only the declared resource is counted, in either column.
+	if bar.done != 1 || bar.total != 1 {
+		t.Errorf("synthetic ids leaked into counts: done=%d total=%d; want 1/1", bar.done, bar.total)
+	}
+	// Excluded ids never enter the in-flight set, even while Pending.
+	bar2 := newStatusBar(newStderrRouter(&bytes.Buffer{}))
+	bar2.color = false
+	bar2.onStatus(boot, store.StatusInfo{Status: store.StatusPending})
+	bar2.onStatus(chart, store.StatusInfo{Status: store.StatusPending})
+	if got := bar2.inflightLabels(); len(got) != 0 {
+		t.Errorf("synthetic ids listed in-flight: %v", got)
+	}
+}
+
 // TestStatusBar_StartFinish: the live lifecycle paints at least one frame and
 // then vanishes completely — finish erases the bar and leaves no trace
 // (exercises the ticker + router under the race detector).


### PR DESCRIPTION
## Problem

The live status bar's `[done/total]` (shipped in #686) overshot every `flate test`/`build` report. Its `total` incremented for **every store id that emitted a status event** — which silently included two id-classes that appear in **no** report:

1. **The synthetic bootstrap GitRepository** (`manifest.BootstrapSourceID`) — `flate test` explicitly skips it (`testrunner/runner.go:122`).
2. **Internally-synthesized HelmCharts** — every HelmRepository-backed HelmRelease seeds a hidden `HelmChart` `"fetching chart"` status (`helmrelease/controller.go:439`); the `flate test` kind set never lists `HelmChart`.

So `bar_total = KS + HR + declared sources + 1(bootstrap) + (#HelmRepository-backed HRs)`, while `flate test all` "collected" `= KS + HR + declared sources`. That exactly predicts the observed gaps:

| repo | bar | report | gap | cause |
|------|-----|--------|-----|-------|
| k8s-gitops apps | 175 | 174 passed | 1 | all-OCI (0 synth charts) + bootstrap |
| Biohazard | 416 | 373 passed + 16 failed = 389 | 27 | ~26 HelmRepository-backed HRs + bootstrap |

## Fix

A single `barExcluded` guard at the head of `onStatus` drops those two id-classes from **both** the counters and the in-flight name list. The bar's population now matches `flate test all`'s "collected N" exactly (that report set is `{KS, HR, Git, OCI, Helm, Bucket}` — already omits HelmChart and skips the bootstrap id), and the ugly synthesized chart names no longer appear in-flight. `HelmRepository` stays counted (it *is* in the report set).

## Verification

- `gofmt`/`go vet`/`golangci-lint` (0 issues); `go test ./...` green; new `TestStatusBar_ExcludesSyntheticIDs` regression test asserts excluded ids leave `done`/`total` at 0 and the in-flight list empty while a declared resource still counts.
- The bar is **stderr-only** → rendered output untouched. 24/24 cross-repo byte-equivalence sweep identical (base @ `main` vs this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)