### PR TITLE
feat(schedule): generation-guarded rerun-at-drain primitive

### DIFF
--- a/pkg/orchestrator/dagrun.go
+++ b/pkg/orchestrator/dagrun.go
@@ -17,7 +17,7 @@ import (
 // untranslated.
 type dagDispatcher struct{ o *Orchestrator }
 
-func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLevel int) (schedule.Outcome, []schedule.NodeID, bool) {
+func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLevel int) (schedule.Outcome, []schedule.NodeID, bool, bool) {
 	o := d.o
 	var (
 		blocked []manifest.NamedResource
@@ -32,12 +32,15 @@ func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLe
 		blocked, ready = o.src.ReconcileNode(ctx, id, drainLevel)
 	default:
 		// Not a schedulable kind (should never be dispatched) — terminal no-op.
-		return schedule.OutcomeTerminal, nil, true
+		return schedule.OutcomeTerminal, nil, true, false
 	}
+	// rerunAtDrain stays false for KS/HR/source: they park on named deps and are
+	// woken by id-keyed arrivals. The ResourceSet controller (a later step) is
+	// the only producer of rerunAtDrain=true.
 	if len(blocked) > 0 {
-		return schedule.OutcomeBlocked, blocked, false
+		return schedule.OutcomeBlocked, blocked, false, false
 	}
-	return schedule.OutcomeTerminal, nil, ready
+	return schedule.OutcomeTerminal, nil, ready, false
 }
 
 // dagSchedulable reports whether id is a node the scheduler runs

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -77,8 +77,13 @@ type Dispatcher interface {
 	//   - ready: whether id's final store status is Ready (meaningful only
 	//     when Terminal) — the scheduler records it so a node parking on id
 	//     can tell, without reading the store, whether id is satisfied.
+	//   - rerunAtDrain: whether id wants to be re-run at the structural
+	//     fixpoint. A node with no nameable dependency to park on (a
+	//     ResourceSet with a selector-only inputsFrom, whose matching inputs
+	//     may be emitted by an unknown producer) sets this so the scheduler
+	//     re-expands it once the graph is quiescent — see requeueDrainRerunLocked.
 	// drainLevel is one of DrainNone/DrainCascade/DrainForce.
-	Dispatch(ctx context.Context, id NodeID, drainLevel int) (out Outcome, blocked []NodeID, ready bool)
+	Dispatch(ctx context.Context, id NodeID, drainLevel int) (out Outcome, blocked []NodeID, ready, rerunAtDrain bool)
 }
 
 type nodeState uint8
@@ -99,6 +104,13 @@ type node struct {
 	// complete() re-queues it once instead of dropping the wake (the re-run
 	// re-reads the store and re-evaluates its gate against current state).
 	rerunRequested bool
+	// drainRerun marks a node that asked (via Dispatch's rerunAtDrain) to be
+	// re-run at the structural fixpoint. lastGen is the arrival generation
+	// observed when the node was last dispatched; the fixpoint re-runs the node
+	// only if a newer arrival has happened since (gen > lastGen), which bounds
+	// re-runs by the finite, monotone set of arrivals. See requeueDrainRerunLocked.
+	drainRerun bool
+	lastGen    uint64
 }
 
 // Scheduler is a re-entrant fixpoint reconcile driver. Construct with New,
@@ -116,6 +128,10 @@ type Scheduler struct {
 	inFlight  int                            // count of stateRunning nodes (EXCLUDES parked)
 	draining  int                            // DrainNone/DrainCascade/DrainForce
 	canceled  bool
+	// gen counts object arrivals (OnArrival). A drain-rerun node records the gen
+	// it last ran at; the fixpoint re-runs it only when gen has since advanced,
+	// so re-runs are bounded by the finite, monotone arrival set.
+	gen uint64
 }
 
 // New constructs a Scheduler that runs bodies on tasks via disp.
@@ -176,12 +192,17 @@ func (s *Scheduler) Run(ctx context.Context) {
 			n.state = stateRunning
 			n.rerunRequested = false
 			n.blockedOn = nil
+			// Snapshot the arrival generation at dispatch (not completion): any
+			// arrival during or after this body — including the body's own
+			// emissions — then leaves gen > lastGen, so a needed re-expansion is
+			// never missed. The cost is one FingerprintDedup'd no-op re-run.
+			n.lastGen = s.gen
 			s.inFlight++
 			level := s.draining
 			s.mu.Unlock()
 			s.tasks.Go(ctx, "schedule/"+id.String(), func(ctx context.Context) {
-				out, blocked, ready := s.disp.Dispatch(ctx, id, level)
-				s.complete(id, out, blocked, ready)
+				out, blocked, ready, rerunAtDrain := s.disp.Dispatch(ctx, id, level)
+				s.complete(id, out, blocked, ready, rerunAtDrain)
 			})
 			s.mu.Lock()
 		}
