### PR TITLE
fix(manifest): skip non-manifest YAML instead of failing the file

### DIFF
--- a/pkg/manifest/io.go
+++ b/pkg/manifest/io.go
@@ -76,7 +76,9 @@ func ReleaseIfNotRetained(doc map[string]any, obj BaseManifest) {
 }
 
 // DecodeDocs reads zero or more YAML documents from r and returns each
-// as a generic map. Empty / null-scalar documents are skipped.
+// as a generic map. Documents that are empty, null, or whose root is not a
+// mapping (a top-level sequence or scalar — i.e. not a Kubernetes manifest)
+// are skipped; only a genuine YAML syntax error aborts.
 //
 // Decodes directly into map[string]any via the yaml.v4 library — same
 // shape sigs.k8s.io/yaml uses behind real Flux. Letting the library
@@ -107,6 +109,21 @@ func DecodeDocs(r io.Reader) ([]map[string]any, error) {
 			putDecodedMap(m)
 			if errors.Is(err, io.EOF) {
 				return out, nil
+			}
+			// Valid YAML whose root is not a mapping (a top-level sequence or
+			// scalar — e.g. an ansible task file) can't decode into
+			// map[string]any. yaml.v4 records that as a recoverable
+			// *yaml.LoadErrors and the decoder advances past the doc, so the
+			// loop continues with the next one. Such a document simply isn't a
+			// Kubernetes manifest, so skip it like an empty doc rather than
+			// failing the whole file. Decoding into map[string]any, a construct
+			// error can ONLY mean a non-mapping root: every value fits `any`, so
+			// no nested type mismatch is possible. A genuine YAML syntax error
+			// is a single *yaml.LoadError (not the plural *LoadErrors) and so
+			// falls through to the hard error below.
+			var notManifest *yaml.LoadErrors
+			if errors.As(err, &notManifest) {
+				continue
 			}
 			return nil, fmt.Errorf("%w: %w", ErrInput, err)
 		}

--- a/pkg/manifest/io_test.go
+++ b/pkg/manifest/io_test.go
@@ -1,0 +1,60 @@
+package manifest
+
+import "testing"
+
+// TestDecodeDocs_SkipsNonMappingDocs pins the fix for non-manifest YAML noise:
+// a valid YAML document whose root is a sequence or scalar (e.g. an ansible
+// task file) is not a Kubernetes manifest, so it is skipped — no error, no
+// failed-to-parse WARN. Only a genuine syntax error aborts.
+func TestDecodeDocs_SkipsNonMappingDocs(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int // number of mapping docs returned
+		wantErr bool
+	}{
+		{"top-level sequence (ansible)", "- name: a\n- name: b\n", 0, false},
+		{"top-level scalar string", "just a string\n", 0, false},
+		{"top-level scalar number", "42\n", 0, false},
+		{"null doc", "null\n", 0, false},
+		{"empty input", "", 0, false},
+		{"single mapping", "apiVersion: v1\nkind: ConfigMap\n", 1, false},
+		{"mappings interleaved with non-mappings", "- a\n---\nkind: A\n---\nfoo\n---\nkind: B\n", 2, false},
+		{"malformed YAML aborts", "{ unterminated\n", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			docs, err := SplitDocs([]byte(tc.in))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got docs=%v", docs)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(docs) != tc.want {
+				t.Fatalf("got %d docs, want %d: %v", len(docs), tc.want, docs)
+			}
+		})
+	}
+}
+
+// TestDecodeDocs_AdvancesPastSkippedSeq confirms skipping a non-mapping doc
+// advances the decoder so neighbouring manifests in the SAME file survive —
+// previously a single top-level sequence failed the entire file, dropping the
+// real manifests with it.
+func TestDecodeDocs_AdvancesPastSkippedSeq(t *testing.T) {
+	in := "kind: First\n---\n- not\n- a\n- manifest\n---\nkind: Second\n"
+	docs, err := SplitDocs([]byte(in))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("got %d docs, want 2: %v", len(docs), docs)
+	}
+	if docs[0]["kind"] != "First" || docs[1]["kind"] != "Second" {
+		t.Errorf("wrong docs survived: %v", docs)
+	}
+}


### PR DESCRIPTION
## Problem
Running `flate build all` on a repo that mixes non-Kubernetes YAML (e.g. ansible task files) floods the terminal with `WARN msg="loader: file failed to parse"` lines, which interleave with the live status bar on stderr and garble it.

Root cause: an ansible task file has a **top-level YAML sequence** — valid YAML, but not a manifest. `manifest.DecodeDocs` decodes each document straight into a pooled `map[string]any`; a non-mapping root can't construct into a map, so the decode error failed the **entire file** and surfaced at a loader `slog.Warn` site. A top-level sequence/scalar isn't a parse *failure*, it's simply "not a manifest."

## Fix
`DecodeDocs` now skips a document whose root isn't a mapping. yaml.v4 reports that as a recoverable `*yaml.LoadErrors` (plural) and the decoder advances past the doc, so it's dropped like an empty one — and neighbouring manifests in the same file survive (previously one stray sequence dropped the whole file). A genuine YAML **syntax** error is a singular `*yaml.LoadError` and still aborts + WARNs, as it should.

Decoding into `map[string]any`, a construct error can *only* mean a non-mapping root (every value fits `any`, so no nested type mismatch is possible) — so the classification is precise, with no string-matching.

## Verification
- `gofmt` / `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./...` / `go test -race ./pkg/manifest/...` — all green; new `io_test.go` covers sequence/scalar/null skip, interleaved map/seq survival, and that malformed YAML still errors.
- **No perf regression**: the mapping-doc path (the render hot path) is unchanged code, so `BenchmarkDecodeDocs_LargeFile` is flat (6541 allocs/op, unchanged).
- **Byte-identical** render vs `main` on k8s-gitops (2,382,360 B) and zariel/home-ops (3,190,543 B); chkpwd/iac render also identical (2,081,013 B).
- **Repro fixed**: on `chkpwd/iac` the `file failed to parse` WARNs drop **50 → 1** — the 1 remaining is a genuinely malformed file (`apps.json` with a Windows backslash that fails the YAML scanner), which correctly still WARNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)