### PR TITLE
refactor(controllers): log through a pre-bound controller logger

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -68,10 +68,15 @@ type Controller struct {
 
 	// name is the controller's stable identity (e.g. "helmrelease",
 	// "kustomization", "resourceset", "source"), set once at New and never
-	// mutated. It is the single source for the controller-kind label in
-	// reconcile log lines, so concrete controllers no longer thread a literal
-	// through every DispatchNode / FingerprintDedup call. Read via Name().
+	// mutated. Read via Name().
 	name string
+
+	// log is name's logger, pre-bound at New with a controller=<name>
+	// attribute. Reconcile bodies and the shared base helpers log through it
+	// (via Logger()) so the controller identity is a structured field rather
+	// than a per-call message prefix. Bound once from slog.Default(), which the
+	// CLI installs in PersistentPreRunE before any controller is constructed.
+	log *slog.Logger
 
 	started atomic.Bool
 	filter  *change.Filter
@@ -108,12 +113,23 @@ type Controller struct {
 // controller-kind identity, surfaced in reconcile logs via Name()). Concrete
 // controllers call this from their own constructor and embed the result.
 func New(s *store.Store, t *task.Service, name string) *Controller {
-	return &Controller{Store: s, Tasks: t, name: name}
+	return &Controller{
+		Store: s,
+		Tasks: t,
+		name:  name,
+		log:   slog.Default().With(slog.String("controller", name)),
+	}
 }
 
 // Name returns the controller's stable identity (e.g. "helmrelease"). Set once
-// at New; the base reconcile helpers use it for their log-kind label.
+// at New.
 func (c *Controller) Name() string { return c.name }
+
+// Logger returns the controller's slog logger, pre-bound with a
+// controller=<name> attribute. Reconcile bodies (and the emit helper, via the
+// controller they receive) log through it so the controller identity is a
+// structured field rather than a per-call message prefix.
+func (c *Controller) Logger() *slog.Logger { return c.log }
 
 // requireNotStarted panics if the started gate is set, enforcing the
 // invariant that reconcile-shaping config is frozen once dispatch
@@ -303,7 +319,7 @@ func (c *Controller) FingerprintDedup(id manifest.NamedResource, fp string, emit
 	if err := c.PreflightError(id); err != nil {
 		return true, err
 	}
-	slog.Debug(c.name+": skipped re-render (fingerprint unchanged)", "id", id.String())
+	c.log.Debug("skipped re-render (fingerprint unchanged)", "id", id.String())
 	emit(existing.RenderedManifests())
 	return true, nil
 }
@@ -522,21 +538,20 @@ func DepFailed(id manifest.NamedResource) func(depwait.Summary) error {
 
 // Recover catches a panic from the current goroutine and marks id
 // StatusFailed with a "panic: <r>" message so the orchestrator
-// surfaces it. Intended for use as `defer base.Recover(store, id, "kind")`
-// in controllers that don't go through RunWithStatus (e.g. source
-// fetchers that own their own status writes).
+// surfaces it. log is the controller's pre-bound logger (Logger()); the
+// panic is recorded under its controller=<name> attribute.
 //
 // After recording status, re-raises the panic so the enclosing
 // task.Service.Go increments its failures counter — a panicked
 // reconcile MUST count against the orchestrator's failure gate, not
 // silently masquerade as success when Service.Failures() is consulted
 // for the final exit-code decision.
-func Recover(s *store.Store, id manifest.NamedResource, logKind string) {
+func Recover(s *store.Store, id manifest.NamedResource, log *slog.Logger) {
 	r := recover()
 	if r == nil {
 		return
 	}
-	slog.Error(logKind+": panic during reconcile", "id", id.String(), "panic", r)
+	log.Error("panic during reconcile", "id", id.String(), "panic", r)
 	s.UpdateStatus(id, store.StatusFailed, fmt.Sprintf("panic: %v", r))
 	panic(r)
 }
@@ -561,10 +576,10 @@ func RunWithStatus[T manifest.BaseManifest](
 	ctx context.Context,
 	s *store.Store,
 	id manifest.NamedResource,
-	logKind string,
+	log *slog.Logger,
 	fn func(context.Context, T) error,
 ) {
-	_ = RunWithStatusOutcome[T](ctx, s, id, logKind, fn)
+	_ = RunWithStatusOutcome[T](ctx, s, id, log, fn)
 }
 
 // RunWithStatusOutcome is RunWithStatus that additionally reports the dag
@@ -577,10 +592,10 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 	ctx context.Context,
 	s *store.Store,
 	id manifest.NamedResource,
-	logKind string,
+	log *slog.Logger,
 	fn func(context.Context, T) error,
 ) []manifest.NamedResource {
-	defer Recover(s, id, logKind)
+	defer Recover(s, id, log)
 	obj, ok := store.Get[T](s, id)
 	if !ok {
 		// Object deleted (or wrong type) between discovery/enqueue and run.
@@ -653,7 +668,7 @@ func DispatchNode[T manifest.BaseManifest](
 	if !ok {
 		// Vanished — RunWithStatusOutcome's vanished branch records a terminal
 		// status; report it.
-		blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.name, reconcile)
+		blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)
 		return blocked, c.statusReady(id)
 	}
 	if c.PreGate(id, suspended(obj)) {
@@ -663,6 +678,6 @@ func DispatchNode[T manifest.BaseManifest](
 		c.Store.UpdateStatus(id, store.StatusFailed, msg)
 		return nil, false
 	}
-	blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.name, reconcile)
+	blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)
 	return blocked, c.statusReady(id)
 }

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -3,6 +3,7 @@ package base_test
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -20,7 +21,7 @@ func TestRunWithStatus_Success(t *testing.T) {
 	s.AddObject(hr)
 	id := hr.Named()
 
-	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+	base.RunWithStatus(t.Context(), s, id, slog.Default(),
 		func(_ context.Context, obj *manifest.HelmRelease) error {
 			if obj.Name != "app" {
 				t.Errorf("re-read got %q, want app", obj.Name)
@@ -40,7 +41,7 @@ func TestRunWithStatus_Failure(t *testing.T) {
 	s.AddObject(hr)
 	id := hr.Named()
 
-	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+	base.RunWithStatus(t.Context(), s, id, slog.Default(),
 		func(_ context.Context, _ *manifest.HelmRelease) error {
 			return errors.New("render failed")
 		},
@@ -67,7 +68,7 @@ func TestRunWithStatus_Panic(t *testing.T) {
 	var rec any
 	func() {
 		defer func() { rec = recover() }()
-		base.RunWithStatus(t.Context(), s, id, "helmrelease",
+		base.RunWithStatus(t.Context(), s, id, slog.Default(),
 			func(_ context.Context, _ *manifest.HelmRelease) error {
 				panic("kaboom")
 			},
@@ -89,7 +90,7 @@ func TestRunWithStatus_MissingObject(t *testing.T) {
 	s := store.New()
 	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "ns", Name: "ghost"}
 	called := false
-	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+	base.RunWithStatus(t.Context(), s, id, slog.Default(),
 		func(_ context.Context, _ *manifest.HelmRelease) error {
 			called = true
 			return nil
@@ -119,7 +120,7 @@ func TestRunWithStatus_PreservesInformativeReadyMessage(t *testing.T) {
 			id := hr.Named()
 			s.UpdateStatus(id, store.StatusReady, message)
 
-			base.RunWithStatus(t.Context(), s, id, "helmrelease",
+			base.RunWithStatus(t.Context(), s, id, slog.Default(),
 				func(_ context.Context, _ *manifest.HelmRelease) error { return nil },
 			)
 			got, _ := s.GetStatus(id)
@@ -139,7 +140,7 @@ func TestRunWithStatus_PreservesExternalFailure(t *testing.T) {
 	s.AddObject(hr)
 	id := hr.Named()
 
-	base.RunWithStatus(t.Context(), s, id, "helmrelease",
+	base.RunWithStatus(t.Context(), s, id, slog.Default(),
 		func(_ context.Context, _ *manifest.HelmRelease) error {
 			s.UpdateStatus(id, store.StatusFailed, "dependency cycle detected")
 			return nil

--- a/pkg/controllers/emit/emit.go
+++ b/pkg/controllers/emit/emit.go
@@ -68,16 +68,20 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 		leaf         bool // held for pass 2 (Kustomization / HelmRelease)
 	}
 	opts := manifest.ParseDocOptions{WipeSecrets: wipeSecrets}
+	// Log under the invoking controller's identity plus component=emit, so a
+	// "skipped doc" line names both the controller whose render produced the
+	// doc and the emit helper it surfaced in.
+	log := c.Logger().With(slog.String("component", "emit"))
 	objs := make([]parsed, 0, len(docs))
 	for _, doc := range docs {
 		if manifest.IsEncryptedSecret(doc) {
 			name, ns := manifest.DocMetadata(doc)
-			slog.Debug("emit: SOPS-encrypted resource wiped to placeholder",
+			log.Debug("SOPS-encrypted resource wiped to placeholder",
 				"id", id.String(), "ref", manifest.DocKind(doc)+" "+ns+"/"+name)
 		}
 		obj, err := manifest.ParseDoc(doc, opts)
 		if err != nil {
-			slog.Debug("emit: skipped doc", "id", id.String(), "err", err)
+			log.Debug("skipped doc", "id", id.String(), "err", err)
 			continue
 		}
 		if manifest.IsKustomizeBuildDirective(obj) {

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -10,7 +10,6 @@ package helmrelease
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"slices"
 
 	"github.com/home-operations/flate/pkg/controllers/base"
@@ -420,12 +419,12 @@ func (c *Controller) emitRenderedChildren(id manifest.NamedResource, docs []map[
 	for _, doc := range docs {
 		if manifest.IsEncryptedSecret(doc) {
 			name, ns := manifest.DocMetadata(doc)
-			slog.Debug("helmrelease: SOPS-encrypted resource wiped to placeholder",
+			c.Logger().Debug("SOPS-encrypted resource wiped to placeholder",
 				"id", id.String(), "ref", manifest.DocKind(doc)+" "+ns+"/"+name)
 		}
 		obj, err := manifest.ParseDoc(doc, opts)
 		if err != nil {
-			slog.Debug("helmrelease: skipped doc", "id", id.String(), "err", err)
+			c.Logger().Debug("skipped doc", "id", id.String(), "err", err)
 			continue
 		}
 		if manifest.IsKustomizeBuildDirective(obj) {

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -8,7 +8,6 @@ package helmrelease
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
@@ -116,7 +115,7 @@ func (c *Controller) omitValuesFrom(
 		if hasProducer {
 			args = append(args, "producer", producer.String())
 		}
-		slog.Debug("helmrelease: omitted unavailable valuesFrom ref", args...)
+		c.Logger().Debug("omitted unavailable valuesFrom ref", args...)
 	}
 	return cloneWithValuesFrom(hr, filtered)
 }

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/home-operations/flate/pkg/change"
@@ -151,18 +150,18 @@ func (c *Controller) reconcile(ctx context.Context, obj manifest.BaseManifest) e
 		artifact, fetchErr = fetcher.Fetch(ctx, obj)
 	})
 	if fetchErr != nil {
-		slog.Debug("source: fetch failed", "id", id.String(), "duration", time.Since(started), "err", fetchErr)
+		c.Logger().Debug("fetch failed", "id", id.String(), "duration", time.Since(started), "err", fetchErr)
 		// Skip a missing auth Secret either when the user asked globally
 		// (--allow-missing-secrets) or when an in-repo ExternalSecret /
 		// SealedSecret declares it (producer-backed: positive evidence it
 		// materializes live). A missing Secret with neither still fails loud.
 		if errors.Is(fetchErr, manifest.ErrMissingSecret) && (c.allowMissingSecrets || c.producerBacked(fetchErr)) {
-			slog.Info("source: skipped (missing secret)", "id", id.String(), "err", fetchErr)
+			c.Logger().Info("skipped (missing secret)", "id", id.String(), "err", fetchErr)
 			return fmt.Errorf("%w: %s", manifest.ErrSourceSkipped, manifest.TrimSentinelPrefix(fetchErr.Error()))
 		}
 		return fetchErr
 	}
-	slog.Debug("source: fetch complete", "id", id.String(), "duration", time.Since(started), "artifact", artifact != nil)
+	c.Logger().Debug("fetch complete", "id", id.String(), "duration", time.Since(started), "artifact", artifact != nil)
 	// An ExistenceFetcher returns (nil, nil) — the kind doesn't produce
 	// an on-disk artifact (HelmRepository; OCIRepository when fetching
 	// is disabled). RunWithStatus will still mark Ready so dependsOn


### PR DESCRIPTION
## What

Follow-up to the `Name()` seam in [#708](https://github.com/home-operations/flate/pull/708). That PR centralized the controller-kind label for the shared base helpers; this finishes the job by removing the **last** place a controller's identity lived as a per-call string literal — the ad-hoc component prefixes in log messages:

```
"source: fetch failed"   "helmrelease: skipped doc"   "emit: …"
```

`base.Controller` now holds `log = slog.Default().With("controller", name)`, exposed via `Logger()`. The 8 controller-package sites and the 2 base helpers log through it. `Recover` / `RunWithStatusOutcome` take a `*slog.Logger` instead of a `logKind string` (they're store-level generics; `DispatchNode` forwards `c.log`). The `emit` helper — shared by KS and RS — logs under the invoking controller's logger plus a `component=emit` attribute, so an emit line names **both** the controller whose render produced the doc and the helper it surfaced in (strictly more than the old `"emit:"` prefix).

## This changes log output (intended)

The component moves from the message text into a structured field:

```
# before
level=DEBUG msg="source: fetch failed" id=flux-system/podinfo duration=1.2s

# after
level=DEBUG msg="fetch failed" controller=source id=flux-system/podinfo duration=1.2s
```

Confirmed on a real run (`--log-level debug`): `controller=source` appears on every source line, messages are prefix-free, and zero stale `msg="…:"` prefixes remain.

## Why the construction-time binding is safe

`slog.Default()` is installed by the CLI in `PersistentPreRunE` ([root.go:67](internal/cli/root.go:67)) — before `orchestrator.New` builds any controller — so the logger bound at `New` captures the configured handler/level. Verified empirically.

## Verification

- `gofmt` / `go vet` / `golangci-lint` (v2): clean
- `go test ./...` + `go test -race` on controllers/orchestrator: green
- `flate build all` **byte-identical** to `main` (these are debug/info logs, not build output); no test asserts on log message text

🤖 Generated with [Claude Code](https://claude.com/claude-code)