### PR TITLE
chore: remove the unread node readiness signal from the scheduler

### DIFF
--- a/pkg/orchestrator/dagrun.go
+++ b/pkg/orchestrator/dagrun.go
@@ -10,36 +10,34 @@ import (
 )
 
 // dagDispatcher implements schedule.Dispatcher: it routes a node by Kind to the
-// owning controller's ReconcileNode and maps the (blocked, ready) result into a
+// owning controller's ReconcileNode and maps the blocked result into a
 // scheduler Outcome. This is the single composition point where the scheduler,
 // the controllers, and the store meet — pkg/schedule itself imports none of
 // them. NodeID is manifest.NamedResource, so the blocked slice flows through
-// untranslated.
+// untranslated. The controllers' ReconcileNode also reports a readiness bool,
+// which the scheduler does not consume, so it is discarded here.
 type dagDispatcher struct{ o *Orchestrator }
 
-func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLevel int) (schedule.Outcome, []schedule.NodeID, bool) {
+func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLevel int) (schedule.Outcome, []schedule.NodeID) {
 	o := d.o
-	var (
-		blocked []manifest.NamedResource
-		ready   bool
-	)
+	var blocked []manifest.NamedResource
 	switch {
 	case id.Kind == manifest.KindKustomization:
-		blocked, ready = o.ksc.ReconcileNode(ctx, id, drainLevel)
+		blocked, _ = o.ksc.ReconcileNode(ctx, id, drainLevel)
 	case id.Kind == manifest.KindHelmRelease:
-		blocked, ready = o.hrc.ReconcileNode(ctx, id, drainLevel)
+		blocked, _ = o.hrc.ReconcileNode(ctx, id, drainLevel)
 	case id.Kind == manifest.KindResourceSet:
-		blocked, ready = o.rsc.ReconcileNode(ctx, id, drainLevel)
+		blocked, _ = o.rsc.ReconcileNode(ctx, id, drainLevel)
 	case o.src.HasFetcher(id.Kind):
-		blocked, ready = o.src.ReconcileNode(ctx, id, drainLevel)
+		blocked, _ = o.src.ReconcileNode(ctx, id, drainLevel)
 	default:
 		// Not a schedulable kind (should never be dispatched) — terminal no-op.
-		return schedule.OutcomeTerminal, nil, true
+		return schedule.OutcomeTerminal, nil
 	}
 	if len(blocked) > 0 {
-		return schedule.OutcomeBlocked, blocked, false
+		return schedule.OutcomeBlocked, blocked
 	}
-	return schedule.OutcomeTerminal, nil, ready
+	return schedule.OutcomeTerminal, nil
 }
 
 // dagSchedulable reports whether id is a node the scheduler runs

--- a/pkg/schedule/schedule.go
+++ b/pkg/schedule/schedule.go
@@ -74,11 +74,8 @@ type Dispatcher interface {
 	// goroutine (a task.Service worker) and reports back:
 	//   - out: OutcomeTerminal or OutcomeBlocked.
 	//   - blocked: unsatisfied dependency ids (non-nil only when Blocked).
-	//   - ready: whether id's final store status is Ready (meaningful only
-	//     when Terminal) — the scheduler records it so a node parking on id
-	//     can tell, without reading the store, whether id is satisfied.
 	// drainLevel is one of DrainNone/DrainCascade/DrainForce.
-	Dispatch(ctx context.Context, id NodeID, drainLevel int) (out Outcome, blocked []NodeID, ready bool)
+	Dispatch(ctx context.Context, id NodeID, drainLevel int) (out Outcome, blocked []NodeID)
 }
 
 type nodeState uint8
