### PR TITLE
refactor(source): share BasicAuthFromSecret + enforce helmchart TLS pair

### DIFF
--- a/pkg/source/git/auth.go
+++ b/pkg/source/git/auth.go
@@ -62,13 +62,9 @@ func (f *Fetcher) resolveAuth(repo *manifest.GitRepository) (transport.AuthMetho
 	if token := source.StringFromSecret(sec, "bearerToken"); token != "" {
 		return &githttp.TokenAuth{Token: token}, nil
 	}
-	username := source.StringFromSecret(sec, "username")
-	password := source.StringFromSecret(sec, "password")
-	if username == "" || password == "" {
-		// Empty covers both missing-key and PLACEHOLDER-wiped values
-		// (the ExternalSecret case). Same sentinel so
-		// --allow-missing-secrets covers both shapes.
-		return nil, source.MissingSecretErr("GitRepository", repo.Namespace, repo.Name, repo.SecretRef.Name, "missing username/password (or bearerToken) for HTTPS auth")
+	username, password, err := source.BasicAuthFromSecret(sec, "GitRepository", repo.Namespace, repo.Name, repo.SecretRef.Name)
+	if err != nil {
+		return nil, err
 	}
 	return &githttp.BasicAuth{Username: username, Password: password}, nil
 }

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -34,12 +34,9 @@ func (f *Fetcher) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Opti
 	if sec == nil {
 		return nil, source.MissingSecretErr("HelmRepository", r.Namespace, r.Name, r.SecretRef.Name, "not found")
 	}
-	username := source.StringFromSecret(sec, "username")
-	password := source.StringFromSecret(sec, "password")
-	if username == "" || password == "" {
-		// Empty covers missing-key and PLACEHOLDER-wiped values (the
-		// ExternalSecret case). Same sentinel.
-		return nil, source.MissingSecretErr("HelmRepository", r.Namespace, r.Name, r.SecretRef.Name, "missing username/password")
+	username, password, err := source.BasicAuthFromSecret(sec, "HelmRepository", r.Namespace, r.Name, r.SecretRef.Name)
+	if err != nil {
+		return nil, err
 	}
 	opts := []getter.Option{getter.WithBasicAuth(username, password)}
 	if r.PassCredentials {
@@ -95,6 +92,14 @@ func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Optio
 		// A secret present but carrying none of the TLS keys is malformed
 		// config — fail loud (no ErrMissingSecret wrap), like BuildTLSConfig.
 		return nil, noCleanup, fmt.Errorf("%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
+			helmID(r), r.Namespace, r.CertSecretRef.Name)
+	}
+	// A client cert needs both halves; reject a half-pair rather than feed
+	// helm a cert without its key (or vice versa). Matches source.BuildTLSConfig,
+	// which the OCI/Bucket paths enforce via ResolveCertSecret.
+	if (paths[0] == "") != (paths[1] == "") {
+		cleanup()
+		return nil, noCleanup, fmt.Errorf("%s: certSecretRef %s/%s must provide both tls.crt and tls.key (or neither)",
 			helmID(r), r.Namespace, r.CertSecretRef.Name)
 	}
 	return []getter.Option{getter.WithTLSClientConfig(paths[0], paths[1], paths[2])}, cleanup, nil

--- a/pkg/source/secret.go
+++ b/pkg/source/secret.go
@@ -100,3 +100,18 @@ func StringFromSecret(sec *manifest.Secret, key string) string {
 	}
 	return ""
 }
+
+// BasicAuthFromSecret extracts the username/password pair every HTTP-auth
+// fetcher reads from a Secret (git HTTPS, HelmRepository). It returns a uniform
+// MissingSecretErr when either field is absent or PLACEHOLDER-wiped — empty
+// covers both the missing-key and ExternalSecret-stub cases, so a caller's
+// --allow-missing-secrets gate (errors.Is ErrMissingSecret) treats them
+// alike. ownerKind/ns/name/secretRef only shape that error message.
+func BasicAuthFromSecret(sec *manifest.Secret, ownerKind, ns, name, secretRef string) (username, password string, err error) {
+	username = StringFromSecret(sec, "username")
+	password = StringFromSecret(sec, "password")
+	if username == "" || password == "" {
+		return "", "", MissingSecretErr(ownerKind, ns, name, secretRef, "missing username/password")
+	}
+	return username, password, nil
+}


### PR DESCRIPTION
## What

Two small, independent source-layer cleanups (extracted from a larger refactor that was abandoned — the slot-driver abstraction it explored read worse than the explicit per-fetcher flow it replaced, so only these surgical wins survive):

- **`source.BasicAuthFromSecret`** — folds the duplicated `username`/`password` extraction + `MissingSecretErr` that git HTTPS auth and HelmRepository auth each hand-rolled into one helper. Both kinds now return an identical "missing username/password" error for absent or PLACEHOLDER-wiped credentials, so a caller's `--allow-missing-secrets` gate (`errors.Is ErrMissingSecret`) treats them alike.
- **helmchart TLS cert/key parity** — reject a `certSecretRef` carrying `tls.crt` without `tls.key` (or vice versa), matching the invariant `source.BuildTLSConfig` already enforces for the OCI/Bucket paths via `ResolveCertSecret`. Previously a half-pair was silently materialized.

## Scope

`+29 / −13` across 3 files. No behavior change on the success path.

## Verification

- `gofmt` / `go build ./...` / `go vet` / `golangci-lint run` (0 issues) / `go test ./pkg/source/...` — all green
- `flate build all` byte-identical to `main` on **k8s-gitops** (2,382,360 B) and **zariel/home-ops** (3,190,543 B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)