### PR TITLE
ci: path-filter triggers, add concurrency, cache golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:
@@ -35,6 +39,13 @@ jobs:
         with:
           experimental: true
           install_args: --locked
+
+      - name: Cache golangci-lint
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/golangci-lint
+          key: ${{ runner.os }}-golangci-lint-${{ hashFiles('go.sum', '.golangci.yml') }}
+          restore-keys: ${{ runner.os }}-golangci-lint-
 
       - name: Run linter
         run: mise run lint

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded main builds (rolling tag); never interrupt a published release.
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Cancel superseded main builds (rolling tag); never interrupt a published release.
   cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## What changed

Mirrors the CI-efficiency change already merged in home-operations/kromgo#239, tailored to this repo's workflows.

**Part 1 — path filters (`paths-ignore: ["**.md"]`)**
- `tests.yaml` — added under both `push:` and `pull_request:` triggers.
- `lint.yaml` — added under both `push:` and `pull_request:` triggers.
- `release.yaml` — added under the `push:` trigger only (not under `release:`).
- No trigger here had a `paths:` allow-list, so none were skipped on that account.

**Part 2 — concurrency (added only where missing)**
- `release.yaml` — `group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: ${{ github.event_name != 'release' }}` so superseded `main` (rolling-tag) builds are cancelled but a published release is never interrupted.
- `release-please.yaml` — `group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: false`.
- `lint.yaml` and `tests.yaml` already have a concurrency block — left untouched.

**Part 3 — golangci-lint cache**
- `lint.yaml` runs `mise run lint`, whose `[tasks.lint]` invokes `golangci-lint run` directly (not the self-caching action), so a dedicated `actions/cache` step was added immediately after "Setup Mise", keyed on `go.sum` + `.golangci.yml`.

## Skipped
- No `e2e.yaml` exists in this repo (kromgo#239 patched one) — nothing to do there.
- `release-please.yaml`, `renovate.yaml`, `stale.yaml` triggers were not touched (per scope).

## Safety
Trigger metadata, concurrency, and a cache step only — no job logic, no required-check changes. `paths-ignore: ["**.md"]` simply skips runs for Markdown-only pushes/PRs. `zizmor --offline` reports no new findings on all four changed workflows.
