### PR TITLE
fix(cli): suppress the status bar when --stream shares the terminal

### DIFF
--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -7,11 +7,11 @@ import (
 )
 
 // stderrSink is the terminal router live progress is painted through. Set by
-// the root command's PersistentPreRunE when stderr is an interactive terminal
-// and --no-progress is unset; nil disables the status bar entirely (pipes, CI,
-// the in-process e2e harness). When set, slog is also routed through it so log
-// lines interleave cleanly above the bar. stdout is never touched — the
-// rendered output stays byte-deterministic.
+// the root command's PersistentPreRunE when progressBarEnabled allows it; nil
+// disables the status bar entirely (pipes, CI, the in-process e2e harness,
+// --no-progress, or a --stream run that shares the terminal with stdout). When
+// set, slog is also routed through it so log lines interleave cleanly above the
+// bar. stdout is never touched — the rendered output stays byte-deterministic.
 var stderrSink *stderrRouter
 
 // writerIsTTY reports whether w is a character device (an interactive
@@ -24,6 +24,21 @@ func writerIsTTY(w io.Writer) bool {
 	}
 	fi, err := f.Stat()
 	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+// progressBarEnabled reports whether the live status bar should paint. It is
+// off when --no-progress is set, when stderr isn't an interactive terminal
+// (pipes/CI/e2e buffers), or when --stream shares that terminal with stdout:
+// the bar repaints a sticky stderr line, while --stream writes raw YAML to
+// stdout outside the bar's router, so on one terminal the two interleave and
+// corrupt each other — the stream wins. A --stream run whose stdout is
+// redirected (file/pipe) keeps the bar: it paints cleanly to stderr with no
+// collision.
+func progressBarEnabled(noProgress, stream, stdoutTTY, stderrTTY bool) bool {
+	if noProgress || !stderrTTY {
+		return false
+	}
+	return !stream || !stdoutTTY
 }
 
 // stderrRouter multiplexes a sticky single-line status bar with the ordinary

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -67,3 +67,31 @@ func TestWriterIsTTY_NonFile(t *testing.T) {
 		t.Error("bytes.Buffer reported as a TTY")
 	}
 }
+
+// TestProgressBarEnabled covers the bar's on/off gate, including the --stream
+// collision: a sticky stderr bar can't coexist with raw streamed stdout on the
+// same terminal, so --stream suppresses the bar there but keeps it when stdout
+// is redirected.
+func TestProgressBarEnabled(t *testing.T) {
+	cases := []struct {
+		name                                     string
+		noProgress, stream, stdoutTTY, stderrTTY bool
+		want                                     bool
+	}{
+		{"plain interactive", false, false, true, true, true},
+		{"stderr not a tty (pipe/CI)", false, false, true, false, false},
+		{"--no-progress", true, false, true, true, false},
+		{"stream sharing the terminal with stdout", false, true, true, true, false},
+		{"stream with stdout redirected keeps the bar", false, true, false, true, true},
+		{"stream but stderr not a tty", false, true, true, false, false},
+		{"--no-progress wins over a redirected stream", true, true, false, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := progressBarEnabled(c.noProgress, c.stream, c.stdoutTTY, c.stderrTTY); got != c.want {
+				t.Errorf("progressBarEnabled(noProgress=%v, stream=%v, stdoutTTY=%v, stderrTTY=%v) = %v, want %v",
+					c.noProgress, c.stream, c.stdoutTTY, c.stderrTTY, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -46,15 +46,21 @@ func New(version string) *cobra.Command {
 			return err
 		}
 		// The live status bar paints to stderr only when it is an
-		// interactive terminal (pipes/CI/e2e buffers stay clean) and
-		// --no-progress is unset. When active, slog is routed through the
-		// same stderrRouter so log records interleave above the bar instead
-		// of corrupting it; otherwise slog writes straight to stderr.
+		// interactive terminal (pipes/CI/e2e buffers stay clean), --no-progress
+		// is unset, and a --stream build isn't sharing that terminal with its
+		// stdout output (the sticky bar and raw streamed YAML would interleave —
+		// see progressBarEnabled). When active, slog is routed through the same
+		// stderrRouter so log records interleave above the bar instead of
+		// corrupting it; otherwise slog writes straight to stderr.
+		//
+		// `stream` is a build-subcommand flag, absent on other commands —
+		// GetBool then returns (false, err), which is the correct "no stream".
 		noProgress, _ := cmd.Flags().GetBool("no-progress")
+		stream, _ := cmd.Flags().GetBool("stream")
 		stderrSink = nil
 		logSink := cmd.ErrOrStderr()
-		if errW := cmd.ErrOrStderr(); !noProgress && writerIsTTY(errW) {
-			stderrSink = newStderrRouter(errW)
+		if progressBarEnabled(noProgress, stream, writerIsTTY(cmd.OutOrStdout()), writerIsTTY(cmd.ErrOrStderr())) {
+			stderrSink = newStderrRouter(cmd.ErrOrStderr())
 			logSink = stderrSink
 		}
 		lvl, _ := cmd.Flags().GetString("log-level")


### PR DESCRIPTION
## Bug

Running `flate build all --stream` on an interactive terminal interleaves the live status bar into the streamed output — the bar appears to be "in" stdout.

## Root cause

The status bar repaints a sticky single line on **stderr** through the `stderrRouter`, which can only erase/repaint around writes it owns (slog). `--stream` writes raw YAML straight to **stdout**, outside that router. On one terminal the two share the screen, so streamed stdout lines scroll through the bar's sticky line and leave bar fragments interleaved in the output. (The bar never literally writes to the stdout *stream* — redirect stdout to a file and it's clean; the corruption is purely the shared-TTY case.)

## Fix

A new pure `progressBarEnabled(noProgress, stream, stdoutTTY, stderrTTY)` helper centralizes the bar's on/off decision. The bar is now off when `--stream` is active **and** stdout is a TTY (shares the terminal with the bar). A `--stream` run whose stdout is redirected (`--stream > file`) **keeps** the bar — it paints cleanly to stderr with no collision. `--no-progress` and non-TTY-stderr fold into the same helper.

## Verification
- `gofmt`/`go vet`/`golangci-lint` (0 issues); `go test ./...` green, including the existing `TestStreamEmitter_*` suite and the new `TestProgressBarEnabled` table (covers shared-TTY-off, redirected-stdout-on, --no-progress, non-TTY-stderr).
- stderr-only → rendered stdout YAML untouched. **24/24 cross-repo byte-equivalence** (base @ `main` 2776fa3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)