### PR TITLE
fix(git): restore the bounded HTTPS client after a custom-CA fetch

### DIFF
--- a/pkg/source/git/internal/gittransport/gittransport.go
+++ b/pkg/source/git/internal/gittransport/gittransport.go
@@ -64,7 +64,10 @@ func InstallHTTPS(tlsCfg *tls.Config, proxy *source.ProxyConfig) (func(), error)
 	}
 	client.InstallProtocol("https", githttp.NewClient(&http.Client{Transport: tr}))
 	return sync.OnceFunc(func() {
-		client.InstallProtocol("https", githttp.DefaultClient)
+		// Restore the BOUNDED default installed at init (not go-git's unbounded
+		// githttp.DefaultClient) so anonymous fetches after a custom-CA fetch
+		// keep the ResponseHeaderTimeout liveness backstop.
+		client.InstallProtocol("https", boundedHTTPSClient)
 		mu.Unlock()
 	}), nil
 }

--- a/pkg/source/git/internal/gittransport/gittransport_test.go
+++ b/pkg/source/git/internal/gittransport/gittransport_test.go
@@ -1,7 +1,10 @@
 package gittransport
 
 import (
+	"crypto/tls"
 	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/client"
 
 	"github.com/home-operations/flate/pkg/source"
 )
@@ -33,4 +36,26 @@ func TestInstallHTTPS_AnonymousNoOp(t *testing.T) {
 		t.Fatal("restore func is nil")
 	}
 	restore() // must not panic / must not unlock an unheld mutex
+}
+
+// TestInstallHTTPS_RestoresBoundedDefault pins the liveness contract: after a
+// custom-CA fetch's restore runs, go-git's process-global https client is the
+// BOUNDED default again — not go-git's unbounded githttp.DefaultClient. Without
+// this, the first mTLS/custom-CA GitRepository fetch would strip the
+// ResponseHeaderTimeout backstop off every subsequent anonymous fetch in the
+// process, re-exposing the hang this package exists to prevent.
+func TestInstallHTTPS_RestoresBoundedDefault(t *testing.T) {
+	restore, err := InstallHTTPS(&tls.Config{}, nil) // non-nil cfg → takes the install path
+	if err != nil {
+		t.Fatalf("InstallHTTPS: %v", err)
+	}
+	// Mid-install the custom transport is active, not the bounded default.
+	if client.Protocols["https"] == boundedHTTPSClient {
+		t.Fatal("custom transport was not installed under the lock")
+	}
+	restore()
+	// Restore must reinstall the bounded default, not githttp.DefaultClient.
+	if client.Protocols["https"] != boundedHTTPSClient {
+		t.Fatal("restore did not reinstall the bounded default HTTPS client")
+	}
 }


### PR DESCRIPTION
## Bug

`pkg/source/git/internal/gittransport` installs a `ResponseHeaderTimeout`-bounded HTTPS client as go-git's process-global default in `init()` (gittransport.go:45), so every anonymous git fetch (`Fetcher` + bare-mirror cache) inherits a liveness backstop — a host that black-holes after dial can't hang the run.

A custom-CA / mTLS GitRepository fetch swaps in its own bounded transport under the install lock and returns a `restore()` closure. But that closure reinstalled go-git's **unbounded** `githttp.DefaultClient` (gittransport.go:67) — the exact client the package doc explicitly says not to use (line 16: *"restore to this bounded default (not go-git's unbounded githttp.DefaultClient)"*).

**Impact:** after the first mTLS/custom-CA fetch in a process completes, the global `https` client is left unbounded, and every subsequent **anonymous** git fetch runs without the timeout backstop — re-exposing the hang the bounded default exists to prevent.

## Fix

One line: restore `boundedHTTPSClient` (the package var `init()` installs) instead of `githttp.DefaultClient`. `githttp` stays imported (`NewClient` at lines 39, 65).

## Test

New `TestInstallHTTPS_RestoresBoundedDefault` asserts, via go-git's exported `client.Protocols["https"]`, that after `restore()` the bounded default is reinstalled — not `githttp.DefaultClient`. Verified it **fails against the old code** (`restore did not reinstall the bounded default HTTPS client`) and passes with the fix.

## Verification
- `gofmt`/`go vet`/`golangci-lint` (0 issues); `go test ./pkg/source/git/...` + `go test -race ./pkg/source/...` green.
- Transport-only → no rendered-YAML / error-wording change. Cross-repo byte-equivalence holds: 23/24 identical; the lone diff is the known `m00nwtchr` stunner helm render non-determinism (reproducible on the base binary alone — base renders both 96228 and 96692 across runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)