### PR TITLE
refactor(cli): unify the bar + test vocabulary; verdict glyph & timing

### DIFF
--- a/internal/cli/statusbar.go
+++ b/internal/cli/statusbar.go
@@ -135,7 +135,7 @@ func (m barModel) View() tea.View {
 	if names := summarizeInflight(m.inflightLabels(), maxInflightNames); names != "" {
 		line += " " + style.Dim(names, m.color)
 	}
-	line += "  " + style.Dim(fmtElapsed(time.Since(m.startedAt)), m.color)
+	line += "  " + style.Dim(style.Elapsed(time.Since(m.startedAt)), m.color)
 	return tea.NewView(style.Truncate(line, m.width))
 }
 
@@ -188,13 +188,4 @@ func summarizeInflight(names []string, limit int) string {
 	default:
 		return fmt.Sprintf("%s +%d", strings.Join(names[:limit], ", "), len(names)-limit)
 	}
-}
-
-// fmtElapsed renders a duration compactly: tenths of a second under a minute,
-// m+ss above it.
-func fmtElapsed(d time.Duration) string {
-	if d < time.Minute {
-		return fmt.Sprintf("%.1fs", d.Seconds())
-	}
-	return fmt.Sprintf("%dm%02ds", int(d/time.Minute), int(d%time.Minute/time.Second))
 }

--- a/internal/cli/statusbar_test.go
+++ b/internal/cli/statusbar_test.go
@@ -4,7 +4,6 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -127,21 +126,6 @@ func TestSummarizeInflight(t *testing.T) {
 	for _, c := range cases {
 		if got := summarizeInflight(c.names, c.max); got != c.want {
 			t.Errorf("summarizeInflight(%v, %d) = %q, want %q", c.names, c.max, got, c.want)
-		}
-	}
-}
-
-func TestFmtElapsed(t *testing.T) {
-	cases := map[time.Duration]string{
-		0:                        "0.0s",
-		1500 * time.Millisecond:  "1.5s",
-		59900 * time.Millisecond: "59.9s",
-		90 * time.Second:         "1m30s",
-		3725 * time.Second:       "62m05s",
-	}
-	for d, want := range cases {
-		if got := fmtElapsed(d); got != want {
-			t.Errorf("fmtElapsed(%v) = %q, want %q", d, got, want)
 		}
 	}
 }

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -54,10 +55,12 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 				return err
 			}
 			defer stopProfile()
+			start := time.Now()
 			o, res, runErr := runOrchestrator(cmdContext(cmd), *c, *h)
 			if o == nil {
 				return runErr
 			}
+			elapsed := time.Since(start)
 			// testrunner.Report.AnyFailed already covers per-resource
 			// reconcile failures, so the runErr is informational here —
 			// the structured report is what the user reads. We still
@@ -79,7 +82,7 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 			// (colorprofile) honors NO_COLOR / CLICOLOR / TTY-ness; piped or
 			// redirected output stays plain.
 			color := style.ColorEnabled(cmd.OutOrStdout())
-			if err := report.Write(cmd.OutOrStdout(), color); err != nil {
+			if err := report.Write(cmd.OutOrStdout(), color, elapsed); err != nil {
 				return errors.Join(err, runErr)
 			}
 			if report.AnyFailed() {

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -1,7 +1,7 @@
-// Package style is flate's terminal styling layer: lipgloss-backed color
-// helpers and ANSI-aware truncation shared by the CLI status bar and the
-// `flate test` report, so both surfaces speak one styling vocabulary instead of
-// hand-rolling escape codes.
+// Package style is flate's terminal presentation layer: the glyphs, lipgloss
+// color helpers, ANSI-aware truncation, and duration formatting shared by the
+// CLI status bar and the `flate test` report, so both surfaces speak one
+// vocabulary instead of hand-rolling escape codes and symbols.
 //
 // Color is gated per output writer: callers resolve ColorEnabled(w) once (a
 // pipe, NO_COLOR, CLICOLOR=0, or a dumb terminal renders plain) and thread the
@@ -9,12 +9,22 @@
 package style
 
 import (
+	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/colorprofile"
 	"github.com/charmbracelet/x/ansi"
+)
+
+// Status glyphs shared across surfaces: a passing/success mark, a failure mark,
+// and a skipped/secondary dash. Pair with Pass/Fail/Skip for color.
+const (
+	GlyphPass = "✓"
+	GlyphFail = "✗"
+	GlyphSkip = "‒"
 )
 
 // Semantic styles, by ANSI base color (0-7) so they downsample cleanly on
@@ -72,4 +82,13 @@ func Truncate(s string, width int) string {
 		return s
 	}
 	return ansi.Truncate(s, width, "…")
+}
+
+// Elapsed renders a duration compactly for live and summary timing: tenths of a
+// second under a minute, m+ss above it.
+func Elapsed(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return fmt.Sprintf("%dm%02ds", int(d/time.Minute), int(d%time.Minute/time.Second))
 }

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -4,9 +4,26 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/x/ansi"
 )
