### PR TITLE
refactor(controllers): give each controller a name instead of threading a string

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -66,6 +66,13 @@ type Controller struct {
 	Store *store.Store
 	Tasks *task.Service
 
+	// name is the controller's stable identity (e.g. "helmrelease",
+	// "kustomization", "resourceset", "source"), set once at New and never
+	// mutated. It is the single source for the controller-kind label in
+	// reconcile log lines, so concrete controllers no longer thread a literal
+	// through every DispatchNode / FingerprintDedup call. Read via Name().
+	name string
+
 	started atomic.Bool
 	filter  *change.Filter
 
@@ -97,11 +104,16 @@ type Controller struct {
 	renderTracker RenderTracker
 }
 
-// New constructs a base controller. Concrete controllers call this
-// from their own constructor and embed the result.
-func New(s *store.Store, t *task.Service) *Controller {
-	return &Controller{Store: s, Tasks: t}
+// New constructs a base controller with the given stable name (its
+// controller-kind identity, surfaced in reconcile logs via Name()). Concrete
+// controllers call this from their own constructor and embed the result.
+func New(s *store.Store, t *task.Service, name string) *Controller {
+	return &Controller{Store: s, Tasks: t, name: name}
 }
+
+// Name returns the controller's stable identity (e.g. "helmrelease"). Set once
+// at New; the base reconcile helpers use it for their log-kind label.
+func (c *Controller) Name() string { return c.name }
 
 // requireNotStarted panics if the started gate is set, enforcing the
 // invariant that reconcile-shaping config is frozen once dispatch
@@ -283,7 +295,7 @@ func (c *Controller) SetPendingUnlessReady(id manifest.NamedResource, msg string
 // Returns (handled=true, err): the caller returns err. err is non-nil only when
 // a preflight error was discovered mid-flight. Returns (false, nil) to render
 // normally. Centralizes the byte-identical KS/HR dedup short-circuit.
-func (c *Controller) FingerprintDedup(id manifest.NamedResource, fp, logKind string, emit func(docs []map[string]any)) (bool, error) {
+func (c *Controller) FingerprintDedup(id manifest.NamedResource, fp string, emit func(docs []map[string]any)) (bool, error) {
 	existing, ok := c.Store.GetArtifact(id).(store.RenderedArtifact)
 	if !ok || existing.RenderedFingerprint() == "" || existing.RenderedFingerprint() != fp {
 		return false, nil
@@ -291,7 +303,7 @@ func (c *Controller) FingerprintDedup(id manifest.NamedResource, fp, logKind str
 	if err := c.PreflightError(id); err != nil {
 		return true, err
 	}
-	slog.Debug(logKind+": skipped re-render (fingerprint unchanged)", "id", id.String())
+	slog.Debug(c.name+": skipped re-render (fingerprint unchanged)", "id", id.String())
 	emit(existing.RenderedManifests())
 	return true, nil
 }
@@ -634,7 +646,6 @@ func DispatchNode[T manifest.BaseManifest](
 	id manifest.NamedResource,
 	drainLevel int,
 	suspended func(T) bool,
-	logKind string,
 	reconcile func(context.Context, T) error,
 ) (blocked []manifest.NamedResource, ready bool) {
 	ctx = WithDrainLevel(ctx, drainLevel)
@@ -642,7 +653,7 @@ func DispatchNode[T manifest.BaseManifest](
 	if !ok {
 		// Vanished — RunWithStatusOutcome's vanished branch records a terminal
 		// status; report it.
-		blocked = RunWithStatusOutcome[T](ctx, c.Store, id, logKind, reconcile)
+		blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.name, reconcile)
 		return blocked, c.statusReady(id)
 	}
 	if c.PreGate(id, suspended(obj)) {
@@ -652,6 +663,6 @@ func DispatchNode[T manifest.BaseManifest](
 		c.Store.UpdateStatus(id, store.StatusFailed, msg)
 		return nil, false
 	}
-	blocked = RunWithStatusOutcome[T](ctx, c.Store, id, logKind, reconcile)
+	blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.name, reconcile)
 	return blocked, c.statusReady(id)
 }

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -176,7 +176,7 @@ func TestController_CloseDrainsConcurrentAddListener(t *testing.T) {
 
 	for iter := range 100 {
 		s := store.New()
-		c := base.New(s, nil)
+		c := base.New(s, nil, "test")
 
 		var fired atomic.Int64
 		var wg sync.WaitGroup
@@ -228,7 +228,7 @@ func TestController_AddListenerAfterCloseIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	s := store.New()
-	c := base.New(s, nil)
+	c := base.New(s, nil, "test")
 
 	c.Close()
 
@@ -253,7 +253,7 @@ func TestController_DoubleCloseIsSafe(t *testing.T) {
 	t.Parallel()
 
 	s := store.New()
-	c := base.New(s, nil)
+	c := base.New(s, nil, "test")
 
 	var fired atomic.Int64
 	c.AddListener(store.EventObjectAdded, func(manifest.NamedResource, any) {
@@ -287,7 +287,7 @@ func TestController_DoubleCloseIsSafe(t *testing.T) {
 func TestDispatchNode(t *testing.T) {
 	s := store.New()
 	ts := task.New()
-	c := base.New(s, ts)
+	c := base.New(s, ts, "test")
 	c.SetPreflight(func(id manifest.NamedResource) (string, bool) {
 		return "synthetic cycle", id.Name == "preflightfail"
 	})
@@ -298,7 +298,7 @@ func TestDispatchNode(t *testing.T) {
 	suspended := func(hr *manifest.HelmRelease) bool { return hr.Name == "suspended" }
 	reconcile := func(_ context.Context, _ *manifest.HelmRelease) error { ran.Add(1); return nil }
 	dispatch := func(id manifest.NamedResource) bool {
-		_, ready := base.DispatchNode(t.Context(), c, id, 0, suspended, "helmrelease", reconcile)
+		_, ready := base.DispatchNode(t.Context(), c, id, 0, suspended, reconcile)
 		return ready
 	}
 
@@ -344,7 +344,7 @@ func TestDispatchNode(t *testing.T) {
 // (handled=true, err) without emitting.
 func TestFingerprintDedup(t *testing.T) {
 	s := store.New()
-	c := base.New(s, nil)
+	c := base.New(s, nil, "test")
 	ks := &manifest.Kustomization{Name: "k", Namespace: "ns"}
 	s.AddObject(ks)
 	id := ks.Named()
@@ -355,16 +355,16 @@ func TestFingerprintDedup(t *testing.T) {
 	emit := func([]map[string]any) { emitted++ }
 
 	// Fingerprint mismatch → render (not handled), no emit.
-	if handled, err := c.FingerprintDedup(id, "other", "kustomization", emit); handled || err != nil {
+	if handled, err := c.FingerprintDedup(id, "other", emit); handled || err != nil {
 		t.Errorf("mismatch: handled=%v err=%v; want false,nil", handled, err)
 	}
 	// Match → handled, emit replays the cached docs.
-	if handled, err := c.FingerprintDedup(id, "fp1", "kustomization", emit); !handled || err != nil {
+	if handled, err := c.FingerprintDedup(id, "fp1", emit); !handled || err != nil {
 		t.Errorf("match: handled=%v err=%v; want true,nil", handled, err)
 	}
 	// No artifact for the id → render (not handled).
 	none := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "none"}
-	if handled, _ := c.FingerprintDedup(none, "fp1", "kustomization", emit); handled {
+	if handled, _ := c.FingerprintDedup(none, "fp1", emit); handled {
 		t.Error("no-artifact id: handled=true; want false")
 	}
 	if emitted != 1 {
@@ -373,7 +373,7 @@ func TestFingerprintDedup(t *testing.T) {
 
 	// Empty fingerprint never matches (safe re-render), even fp==""==stored.
 	s.SetArtifact(id, &store.KustomizationArtifact{Manifests: docs, Fingerprint: ""})
-	if handled, _ := c.FingerprintDedup(id, "", "kustomization", emit); handled {
+	if handled, _ := c.FingerprintDedup(id, "", emit); handled {
 		t.Error("empty fingerprint matched; want never-match (false)")
 	}
 }
@@ -382,14 +382,14 @@ func TestFingerprintDedup(t *testing.T) {
 // mid-flight preflight failure returns (handled=true, err) and does not emit.
 func TestFingerprintDedup_PreflightError(t *testing.T) {
 	s := store.New()
-	c := base.New(s, nil)
+	c := base.New(s, nil, "test")
 	ks := &manifest.Kustomization{Name: "k", Namespace: "ns"}
 	s.AddObject(ks)
 	id := ks.Named()
 	s.SetArtifact(id, &store.KustomizationArtifact{Fingerprint: "fp1"})
 	c.SetPreflight(func(manifest.NamedResource) (string, bool) { return "cycle detected", true })
 
-	handled, err := c.FingerprintDedup(id, "fp1", "kustomization", func([]map[string]any) {
+	handled, err := c.FingerprintDedup(id, "fp1", func([]map[string]any) {
 		t.Error("emit must not run when a preflight error is surfaced")
 	})
 	if !handled || err == nil {

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -74,7 +74,7 @@ type ReconcileOptions struct {
 // New constructs a HelmRelease controller.
 func New(s *store.Store, t *task.Service, h *helm.Client, opts helm.Options, wipeSecrets bool) *Controller {
 	return &Controller{
-		Controller:  base.New(s, t),
+		Controller:  base.New(s, t, "helmrelease"),
 		Helm:        h,
 		Options:     opts,
 		WipeSecrets: wipeSecrets,
@@ -110,7 +110,7 @@ func (c *Controller) Start(_ context.Context) {
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		func(hr *manifest.HelmRelease) bool { return hr.Suspend },
-		"helmrelease", c.reconcile)
+		c.reconcile)
 }
 
 // onRawProducerAdded returns a listener that indexes RawObject producers
@@ -257,7 +257,7 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// HR-emitted source CR re-emit is a DeepEqual no-op anyway) — see its doc
 	// for the rationale (#657–#660). fp is reused for SetArtifact below.
 	fp := helmReleaseFingerprint(hr)
-	if handled, err := c.FingerprintDedup(id, fp, "helmrelease", func(docs []map[string]any) {
+	if handled, err := c.FingerprintDedup(id, fp, func(docs []map[string]any) {
 		c.emitRenderedChildren(id, docs, false)
 	}); handled {
 		return err

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -60,7 +60,7 @@ type Options struct {
 // New constructs a Kustomization controller.
 func New(s *store.Store, t *task.Service, trees *kustomize.TreeCache, wipeSecrets bool) *Controller {
 	return &Controller{
-		Controller:  base.New(s, t),
+		Controller:  base.New(s, t, "kustomization"),
 		Trees:       trees,
 		WipeSecrets: wipeSecrets,
 	}
@@ -87,7 +87,7 @@ func (c *Controller) Start(_ context.Context) {
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		func(ks *manifest.Kustomization) bool { return ks.Suspend },
-		"kustomization", c.reconcile)
+		c.reconcile)
 }
 
 func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) error {
@@ -153,7 +153,7 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	// shared helper publishes nothing (publish=false) — see its doc for the
 	// churn/quiescence rationale (#657–#660). fp is reused for SetArtifact below.
 	fp := kustomizationFingerprint(ks, sourceRoot)
-	if handled, err := c.FingerprintDedup(id, fp, "kustomization", func(docs []map[string]any) {
+	if handled, err := c.FingerprintDedup(id, fp, func(docs []map[string]any) {
 		c.emitRenderedChildren(id, docs, false)
 	}); handled {
 		return err

--- a/pkg/controllers/kustomization/dispatch_test.go
+++ b/pkg/controllers/kustomization/dispatch_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestEmitRenderedChildrenBatchesLeafDispatch(t *testing.T) {
 	s := store.New()
-	c := &Controller{Controller: base.New(s, task.New())}
+	c := &Controller{Controller: base.New(s, task.New(), "kustomization")}
 	idA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "a"}
 	idB := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "b"}
 	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "parent"}
@@ -40,7 +40,7 @@ func TestEmitRenderedChildrenBatchesLeafDispatch(t *testing.T) {
 // reported)"). A real Flux Kustomization in the same batch is still emitted.
 func TestEmitRenderedChildren_DropsKustomizeBuildDirective(t *testing.T) {
 	s := store.New()
-	c := &Controller{Controller: base.New(s, task.New())}
+	c := &Controller{Controller: base.New(s, task.New(), "kustomization")}
 	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "parent"}
 
 	var leaked bool
@@ -88,7 +88,7 @@ func (r *recordingTracker) MarkRenderedBatch(parent manifest.NamedResource, chil
 // fresh-render path (publish=true) still publishes.
 func TestEmitRenderedChildren_DedupSkip_NoStoreWrites(t *testing.T) {
 	s := store.New()
-	c := &Controller{Controller: base.New(s, task.New())}
+	c := &Controller{Controller: base.New(s, task.New(), "kustomization")}
 	rt := &recordingTracker{}
 	c.SetRenderTracker(rt)
 

--- a/pkg/controllers/resourceset/controller.go
+++ b/pkg/controllers/resourceset/controller.go
@@ -57,7 +57,7 @@ type Options struct {
 // New constructs a ResourceSet controller.
 func New(s *store.Store, t *task.Service, wipeSecrets bool) *Controller {
 	return &Controller{
-		Controller:  base.New(s, t),
+		Controller:  base.New(s, t, "resourceset"),
 		WipeSecrets: wipeSecrets,
 	}
 }
@@ -85,7 +85,7 @@ func (c *Controller) Start(_ context.Context) {
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		func(*manifest.ResourceSet) bool { return false },
-		"resourceset", c.reconcile)
+		c.reconcile)
 }
 
 func (c *Controller) reconcile(ctx context.Context, rs *manifest.ResourceSet) error {
@@ -136,7 +136,7 @@ func (c *Controller) reconcile(ctx context.Context, rs *manifest.ResourceSet) er
 	// change re-reads a different fingerprint and re-renders below. fp is
 	// reused for SetArtifact.
 	fp := resourceSetFingerprint(rs, c.Store)
-	if handled, err := c.FingerprintDedup(id, fp, "resourceset", func([]map[string]any) {}); handled {
+	if handled, err := c.FingerprintDedup(id, fp, func([]map[string]any) {}); handled {
 		return err
 	}
 

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -66,7 +66,7 @@ type FetchOptions struct {
 // returned struct's Fetchers map before Start.
 func New(s *store.Store, t *task.Service) *Controller {
 	return &Controller{
-		Controller: base.New(s, t),
+		Controller: base.New(s, t, "source"),
 		Fetchers:   map[string]src.Fetcher{},
 	}
 }
@@ -106,7 +106,7 @@ func (c *Controller) HasFetcher(kind string) bool {
 // for source-kind nodes.
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
-		suspendedSource, "source", c.reconcile)
+		suspendedSource, c.reconcile)
 }
 
 // reconcile fetches the source artifact via the registered Fetcher and


### PR DESCRIPTION
## What

The reconcile-kind label was passed as a string literal — `"helmrelease"`, `"kustomization"`, `"resourceset"`, `"source"` — into `base.DispatchNode` and `base.FingerprintDedup` at every call site. As @buroa noted, the controllers passing their own identity around as ad-hoc strings wasn't clean.

Now the controller **owns its identity**:

- `base.New(store, tasks, name)` stores an immutable `name`, exposed via a `Name()` accessor.
- `DispatchNode` and `FingerprintDedup` drop their `logKind` parameter — they read `c.name`.
- Each controller calls `base.New(s, t, "<kind>")` exactly once. No more literals threaded through call sites.

The store-level primitives `RunWithStatus` / `RunWithStatusOutcome` / `Recover` **keep** their `logKind` argument — they operate on `(store, id)` with no `*Controller` in scope (tests exercise them directly). `DispatchNode` forwards `c.name` into them.

## Scope boundary

The in-package operational `slog` prefixes (`slog.Debug("source: fetch failed", …)`, `"emit: …"`) are deliberately left as literals. They are **operation** labels, not reconcile-kind identity — and the source controller reconciles many kinds (GitRepository, OCIRepository, …) under one `name="source"`, so `"source:"` there isn't a per-kind identity at all. Routing them through `Name()` would add churn and risk the byte/log baseline for no correctness gain. A future consistency pass (pre-bound logger) is a separate, lower-priority improvement.

## Verification

Pure parameter-to-field move; each controller passes its exact prior literal, so the log label is character-identical:

- `gofmt` / `go vet` / `golangci-lint` (v2): clean
- `go test ./...` + `go test -race` on schedule/controllers/orchestrator: green
- **Byte-identical** `flate build all` on `k8s-gitops` vs `main` (2,382,360 bytes)
- Adversarial 3-lens review (completeness / idiomaticity / correctness): praise-only, zero actionable findings, merge-ready as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)