### PR TITLE
refactor(source): pass-1 cleanups — dead code, bucket alloc, resolve-persist dedup

### DIFF
--- a/pkg/source/bucket/fetcher.go
+++ b/pkg/source/bucket/fetcher.go
@@ -61,7 +61,7 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 		}
 	}
 
-	keys, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot.Path)
+	objectCount, revHash, err := walkBucket(ctx, client, b.BucketName, b.Prefix, slot.Path)
 	if err != nil {
 		return nil, fmt.Errorf("%s walk: %w", bucketID(b), err)
 	}
@@ -83,7 +83,7 @@ func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceA
 		LocalPath: slot.Path,
 		Revision:  revHash,
 		Metadata: map[string]string{
-			"objectCount": strconv.Itoa(len(keys)),
+			"objectCount": strconv.Itoa(objectCount),
 		},
 	}, nil
 }

--- a/pkg/source/bucket/walk.go
+++ b/pkg/source/bucket/walk.go
@@ -23,9 +23,9 @@ const downloadBufSize = 256 << 10
 
 // walkBucket lists the bucket under prefix, downloads each object
 // into slot preserving the prefix-relative path, and returns the
-// sorted key list + a content-addressed revision (sha256 of
-// "<key> <etag>\n" pairs, sorted).
-func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot string) ([]string, string, error) {
+// number of objects downloaded + a content-addressed revision (sha256
+// of "<key> <etag>\n" pairs, sorted).
+func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot string) (int, string, error) {
 	type entry struct{ key, etag string }
 	var entries []entry
 
@@ -33,7 +33,7 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 		Prefix: prefix, Recursive: true,
 	}) {
 		if obj.Err != nil {
-			return nil, "", obj.Err
+			return 0, "", obj.Err
 		}
 		if strings.HasSuffix(obj.Key, "/") {
 			continue // S3 directory-placeholder objects
@@ -68,7 +68,7 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 		})
 	}
 	if err := g.Wait(); err != nil {
-		return nil, "", err
+		return 0, "", err
 	}
 
 	// Format matches source-controller's internal/index/digest.go:
@@ -77,12 +77,10 @@ func walkBucket(ctx context.Context, client *minio.Client, bucket, prefix, slot 
 	// for identical contents — change detection across runs and any
 	// readyExpr keyed off status.artifact.revision would never align.
 	h := sha256.New()
-	keys := make([]string, len(entries))
-	for i, e := range entries {
+	for _, e := range entries {
 		_, _ = fmt.Fprintf(h, "%s %s\n", e.key, e.etag)
-		keys[i] = e.key
 	}
-	return keys, "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+	return len(entries), "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func downloadObject(ctx context.Context, client *minio.Client, bucket, key, dst string) error {

--- a/pkg/source/cache.go
+++ b/pkg/source/cache.go
@@ -349,6 +349,31 @@ func (s *Slot) StageRefresh() error {
 	return s.allocStaging("refresh stage")
 }
 
+// PersistMeta atomically records meta-only sidecar fields on the slot: the
+// resolve-cache write path (OCI digest, helm chart resolution) whose only
+// on-disk product is the .flate-meta.json sidecar, never a materialized tree.
+// On a cache hit it stages a refresh (keeping the old slot readable until
+// commit), applies mutate to the SlotMeta via the read-modify-write
+// UpdateSlotMeta, then commits under the held slot lock. It is the meta-only
+// sibling of Commit and folds the previously-duplicated stage→write→commit
+// dance the OCI and helmchart resolve writers each carried. Callers keep their
+// own no-op guard (a nil slot or an incomplete resolution) since the predicate
+// differs per source kind.
+func (s *Slot) PersistMeta(mutate func(*SlotMeta)) error {
+	if s.Exists {
+		if err := s.StageRefresh(); err != nil {
+			return fmt.Errorf("slot meta stage: %w", err)
+		}
+	}
+	if err := UpdateSlotMeta(s.Path, mutate); err != nil {
+		return fmt.Errorf("slot meta write: %w", err)
+	}
+	if err := s.Commit(); err != nil {
+		return fmt.Errorf("slot meta commit: %w", err)
+	}
+	return nil
+}
+
 func (s *Slot) lockFile(ctx context.Context) error {
 	s.fileLock = flock.New(s.final+".lock", flock.SetPermissions(0o600))
 	locked, err := s.fileLock.TryLockContext(ctx, 100*time.Millisecond)

--- a/pkg/source/gc.go
+++ b/pkg/source/gc.go
@@ -3,7 +3,6 @@ package source
 import (
 	"fmt"
 	"io/fs"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -290,14 +289,4 @@ func entrySize(path string) int64 {
 		return nil
 	})
 	return total
-}
-
-// Log emits a structured summary of res at slog.LevelInfo. Convenience
-// for CLI / orchestrator callers that don't want to format the result
-// inline.
-func (res *SweepResult) Log() {
-	slog.Info("cache sweep",
-		"removed", len(res.Removed),
-		"bytes", res.Bytes,
-		"errors", len(res.Errors))
 }

--- a/pkg/source/helmchart/resolve.go
+++ b/pkg/source/helmchart/resolve.go
@@ -1,7 +1,6 @@
 package helmchart
 
 import (
-	"fmt"
 	"regexp"
 	"time"
 
@@ -55,33 +54,16 @@ func readResolveFresh(slotDir string, maxAge time.Duration) (chartResolution, bo
 	return r, true
 }
 
-// writeResolve records r in the slot's meta sidecar, preserving any other
-// fields (none today on a resolve slot — it carries only the Chart* triple).
-func writeResolve(slotDir string, r chartResolution) error {
-	return source.UpdateSlotMeta(slotDir, func(m *source.SlotMeta) {
-		m.ChartVersion = r.Version
-		m.ChartDigest = r.Digest
-		m.ChartURL = r.ChartURL
-	})
-}
-
 // persistResolve writes r into the resolve slot atomically (stage on a cache
-// hit, write, commit), mirroring oci.persistOCIResolve. A no-op when the
+// hit, write the Chart* triple, commit), via Slot.PersistMeta. A no-op when the
 // resolution is incomplete, so a failed resolve never poisons the slot.
 func persistResolve(slot *source.Slot, r chartResolution) error {
 	if slot == nil || !r.valid() {
 		return nil
 	}
-	if slot.Exists {
-		if err := slot.StageRefresh(); err != nil {
-			return fmt.Errorf("helm resolve stage: %w", err)
-		}
-	}
-	if err := writeResolve(slot.Path, r); err != nil {
-		return fmt.Errorf("helm resolve write: %w", err)
-	}
-	if err := slot.Commit(); err != nil {
-		return fmt.Errorf("helm resolve commit: %w", err)
-	}
-	return nil
+	return slot.PersistMeta(func(m *source.SlotMeta) {
+		m.ChartVersion = r.Version
+		m.ChartDigest = r.Digest
+		m.ChartURL = r.ChartURL
+	})
 }

--- a/pkg/source/oci/cache.go
+++ b/pkg/source/oci/cache.go
@@ -92,18 +92,7 @@ func writeResolveCache(slot *source.Slot, digest string) error {
 	if slot == nil || digest == "" {
 		return nil
 	}
-	if slot.Exists {
-		if err := slot.StageRefresh(); err != nil {
-			return fmt.Errorf("cache resolve stage: %w", err)
-		}
-	}
-	if err := writeCachedDigest(slot.Path, digest); err != nil {
-		return fmt.Errorf("cache resolve digest: %w", err)
-	}
-	if err := slot.Commit(); err != nil {
-		return fmt.Errorf("cache resolve commit: %w", err)
-	}
-	return nil
+	return slot.PersistMeta(func(m *source.SlotMeta) { m.Digest = digest })
 }
 
 // checkCacheHit applies the cache-hit gauntlet to a populated slot:


### PR DESCRIPTION
First pass of the `pkg/source` refactor loop. An adversarial per-package survey (8 read-only survey agents → 2 skeptics per candidate, accept only if both confirm genuine *and* byte-neutral) surfaced 8 candidates; **3 survived**, the rest were rejected as churn (cosmetic 2-site "helpers", a deliberate documented narrowing, a not-clean-in-isolation deletion, an error-string-changing fold). These are the 3 survivors:

### 1. Dead code — `(*SweepResult).Log()` (`gc.go`)
Zero callers across the whole repo; the sole `source.Sweep` consumer (`internal/cli/cache.go`) formats `Removed`/`Bytes`/`Errors` itself. `slog` was used only inside `Log()`, so the `log/slog` import drops with it.

### 2. Alloc — `walkBucket` returns a key slice only to count it (`bucket/walk.go`)
`walkBucket` built `[]string` of every object key purely for `len()` at its one call site (`objectCount` metadata). Return the count directly; the sha256 revision loop already ranges `entries`, so the digest and count are unchanged. Drops a slice of N string headers that scales with bucket size, and makes the signature return exactly what the caller uses.

### 3. Dedup — `Slot.PersistMeta` (`source/cache.go` + `oci` + `helmchart`)
The OCI digest writer (`writeResolveCache`) and the helm chart-resolution writer (`persistResolve`) carried an identical `StageRefresh`→write-sidecar→`Commit` dance. Hoisted to a `Slot.PersistMeta(mutate)` method alongside the existing `StageRefresh`/`Commit` lifecycle — the meta-only commit path for resolve-cache slots whose only on-disk product is the `.flate-meta.json` sidecar. Each caller keeps its own no-op guard (the predicate differs per kind); the now-redundant `writeResolve` folds into the callback. The per-step error prefixes are internal and asserted by no test.

## Verification
- `gofmt`/`go vet`/`golangci-lint` (0 issues); `go test ./...` + `go test -race ./pkg/source/...` green.
- All three are stderr/error-path or count-only → no rendered-output change. **24/24 cross-repo byte-equivalence** (base @ `main` 80095a9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)