### PR TITLE
refactor(emit): return parsed children so ResourceSet skips a re-parse

### DIFF
--- a/pkg/controllers/emit/emit.go
+++ b/pkg/controllers/emit/emit.go
@@ -12,6 +12,15 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// Child is one parsed render-emission: the typed object and the source doc it
+// was parsed from. Children returns these in doc order so a caller can
+// post-process them (e.g. the ResourceSet controller routes RawObject children
+// to its output sink) without re-parsing.
+type Child struct {
+	Obj manifest.BaseManifest
+	Doc map[string]any
+}
+
 // Children parses the rendered docs and lands them in the store using a
 // two-pass emission strategy:
 //
@@ -48,9 +57,13 @@ import (
 // provenance (ReportRendered) and keep-set (KeepEmitted) side-effects
 // the replay exists for are idempotent and event-free, so they still
 // run on both paths; only the redundant republish is skipped.
-func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, docs []map[string]any, publish bool) {
+//
+// Returns the parsed children in doc order (build directives and parse
+// failures excluded), so a caller can post-process them without re-parsing —
+// the ResourceSet controller routes the RawObject children to its output sink.
+func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, docs []map[string]any, publish bool) []Child {
 	type parsed struct {
-		obj          manifest.BaseManifest
+		Child
 		reconcilable bool
 		leaf         bool // held for pass 2 (Kustomization / HelmRelease)
 	}
@@ -72,7 +85,7 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 		}
 		reconcilable := ShouldDispatchAsObject(obj)
 		objs = append(objs, parsed{
-			obj:          obj,
+			Child:        Child{Obj: obj, Doc: doc},
 			reconcilable: reconcilable,
 			leaf:         reconcilable && IsLeafReconcilable(obj),
 		})
@@ -93,26 +106,31 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 		case p.leaf:
 			continue // held for pass 2
 		case p.reconcilable:
-			keep(p.obj)
+			keep(p.Obj)
 			if publish {
-				c.Store.AddObject(p.obj)
+				c.Store.AddObject(p.Obj)
 			}
 		default:
-			c.Store.AddRendered(p.obj)
+			c.Store.AddRendered(p.Obj)
 		}
 	}
 	// Pass 2 — leaf reconcilables.
 	var leaves []manifest.BaseManifest
 	for _, p := range objs {
 		if p.leaf {
-			keep(p.obj)
-			leaves = append(leaves, p.obj)
+			keep(p.Obj)
+			leaves = append(leaves, p.Obj)
 		}
 	}
 	c.ReportRendered(id, rendered)
 	if publish {
 		c.Store.AddObjects(leaves)
 	}
+	children := make([]Child, len(objs))
+	for i, p := range objs {
+		children[i] = p.Child
+	}
+	return children
 }
 
 // ShouldDispatchAsObject reports whether a render-emitted Flux

--- a/pkg/controllers/resourceset/controller.go
+++ b/pkg/controllers/resourceset/controller.go
@@ -170,7 +170,7 @@ func (c *Controller) reconcile(ctx context.Context, rs *manifest.ResourceSet) er
 // otherwise — the cached docs were already sunk by the render that set
 // the artifact).
 func (c *Controller) emit(id manifest.NamedResource, docs []map[string]any, publish bool) {
-	emit.Children(c.Controller, c.WipeSecrets, id, docs, publish)
+	children := emit.Children(c.Controller, c.WipeSecrets, id, docs, publish)
 	if !publish || c.rawSink == nil {
 		return
 	}
@@ -178,16 +178,13 @@ func (c *Controller) emit(id manifest.NamedResource, docs []map[string]any, publ
 	if !ok {
 		return
 	}
-	opts := manifest.ParseDocOptions{WipeSecrets: c.WipeSecrets}
-	for _, doc := range docs {
-		obj, err := manifest.ParseDoc(doc, opts)
-		if err != nil {
-			continue
+	// Route the RawObject (non-Flux) children to the orchestrator's output sink,
+	// reusing emit.Children's parse — they group under the parent KS in the
+	// build output, the same as the deleted post-run pass produced.
+	for _, child := range children {
+		if _, raw := child.Obj.(*manifest.RawObject); raw {
+			c.rawSink(id, parentKS, child.Doc)
 		}
-		if _, raw := obj.(*manifest.RawObject); !raw {
-			continue
-		}
-		c.rawSink(id, parentKS, doc)
 	}
 }
 

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -263,8 +263,10 @@ func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready, re
 	defer s.cond.Broadcast()
 	n := s.nodes[id]
 	s.inFlight--
-	// Record the node's rerun intent (static per node — a selector ResourceSet
-	// always asks). Read by requeueRerunLocked at the fixpoint.
+	// Record the node's rerun intent, re-evaluated at each dispatch. The value
+	// is stable per node — a selector-only ResourceSet's rerun status is a fixed
+	// spec property — so each write sets the same value. Read by
+	// requeueRerunLocked at the fixpoint.
 	n.rerun = rerun
 
 	// A wake landed while this body was running: honor it exactly once by


### PR DESCRIPTION
## What

Two byte-safe polish items surfaced by an adversarial re-review of this session's work (the scheduler primitive, ResourceSet first-class, secrets). The review's verdict was that the landed code is already exceptional; these are the only substantive findings.

1. **Eliminate a double-parse in the ResourceSet emit path.** `emit.Children` now returns the parsed children (`Child{Obj, Doc}`, in doc order) it already built. The RS controller routed RawObject children to its output sink by re-parsing every rendered doc a second time with identical options — it now filters the returned slice. N `ParseDoc` calls per RS publish instead of 2N. The kustomization caller ignores the new return value.
2. **Clarify the scheduler's `n.rerun` comment** — the field is re-evaluated each dispatch but stable per node (a selector-only ResourceSet's rerun status is a fixed spec property); the old "static per node" wording could be misread as "never updated".

## Verification

`gofmt`/`vet`/`golangci-lint` (0); full `go test ./...`; `-race` on emit + resourceset + schedule + orchestrator + kustomization. **Byte-identical `build all` on k8s-gitops (2,382,360 bytes)** — pure refactor, same parse results, same RawObject set, same sink ordering + dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