+
+// TestElapsed: compact duration formatting shared by the bar and the report.
+func TestElapsed(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                        "0.0s",
+		1500 * time.Millisecond:  "1.5s",
+		59900 * time.Millisecond: "59.9s",
+		90 * time.Second:         "1m30s",
+		3725 * time.Second:       "62m05s",
+	}
+	for d, want := range cases {
+		if got := Elapsed(d); got != want {
+			t.Errorf("Elapsed(%v) = %q, want %q", d, got, want)
+		}
+	}
+}
 
 // TestColorEnabled_NonTTY: a buffer (pipe/CI/e2e sink) is never a terminal, so
 // styling stays off without a flag.

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/home-operations/flate/internal/style"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -67,18 +68,19 @@ func (r Report) AnyFailed() bool { return r.Failed > 0 }
 func (o Outcome) decorate() (glyph string, paint func(string, bool) string) {
 	switch o {
 	case OutcomePassed:
-		return "✓", style.Pass
+		return style.GlyphPass, style.Pass
 	case OutcomeFailed:
-		return "✗", style.Fail
+		return style.GlyphFail, style.Fail
 	default: // OutcomeSkipped
-		return "‒", style.Skip
+		return style.GlyphSkip, style.Skip
 	}
 }
 
 // Write renders the report: one row per case (status glyph, dimmed kind column,
-// namespace/name, dimmed reason) followed by a colored count summary. color
+// namespace/name, dimmed reason) followed by a summary — an overall verdict
+// glyph, the colored counts, and a dim elapsed clock (omitted when zero). color
 // gates the ANSI codes — the caller decides based on the sink (see cli.test).
