### PR TITLE
fix(cli): keep kustomize's stderr chatter from shredding the status bar

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -555,11 +555,19 @@ func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config, pre ...fun
 		)
 		barSink.setProgram(p)
 		go func() { _, _ = p.Run() }()
+		// kustomize writes deprecation/sort-order warnings straight to the
+		// stderr fd (no injectable writer), which would shred the inline frame.
+		// Capture the fd for the bar's lifetime and demote those lines to
+		// slog.Debug — flate's own structured warnings still reach the user
+		// above the frame via barSink, while dependency fd chatter stays off the
+		// clean bar unless --log-level debug asks for it.
+		restoreStderr := captureStderr(func(line string) { slog.Debug(line) })
 		unsub := o.Store().OnStatus(func(id manifest.NamedResource, info store.StatusInfo) {
 			p.Send(statusMsg{id: id, info: info})
 		}, false)
 		defer func() {
 			unsub()
+			restoreStderr() // restore os.Stderr + flush the drain while the frame is still live
 			p.Send(finishMsg{})
 			p.Wait()
 			barSink.setProgram(nil)

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"io"
 	"os"
 	"strings"
@@ -54,6 +55,52 @@ func (w *barWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	return w.out.Write(p)
+}
+
+// captureStderr redirects the process os.Stderr to a pipe and delivers each
+// line written to it to emit, returning a restore func that puts the original
+// os.Stderr back and blocks until the drain has flushed. It exists for output
+// from libraries that write to the stderr file descriptor directly and take no
+// injectable writer — notably kustomize, which prints deprecation and
+// sort-order warnings via fmt.Fprintf(os.Stderr, …) deep in its build. Left
+// alone those writes shred the status bar's inline frame; routed through emit
+// (slog.Debug) they stay off the clean bar yet remain available under
+// --log-level debug. flate's own structured logs are unaffected: slog and
+// Bubble Tea hold barSink.out (the real stderr captured at startup), not the
+// os.Stderr variable this swaps.
+//
+// The caller installs it while the bar is live and defers restore() before the
+// program is torn down, so the last drained lines still land above the frame.
+// The swap is race-free: it is installed once before Render fans out the build
+// goroutines (the only readers of os.Stderr) and restored once after Render
+// joins them, so no read races the write. If the pipe cannot be created,
+// os.Stderr is left untouched and restore is a no-op — a build never fails
+// because capture was unavailable.
+func captureStderr(emit func(line string)) (restore func()) {
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		return func() {}
+	}
+	os.Stderr = w
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+		for sc.Scan() {
+			emit(sc.Text())
+		}
+		// A line past the 1 MiB cap stops Scan; keep draining so a writer
+		// never blocks on a full pipe.
+		_, _ = io.Copy(io.Discard, r)
+	}()
+	return func() {
+		os.Stderr = orig
+		_ = w.Close() // EOF the read end so the drain goroutine returns
+		<-done
+		_ = r.Close()
+	}
 }
 
 // writerIsTTY reports whether w is a character device (an interactive terminal).

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -2,8 +2,41 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"slices"
+	"sync"
 	"testing"
 )
+
+// TestCaptureStderr verifies the stray-fd capture: lines written straight to
+// os.Stderr (as kustomize does for its deprecation warnings) are delivered to
+// emit one per line — including a final line with no trailing newline, flushed
+// at EOF — and os.Stderr is restored afterward. Not parallel: it swaps the
+// process-wide os.Stderr.
+func TestCaptureStderr(t *testing.T) {
+	orig := os.Stderr
+	var mu sync.Mutex
+	var got []string
+	restore := captureStderr(func(line string) {
+		mu.Lock()
+		got = append(got, line)
+		mu.Unlock()
+	})
+	fmt.Fprintln(os.Stderr, "# Warning: 'commonLabels' is deprecated.")
+	fmt.Fprint(os.Stderr, "tail-without-newline")
+	restore()
+
+	if os.Stderr != orig {
+		t.Error("captureStderr did not restore os.Stderr")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"# Warning: 'commonLabels' is deprecated.", "tail-without-newline"}
+	if !slices.Equal(got, want) {
+		t.Errorf("captured lines = %q, want %q", got, want)
+	}
+}
 
 // TestBarWriter_NoProgramWritesThrough: with no Bubble Tea program attached, the
 // slog adapter is a plain passthrough to the underlying stderr (the non-TTY /


### PR DESCRIPTION
## Problem

On an interactive `flate test all` / `flate build all`, the live status bar gets corrupted by lines like:

```
⠸ [119/173] immich, matter-server +52# Warning: 'commonLabels' is deprecated. Please use 'labels' instead. ...
```

kustomize prints deprecation and sort-order warnings **straight to the `os.Stderr` fd** via `fmt.Fprintf(os.Stderr, …)` deep in its build ([`internal/target/kusttarget.go`](https://github.com/kubernetes-sigs/kustomize)), with no injectable writer. Those raw writes interleave with the Bubble Tea inline frame and shred it.

## Fix (presentation layer)

flate already composites its own slog output cleanly above the frame via `barWriter → Program.Println`. The only gap was output that bypasses that path by writing the fd directly. Close it where the terminal is owned:

- For the bar's lifetime, redirect `os.Stderr` to a pipe and **demote each captured line to `slog.Debug`** — dependency fd chatter stays off the clean bar by default, but is available under `--log-level debug`.
- flate's own structured warnings (e.g. the cosign-skip `WARN`) are **unaffected**: slog and Bubble Tea hold the real stderr (`barSink.out`) captured at startup, not the `os.Stderr` variable this swaps. So genuine warnings still surface above the frame; only raw dependency fd writes get demoted.

`pkg/kustomize` and `pkg/helm` stay **completely untouched** — no stderr hack in the build path.

### Why it's safe
- **Race-free:** the `os.Stderr` swap is installed once *before* `Render` fans out the build goroutines (the only `os.Stderr` readers) and restored once *after* they join — no read races the write. Verified under `go test -race`.
- **TTY-gated:** only runs when the bar runs (interactive stderr). In CI/pipes the bar is off and stderr flows normally.
- **No deadlock:** a dedicated goroutine drains the pipe line-by-line; a line past the 1 MiB cap falls back to discard-drain so a writer never blocks.

## Verification

On `zariel/home-ops` under a PTY (`script`):
- default level: **0** `# Warning: 'commonLabels'` lines leak (was corrupting the bar)
- `--log-level debug`: all **6** reappear — demoted, not lost
- `flate build all` **stdout byte-identical** (2,382,360 bytes) — pure presentation change

Plus: `gofmt`/`go vet`/`golangci-lint` clean; full `go test ./...` + `-race` on `internal/cli` green; new `TestCaptureStderr` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)