### PR TITLE
test(orchestrator): pin dependsOn cycle/self-edge contract; document Result.DependsOn

### DIFF
--- a/pkg/orchestrator/depgraph.go
+++ b/pkg/orchestrator/depgraph.go
@@ -294,6 +294,11 @@ func (g *dependencyGraph) snapshotEdgesLocked() map[manifest.NamedResource][]man
 		if len(dsts) == 0 {
 			continue
 		}
+		// Collect-and-sort by hand (pre-sized) rather than the sortedNeighbors
+		// helper: sortedNeighbors goes through slices.SortedFunc(maps.Keys(...)),
+		// which starts from a nil slice with no capacity hint and allocates an
+		// iterator closure per call. This snapshot walks the whole graph, so the
+		// pre-sized make() is the leaner form — don't "DRY" it into sortedNeighbors.
 		deps := make([]manifest.NamedResource, 0, len(dsts))
 		for dst := range dsts {
 			deps = append(deps, dst)
@@ -311,6 +316,11 @@ func (g *dependencyGraph) snapshotEdgesLocked() map[manifest.NamedResource][]man
 // or HelmRelease that names dependencies → the sorted ids it depends on
 // (same-kind only, per the Flux spec). The orchestrator installs it into
 // Result.DependsOn for impact / blast-radius analysis. Safe for concurrent use.
+//
+// The declared graph is returned verbatim: cycle members and self-edges (A → A)
+// are NOT pruned — cycle reporting is the separate concern of Failures(), and a
+// consumer walking these edges must tolerate them (e.g. a visited set). Returns
+// nil (not an empty map) when nothing declares a dependsOn, mirroring Failures().
 func (g *dependencyGraph) Edges() map[manifest.NamedResource][]manifest.NamedResource {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/pkg/orchestrator/depgraph_test.go
+++ b/pkg/orchestrator/depgraph_test.go
@@ -8,14 +8,17 @@ import (
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
+// ksNode builds a Kustomization NamedResource in the "ns" namespace for the
+// dependency-graph snapshot tests.
+func ksNode(name string) manifest.NamedResource {
+	return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
+}
+
 // TestDependencyGraph_Edges pins the snapshot the orchestrator installs into
 // Result.DependsOn: dependencies are sorted, nodes with no declared deps are
 // omitted, an empty graph yields nil, and the result is an independent copy.
 func TestDependencyGraph_Edges(t *testing.T) {
-	mk := func(name string) manifest.NamedResource {
-		return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
-	}
-	a, b, c, lonely := mk("a"), mk("b"), mk("c"), mk("lonely")
+	a, b, c, lonely := ksNode("a"), ksNode("b"), ksNode("c"), ksNode("lonely")
 
 	g := newDependencyGraph()
 	g.ReplaceEdges(a, []manifest.NamedResource{c, b}) // deliberately out of order
@@ -40,6 +43,60 @@ func TestDependencyGraph_Edges(t *testing.T) {
 
 	if got := newDependencyGraph().Edges(); got != nil {
 		t.Errorf("empty graph Edges = %+v, want nil", got)
+	}
+}
+
+// TestDependencyGraph_Edges_CyclesAndSelfEdges pins the load-bearing contract
+// that Edges() returns cycle members and self-edges VERBATIM — the declared
+// graph, unpruned. konflate's blast-radius walk relies on this: its visited-set
+// cycle tolerance exists precisely because the producer emits cycle edges, so a
+// refactor that silently filtered them would pass every other test while
+// corrupting that analysis. (Cycles are still flagged via Failures(); that is a
+// separate concern from the declared edges this snapshot exposes.)
+func TestDependencyGraph_Edges_CyclesAndSelfEdges(t *testing.T) {
+	a, b, self := ksNode("a"), ksNode("b"), ksNode("self")
+
+	g := newDependencyGraph()
+	g.ReplaceEdges(a, []manifest.NamedResource{b})       // a → b
+	g.ReplaceEdges(b, []manifest.NamedResource{a})       // b → a : a 2-cycle
+	g.ReplaceEdges(self, []manifest.NamedResource{self}) // self → self : a trivial 1-node cycle
+
+	edges := g.Edges()
+	if got := edges[a]; len(got) != 1 || got[0] != b {
+		t.Errorf("cycle member a: Edges[a] = %+v, want [b] verbatim", got)
+	}
+	if got := edges[b]; len(got) != 1 || got[0] != a {
+		t.Errorf("cycle member b: Edges[b] = %+v, want [a] verbatim", got)
+	}
+	if got := edges[self]; len(got) != 1 || got[0] != self {
+		t.Errorf("self-edge: Edges[self] = %+v, want [self] verbatim", got)
+	}
+}
+
+// TestDependencyGraph_Edges_TransitiveChain covers the canonical multi-level
+// shape a → b → c, where b is simultaneously a dependency (of a) and a dependent
+// (of c) — the structure konflate inverts and walks for transitive blast radius.
+// Edges() exposes only DIRECTLY declared edges (no transitive closure), and the
+// leaf c is omitted as a key while still appearing as b's dependency.
+func TestDependencyGraph_Edges_TransitiveChain(t *testing.T) {
+	a, b, c := ksNode("a"), ksNode("b"), ksNode("c")
+
+	g := newDependencyGraph()
+	g.ReplaceEdges(a, []manifest.NamedResource{b})
+	g.ReplaceEdges(b, []manifest.NamedResource{c})
+
+	edges := g.Edges()
+	if len(edges) != 2 {
+		t.Fatalf("Edges = %+v, want keys {a, b} (c is a leaf)", edges)
+	}
+	if got := edges[a]; len(got) != 1 || got[0] != b {
+		t.Errorf("Edges[a] = %+v, want [b] — direct only, NOT transitive [b c]", got)
+	}
+	if got := edges[b]; len(got) != 1 || got[0] != c {
+		t.Errorf("Edges[b] = %+v, want [c]", got)
+	}
+	if _, ok := edges[c]; ok {
+		t.Error("leaf c declares no deps; it must be omitted as a key")
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -300,8 +300,15 @@ type Result struct {
 	// HelmRelease that names dependencies maps to the sorted ids it depends on.
 	// Same-kind only (KS→KS, HR→HR per the Flux spec); implicit coupling
 	// (healthChecks, shared CRDs, service DNS) is not represented. Nodes with no
-	// declared dependencies are omitted. Consumers invert this into a dependents
+	// declared dependencies are omitted, and the map is nil (not empty) when
+	// nothing declares a dependsOn. Consumers invert this into a dependents
 	// adjacency list for impact / "blast radius" analysis.
+	//
+	// It is the declared graph verbatim: cycle members and self-edges (A → A) are
+	// retained, not pruned (cycles also surface as render Failures) — a consumer
+	// that walks it must tolerate them. It is also independent of the --skip-*
+	// render filters, so an id here may have no entry in Manifests when its kind
+	// was skipped.
 	DependsOn map[manifest.NamedResource][]manifest.NamedResource
 }
 


### PR DESCRIPTION
## What

Hardens the `Result.DependsOn` graph API shipped in #722, treating it as the public surface it is rather than an internal snapshot. **No production logic changes** — only tests, doc comments, and one explanatory code comment; `flate build` output is byte-identical.

This is the actionable output of a re-review of #722 against a "modern, clean, understandable, performant" bar. The implementation itself held up (correct, concurrency-safe, deterministic, allocation-minimal, mirrors the file's `Failures()/snapshotFailedLocked()` convention); what it lacked was contract pinning and documentation appropriate to a new public API.

## Changes

**Pin the load-bearing contract (test).** `Edges()` returns cycle members and self-edges *verbatim* — konflate's blast-radius walk tolerates cycles via a visited set *precisely because* the producer emits them. A refactor that silently filtered cycle/self edges would pass every existing test while corrupting that analysis. New `TestDependencyGraph_Edges_CyclesAndSelfEdges` asserts the passthrough; new `TestDependencyGraph_Edges_TransitiveChain` covers the `a→b→c` node-is-both-key-and-value shape and the direct-only (no transitive closure) guarantee. Hoisted the shared `ksNode` test helper.

**Document the contract on the exported surface.** The field doc and `Edges()` doc now state cycle/self-edge retention, nil-on-empty, and independence from the `--skip-*` render filters (so an id may be absent from `Manifests`).

**Explain the deliberate hand-rolled loop.** `snapshotEdgesLocked` pre-sizes its sort slice rather than reusing the file's `sortedNeighbors` helper — the helper's `slices.SortedFunc(maps.Keys(...))` drops the capacity hint and adds an iterator closure, so a naive "DRY" pass would regress allocations on the render path. A comment now records that so it isn't undone later.

## Why nil-on-empty (not a non-nil empty map)

Considered making `DependsOn` non-nil to match its three sibling `Result` maps, but kept nil-on-empty and documented it: it preserves the `Edges()`↔`Failures()` symmetry, nil maps are read-safe (konflate consumes read-only + inverts into a fresh map), and it avoids changing a released method's contract for cosmetic uniformity. The fix for the *surprise* is the doc, not the allocation.

## Test plan
- `gofmt` · `go build ./...` · `go vet ./pkg/orchestrator/` clean
- `go test ./pkg/orchestrator/` — all pass, including the 2 new contract tests
- `go test -race ./pkg/orchestrator/` clean
- `golangci-lint run ./pkg/orchestrator/...` — 0 issues
- No logic change → byte-equivalent render output

🤖 Generated with [Claude Code](https://claude.com/claude-code)