### PR TITLE
feat(orchestrator): expose the dependsOn graph on Result

### DIFF
--- a/pkg/orchestrator/depgraph.go
+++ b/pkg/orchestrator/depgraph.go
@@ -282,3 +282,37 @@ func (g *dependencyGraph) Failures() map[manifest.NamedResource]string {
 	defer g.mu.Unlock()
 	return g.snapshotFailedLocked()
 }
+
+// snapshotEdgesLocked returns the dependsOn graph as src → sorted dependency
+// list, a defensive copy that doesn't alias the graph's internal sets. Nodes
+// registered with no out-edges are omitted (only nodes that declare a
+// dependency appear); dependencies are sorted for deterministic output. Returns
+// nil when nothing depends on anything. Caller holds mu.
+func (g *dependencyGraph) snapshotEdgesLocked() map[manifest.NamedResource][]manifest.NamedResource {
+	out := make(map[manifest.NamedResource][]manifest.NamedResource, len(g.outEdges))
+	for src, dsts := range g.outEdges {
+		if len(dsts) == 0 {
+			continue
+		}
+		deps := make([]manifest.NamedResource, 0, len(dsts))
+		for dst := range dsts {
+			deps = append(deps, dst)
+		}
+		slices.SortFunc(deps, manifest.NamedResource.Compare)
+		out[src] = deps
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// Edges returns a snapshot of the declared dependsOn graph: each Kustomization
+// or HelmRelease that names dependencies → the sorted ids it depends on
+// (same-kind only, per the Flux spec). The orchestrator installs it into
+// Result.DependsOn for impact / blast-radius analysis. Safe for concurrent use.
+func (g *dependencyGraph) Edges() map[manifest.NamedResource][]manifest.NamedResource {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.snapshotEdgesLocked()
+}

--- a/pkg/orchestrator/depgraph_test.go
+++ b/pkg/orchestrator/depgraph_test.go
@@ -1,0 +1,89 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestDependencyGraph_Edges pins the snapshot the orchestrator installs into
+// Result.DependsOn: dependencies are sorted, nodes with no declared deps are
+// omitted, an empty graph yields nil, and the result is an independent copy.
+func TestDependencyGraph_Edges(t *testing.T) {
+	mk := func(name string) manifest.NamedResource {
+		return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
+	}
+	a, b, c, lonely := mk("a"), mk("b"), mk("c"), mk("lonely")
+
+	g := newDependencyGraph()
+	g.ReplaceEdges(a, []manifest.NamedResource{c, b}) // deliberately out of order
+	g.ReplaceEdges(lonely, nil)                       // registered, but declares no deps
+
+	edges := g.Edges()
+	if len(edges) != 1 {
+		t.Fatalf("Edges = %+v, want only 'a' (lonely declares no deps)", edges)
+	}
+	if got := edges[a]; len(got) != 2 || got[0] != b || got[1] != c {
+		t.Fatalf("Edges[a] = %+v, want sorted [b c]", got)
+	}
+	if _, ok := edges[lonely]; ok {
+		t.Error("a node with no dependencies must be omitted from Edges")
+	}
+
+	// Mutating a returned slice must not corrupt a later snapshot.
+	edges[a][0] = manifest.NamedResource{}
+	if again := g.Edges()[a]; again[0] != b {
+		t.Errorf("Edges must return an independent snapshot; second call got %+v", again)
+	}
+
+	if got := newDependencyGraph().Edges(); got != nil {
+		t.Errorf("empty graph Edges = %+v, want nil", got)
+	}
+}
+
+// TestOrchestrator_Render_ExposesDependsOn confirms a full render surfaces the
+// declared spec.dependsOn graph on Result.DependsOn — the blast-radius input
+// konflate consumes — keyed by the dependent, with declarationless nodes omitted.
+func TestOrchestrator_Render_ExposesDependsOn(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "flux/base.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: base, namespace: flux-system}
+spec:
+  path: ./base
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "flux/app.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: app, namespace: flux-system}
+spec:
+  path: ./app
+  dependsOn:
+    - name: base
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "base/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "base/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: base}\ndata: {k: v}\n")
+	testutil.WriteFile(t, dir, "app/kustomization.yaml", "resources:\n- cm.yaml\n")
+	testutil.WriteFile(t, dir, "app/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: app}\ndata: {k: v}\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true, Concurrency: 4})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	appID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "app"}
+	baseID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "base"}
+	if got := res.DependsOn[appID]; len(got) != 1 || got[0] != baseID {
+		t.Fatalf("DependsOn[app] = %+v, want [%v]", got, baseID)
+	}
+	if got, ok := res.DependsOn[baseID]; ok {
+		t.Errorf("base declares no dependsOn; it must be omitted, got %+v", got)
+	}
+}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -296,6 +296,13 @@ type Result struct {
 	Manifests map[manifest.NamedResource][]map[string]any
 	Failed    map[manifest.NamedResource]store.StatusInfo
 	Orphans   map[manifest.NamedResource]string
+	// DependsOn is the declared spec.dependsOn graph: each Kustomization or
+	// HelmRelease that names dependencies maps to the sorted ids it depends on.
+	// Same-kind only (KS→KS, HR→HR per the Flux spec); implicit coupling
+	// (healthChecks, shared CRDs, service DNS) is not represented. Nodes with no
+	// declared dependencies are omitted. Consumers invert this into a dependents
+	// adjacency list for impact / "blast radius" analysis.
+	DependsOn map[manifest.NamedResource][]manifest.NamedResource
 }
 
 // New constructs an Orchestrator. It allocates the Store and TaskService

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -196,6 +196,9 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 		Manifests: map[manifest.NamedResource][]map[string]any{},
 		Failed:    map[manifest.NamedResource]store.StatusInfo{},
 		Orphans:   map[manifest.NamedResource]string{},
+		// The dependsOn graph is fully populated by now (Bootstrap's rebuild +
+		// per-id ReplaceEdges during Run); snapshot it for blast-radius consumers.
+		DependsOn: o.depGraph.Edges(),
 	}
 	// Apply --skip-secrets / --skip-crds / --skip-kinds uniformly here
 	// so embedders calling Render see consistent Result.Manifests