@@ -190,6 +211,13 @@ func (s *Scheduler) Run(ctx context.Context) {
 		//    must be drained.
 		if s.inFlight == 0 {
 			if !s.hasParkedLocked() {
+				// Quiescent: nothing running, nothing parked. Before declaring
+				// the fixpoint, re-run any drain-rerun node that has seen a new
+				// arrival since it last ran — a selector ResourceSet re-expands
+				// here against the now-complete store. The gen-guard bounds this.
+				if s.requeueDrainRerunLocked() {
+					continue
+				}
 				break // clean fixpoint: every node terminal
 			}
 			// Parked nodes remain with nothing in flight. Escalate the drain
@@ -220,7 +248,7 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 // complete records the result of one Dispatch. Runs on the worker goroutine;
 // acquires mu. Touches ONLY scheduler state — never the store or the pool.
-func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready bool) {
+func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready, rerunAtDrain bool) {
 	s.mu.Lock()
 	// Broadcast on EVERY path (terminalize, park, re-queue) so the Run loop
 	// re-evaluates inFlight/runq after any transition — a terminalize that
@@ -230,6 +258,9 @@ func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready boo
 	defer s.cond.Broadcast()
 	n := s.nodes[id]
 	s.inFlight--
+	// Record the node's drain-rerun intent (static per node — a selector
+	// ResourceSet always asks). Read by requeueDrainRerunLocked at the fixpoint.
+	n.drainRerun = rerunAtDrain
 
 	// A wake landed while this body was running: honor it exactly once by
 	// re-queuing, regardless of the outcome just reported. The re-run
@@ -334,6 +365,9 @@ func (s *Scheduler) unparkLocked(n *node) {
 func (s *Scheduler) OnArrival(id NodeID, schedulable bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// An arrival is the only thing that can change a drain-rerun node's resolved
+	// input set; bump the generation so the fixpoint knows a re-expansion is due.
+	s.gen++
 	if n := s.nodes[id]; n == nil {
 		if schedulable {
 			// Render-discovered node: register and queue it.
@@ -425,6 +459,33 @@ func (s *Scheduler) requeueAllParkedLocked() {
 	for _, n := range parked {
 		s.unparkLocked(n)
 	}
+}
+
+// requeueDrainRerunLocked re-queues, in id order, every terminal drain-rerun
+// node that has seen a new arrival since it last ran (gen advanced past its
+// lastGen), so it re-expands against the now-complete store at quiescence.
+// Returns whether any node was re-queued. Termination: a re-run requires an
+// arrival since the node's last run, arrivals are finite and monotone, and a
+// re-run that resolves identically is a fingerprint-dedup no-op that adds
+// nothing to the runq — so the gen-guard converges. Caller holds mu.
+func (s *Scheduler) requeueDrainRerunLocked() bool {
+	var due []*node
+	for _, n := range s.nodes {
+		if n.state == stateTerminal && n.drainRerun && n.lastGen < s.gen {
+			due = append(due, n)
+		}
+	}
+	if len(due) == 0 {
+		return false
+	}
+	slices.SortFunc(due, func(a, b *node) int { return a.id.Compare(b.id) })
+	for _, n := range due {
+		n.state = stateRunnable
+		n.ready = false
+		n.blockedOn = nil
+		s.runq = append(s.runq, n.id)
+	}
+	return true
 }
 
 // finalSweepLocked is a defensive backstop: after DrainForce every parked node

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -36,6 +36,10 @@ type fakeDisp struct {
 	// closed — used to force interleavings (e.g. the lost-wakeup race).
 	gate map[NodeID]chan struct{}
 
+	// drainRerun, if set for an id, makes Dispatch return rerunAtDrain=true for
+	// it — modeling a selector ResourceSet that re-expands at the fixpoint.
+	drainRerun map[NodeID]bool
+
 	mu        sync.Mutex
 	termReady map[NodeID]bool
 	termAny   map[NodeID]bool
@@ -45,15 +49,16 @@ type fakeDisp struct {
 
 func newFake(graph map[NodeID][]NodeID) *fakeDisp {
 	return &fakeDisp{
-		graph:     graph,
-		gate:      map[NodeID]chan struct{}{},
-		termReady: map[NodeID]bool{},
-		termAny:   map[NodeID]bool{},
-		runs:      map[NodeID]int{},
+		graph:      graph,
+		gate:       map[NodeID]chan struct{}{},
+		drainRerun: map[NodeID]bool{},
+		termReady:  map[NodeID]bool{},
+		termAny:    map[NodeID]bool{},
+		runs:       map[NodeID]int{},
 	}
 }
 
-func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outcome, []NodeID, bool) {
+func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outcome, []NodeID, bool, bool) {
 	f.mu.Lock()
 	g := f.gate[nid]
 	f.mu.Unlock()
@@ -67,6 +72,7 @@ func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outc
 	if drainLevel > f.maxDrain {
 		f.maxDrain = drainLevel
 	}
+	rerun := f.drainRerun[nid]
 	deps := f.graph[nid]
 	var blocked []NodeID
 	failed := false
@@ -97,13 +103,13 @@ func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outc
 	case failed:
 		f.termAny[nid] = true
 		f.termReady[nid] = false
-		return OutcomeTerminal, nil, false
+		return OutcomeTerminal, nil, false, rerun
 	case len(blocked) > 0:
-		return OutcomeBlocked, blocked, false
+		return OutcomeBlocked, blocked, false, rerun
 	default:
 		f.termAny[nid] = true
 		f.termReady[nid] = true
-		return OutcomeTerminal, nil, true
+		return OutcomeTerminal, nil, true, rerun
 	}
 }
 
@@ -298,6 +304,51 @@ func TestCrossKindCycleForceDrains(t *testing.T) {
 	if f.maxDrainLevel() != DrainForce {
 		t.Fatalf("a cycle must escalate to DrainForce; maxDrain=%d", f.maxDrainLevel())
 	}
+}
+
+func TestDrainRerunReexpandsOnArrival(t *testing.T) {
+	// A drain-rerun node (a selector ResourceSet) terminalizes immediately, then
+	// a later arrival bumps gen. At the structural fixpoint the node must re-run
+	// once — re-expanding against the now-complete store — even though it parked
+	// on nothing and the arriving id is not one it waited on.
+	f := newFake(map[NodeID][]NodeID{
+		id("rs"):        nil,
+		id("keepalive"): nil,
+	})
+	f.drainRerun[id("rs")] = true
+	gate := make(chan struct{})
+	f.gate[id("keepalive")] = gate
+
+	ts := task.NewBounded(8)
+	s := New(ts, f)
+	s.Seed([]NodeID{id("rs"), id("keepalive")})
+	done := make(chan struct{})
+	go func() { s.Run(context.Background()); close(done) }()
+
+	// rs ran once (gen still 0). Now a late data arrival bumps gen; with the
+	// pool held non-idle by keepalive, the fixpoint can't fire until we release.
+	waitUntil(t, func() bool { return f.runCount(id("rs")) >= 1 })
+	s.OnArrival(NodeID{Kind: manifest.KindConfigMap, Namespace: "ns", Name: "late"}, false)
+	close(gate)
+	<-done
+
+	if rc := f.runCount(id("rs")); rc != 2 {
+		t.Fatalf("drain-rerun node ran %d times; want exactly 2 (initial + one re-expansion)", rc)
+	}
+	assertReady(t, f, "rs")
+}
+
+func TestDrainRerunTerminatesWithoutArrival(t *testing.T) {
+	// With no arrival after its run, a drain-rerun node converges: gen never
+	// advances past its lastGen, so the fixpoint does NOT re-run it. This is the
+	// termination bound — re-runs require a fresh arrival.
+	f := newFake(map[NodeID][]NodeID{id("rs"): nil})
+	f.drainRerun[id("rs")] = true
+	run(t, f, 8)
+	if rc := f.runCount(id("rs")); rc != 1 {
+		t.Fatalf("drain-rerun node ran %d times with no arrival; want exactly 1 (no re-run)", rc)
+	}
+	assertReady(t, f, "rs")
 }
 
 func TestDanglingChainRunCountBounded(t *testing.T) {


### PR DESCRIPTION
## What

Adds a bounded **rerun-at-the-structural-fixpoint** capability to the scheduler. A node can report `rerunAtDrain` (a new 4th `Dispatch` return); when the graph is quiescent (nothing in flight, nothing parked) the scheduler re-runs such a node **iff a new object has arrived since it last ran** (`gen > lastGen`).

## Why

It's the primitive a first-class `ResourceSet` needs (follow-up PR): an RS with a **selector** `inputsFrom` matching an RSIP that's emitted by *another* Kustomization's render has **no nameable producer to park on**, so the existing id-keyed park/wake can't re-expand it once it terminalizes. `rerunAtDrain` lets it re-render against the complete input set after every producible RSIP has materialized.

## Design

- `Scheduler.gen` increments on every `OnArrival`; `node.lastGen` is snapshotted **at dispatch** (not completion) so an arrival during a body's own emission window is never missed.
- The clean-fixpoint branch (`inFlight==0 && !hasParked`) calls `requeueDrainRerunLocked()` before breaking: re-queues, in id order, every terminal drain-rerun node with `lastGen < gen`.
- **Termination:** a re-run requires a fresh arrival between runs; arrivals are content-change-gated and the object set is monotone within a run, so the gen-guard converges (a re-run that resolves identically is a fingerprint-dedup no-op that adds nothing to the runq).

## Inert until armed

`dagDispatcher` returns `rerunAtDrain=false` for every current kind (KS/HR/source), so behavior is unchanged — **byte-identical `flate build all` on k8s-gitops (2,382,375 bytes)**. The ResourceSet controller that arms it lands next.

## Verification

`gofmt`/`go vet`/`golangci-lint` (0); full `go test ./...`; `-race` on `pkg/schedule` + `pkg/orchestrator`. New scheduler tests: re-run fires when an arrival advances `gen`; **does not** fire (terminates) without an arrival.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