-func (r Report) Write(w io.Writer, color bool) error {
+func (r Report) Write(w io.Writer, color bool, elapsed time.Duration) error {
 	kindW := 0
 	for _, c := range r.Cases {
 		kindW = max(kindW, len(c.ID.Kind))
@@ -98,15 +100,23 @@ func (r Report) Write(w io.Writer, color bool) error {
 		b.WriteByte('\n')
 	}
 
-	// Summary: always the passed count; skipped/failed only when non-zero, so
-	// an all-green run reads "N passed" and an empty run still prints something.
-	b.WriteString("\n  ")
+	// Summary: a verdict glyph (green ✓ / red ✗) leads the colored counts —
+	// always the passed count; skipped/failed only when non-zero — and a dim
+	// elapsed clock closes it. An empty run still reads "✓ 0 passed".
+	verdict, paintVerdict := style.GlyphPass, style.Pass
+	if r.Failed > 0 {
+		verdict, paintVerdict = style.GlyphFail, style.Fail
+	}
+	b.WriteString("\n  " + paintVerdict(verdict, color) + " ")
 	b.WriteString(style.Pass(fmt.Sprintf("%d passed", r.Passed), color))
 	if r.Skipped > 0 {
 		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d skipped", r.Skipped), color))
 	}
 	if r.Failed > 0 {
 		b.WriteString(" · " + style.Fail(fmt.Sprintf("%d failed", r.Failed), color))
+	}
+	if elapsed > 0 {
+		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
 	}
 	b.WriteByte('\n')
 

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -5,10 +5,43 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/home-operations/flate/internal/style"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
+
+// TestWrite_VerdictGlyphAndElapsed: the summary leads with a green ✓ when all
+// pass and a red ✗ when anything fails, and shows the elapsed clock only when
+// non-zero.
+func TestWrite_VerdictGlyphAndElapsed(t *testing.T) {
+	pass := store.New()
+	ok := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "ok"}
+	pass.AddObject(&manifest.Kustomization{Name: ok.Name, Namespace: ok.Namespace})
+	pass.UpdateStatus(ok, store.StatusReady, "")
+	var pb bytes.Buffer
+	if err := Run(Job{Store: pass}).Write(&pb, false, 1500*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if out := pb.String(); !strings.Contains(out, style.GlyphPass) || strings.Contains(out, style.GlyphFail) {
+		t.Errorf("all-pass summary wants ✓ and no ✗:\n%s", out)
+	} else if !strings.Contains(out, "1.5s") {
+		t.Errorf("summary should show the elapsed clock:\n%s", out)
+	}
+
+	fail := store.New()
+	bad := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "bad"}
+	fail.AddObject(&manifest.Kustomization{Name: bad.Name, Namespace: bad.Namespace})
+	fail.UpdateStatus(bad, store.StatusFailed, "boom")
+	var fb bytes.Buffer
+	_ = Run(Job{Store: fail}).Write(&fb, false, 0)
+	if out := fb.String(); !strings.Contains(out, style.GlyphFail) {
+		t.Errorf("failing summary wants ✗:\n%s", out)
+	} else if strings.Contains(out, "0.0s") {
+		t.Errorf("elapsed=0 should be omitted, not rendered:\n%s", out)
+	}
+}
 
 func TestRun_AllPass(t *testing.T) {
 	s := store.New()
@@ -22,7 +55,7 @@ func TestRun_AllPass(t *testing.T) {
 		t.Errorf("expected 2 passed, got %+v", rep)
 	}
 	var b bytes.Buffer
-	if err := rep.Write(&b, false); err != nil {
+	if err := rep.Write(&b, false, 0); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	if !strings.Contains(b.String(), "2 passed") {
@@ -105,7 +138,7 @@ func TestWrite_ShowsSkippedByDefault(t *testing.T) {
 	rep := Run(Job{Store: s})
 
 	var b bytes.Buffer
-	if err := rep.Write(&b, false); err != nil {
+	if err := rep.Write(&b, false, 0); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	out := b.String()
@@ -132,7 +165,7 @@ func TestWrite_FailedNeverHidden(t *testing.T) {
 
 	rep := Run(Job{Store: s})
 	var b bytes.Buffer
-	if err := rep.Write(&b, false); err != nil {
+	if err := rep.Write(&b, false, 0); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	if out := b.String(); !strings.Contains(out, "✗") || !strings.Contains(out, "broken") {
@@ -153,10 +186,10 @@ func TestWrite_Color(t *testing.T) {
 	rep := Run(Job{Store: s})
 
 	var colored, plain bytes.Buffer
-	if err := rep.Write(&colored, true); err != nil {
+	if err := rep.Write(&colored, true, 0); err != nil {
 		t.Fatalf("Write(color): %v", err)
 	}
-	if err := rep.Write(&plain, false); err != nil {
+	if err := rep.Write(&plain, false, 0); err != nil {
 		t.Fatalf("Write(plain): %v", err)
 	}
 	if !strings.Contains(colored.String(), "\x1b") {
@@ -200,7 +233,7 @@ func TestWrite_ReturnsWriterError(t *testing.T) {
 	want := errors.New("write failed")
 	rep := Report{Cases: []Case{{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "apps"}}}}
 
-	if err := rep.Write(errWriter{err: want}, false); !errors.Is(err, want) {
+	if err := rep.Write(errWriter{err: want}, false, 0); !errors.Is(err, want) {
 		t.Fatalf("Write error = %v, want %v", err, want)
 	}
 }


### PR DESCRIPTION
Follows #696/#697/#698. With both the status bar and `flate test` now riding `internal/style`, this folds the last duplicated bits into that one vocabulary and spends the headroom on a couple of modern touches — lean, no new types.

## Dedup
- `internal/style` becomes the single source for the **status glyphs** (`GlyphPass ✓` / `GlyphFail ✗` / `GlyphSkip ‒`) and **`Elapsed(d)`** — the compact duration formatter that was the bar's private `fmtElapsed`. Both surfaces now draw symbols *and* timing from one place.
- The status bar renders its clock via `style.Elapsed` (`fmtElapsed` deleted); the report's rows use the shared glyphs.

## Modern touches (`flate test`)
- The summary leads with a **verdict glyph** — green `✓` when everything passes, red `✗` on any failure — and closes with a **dim elapsed clock**:
  ```
  ✗ 57 passed · 49 failed   3.1s
  ```
- `Report.Write` takes the elapsed duration (**omitted when zero**, so unit tests stay deterministic); the `test` command measures the run and passes it.

## Verification
- `gofmt`/`go vet`/`golangci-lint` (0); `go test ./...` incl. the moved `TestElapsed` and a verdict-glyph/elapsed regression; e2e `flate test` assertions green.
- Eyeballed plain + forced-color: red `✗` verdict, green/red counts, dim elapsed.
- CLI/test-output only — no rendered-YAML change; `build` byte-equivalence untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)