### PR DESCRIPTION
## What
Surface flate's `spec.dependsOn` graph on `orchestrator.Result` so SDK consumers (konflate) can compute a "blast radius" — e.g. *"rook-ceph has 2 direct, 21 transitive dependents"*.

flate already builds this graph for cycle detection (`pkg/orchestrator/depgraph.go`) and then discards it. This is pure data exposure — no new computation, no behavioral change.

## Changes (~50 lines + tests)
- **`dependencyGraph.Edges()`** — snapshots `outEdges` as `src → sorted dependency list`, mirroring the existing `Failures()` snapshot. Omits nodes that declare no deps; deterministic.
- **`Result.DependsOn map[NamedResource][]NamedResource`** — populated in `render()` from the fully-built graph (after Bootstrap's rebuild + per-id updates during Run).

## Scope of the graph (by design)
- **Declared `spec.dependsOn` only** — implicit coupling (healthChecks, shared CRDs, service DNS) is not represented; declared ordering is what wedges reconciliation.
- **Same-kind only** (KS→KS, HR→HR per the Flux spec).
- Keyed by `manifest.NamedResource`, matching `Result`'s existing maps. Consumers invert it into a dependents adjacency list and BFS reverse edges for impact.

## Verification
- `gofmt` / `go build` / `go vet` / `golangci-lint` (0 issues) / `go test ./...` / `go test -race ./pkg/orchestrator/...` — all green. New tests cover `Edges()` (sorting, omit-empty, independent snapshot, empty→nil) and an end-to-end `Render` asserting `Result.DependsOn`.
- **Byte-identical** render vs `main` on k8s-gitops (2,382,360 B) and zariel/home-ops (3,190,543 B) — `flate build` emits `Manifests`, not `DependsOn`, so output is unchanged.
- **Additive + backward-compatible**: existing `Result` consumers are unaffected; the konflate blast-radius feature lands in a follow-up PR on its side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)