### PR TITLE
chore: drop the unused ReconcileNode readiness return

### DIFF
--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -641,20 +641,11 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 	return nil
 }
 
-// statusReady reports whether id's current store status is Ready — the dag
-// scheduler's "this terminal node satisfies a dependency" signal.
-func (c *Controller) statusReady(id manifest.NamedResource) bool {
-	info, ok := c.Store.GetStatus(id)
-	return ok && info.Status == store.StatusReady
-}
-
-// DispatchNode runs id's reconcile body under the dag engine and reports what
-// the scheduler needs: the blocked dependency set (nil = terminalized) and
-// whether id's final store status is Ready. It performs the PreGate /
+// DispatchNode runs id's reconcile body under the dag engine and reports the
+// blocked dependency set (nil = terminalized). It performs the PreGate /
 // preflight pre-checks, then RunWithStatusOutcome. drainLevel threads the
-// scheduler's fixpoint level into
-// Require via ctx. The orchestrator's Dispatcher calls this, routing by Kind, so
-// no per-kind match check is needed here.
+// scheduler's fixpoint level into Require via ctx. The orchestrator's Dispatcher
+// calls this, routing by Kind, so no per-kind match check is needed here.
 func DispatchNode[T manifest.BaseManifest](
 	ctx context.Context,
 	c *Controller,
@@ -662,22 +653,19 @@ func DispatchNode[T manifest.BaseManifest](
 	drainLevel int,
 	suspended func(T) bool,
 	reconcile func(context.Context, T) error,
-) (blocked []manifest.NamedResource, ready bool) {
+) []manifest.NamedResource {
 	ctx = WithDrainLevel(ctx, drainLevel)
 	obj, ok := store.Get[T](c.Store, id)
 	if !ok {
-		// Vanished — RunWithStatusOutcome's vanished branch records a terminal
-		// status; report it.
-		blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)
-		return blocked, c.statusReady(id)
+		// Vanished — RunWithStatusOutcome's vanished branch records a terminal status.
+		return RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)
 	}
 	if c.PreGate(id, suspended(obj)) {
-		return nil, c.statusReady(id) // gated out: Ready (suspended/unchanged)
+		return nil // gated out (suspended/unchanged)
 	}
 	if msg, failed := c.PreflightFailure(id); failed {
 		c.Store.UpdateStatus(id, store.StatusFailed, msg)
-		return nil, false
+		return nil
 	}