@@ -93,7 +90,6 @@ const (
 type node struct {
 	id        NodeID
 	state     nodeState
-	ready     bool     // for stateTerminal: did it end Ready (vs Failed)?
 	blockedOn []NodeID // deps recorded at the last OutcomeBlocked
 	// rerunRequested is set when a wake arrives while the node is running, so
 	// complete() re-queues it once instead of dropping the wake (the re-run
@@ -201,9 +197,9 @@ func (s *Scheduler) Run(ctx context.Context) {
 			level := s.draining
 			s.mu.Unlock()
 			s.tasks.Go(ctx, "schedule/"+id.String(), func(ctx context.Context) {
-				out, blocked, ready := s.disp.Dispatch(ctx, id, level)
+				out, blocked := s.disp.Dispatch(ctx, id, level)
 				rerun := s.rerunAtDrain != nil && s.rerunAtDrain(id)
-				s.complete(id, out, blocked, ready, rerun)
+				s.complete(id, out, blocked, rerun)
 			})
 			s.mu.Lock()
 		}
@@ -253,7 +249,7 @@ func (s *Scheduler) Run(ctx context.Context) {
 
 // complete records the result of one Dispatch. Runs on the worker goroutine;
 // acquires mu. Touches ONLY scheduler state — never the store or the pool.
-func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready, rerun bool) {
+func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, rerun bool) {
 	s.mu.Lock()
 	// Broadcast on EVERY path (terminalize, park, re-queue) so the Run loop
 	// re-evaluates inFlight/runq after any transition — a terminalize that
@@ -286,7 +282,6 @@ func (s *Scheduler) complete(id NodeID, out Outcome, blocked []NodeID, ready, re
 	switch out {
 	case OutcomeTerminal:
 		n.state = stateTerminal
-		n.ready = ready
 		n.blockedOn = nil
 		s.wakeWaitersLocked(id)
 	case OutcomeBlocked:
@@ -389,7 +384,6 @@ func (s *Scheduler) OnArrival(id NodeID, schedulable bool) {
 			// Content changed (Refire reset, or a parent re-emitted a mutated
 			// spec): re-run so the new content is reconciled.
 			n.state = stateRunnable
-			n.ready = false
 			s.runq = append(s.runq, id)
 		case stateRunning:
 			n.rerunRequested = true
@@ -471,7 +465,6 @@ func (s *Scheduler) requeueRerunLocked() bool {
 	slices.SortFunc(due, func(a, b *node) int { return a.id.Compare(b.id) })
 	for _, n := range due {
 		n.state = stateRunnable
-		n.ready = false
 		n.blockedOn = nil
 		s.runq = append(s.runq, n.id)
 	}
@@ -486,7 +479,6 @@ func (s *Scheduler) finalSweepLocked() {
 	for _, n := range s.nodes {
 		if n.state == stateParked {
 			n.state = stateTerminal
-			n.ready = false
 			s.unparkSelfLocked(n)
 		}
 	}

--- a/pkg/schedule/schedule_test.go
+++ b/pkg/schedule/schedule_test.go
@@ -58,7 +58,7 @@ func newFake(graph map[NodeID][]NodeID) *fakeDisp {
 	}
 }
 
-func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outcome, []NodeID, bool) {
+func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outcome, []NodeID) {
 	f.mu.Lock()
 	g := f.gate[nid]
 	f.mu.Unlock()
@@ -102,13 +102,13 @@ func (f *fakeDisp) Dispatch(_ context.Context, nid NodeID, drainLevel int) (Outc
 	case failed:
 		f.termAny[nid] = true
 		f.termReady[nid] = false
-		return OutcomeTerminal, nil, false
+		return OutcomeTerminal, nil
 	case len(blocked) > 0:
-		return OutcomeBlocked, blocked, false
+		return OutcomeBlocked, blocked
 	default:
 		f.termAny[nid] = true
 		f.termReady[nid] = true
-		return OutcomeTerminal, nil, true
+		return OutcomeTerminal, nil
 	}
 }
 


### PR DESCRIPTION
Second pass of the dead-code loop. After #717, `deadcode -test ./...` and `golangci-lint` are clean at the function level, so a directed multi-agent hunt swept the *linter-blind* categories (write-only fields, unused consts, dead branches) and adversarially verified each candidate against the [konflate](https://github.com/home-operations/konflate) consumer.

One confirmed find: **`node.ready`** in `pkg/schedule` — written at four sites, **read nowhere**. It backed a documented "a parker can tell if a dep is satisfied without reading the store" optimization that was never wired. This PR removes the whole dead thread:

- `node.ready` field + its 4 dead writes.
- `complete()`'s `ready` parameter.
- the `ready` return from the `schedule.Dispatcher` interface and its sole impl `dagDispatcher` (which now discards the controllers' `ReconcileNode` readiness bool).

`pkg/schedule` and the `Dispatcher` interface are internal to flate's binary — konflate imports neither, so this cannot affect the consumer. (The verify pass also correctly **rejected** `SourceArtifact.Size`/`.Metadata`, which look write-only but are read via `reflect.DeepEqual` in the store's dedup path.)

### Verification
- `gofmt` / `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./...` / `go test -race ./pkg/schedule/... ./pkg/orchestrator/... ./pkg/controllers/...` — all green.
- **Byte-identical** render vs `main`: k8s-gitops (2,382,360 B) and zariel/home-ops (3,190,543 B). `ready` was never read, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)