### PR TITLE
refactor(controllers): lift shared reconcile config into base.Options

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -148,6 +148,47 @@ func (c *Controller) SetRenderTracker(rt RenderTracker) {
 	c.renderTracker = rt
 }
 
+// Options is the post-bootstrap, reconcile-shaping config common to every
+// render controller (Kustomization, HelmRelease, ResourceSet). The
+// orchestrator wires it once before Start; the source controller is fetch-only
+// and configures just its filter directly, so it does NOT embed this. A
+// concrete controller embeds Options in its own option struct and forwards it
+// to Configure, then assigns its controller-specific fields.
+type Options struct {
+	// Filter narrows reconciliation to changed resources in changed-only mode.
+	Filter *change.Filter
+	// ParentOf maps a resource to its structural-parent Kustomization so
+	// reconcile waits for the parent's Ready before rendering — any
+	// parent-render-time spec mutation (replacements injecting
+	// targetNamespace, postBuild substitutions, a re-emitted patched spec) is
+	// then observable. Nil disables parent enforcement.
+	ParentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
+	// RenderTracker receives every reconcilable child a render emits, feeding
+	// the orchestrator's parent-provenance index (orphan detection, parent
+	// resolution, attribution).
+	RenderTracker RenderTracker
+	// Existence is the file-existence lookup depwait uses to lazy-promote
+	// file-indexed deps and to distinguish a render-only dep still in flight
+	// from a typo'd one. See depwait.ExistenceLookup.
+	Existence depwait.ExistenceLookup
+	// PreflightFailure reports dependency-graph errors discovered before
+	// reconcile; when set for an id the controller marks it Failed and renders
+	// nothing.
+	PreflightFailure func(manifest.NamedResource) (string, bool)
+}
+
+// Configure applies the common reconcile-shaping config. A concrete controller
+// calls c.Controller.Configure(opts.Options) before assigning its own fields.
+// The five setters are independent single-field writes, so their order is
+// immaterial; each still panics if called after Start.
+func (c *Controller) Configure(opts Options) {
+	c.SetFilter(opts.Filter)
+	c.SetDepwait(opts.Existence)
+	c.SetPreflight(opts.PreflightFailure)
+	c.SetParentOf(opts.ParentOf)
+	c.SetRenderTracker(opts.RenderTracker)
+}
+
 // KeepEmitted extends the change filter's keep set so render-emitted
 // children pass the changed-only-mode PreGate check. Without this, a
 // parent whose render emits a child that wasn't on disk at filter-build

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -13,7 +13,6 @@ import (
 	"log/slog"
 	"slices"
 
-	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/helm"
@@ -54,34 +53,14 @@ type Controller struct {
 	producers *manifest.ProducerIndex
 }
 
-// ReconcileOptions carries the post-bootstrap state the orchestrator
-// wires onto the controller. Filter narrows reconciliation to changed
-// HelmReleases (and their referenced sources/values) in changed-only
-// mode. ParentOf resolves each HR to its enclosing KS at lookup time
-// (combines the file-loaded path-prefix index with the runtime
-// renderedSet); reconcile depwaits on the parent before rendering so
-// spec patches (driftDetection / upgrade strategy / CRD policy at the
-// cluster KS level, post-build substitutions, kustomize replacements)
-// land before the first helm.Template call.
+// ReconcileOptions carries the post-bootstrap state the orchestrator wires
+// onto the controller. base.Options holds the config common to every render
+// controller (Filter / ParentOf — here resolving each HR to its enclosing KS,
+// which reconcile depwaits on so cluster-KS spec patches land before the first
+// helm.Template call — RenderTracker / Existence / PreflightFailure);
+// AllowMissingSecrets and Producers are HelmRelease-specific.
 type ReconcileOptions struct {
-	Filter   *change.Filter
-	ParentOf func(manifest.NamedResource) (manifest.NamedResource, bool)
-	// RenderTracker receives every source-kind child emitted during HR
-	// render. Mirrors kustomization.Options.RenderTracker; feeds the
-	// orchestrator's parent-provenance index (detectOrphans, parent
-	// resolver, ResourceSet attribution). Nil is OK — no-op.
-	RenderTracker base.RenderTracker
-	// Existence is the file-existence lookup the orchestrator wires
-	// against the loader's ExistenceIndex. Classify uses it to lazy-
-	// promote file-indexed deps (HelmRepository, OCIRepository,
-	// HelmChart, …) and to distinguish render-only deps from typo'd
-	// ones. See depwait.ExistenceLookup for the decision matrix.
-	// Forwarded to every Waiter built during reconcile.
-	Existence depwait.ExistenceLookup
-	// PreflightFailure reports dependency-graph errors discovered by the
-	// orchestrator before reconcile. When set for an id, the controller
-	// marks the resource Failed and does not render it.
-	PreflightFailure func(manifest.NamedResource) (string, bool)
+	base.Options
 	// AllowMissingSecrets omits non-optional valuesFrom refs that point
 	// at known live-cluster/generated data or fail to materialize offline.
 	AllowMissingSecrets bool
@@ -106,13 +85,9 @@ func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wip
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once dispatch begins.
 func (c *Controller) Configure(opts ReconcileOptions) {
-	c.SetFilter(opts.Filter)
-	c.SetDepwait(opts.Existence)
-	c.SetPreflight(opts.PreflightFailure)
-	c.SetParentOf(opts.ParentOf)
+	c.Controller.Configure(opts.Options)
 	c.allowMissingSecrets = opts.AllowMissingSecrets
 	c.producers = opts.Producers
-	c.SetRenderTracker(opts.RenderTracker)
 }
 
 // Start registers the listeners. The controller runs until Close.

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
@@ -21,7 +22,7 @@ import (
 
 func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store.Store) {
 	t.Helper()
-	return newTestControllerWithOptions(t, ReconcileOptions{Filter: filter})
+	return newTestControllerWithOptions(t, ReconcileOptions{Options: base.Options{Filter: filter}})
 }
 
 func newTestControllerWithParentOf(t *testing.T, parentOf map[manifest.NamedResource]manifest.NamedResource) (*Controller, *store.Store) {
@@ -30,7 +31,7 @@ func newTestControllerWithParentOf(t *testing.T, parentOf map[manifest.NamedReso
 		parent, ok := parentOf[id]
 		return parent, ok
 	}
-	return newTestControllerWithOptions(t, ReconcileOptions{ParentOf: resolver})
+	return newTestControllerWithOptions(t, ReconcileOptions{Options: base.Options{ParentOf: resolver}})
 }
 
 func newTestControllerWithOptions(t *testing.T, opts ReconcileOptions) (*Controller, *store.Store) {
@@ -638,10 +639,10 @@ func TestEmitRenderedChildren_SourceKindGetsKeepEmittedAndMarkRendered(t *testin
 	)
 
 	c := New(st, ts, hc, helm.Options{}, false)
-	c.Configure(ReconcileOptions{
+	c.Configure(ReconcileOptions{Options: base.Options{
 		Filter:        filter,
 		RenderTracker: tracker,
-	})
+	}})
 	c.Start(context.Background())
 	t.Cleanup(func() { c.Close(); ts.BlockTillDone() })
 
@@ -723,7 +724,7 @@ func TestEmitRenderedChildren_DedupReplay_NoStoreWrites(t *testing.T) {
 		testutil.MapLister{},
 	)
 	c := New(st, ts, hc, helm.Options{}, false)
-	c.Configure(ReconcileOptions{Filter: filter, RenderTracker: tracker})
+	c.Configure(ReconcileOptions{Options: base.Options{Filter: filter, RenderTracker: tracker}})
 	c.Start(context.Background())
 	t.Cleanup(func() { c.Close(); ts.BlockTillDone() })
 

--- a/pkg/controllers/helmrelease/reconcile_test.go
+++ b/pkg/controllers/helmrelease/reconcile_test.go
@@ -9,6 +9,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -124,7 +125,7 @@ func TestReconcile_ParentGateViaResolverFunc(t *testing.T) {
 		}
 		return manifest.NamedResource{}, false
 	}
-	c, st := newTestControllerWithOptions(t, ReconcileOptions{ParentOf: resolver})
+	c, st := newTestControllerWithOptions(t, ReconcileOptions{Options: base.Options{ParentOf: resolver}})
 	st.AddObject(parent) // never reaches Ready
 	st.AddObject(hr)
 	info := dispatchToFixpoint(t, c, st, hr.Named())

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -11,9 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 
-	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
-	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/kustomize"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -44,29 +42,12 @@ type Controller struct {
 	selfProduces func(cm, consumer manifest.NamedResource) bool
 }
 
-// Options carries the post-bootstrap state the orchestrator wires onto
-// the controller before Start. Filter narrows reconciliation to
-// changed resources in changed-only mode. ParentOf maps each Flux
-// Kustomization to its structural parent so reconcile waits for the
-// parent's Ready before rendering (so any parent-render-time spec
-// mutations — e.g. `replacements:` injecting spec.targetNamespace —
-// are observable when the child renders). A nil ParentOf disables
-// parent-enforcement, matching pre-#102 behavior. RenderTracker
-// receives every reconcilable child this KS emits during render.
+// Options carries the post-bootstrap state the orchestrator wires onto the
+// controller before Start. base.Options holds the config common to every
+// render controller (Filter / ParentOf / RenderTracker / Existence /
+// PreflightFailure); SelfProduces is Kustomization-specific.
 type Options struct {
-	Filter        *change.Filter
-	ParentOf      func(manifest.NamedResource) (manifest.NamedResource, bool)
-	RenderTracker base.RenderTracker
-	// Existence is the file-existence lookup the orchestrator wires
-	// against the loader's ExistenceIndex. Classify uses it to lazy-
-	// promote file-indexed deps and to distinguish render-only
-	// deps from typo'd ones. See depwait.ExistenceLookup for the
-	// decision matrix. Forwarded to every Waiter built during reconcile.
-	Existence depwait.ExistenceLookup
-	// PreflightFailure reports dependency-graph errors discovered by the
-	// orchestrator before reconcile. When set for an id, the controller
-	// marks the resource Failed and does not render it.
-	PreflightFailure func(manifest.NamedResource) (string, bool)
+	base.Options
 	// SelfProduces reports whether consumer's OWN render emits cm. When
 	// it does, collectDeps drops cm from the dependency set — a KS can't
 	// hard-wait on a postBuild.substituteFrom ConfigMap that only its own
@@ -89,11 +70,7 @@ func New(s *store.Store, t *task.Service, trees *kustomize.TreeCache, wipeSecret
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once the controller is dispatching.
 func (c *Controller) Configure(opts Options) {
-	c.SetFilter(opts.Filter)
-	c.SetDepwait(opts.Existence)
-	c.SetPreflight(opts.PreflightFailure)
-	c.SetParentOf(opts.ParentOf)
-	c.SetRenderTracker(opts.RenderTracker)
+	c.Controller.Configure(opts.Options)
 	c.selfProduces = opts.SelfProduces
 }
 

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -22,9 +23,9 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{ParentOf: mapResolver(map[manifest.NamedResource]manifest.NamedResource{
+	c.Configure(Options{Options: base.Options{ParentOf: mapResolver(map[manifest.NamedResource]manifest.NamedResource{
 		child.Named(): parent,
-	})})
+	})}})
 	deps := c.collectDeps(child)
 	for _, d := range deps {
 		if d.NamedResource == parent {
@@ -153,7 +154,7 @@ func TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer(t *testing.T) {
 	)
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{Filter: f})
+	c.Configure(Options{Options: base.Options{Filter: f}})
 	deps := c.collectDeps(consumerObj)
 
 	wantCM := manifest.NamedResource{
@@ -205,7 +206,7 @@ func TestCollectDeps_SkipsSelfProducer(t *testing.T) {
 	)
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{Filter: f})
+	c.Configure(Options{Options: base.Options{Filter: f}})
 	deps := c.collectDeps(selfObj)
 
 	for _, d := range deps {

--- a/pkg/controllers/resourceset/controller.go
+++ b/pkg/controllers/resourceset/controller.go
@@ -11,10 +11,8 @@ import (
 	"cmp"
 	"context"
 
-	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/controllers/emit"
-	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/resourceset"
 	"github.com/home-operations/flate/pkg/store"
@@ -45,20 +43,15 @@ type Controller struct {
 	rawSink RawSink
 }
 
-// Options carries the post-bootstrap state the orchestrator wires onto
-// the controller before Start. Filter narrows reconciliation in
-// changed-only mode. ParentOf maps each RS to its structural parent KS
-// so reconcile waits for the parent's Ready before rendering (the parent
-// may re-emit the RS with a substituted name/namespace). RenderTracker
-// receives every reconcilable child this RS emits. RawSink receives the
-// RS's RawObject children for output grouping under the parent KS.
+// Options carries the post-bootstrap state the orchestrator wires onto the
+// controller before Start. base.Options holds the config common to every
+// render controller (Filter / ParentOf — here gating the RS render on its
+// structural parent KS, which may re-emit the RS with a substituted
+// name/namespace — RenderTracker / Existence / PreflightFailure); RawSink is
+// ResourceSet-specific.
 type Options struct {
-	Filter           *change.Filter
-	ParentOf         func(manifest.NamedResource) (manifest.NamedResource, bool)
-	RenderTracker    base.RenderTracker
-	Existence        depwait.ExistenceLookup
-	PreflightFailure func(manifest.NamedResource) (string, bool)
-	RawSink          RawSink
+	base.Options
+	RawSink RawSink
 }
 
 // New constructs a ResourceSet controller.
@@ -73,11 +66,7 @@ func New(s *store.Store, t *task.Service, wipeSecrets bool) *Controller {
 // Start — encodes the invariant that reconcile-shaping config is
 // read-only once the controller is dispatching.
 func (c *Controller) Configure(opts Options) {
-	c.SetFilter(opts.Filter)
-	c.SetDepwait(opts.Existence)
-	c.SetPreflight(opts.PreflightFailure)
-	c.SetParentOf(opts.ParentOf)
-	c.SetRenderTracker(opts.RenderTracker)
+	c.Controller.Configure(opts.Options)
 	c.rawSink = opts.RawSink
 }
 

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/controllers/helmrelease"
 	"github.com/home-operations/flate/pkg/controllers/kustomization"
 	resourcesetctrl "github.com/home-operations/flate/pkg/controllers/resourceset"
@@ -118,20 +119,18 @@ func (o *Orchestrator) configureControllers() {
 	selfProduces := func(cm, consumer manifest.NamedResource) bool {
 		return slices.Contains(o.selfProduce.ProducedBy(cm), consumer)
 	}
-	o.ksc.Configure(kustomization.Options{
+	// The reconcile-shaping config common to all three render controllers,
+	// built once; each Configure adds its controller-specific fields.
+	common := base.Options{
 		Filter:           o.filter,
 		ParentOf:         parentResolver,
 		RenderTracker:    o.rendered,
 		Existence:        existence,
 		PreflightFailure: o.preflightFailure,
-		SelfProduces:     selfProduces,
-	})
+	}
+	o.ksc.Configure(kustomization.Options{Options: common, SelfProduces: selfProduces})
 	o.hrc.Configure(helmrelease.ReconcileOptions{
-		Filter:              o.filter,
-		ParentOf:            parentResolver,
-		RenderTracker:       o.rendered,
-		Existence:           existence,
-		PreflightFailure:    o.preflightFailure,
+		Options:             common,
 		AllowMissingSecrets: o.cfg.AllowMissingSecrets,
 		Producers:           o.producers,
 	})
@@ -140,11 +139,7 @@ func (o *Orchestrator) configureControllers() {
 	// into rsExtensions for the Result.Manifests grouping. DedupKey is
 	// computed here so the sink stays orchestrator-internal.
 	o.rsc.Configure(resourcesetctrl.Options{
-		Filter:           o.filter,
-		ParentOf:         parentResolver,
-		RenderTracker:    o.rendered,
-		Existence:        existence,
-		PreflightFailure: o.preflightFailure,
+		Options: common,
 		RawSink: func(owner, parentKS manifest.NamedResource, doc map[string]any) {
 			o.rsRawSink.Record(owner, parentKS, resourceset.DedupKey(doc), doc)
 		},


### PR DESCRIPTION
## What

The Kustomization, HelmRelease, and ResourceSet controllers each carried the **same five** reconcile-shaping fields on their option structs — `Filter`, `ParentOf`, `RenderTracker`, `Existence`, `PreflightFailure` — plus the **same five-setter** `Configure` preamble. That's the duplication the "dig deep" pass was after.

This lifts both into one place:

- **`base.Options`** — the common config struct, with the field docs consolidated onto it.
- **`base.Controller.Configure(base.Options)`** — the five independent setter writes (order-immaterial; each still panics after `Start`).

Each controller's option struct now **embeds** `base.Options` and forwards to `c.Controller.Configure(opts.Options)` before assigning its own kind-specific fields:

| Controller | kind-specific fields |
|---|---|
| Kustomization | `SelfProduces` |
| HelmRelease | `AllowMissingSecrets`, `Producers` |
| ResourceSet | `RawSink` |

The orchestrator builds the common block once (`common := base.Options{…}`) and hands it to all three `Configure` calls.

## Why the source controller stays out

`source` is fetch-only — it shares just `Filter`, not the parent/render/preflight machinery — so embedding `base.Options` there would be four always-nil fields. It keeps its own `FetchOptions`. The adversarial pass confirmed this is the only genuine win; every grander abstraction is load-bearing per-kind variation.

## Verification

Pure refactor — no runtime behavior change (struct embedding only):

- `gofmt` / `go vet` / `golangci-lint` (v2): clean
- `go test ./...` + `go test -race` on schedule/controllers/orchestrator/store/task: green
- **Byte-equivalence:** `flate build all` on `k8s-gitops` is **byte-identical** to `main` (2,382,360 bytes)

Net **−20 lines** (85 insertions, 105 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)