### PR TITLE
refactor(cli): drive the status bar with Bubble Tea v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/home-operations/flate
 go 1.26.4
 
 require (
+	charm.land/bubbles/v2 v2.1.0
+	charm.land/bubbletea/v2 v2.0.7
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/alecthomas/chroma/v2 v2.26.1
@@ -36,7 +38,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.5
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0
-	golang.org/x/term v0.44.0
 	helm.sh/helm/v4 v4.2.0
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -62,7 +63,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
@@ -182,6 +183,7 @@ require (
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
 cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
+charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
+charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbletea/v2 v2.0.7 h1:7qw2tTAVar7m7klOPBYfTB0mniv/RuexsYwMRNxSeL0=
+charm.land/bubbletea/v2 v2.0.7/go.mod h1:DGW2q8gvzHnOpMpZTORs0aySVHCox5C+2Svk0fci1qs=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
@@ -43,6 +47,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
+github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -57,10 +63,12 @@ github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnT
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318 h1:OqDqxQZliC7C8adA7KjelW3OjtAxREfeHkNcd66wpeI=
-github.com/charmbracelet/ultraviolet v0.0.0-20251205161215-1948445e3318/go.mod h1:Y6kE2GzHfkyQQVCSL9r2hwokSrIlHGzZG+71+wDYSZI=
+github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 h1:FpSYhY28ucg9ZRr+2wj67FAQ0Ey5yiK0072PmRDJNek=
+github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654/go.mod h1:hFpumms29Smx3LStRfku8vcCTBe1Kq8aCXtHUJa3mjY=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f h1:pk6gmGpCE7F3FcjaOEKYriCvpmIN4+6OS/RD0vm4uIA=
+github.com/charmbracelet/x/exp/golden v0.0.0-20250806222409-83e3a29d542f/go.mod h1:IfZAMTHB6XkZSeXUqriemErjAWCCzT0LwjKFYCZyw0I=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8JawjaNZY=

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -539,15 +540,29 @@ func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config, pre ...fun
 	if err != nil {
 		return nil, nil, err
 	}
-	// Live status bar on stderr (TTY-gated via stderrSink). Attached before
-	// Render so its counters and spinner track the reconcile as it runs;
-	// stdout (the rendered output) is untouched. Defers run LIFO, so the
-	// unsubscribe fires before finish() draws the summary.
-	if stderrSink != nil {
-		bar := newStatusBar(stderrSink)
-		defer bar.finish()
-		defer bar.attach(o.Store())()
-		bar.start()
+	// Live status bar on stderr (TTY-gated via barSink). A Bubble Tea program
+	// runs the inline frame; store status events feed it via Program.Send, so
+	// its counters and spinner track the reconcile as it runs. stdout (the
+	// rendered output) is untouched. Defers run LIFO: the unsubscribe fires,
+	// then finishMsg clears the frame and the program is detached from slog
+	// before Render's callers print anything.
+	if barSink != nil {
+		p := tea.NewProgram(newBarModel(barSink.color),
+			tea.WithOutput(barSink.out),
+			tea.WithInput(nil),         // output-only: never capture the keyboard
+			tea.WithoutSignalHandler(), // the CLI context owns Ctrl-C, not the bar
+		)
+		barSink.setProgram(p)
+		go func() { _, _ = p.Run() }()
+		unsub := o.Store().OnStatus(func(id manifest.NamedResource, info store.StatusInfo) {
+			p.Send(statusMsg{id: id, info: info})
+		}, false)
+		defer func() {
+			unsub()
+			p.Send(finishMsg{})
+			p.Wait()
+			barSink.setProgram(nil)
+		}()
 	}
 	for _, hook := range pre {
 		defer hook(o)()

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -3,20 +3,62 @@ package cli
 import (
 	"io"
 	"os"
+	"strings"
 	"sync"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/home-operations/flate/internal/style"
 )
 
-// stderrSink is the terminal router live progress is painted through. Set by
-// the root command's PersistentPreRunE when progressBarEnabled allows it; nil
-// disables the status bar entirely (pipes, CI, the in-process e2e harness,
-// --no-progress, or a --stream run that shares the terminal with stdout). When
-// set, slog is also routed through it so log lines interleave cleanly above the
-// bar. stdout is never touched — the rendered output stays byte-deterministic.
-var stderrSink *stderrRouter
+// barSink is the slog routing adapter active while the live status bar runs; nil
+// disables the bar entirely (pipes, CI, the in-process e2e harness,
+// --no-progress, or a --stream run that shares the terminal with stdout). Set by
+// the root command's PersistentPreRunE when progressBarEnabled allows it, and
+// pointed at by slog so log records interleave cleanly above the bar. stdout is
+// never touched — rendered output stays byte-deterministic.
+var barSink *barWriter
 
-// writerIsTTY reports whether w is a character device (an interactive
-// terminal). Buffers and pipes — CI, redirections, the e2e harness's
-// bytes.Buffer — are not, so the bar stays off there without a flag.
+// barWriter routes slog output around the Bubble Tea status bar. With a Program
+// attached (the bar is live), each record prints above the sticky frame via
+// Program.Println; without one, it writes straight through to the underlying
+// stderr. It is the io.Writer the root command points slog at, so log lines
+// never corrupt the bar.
+type barWriter struct {
+	out   io.Writer // underlying stderr (a *os.File TTY)
+	color bool      // whether the bar/report should emit ANSI on this stderr
+
+	mu   sync.Mutex
+	prog *tea.Program
+}
+
+func newBarWriter(out io.Writer) *barWriter {
+	return &barWriter{out: out, color: style.ColorEnabled(out)}
+}
+
+// setProgram attaches (or, with nil, detaches) the live Bubble Tea program so
+// Write knows whether to route records above the frame or straight to stderr.
+func (w *barWriter) setProgram(p *tea.Program) {
+	w.mu.Lock()
+	w.prog = p
+	w.mu.Unlock()
+}
+
+func (w *barWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	prog := w.prog
+	w.mu.Unlock()
+	if prog != nil {
+		// Println places the line above the live frame and owns the newline.
+		prog.Println(strings.TrimRight(string(p), "\n"))
+		return len(p), nil
+	}
+	return w.out.Write(p)
+}
+
+// writerIsTTY reports whether w is a character device (an interactive terminal).
+// Buffers and pipes — CI, redirections, the e2e harness's bytes.Buffer — are
+// not, so the bar stays off there without a flag.
 func writerIsTTY(w io.Writer) bool {
 	f, ok := w.(*os.File)
 	if !ok {
@@ -30,7 +72,7 @@ func writerIsTTY(w io.Writer) bool {
 // off when --no-progress is set, when stderr isn't an interactive terminal
 // (pipes/CI/e2e buffers), or when --stream shares that terminal with stdout:
 // the bar repaints a sticky stderr line, while --stream writes raw YAML to
-// stdout outside the bar's router, so on one terminal the two interleave and
+// stdout outside the bar's renderer, so on one terminal the two interleave and
 // corrupt each other — the stream wins. A --stream run whose stdout is
 // redirected (file/pipe) keeps the bar: it paints cleanly to stderr with no
 // collision.
@@ -40,66 +82,3 @@ func progressBarEnabled(noProgress, stream, stdoutTTY, stderrTTY bool) bool {
 	}
 	return !stream || !stdoutTTY
 }
-
-// stderrRouter multiplexes a sticky single-line status bar with the ordinary
-// scroll-back stream (slog records, failure lines, the final summary) on one
-// terminal. It is the single point that knows whether a bar frame is currently
-// painted, so every permanent write can erase the bar, print, and repaint it
-// beneath — keeping the bar pinned to the bottom line without ever tangling
-// with log output.
-//
-//	Paint(frame) — repaint the sticky bar in place (the spinner ticker).
-//	Write(p)     — emit permanent output above the bar (slog + bar lines).
-//	Stop()       — erase the bar for good (run teardown).
-type stderrRouter struct {
-	w  io.Writer
-	mu sync.Mutex
-	// bar is the frame currently painted on the bottom line ("" = none).
-	bar string
-}
-
-func newStderrRouter(w io.Writer) *stderrRouter { return &stderrRouter{w: w} }
-
-// Write emits p as permanent scroll-back, repainting the sticky bar beneath it
-// so the bar never scrolls away. slog, the bar's own failure lines, and the
-// final summary all flow through here. n counts bytes of p (the erase/repaint
-// control bytes are bookkeeping, not the caller's payload).
-func (r *stderrRouter) Write(p []byte) (int, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.bar != "" {
-		_, _ = io.WriteString(r.w, eraseLine)
-	}
-	n, err := r.w.Write(p)
-	if r.bar != "" {
-		_, _ = io.WriteString(r.w, r.bar)
-	}
-	return n, err
-}
-
-// Paint repaints the sticky bar in place (carriage-return + clear-to-EOL, then
-// the frame, no trailing newline so the line stays sticky).
-func (r *stderrRouter) Paint(frame string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	_, _ = io.WriteString(r.w, eraseLine+frame)
-	r.bar = frame
-}
-
-// Stop erases the bar and forgets it, leaving the cursor at column 0 of a
-// clean line for the caller's final output.
-func (r *stderrRouter) Stop() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.bar != "" {
-		_, _ = io.WriteString(r.w, eraseLine)
-		r.bar = ""
-	}
-}
-
-// width reports the terminal's column count for frame truncation, falling back
-// to 80 when the underlying writer isn't a sized terminal.
-func (r *stderrRouter) width() int { return terminalWidth(r.w) }
-
-// eraseLine returns the cursor to column 0 and clears to end of line.
-const eraseLine = "\r\x1b[K"

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -5,58 +5,17 @@ import (
 	"testing"
 )
 
-// TestStderrRouter_PaintWriteRepaint: painting a frame then writing a
-// permanent line erases the bar, prints the line, and repaints the bar beneath
-// it — so scroll-back (slog, failure lines) never tangles with the sticky bar.
-func TestStderrRouter_PaintWriteRepaint(t *testing.T) {
+// TestBarWriter_NoProgramWritesThrough: with no Bubble Tea program attached, the
+// slog adapter is a plain passthrough to the underlying stderr (the non-TTY /
+// pre-bar / post-bar path) — no stray control bytes.
+func TestBarWriter_NoProgramWritesThrough(t *testing.T) {
 	var buf bytes.Buffer
-	r := newStderrRouter(&buf)
-
-	r.Paint("BAR")
-	if got := buf.String(); got != eraseLine+"BAR" {
-		t.Fatalf("after Paint = %q, want erase+frame", got)
-	}
-	buf.Reset()
-
-	n, err := r.Write([]byte("log line\n"))
-	if err != nil || n != len("log line\n") {
-		t.Fatalf("Write n=%d err=%v, want full payload count", n, err)
-	}
-	// erase the old bar, emit the line, repaint the bar below it.
-	if got, want := buf.String(), eraseLine+"log line\n"+"BAR"; got != want {
-		t.Fatalf("Write sequence = %q, want %q", got, want)
-	}
-}
-
-// TestStderrRouter_WritePassthrough: with no bar painted, Write is a plain
-// passthrough (no stray control bytes) — the e2e/non-TTY path.
-func TestStderrRouter_WritePassthrough(t *testing.T) {
-	var buf bytes.Buffer
-	r := newStderrRouter(&buf)
-	if _, err := r.Write([]byte("hello\n")); err != nil {
+	w := &barWriter{out: &buf}
+	if _, err := w.Write([]byte("hello\n")); err != nil {
 		t.Fatal(err)
 	}
 	if got := buf.String(); got != "hello\n" {
-		t.Fatalf("passthrough Write = %q, want bare line", got)
-	}
-}
-
-// TestStderrRouter_Stop erases the bar and forgets it: a later Write is a clean
-// passthrough again.
-func TestStderrRouter_Stop(t *testing.T) {
-	var buf bytes.Buffer
-	r := newStderrRouter(&buf)
-	r.Paint("BAR")
-	buf.Reset()
-
-	r.Stop()
-	if got := buf.String(); got != eraseLine {
-		t.Fatalf("Stop = %q, want lone erase", got)
-	}
-	buf.Reset()
-	_, _ = r.Write([]byte("after\n"))
-	if got := buf.String(); got != "after\n" {
-		t.Fatalf("post-Stop Write = %q, want bare line (bar forgotten)", got)
+		t.Errorf("passthrough Write = %q, want bare line", got)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -57,11 +57,11 @@ func New(version string) *cobra.Command {
 		// GetBool then returns (false, err), which is the correct "no stream".
 		noProgress, _ := cmd.Flags().GetBool("no-progress")
 		stream, _ := cmd.Flags().GetBool("stream")
-		stderrSink = nil
+		barSink = nil
 		logSink := cmd.ErrOrStderr()
 		if progressBarEnabled(noProgress, stream, writerIsTTY(cmd.OutOrStdout()), writerIsTTY(cmd.ErrOrStderr())) {
-			stderrSink = newStderrRouter(cmd.ErrOrStderr())
-			logSink = stderrSink
+			barSink = newBarWriter(cmd.ErrOrStderr())
+			logSink = barSink
 		}
 		lvl, _ := cmd.Flags().GetString("log-level")
 		return setLogLevel(lvl, logSink)

--- a/internal/cli/statusbar.go
+++ b/internal/cli/statusbar.go
@@ -2,45 +2,44 @@ package cli
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
-	"golang.org/x/term"
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/home-operations/flate/internal/style"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
 
-// statusBar is the live, single-line progress indicator flate paints to
-// stderr during a run — one sticky frame that repaints in place:
+// barModel is the live, single-line progress indicator flate paints to stderr
+// during a run — a Bubble Tea model rendered inline:
 //
 //	⠹ [42/86] plex, factorio +3  12.3s
 //
-// A background ticker advances a braille spinner ~10×/s; the store's status
-// events drive the counters and the in-flight set. The bar is purely a
-// loading indicator: it prints nothing permanent and is erased without a
-// trace when the run ends (finish). Failures aren't surfaced here — flate's
-// own end-of-run report prints them once the bar is gone.
+// Bubble Tea owns the render loop, the braille spinner (bubbles/spinner), resize,
+// and printing log lines above the frame; the store's status events feed it via
+// Program.Send. The bar is purely a loading indicator: it prints nothing
+// permanent and clears itself (an empty View on finishMsg) when the run ends.
+// Failures aren't surfaced here — flate's end-of-run report prints them once the
+// bar is gone.
 //
-// The bar paints exclusively through a stderrRouter, which also carries slog
-// output, so log records slot in cleanly above the bar without ever
-// corrupting it. stdout is untouched.
-type statusBar struct {
-	r         *stderrRouter
+// Update runs on Bubble Tea's single goroutine, so the model needs no mutex even
+// though statusMsg crosses from the orchestrator's reconcile goroutines.
+type barModel struct {
+	spinner   spinner.Model
 	color     bool
+	width     int
 	startedAt time.Time
+	finished  bool // set on finishMsg → View renders empty so the bar vanishes
 
-	mu sync.Mutex
 	// first records each id's first-seen time — drives in-flight ordering.
 	first    map[manifest.NamedResource]time.Time
 	inflight map[manifest.NamedResource]struct{}
-	// printed records the last terminal status counted per id, so an
-	// idempotent re-write doesn't double-count and a genuine flip recounts.
+	// printed records the last terminal status counted per id, so an idempotent
+	// re-write doesn't double-count and a genuine flip recounts.
 	printed map[manifest.NamedResource]store.Status
 	done    int // declared resources that reached a terminal status
 	// total counts every declared id seen so far — a live lower bound that grows
@@ -48,15 +47,22 @@ type statusBar struct {
 	// (the bootstrap source, synthesized HelmCharts) are excluded via barExcluded
 	// so the denominator matches flate's own report rather than overshooting it.
 	total int
-
-	stop chan struct{}
-	wg   sync.WaitGroup
 }
 
-func newStatusBar(r *stderrRouter) *statusBar {
-	return &statusBar{
-		r:         r,
-		color:     style.ColorEnabled(r.w),
+// statusMsg carries one store status event into the bar's Update loop.
+type statusMsg struct {
+	id   manifest.NamedResource
+	info store.StatusInfo
+}
+
+// finishMsg clears the frame and quits the program — the bar leaves no trace.
+type finishMsg struct{}
+
+func newBarModel(color bool) barModel {
+	return barModel{
+		spinner:   spinner.New(spinner.WithSpinner(spinner.MiniDot)),
+		color:     color,
+		width:     80,
 		startedAt: time.Now(),
 		first:     map[manifest.NamedResource]time.Time{},
 		inflight:  map[manifest.NamedResource]struct{}{},
@@ -64,10 +70,73 @@ func newStatusBar(r *stderrRouter) *statusBar {
 	}
 }
 
-// attach subscribes the bar to s's status events. Call before the run starts;
-// the returned unsubscribe must fire when it ends (before finish).
-func (b *statusBar) attach(s *store.Store) store.Unsubscribe {
-	return s.OnStatus(b.onStatus, false)
+// Init starts the spinner animation; subsequent TickMsgs re-render the frame
+// (which also refreshes the elapsed clock).
+func (m barModel) Init() tea.Cmd { return m.spinner.Tick }
+
+func (m barModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+	case tea.WindowSizeMsg:
+		if msg.Width > 0 {
+			m.width = msg.Width
+		}
+		return m, nil
+	case statusMsg:
+		m.track(msg.id, msg.info)
+		return m, nil
+	case finishMsg:
+		m.finished = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+// track applies one status event: the declared-only counting + in-flight set
+// behind the [done/total] gauge. A first sighting grows total (and joins the
+// in-flight set while Pending); any terminal status (Ready / Failed / a
+// skipped-or-suspended Ready) counts toward done once and drops the id from
+// in-flight. barExcluded drops synthetic/internal ids so the gauge mirrors the
+// report.
+func (m *barModel) track(id manifest.NamedResource, info store.StatusInfo) {
+	if barExcluded(id) {
+		return
+	}
+	if _, seen := m.first[id]; !seen {
+		m.first[id] = time.Now()
+		m.total++
+		if info.Status == store.StatusPending {
+			m.inflight[id] = struct{}{}
+		}
+	}
+	if info.Status != store.StatusReady && info.Status != store.StatusFailed {
+		return
+	}
+	if m.printed[id] == info.Status {
+		return
+	}
+	m.printed[id] = info.Status
+	delete(m.inflight, id)
+	m.done++
+}
+
+// View composes one frame, styled via internal/style and truncated to the
+// terminal width (ANSI- and wide-rune-aware). An empty frame after finishMsg
+// clears the line so the bar vanishes without a trace.
+func (m barModel) View() tea.View {
+	if m.finished {
+		return tea.NewView("")
+	}
+	line := style.Cyan(m.spinner.View(), m.color) + " " +
+		style.Bold(fmt.Sprintf("[%d/%d]", m.done, m.total), m.color)
+	if names := summarizeInflight(m.inflightLabels(), maxInflightNames); names != "" {
+		line += " " + style.Dim(names, m.color)
+	}
+	line += "  " + style.Dim(fmtElapsed(time.Since(m.startedAt)), m.color)
+	return tea.NewView(style.Truncate(line, m.width))
 }
 
 // barExcluded reports ids the bar must neither count nor name: the synthetic
@@ -83,86 +152,15 @@ func barExcluded(id manifest.NamedResource) bool {
 	return id == manifest.BootstrapSourceID || id.Kind == manifest.KindHelmChart
 }
 
-func (b *statusBar) onStatus(id manifest.NamedResource, info store.StatusInfo) {
-	if barExcluded(id) {
-		return
-	}
-	now := time.Now()
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if _, seen := b.first[id]; !seen {
-		b.first[id] = now
-		b.total++
-		if info.Status == store.StatusPending {
-			b.inflight[id] = struct{}{}
-		}
-	}
-	if info.Status != store.StatusReady && info.Status != store.StatusFailed {
-		return
-	}
-	if b.printed[id] == info.Status {
-		return
-	}
-	// Any terminal status (Ready, Failed, or a skipped/suspended/unchanged
-	// Ready) means the resource is done loading: count it and drop it from the
-	// in-flight set. The bar emits nothing here — it's a pure loading
-	// indicator; failures surface via flate's end-of-run report after the bar
-	// is erased.
-	b.printed[id] = info.Status
-	delete(b.inflight, id)
-	b.done++
-}
-
-// start launches the spinner ticker. It paints ~10×/s until stop is closed.
-func (b *statusBar) start() {
-	b.stop = make(chan struct{})
-	b.wg.Go(func() {
-		t := time.NewTicker(100 * time.Millisecond)
-		defer t.Stop()
-		for spin := 0; ; spin++ {
-			select {
-			case <-b.stop:
-				return
-			case <-t.C:
-				b.repaint(spin)
-			}
-		}
-	})
-}
-
-// finish stops the ticker and erases the bar, leaving no trace — the bar
-// exists only during the loading phase. Safe to call once after the attach
-// unsubscribe has fired.
-func (b *statusBar) finish() {
-	if b.stop != nil {
-		close(b.stop)
-		b.wg.Wait()
-	}
-	b.r.Stop()
-}
-
-// repaint snapshots the live counts under the lock and paints one frame.
-func (b *statusBar) repaint(spin int) {
-	b.mu.Lock()
-	done, total := b.done, b.total
-	labels := b.inflightLabels()
-	b.mu.Unlock()
-	glyph := string(spinnerFrames[spin%len(spinnerFrames)])
-	frame := renderFrame(glyph, done, total, labels,
-		time.Since(b.startedAt), b.r.width(), b.color)
-	b.r.Paint(frame)
-}
-
 // inflightLabels returns the in-flight resource names ordered by first-seen
-// (id-tiebroken) so the bar's name list is stable frame to frame. Caller holds
-// b.mu.
-func (b *statusBar) inflightLabels() []string {
-	ids := make([]manifest.NamedResource, 0, len(b.inflight))
-	for id := range b.inflight {
+// (id-tiebroken) so the bar's name list is stable frame to frame.
+func (m barModel) inflightLabels() []string {
+	ids := make([]manifest.NamedResource, 0, len(m.inflight))
+	for id := range m.inflight {
 		ids = append(ids, id)
 	}
 	sort.Slice(ids, func(i, j int) bool {
-		ti, tj := b.first[ids[i]], b.first[ids[j]]
+		ti, tj := m.first[ids[i]], m.first[ids[j]]
 		if !ti.Equal(tj) {
 			return ti.Before(tj)
 		}
@@ -178,29 +176,6 @@ func (b *statusBar) inflightLabels() []string {
 // maxInflightNames caps how many in-flight resource names the bar lists before
 // collapsing the rest into a "+N" tail.
 const maxInflightNames = 2
-
-// spinnerFrames is the classic braille spinner cycle.
-var spinnerFrames = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
-
-// renderFrame composes one status-bar line, styled via internal/style and
-// truncated to width by visible columns (style.Truncate is ANSI- and wide-rune-
-// aware, so escape codes never count against the budget). Pure: deterministic in
-// its inputs, so the layout, truncation, and "+N" collapse are unit-testable.
-//
-//	⠹ [42/86] plex, factorio +3  12.3s
-func renderFrame(spin string, done, total int, inflight []string, elapsed time.Duration, width int, color bool) string {
-	var b strings.Builder
-	b.WriteString(style.Cyan(spin, color))
-	b.WriteByte(' ')
-	b.WriteString(style.Bold(fmt.Sprintf("[%d/%d]", done, total), color))
-	if names := summarizeInflight(inflight, maxInflightNames); names != "" {
-		b.WriteByte(' ')
-		b.WriteString(style.Dim(names, color))
-	}
-	b.WriteString("  ")
-	b.WriteString(style.Dim(fmtElapsed(elapsed), color))
-	return style.Truncate(b.String(), width)
-}
 
 // summarizeInflight renders up to limit names joined by ", ", collapsing any
 // remainder into a "+N" tail. Empty in → empty out.
@@ -222,14 +197,4 @@ func fmtElapsed(d time.Duration) string {
 		return fmt.Sprintf("%.1fs", d.Seconds())
 	}
 	return fmt.Sprintf("%dm%02ds", int(d/time.Minute), int(d%time.Minute/time.Second))
-}
-
-// terminalWidth reports w's column count when it is a sized terminal, else 80.
-func terminalWidth(w io.Writer) int {
-	if f, ok := w.(*os.File); ok {
-		if cols, _, err := term.GetSize(int(f.Fd())); err == nil && cols > 0 {
-			return cols
-		}
-	}
-	return 80
 }

--- a/internal/cli/statusbar_test.go
+++ b/internal/cli/statusbar_test.go
@@ -1,11 +1,12 @@
 package cli
 
 import (
-	"bytes"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
+
+	tea "charm.land/bubbletea/v2"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -21,13 +22,23 @@ func barID(name string) manifest.NamedResource {
 	return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
 }
 
-// TestRenderFrame_FitsWidth: the frame never exceeds the terminal width at any
-// size, so it can repaint in place without wrapping (a wrap breaks \r repaint).
-func TestRenderFrame_FitsWidth(t *testing.T) {
-	names := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+// inflightModel builds a model with names tracked as in-flight (Pending).
+func inflightModel(color bool, names ...string) barModel {
+	m := newBarModel(color)
+	for _, n := range names {
+		m.track(barID(n), store.StatusInfo{Status: store.StatusPending})
+	}
+	return m
+}
+
+// TestView_FitsWidth: the frame never exceeds the terminal width at any size, so
+// Bubble Tea's inline renderer never wraps (a wrap would break the sticky line).
+func TestView_FitsWidth(t *testing.T) {
 	for _, width := range []int{1, 3, 8, 20, 40, 80, 200} {
 		for _, color := range []bool{false, true} {
-			got := renderFrame("⠹", 42, 86, names, 12300*time.Millisecond, width, color)
+			m := inflightModel(color, "alpha", "bravo", "charlie", "delta", "echo")
+			m.done, m.total, m.width = 42, 86, width
+			got := m.View().Content
 			if vl := visibleLen(got); vl > width {
 				t.Errorf("width=%d color=%v: visible len %d > width (%q)", width, color, vl, got)
 			}
@@ -35,30 +46,69 @@ func TestRenderFrame_FitsWidth(t *testing.T) {
 	}
 }
 
-// TestRenderFrame_PlainNoColor: with color off the frame carries no escape
-// codes and shows the counts, spinner, names, and elapsed.
-func TestRenderFrame_PlainNoColor(t *testing.T) {
-	got := renderFrame("⠹", 3, 10, []string{"plex"}, 1500*time.Millisecond, 80, false)
+// TestView_PlainNoColor: with color off the frame carries no escape codes and
+// shows the counts + in-flight names.
+func TestView_PlainNoColor(t *testing.T) {
+	m := inflightModel(false, "plex")
+	m.done, m.total, m.width = 3, 10, 80
+	got := m.View().Content
 	if strings.Contains(got, "\x1b") {
 		t.Errorf("color=false leaked an escape code: %q", got)
 	}
-	for _, want := range []string{"⠹", "[3/10]", "plex", "1.5s"} {
+	for _, want := range []string{"[3/10]", "plex"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("frame %q missing %q", got, want)
 		}
 	}
 }
 
-// TestRenderFrame_ColorInvisibleToWidth: the same logical content fits the same
-// width whether or not it is colorized — codes don't consume columns.
-func TestRenderFrame_ColorInvisibleToWidth(t *testing.T) {
-	plain := renderFrame("⠹", 3, 10, []string{"plex"}, time.Second, 40, false)
-	color := renderFrame("⠹", 3, 10, []string{"plex"}, time.Second, 40, true)
-	if visibleLen(plain) != visibleLen(color) {
-		t.Errorf("visible lengths differ: plain=%d color=%d", visibleLen(plain), visibleLen(color))
+// TestView_ColorInvisibleToWidth: the same content fits the same width whether
+// colorized or not — codes don't consume columns.
+func TestView_ColorInvisibleToWidth(t *testing.T) {
+	plain := inflightModel(false, "plex")
+	plain.done, plain.total, plain.width = 3, 10, 40
+	color := inflightModel(true, "plex")
+	color.done, color.total, color.width = 3, 10, 40
+
+	pc, cc := plain.View().Content, color.View().Content
+	if visibleLen(pc) != visibleLen(cc) {
+		t.Errorf("visible lengths differ: plain=%d color=%d", visibleLen(pc), visibleLen(cc))
 	}
-	if !strings.Contains(color, "\x1b") {
-		t.Errorf("color frame carries no ANSI styling: %q", color)
+	if !strings.Contains(cc, "\x1b") {
+		t.Errorf("color frame carries no ANSI styling: %q", cc)
+	}
+}
+
+// TestModel_FinishVanishes: finishMsg sets the bar to render an empty frame
+// (clearing the line so it vanishes) and returns the quit command.
+func TestModel_FinishVanishes(t *testing.T) {
+	m := inflightModel(false, "a")
+	m.done, m.total = 1, 1
+	updated, cmd := m.Update(finishMsg{})
+	if c := updated.View().Content; c != "" {
+		t.Errorf("finished view should be empty, got %q", c)
+	}
+	if cmd == nil {
+		t.Fatal("finishMsg should return a quit command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Errorf("finishMsg should quit; got cmd msg %T", cmd())
+	}
+}
+
+// TestModel_InitTicks: Init kicks off the spinner animation.
+func TestModel_InitTicks(t *testing.T) {
+	if newBarModel(false).Init() == nil {
+		t.Error("Init should return the spinner tick command")
+	}
+}
+
+// TestModel_WindowSize: a resize updates the width used for truncation.
+func TestModel_WindowSize(t *testing.T) {
+	m := newBarModel(false)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120})
+	if w := updated.(barModel).width; w != 120 {
+		t.Errorf("width = %d, want 120", w)
 	}
 }
 
@@ -96,116 +146,70 @@ func TestFmtElapsed(t *testing.T) {
 	}
 }
 
-// TestStatusBar_CountsAndFailureLine drives onStatus through realistic events:
-// counters track unique terminal ids, but the bar writes nothing permanent —
-// it is a pure loading indicator.
-func TestStatusBar_CountsNoPermanentOutput(t *testing.T) {
-	var buf bytes.Buffer
-	bar := newStatusBar(newStderrRouter(&buf))
-	bar.color = false
-
+// TestModel_Counts drives track through realistic events: counters track unique
+// terminal ids; Ready, Failed, and skipped all count as "done loading".
+func TestModel_Counts(t *testing.T) {
+	m := newBarModel(false)
 	a, b, s := barID("a"), barID("b"), barID("suspended")
-	bar.onStatus(a, store.StatusInfo{Status: store.StatusPending})
-	bar.onStatus(b, store.StatusInfo{Status: store.StatusPending})
-	bar.onStatus(a, store.StatusInfo{Status: store.StatusReady})
-	bar.onStatus(b, store.StatusInfo{Status: store.StatusFailed, Message: "boom: chart not found"})
-	bar.onStatus(s, store.StatusInfo{Status: store.StatusReady, Message: store.MsgSuspended})
+	m.track(a, store.StatusInfo{Status: store.StatusPending})
+	m.track(b, store.StatusInfo{Status: store.StatusPending})
+	m.track(a, store.StatusInfo{Status: store.StatusReady})
+	m.track(b, store.StatusInfo{Status: store.StatusFailed, Message: "boom: chart not found"})
+	m.track(s, store.StatusInfo{Status: store.StatusReady, Message: store.MsgSuspended})
 
-	// Ready, Failed, and skipped all count as "done loading" — and none of
-	// them write a permanent line.
-	if buf.Len() != 0 {
-		t.Fatalf("bar wrote permanent output (it must stay silent): %q", buf.String())
+	if m.done != 3 || m.total != 3 {
+		t.Errorf("counts: done=%d total=%d; want 3/3", m.done, m.total)
 	}
-	if bar.done != 3 || bar.total != 3 {
-		t.Errorf("counts: done=%d total=%d; want 3/3", bar.done, bar.total)
-	}
-	if got := bar.inflightLabels(); len(got) != 0 {
+	if got := m.inflightLabels(); len(got) != 0 {
 		t.Errorf("all resources terminal but still in-flight: %v", got)
 	}
 }
 
-// TestStatusBar_DedupAndInflight: an idempotent terminal re-write doesn't
+// TestModel_DedupAndInflight: an idempotent terminal re-write doesn't
 // double-count, and a resource drops out of the in-flight set the moment it
 // reaches a terminal status.
-func TestStatusBar_DedupAndInflight(t *testing.T) {
-	bar := newStatusBar(newStderrRouter(&bytes.Buffer{}))
-	bar.color = false
-
+func TestModel_DedupAndInflight(t *testing.T) {
+	m := newBarModel(false)
 	a := barID("a")
-	bar.onStatus(a, store.StatusInfo{Status: store.StatusPending})
-	if got := bar.inflightLabels(); len(got) != 1 || got[0] != "a" {
+	m.track(a, store.StatusInfo{Status: store.StatusPending})
+	if got := m.inflightLabels(); len(got) != 1 || got[0] != "a" {
 		t.Fatalf("in-flight after Pending = %v, want [a]", got)
 	}
-	bar.onStatus(a, store.StatusInfo{Status: store.StatusReady})
-	bar.onStatus(a, store.StatusInfo{Status: store.StatusReady}) // duplicate
-	if bar.done != 1 {
-		t.Errorf("duplicate Ready double-counted: done=%d, want 1", bar.done)
+	m.track(a, store.StatusInfo{Status: store.StatusReady})
+	m.track(a, store.StatusInfo{Status: store.StatusReady}) // duplicate
+	if m.done != 1 {
+		t.Errorf("duplicate Ready double-counted: done=%d, want 1", m.done)
 	}
-	if got := bar.inflightLabels(); len(got) != 0 {
+	if got := m.inflightLabels(); len(got) != 0 {
 		t.Errorf("terminal resource still in-flight: %v", got)
 	}
 }
 
-// TestStatusBar_ExcludesSyntheticIDs: the synthetic bootstrap GitRepository and
-// internally-synthesized HelmCharts are reconciled internally but appear in no
-// `flate test`/`build` report, so the bar must neither count them nor list them
-// in-flight — otherwise its [done/total] overshoots every report (the 175-vs-174
-// gap). A normal declared resource alongside them still counts and names.
-func TestStatusBar_ExcludesSyntheticIDs(t *testing.T) {
-	bar := newStatusBar(newStderrRouter(&bytes.Buffer{}))
-	bar.color = false
-
+// TestModel_ExcludesSyntheticIDs: the synthetic bootstrap GitRepository and
+// internally-synthesized HelmCharts appear in no `flate test`/`build` report, so
+// the bar must neither count them nor list them in-flight — otherwise its
+// [done/total] overshoots every report (the 175-vs-174 gap).
+func TestModel_ExcludesSyntheticIDs(t *testing.T) {
+	m := newBarModel(false)
 	boot := manifest.BootstrapSourceID
 	chart := manifest.NamedResource{Kind: manifest.KindHelmChart, Namespace: "ns", Name: "repo-app-abc1234"}
 	declared := barID("declared")
 
-	// Drive each excluded id through a full Pending→terminal lifecycle, and the
-	// declared one too.
 	for _, id := range []manifest.NamedResource{boot, chart, declared} {
-		bar.onStatus(id, store.StatusInfo{Status: store.StatusPending})
+		m.track(id, store.StatusInfo{Status: store.StatusPending})
 	}
 	for _, id := range []manifest.NamedResource{boot, chart, declared} {
-		bar.onStatus(id, store.StatusInfo{Status: store.StatusReady})
+		m.track(id, store.StatusInfo{Status: store.StatusReady})
+	}
+	if m.done != 1 || m.total != 1 {
+		t.Errorf("synthetic ids leaked into counts: done=%d total=%d; want 1/1", m.done, m.total)
 	}
 
-	// Only the declared resource is counted, in either column.
-	if bar.done != 1 || bar.total != 1 {
-		t.Errorf("synthetic ids leaked into counts: done=%d total=%d; want 1/1", bar.done, bar.total)
-	}
 	// Excluded ids never enter the in-flight set, even while Pending.
-	bar2 := newStatusBar(newStderrRouter(&bytes.Buffer{}))
-	bar2.color = false
-	bar2.onStatus(boot, store.StatusInfo{Status: store.StatusPending})
-	bar2.onStatus(chart, store.StatusInfo{Status: store.StatusPending})
-	if got := bar2.inflightLabels(); len(got) != 0 {
+	m2 := newBarModel(false)
+	m2.track(boot, store.StatusInfo{Status: store.StatusPending})
+	m2.track(chart, store.StatusInfo{Status: store.StatusPending})
+	if got := m2.inflightLabels(); len(got) != 0 {
 		t.Errorf("synthetic ids listed in-flight: %v", got)
-	}
-}
-
-// TestStatusBar_StartFinish: the live lifecycle paints at least one frame and
-// then vanishes completely — finish erases the bar and leaves no trace
-// (exercises the ticker + router under the race detector).
-func TestStatusBar_StartFinish(t *testing.T) {
-	var buf bytes.Buffer
-	bar := newStatusBar(newStderrRouter(&buf))
-	bar.color = false
-
-	bar.onStatus(barID("a"), store.StatusInfo{Status: store.StatusPending})
-	bar.start()
-	bar.onStatus(barID("a"), store.StatusInfo{Status: store.StatusReady})
-	time.Sleep(250 * time.Millisecond) // let the ticker paint a few frames
-	bar.finish()
-
-	out := buf.String()
-	if !strings.Contains(out, eraseLine) {
-		t.Errorf("no in-place repaint observed: %q", out)
-	}
-	// Pure loading indicator: nothing permanent survives the run.
-	if strings.Contains(out, "flate:") {
-		t.Errorf("bar left a summary/trace behind; it must vanish: %q", out)
-	}
-	// finish ends with a bare erase, leaving the cursor on a clean empty line.
-	if !strings.HasSuffix(out, eraseLine) {
-		t.Errorf("bar not erased on finish; want trailing erase: %q", out)
 	}
 }


### PR DESCRIPTION
Follows #696/#697. The lipgloss work restyled the bar, but its *engine* was still hand-rolled — the 100ms spinner ticker/goroutine (`statusbar.go`) and the `stderrRouter` carriage-return repaint / erase-line / log-above-bar plumbing (`progress.go`), ~340 lines. This hands that to **`charm.land/bubbletea/v2` + `bubbles/v2`**, the runtime that composes with the lipgloss/v2 already in use.

## What Bubble Tea now owns
The render loop, the braille spinner (`bubbles/spinner` **MiniDot** — byte-identical charset), inline sticky rendering, terminal resize, printing log lines above the frame, and teardown.

## Changes
- **`statusbar.go` → a `tea.Model`.** Store status events feed it via `Program.Send` (`statusMsg`), so `Update` runs on Bubble Tea's single goroutine and the model needs **no mutex**. The declared-only counting (`barExcluded`, #691), in-flight ordering, "+N" overflow, and elapsed clock are unchanged; `View` renders through `internal/style` and truncates with `style.Truncate`. A `finishMsg` renders an empty frame then quits, so the bar still **vanishes without a trace** (#687).
- **`progress.go`'s `stderrRouter` is deleted.** A small `barWriter` routes slog above the live frame via `Program.Println` when the bar runs, else straight to stderr. `writerIsTTY` + `progressBarEnabled` (the `--stream` collision gate, #695) stay.
- **Output-only program:** `tea.WithInput(nil)` (never captures the keyboard) + `tea.WithoutSignalHandler()` (the CLI context owns Ctrl-C) + `tea.WithOutput(stderr)`. Still TTY/`--stream`-gated, so CI / pipes / `--no-progress` start no program.

Net **−68 lines**.

## Verification
- Unit: the model's counting/dedup/exclusion/width-fit/color/finish-vanish invariants (`statusbar_test.go` rewritten as Update/View tests); `progressBarEnabled` + `barWriter` passthrough (`progress_test.go`).
- Runtime (sized pty): spinner animates, the `[done/total]` gauge + in-flight names render and **truncate to width**, logs interleave **above** the frame, the frame **clears on completion**, input is untouched, and the terminal is restored on exit.
- `gofmt`/`go vet`/`golangci-lint` (0); `go test ./...` + `go test -race ./internal/cli/`.
- stderr-only — rendered YAML and `build` byte-equivalence are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)