-	blocked = RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)
-	return blocked, c.statusReady(id)
+	return RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)
 }

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -283,8 +283,8 @@ func TestController_DoubleCloseIsSafe(t *testing.T) {
 // TestDispatchNode pins the dag scheduler's per-node entry point: it must bail
 // (via PreGate) on a suspended object — Ready/"suspended", no reconcile — mark a
 // preflight-failed id Failed without running it, and run the reconcile only for
-// a non-suspended, preflight-clean object, reporting ready accordingly. (The
-// scheduler's Dispatcher routes by Kind, so DispatchNode does no match check.)
+// a non-suspended, preflight-clean object. (The scheduler's Dispatcher routes by
+// Kind, so DispatchNode does no match check.)
 func TestDispatchNode(t *testing.T) {
 	s := store.New()
 	ts := task.NewBounded(0)
@@ -298,27 +298,22 @@ func TestDispatchNode(t *testing.T) {
 	var ran atomic.Int64
 	suspended := func(hr *manifest.HelmRelease) bool { return hr.Name == "suspended" }
 	reconcile := func(_ context.Context, _ *manifest.HelmRelease) error { ran.Add(1); return nil }
-	dispatch := func(id manifest.NamedResource) bool {
-		_, ready := base.DispatchNode(t.Context(), c, id, 0, suspended, reconcile)
-		return ready
+	dispatch := func(id manifest.NamedResource) {
+		base.DispatchNode(t.Context(), c, id, 0, suspended, reconcile)
 	}
 
 	// Suspended → PreGate bails to Ready/"suspended", no reconcile.
 	susHR := &manifest.HelmRelease{Name: "suspended", Namespace: "ns"}
 	s.AddObject(susHR)
-	if !dispatch(susHR.Named()) {
-		t.Error("suspended HR: want ready=true (PreGate→Ready)")
-	}
+	dispatch(susHR.Named())
 	if info, _ := s.GetStatus(susHR.Named()); info.Message != "suspended" {
 		t.Errorf("suspended HR status = %+v; want Ready/suspended via PreGate", info)
 	}
 
-	// Preflight-failed → Failed, ready=false, no reconcile.
+	// Preflight-failed → Failed, no reconcile.
 	pfHR := &manifest.HelmRelease{Name: "preflightfail", Namespace: "ns"}
 	s.AddObject(pfHR)
-	if dispatch(pfHR.Named()) {
-		t.Error("preflight-failed HR: want ready=false")
-	}
+	dispatch(pfHR.Named())
 	if info, _ := s.GetStatus(pfHR.Named()); info.Status != store.StatusFailed {
 		t.Errorf("preflight-failed HR status = %+v; want Failed", info)
 	}
@@ -326,9 +321,7 @@ func TestDispatchNode(t *testing.T) {
 	// Clean → reconcile runs → Ready.
 	hr := &manifest.HelmRelease{Name: "app", Namespace: "ns"}
 	s.AddObject(hr)
-	if !dispatch(hr.Named()) {
-		t.Error("clean HR: want ready=true")
-	}
+	dispatch(hr.Named())
 	if info, _ := s.GetStatus(hr.Named()); info.Status != store.StatusReady {
 		t.Errorf("clean HR status = %+v; want Ready", info)
 	}

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -106,7 +106,7 @@ func (c *Controller) Start(_ context.Context) {
 // ReconcileNode runs id's reconcile under the dag engine, returning the blocked
 // dependency set (nil = terminalized) and whether id ended Ready. The
 // orchestrator's scheduler Dispatcher calls this for HelmRelease nodes.
-func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		func(hr *manifest.HelmRelease) bool { return hr.Suspend },
 		c.reconcile)

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -70,7 +70,7 @@ func newTestControllerWithOptions(t *testing.T, opts ReconcileOptions) (*Control
 func dispatchToFixpoint(t *testing.T, c *Controller, st *store.Store, id manifest.NamedResource) store.StatusInfo {
 	t.Helper()
 	for _, drain := range []int{0, 1, 2} {
-		if blocked, _ := c.ReconcileNode(context.Background(), id, drain); len(blocked) == 0 {
+		if blocked := c.ReconcileNode(context.Background(), id, drain); len(blocked) == 0 {
 			break
 		}
 	}

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -84,7 +84,7 @@ func (c *Controller) Start(_ context.Context) {
 // ReconcileNode runs id's reconcile under the dag engine, returning the blocked
 // dependency set (nil = terminalized) and whether id ended Ready. The
 // orchestrator's scheduler Dispatcher calls this for Kustomization nodes.
-func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		func(ks *manifest.Kustomization) bool { return ks.Suspend },
 		c.reconcile)

--- a/pkg/controllers/kustomization/reconcile_test.go
+++ b/pkg/controllers/kustomization/reconcile_test.go
@@ -66,7 +66,7 @@ data: {greeting: hi}
 func dispatchToFixpoint(t *testing.T, c *Controller, st *store.Store, id manifest.NamedResource) store.StatusInfo {
 	t.Helper()
 	for _, drain := range []int{0, 1, 2} {
-		if blocked, _ := c.ReconcileNode(context.Background(), id, drain); len(blocked) == 0 {
+		if blocked := c.ReconcileNode(context.Background(), id, drain); len(blocked) == 0 {
 			break
 		}
 	}

--- a/pkg/controllers/resourceset/controller.go
+++ b/pkg/controllers/resourceset/controller.go
@@ -82,7 +82,7 @@ func (c *Controller) Start(_ context.Context) {
 // The orchestrator's scheduler Dispatcher calls this for ResourceSet
 // nodes. A ResourceSet has no Suspend field, so the suspended predicate
 // is always false.
-func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		func(*manifest.ResourceSet) bool { return false },
 		c.reconcile)

--- a/pkg/controllers/resourceset/controller_test.go
+++ b/pkg/controllers/resourceset/controller_test.go
@@ -37,7 +37,7 @@ func newController(t *testing.T) (*Controller, *store.Store) {
 func dispatchToFixpoint(t *testing.T, c *Controller, s *store.Store, id manifest.NamedResource) store.StatusInfo {
 	t.Helper()
 	for _, drain := range []int{0, 1, 2} {
-		if blocked, _ := c.ReconcileNode(context.Background(), id, drain); len(blocked) == 0 {
+		if blocked := c.ReconcileNode(context.Background(), id, drain); len(blocked) == 0 {
 			break
 		}
 	}
@@ -101,7 +101,7 @@ metadata: {name: << inputs.user >>, namespace: flux-system}
 
 	// First dispatch (no RSIP yet): the named dep is absent, so the node
 	// blocks rather than terminalizing.
-	blocked, _ := c.ReconcileNode(context.Background(), rs.Named(), 0)
+	blocked := c.ReconcileNode(context.Background(), rs.Named(), 0)
 	if len(blocked) != 1 {
 		t.Fatalf("first dispatch blocked = %v, want [rsip] (parked on the named RSIP)", blocked)
 	}

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -103,7 +103,7 @@ func (c *Controller) HasFetcher(kind string) bool {
 // blocked dependency set (always nil — sources have no depwait gates) and
 // whether id ended Ready. The orchestrator's scheduler Dispatcher calls this
 // for source-kind nodes.
-func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) (blocked []manifest.NamedResource, ready bool) {
+func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
 	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
 		suspendedSource, c.reconcile)
 }

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -83,7 +83,7 @@ func dispatchToFixpoint(t *testing.T, c *Controller, st *store.Store, id manifes
 func reconcileNode(c *Controller, id manifest.NamedResource, drain int) (terminal bool) {
 	done := make(chan struct{})
 	c.Tasks.Go(context.Background(), "test/"+id.String(), func(ctx context.Context) {
-		blocked, _ := c.ReconcileNode(ctx, id, drain)
+		blocked := c.ReconcileNode(ctx, id, drain)
 		terminal = len(blocked) == 0
 		close(done)
 	})

--- a/pkg/orchestrator/dagrun.go
+++ b/pkg/orchestrator/dagrun.go
@@ -14,8 +14,7 @@ import (
 // scheduler Outcome. This is the single composition point where the scheduler,
 // the controllers, and the store meet — pkg/schedule itself imports none of
 // them. NodeID is manifest.NamedResource, so the blocked slice flows through
-// untranslated. The controllers' ReconcileNode also reports a readiness bool,
-// which the scheduler does not consume, so it is discarded here.
+// untranslated.
 type dagDispatcher struct{ o *Orchestrator }
 
 func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLevel int) (schedule.Outcome, []schedule.NodeID) {
@@ -23,13 +22,13 @@ func (d dagDispatcher) Dispatch(ctx context.Context, id schedule.NodeID, drainLe
 	var blocked []manifest.NamedResource
 	switch {
 	case id.Kind == manifest.KindKustomization:
-		blocked, _ = o.ksc.ReconcileNode(ctx, id, drainLevel)
+		blocked = o.ksc.ReconcileNode(ctx, id, drainLevel)
 	case id.Kind == manifest.KindHelmRelease:
-		blocked, _ = o.hrc.ReconcileNode(ctx, id, drainLevel)
+		blocked = o.hrc.ReconcileNode(ctx, id, drainLevel)
 	case id.Kind == manifest.KindResourceSet:
-		blocked, _ = o.rsc.ReconcileNode(ctx, id, drainLevel)
+		blocked = o.rsc.ReconcileNode(ctx, id, drainLevel)
 	case o.src.HasFetcher(id.Kind):
-		blocked, _ = o.src.ReconcileNode(ctx, id, drainLevel)
+		blocked = o.src.ReconcileNode(ctx, id, drainLevel)
 	default:
 		// Not a schedulable kind (should never be dispatched) — terminal no-op.
 		return schedule.OutcomeTerminal, nil


### PR DESCRIPTION
Third pass of the dead-code loop — finishing the thread #718 started.

#718 removed the scheduler's `node.ready` field, which was the **only** consumer of the readiness bool that `base.DispatchNode` → the four controllers' `ReconcileNode` → `dagDispatcher` threaded up. With that consumer gone, the bool is computed (via `statusReady`) only to be discarded by every caller. This removes it end-to-end:

- `base.DispatchNode` returns just the blocked set; `statusReady` (its only caller) goes with it.
- the four controllers' `ReconcileNode` drop the `(…, ready bool)` return.
- `dagDispatcher` and the affected tests stop discarding it; `TestDispatchNode` keeps its store-status + reconcile-ran assertions (the real behavioral checks) and drops the obsolete `ready`-return checks.

`konflate` imports neither `pkg/controllers` nor `pkg/schedule`, so this can't affect the consumer.

### Verification
- `gofmt` / `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./...` / `go test -race ./pkg/schedule/... ./pkg/orchestrator/... ./pkg/controllers/...` — all green.
- **Byte-identical** render vs `main`: k8s-gitops (2,382,360 B) and zariel/home-ops (3,190,543 B). `ready` was already unread, so behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)