### PR TITLE
fix(diff): drop dyff's spurious file-level "order changed" on a rename

### DIFF
--- a/pkg/diff/dyff.go
+++ b/pkg/diff/dyff.go
@@ -3,6 +3,7 @@ package diff
 import (
 	"bytes"
 	"fmt"
+	"slices"
 
 	"github.com/gonvenience/ytbx"
 	"github.com/homeport/dyff/pkg/dyff"
@@ -17,6 +18,7 @@ func dyffReport(from, to ytbx.InputFile, style Format) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("dyff compare: %w", err)
 	}
+	report.Diffs = slices.DeleteFunc(report.Diffs, isFileLevelOrderChange)
 	if len(report.Diffs) == 0 {
 		return nil, nil
 	}
@@ -29,6 +31,33 @@ func dyffReport(from, to ytbx.InputFile, style Format) ([]byte, error) {
 		return nil, fmt.Errorf("dyff render: %w", err)
 	}
 	return buf.Bytes(), nil
+}
+
+// isFileLevelOrderChange reports whether d is dyff's document-SET "order
+// changed" note: a nil path (dyff renders it as "(file level)") whose details
+// are all ORDERCHANGE. A nil path uniquely marks that top-level
+// document-sequence diff — every document add/remove/change and every
+// in-resource diff carries a non-nil path.
+//
+// flate emits documents in a deterministic sorted order, so the document
+// sequence never reorders on its own. dyff raises this note only when an
+// add/remove/rename keeps the document COUNT equal but shifts identities in the
+// list: its order check excludes modified documents but NOT added/removed ones
+// (see homeport/dyff core.go), so a single rename — already reported as the
+// remove + add — explodes into a wall of "order changed" spanning every
+// untouched resource. Dropping it removes that noise. In-resource list reorders
+// (container/env order) carry a non-nil path and are kept — that K8s-aware
+// signal is exactly why dyff's order detection stays enabled.
+func isFileLevelOrderChange(d dyff.Diff) bool {
+	if d.Path != nil || len(d.Details) == 0 {
+		return false
+	}
+	for _, detail := range d.Details {
+		if detail.Kind != dyff.ORDERCHANGE {
+			return false
+		}
+	}
+	return true
 }
 
 // dyffWriter builds the dyff ReportWriter for a style. The diff-syntax

--- a/pkg/diff/native_test.go
+++ b/pkg/diff/native_test.go
@@ -142,3 +142,33 @@ func TestRenderDocs_ContainerByNameImageChange(t *testing.T) {
 		t.Errorf("expected image value change lines; got:\n%s", s)
 	}
 }
+
+// TestRenderDocs_RenameNoFileLevelOrderChange locks the changeset fix: renaming
+// ONE resource (a remove of the old identity + an add of the new) keeps the
+// document COUNT equal, which makes dyff raise a file-level "order changed" note
+// listing every document — dragging untouched neighbors into a localized diff.
+// flate emits documents in a deterministic sorted order, so that note is always
+// an artifact of the add/remove (already reported) and is filtered out. The
+// rename itself must still surface; the unchanged neighbors must not.
+func TestRenderDocs_RenameNoFileLevelOrderChange(t *testing.T) {
+	// Equal count on both sides (3 == 3) is what arms dyff's order check; the
+	// middle doc is renamed, the neighbors are byte-identical.
+	left := []Doc{ncm("aaa", "k", "v"), ncm("plex", "k", "v"), ncm("zzz", "k", "v")}
+	right := []Doc{ncm("aaa", "k", "v"), ncm("plex2", "k", "v"), ncm("zzz", "k", "v")}
+	for _, style := range []Format{FormatHuman, FormatGitHub} {
+		out, err := RenderDocs(left, right, Options{Format: style})
+		if err != nil {
+			t.Fatalf("%s: %v", style, err)
+		}
+		s := string(out)
+		if !strings.Contains(s, "plex2") {
+			t.Errorf("%s: the rename must surface (added plex2); got:\n%s", style, s)
+		}
+		if strings.Contains(s, "order changed") {
+			t.Errorf("%s: a localized rename must not emit a file-level 'order changed':\n%s", style, s)
+		}
+		if strings.Contains(s, "aaa") || strings.Contains(s, "zzz") {
+			t.Errorf("%s: untouched neighbors must not be dragged into the diff:\n%s", style, s)
+		}
+	}
+}


### PR DESCRIPTION
## Symptom

Renaming a rendered resource — e.g. editing a Kustomization's `postBuild.substitute` that feeds `${APP}` into resource names — produced a cluster-wide **`(file level) ⇆ order changed`** block listing every unrelated, unchanged resource. On `k8s-gitops`, changing `media/plex`'s `APP` substitute to `plex2` ballooned the diff to **1439 lines** with an **830-entry** order-changed wall, burying the actual 5 renamed resources.

A pure *value* change (e.g. bumping `VOLSYNC_CAPACITY`) was always clean — only renames triggered it.

## Root cause

In the human/dyff path, flate compares the two rendered doc streams via `dyff.CompareInputFiles` with order detection on (deliberately — it surfaces *in-resource* list reorders like container order). dyff's **document-set** order check (`core.go`) excludes only **modified** documents from the comparison, **not added/removed** ones. A rename is a remove (old name) + add (new name), so:

- the document **count** stays equal (`len(fromNames) == len(toNames)`), arming the check, and
- the name **sequence** diverges at the renamed position → dyff emits a file-level `ORDERCHANGE` spanning the *entire* stream,

even though the real change is already reported as the remove + add. A value change leaves the doc "modified" (excluded) → no trigger. That's exactly the observed value-vs-rename split.

flate emits documents in a deterministic sorted order, so the document **sequence** never reorders on its own — this note is *always* an artifact of an add/remove/rename.

## Fix

Filter the file-level (nil-path) `ORDERCHANGE` diff out of the dyff report in `dyffReport`, the shared chokepoint for every dyff text style (human/github/gitlab/gitea/brief). A `nil` path uniquely marks dyff's top-level document-sequence diff; document add/remove/change and every in-resource diff carry a non-nil path, so **in-resource list reorders (container/env order) are preserved** — that K8s-aware signal is why order detection stays enabled.

## Result

`flate diff all --base HEAD` on the `media/plex` `APP` rename: **1439 → 350 lines**, order-changed wall gone, leaving the correct **5 removed + 5 added**. No render-path change, so `flate build` output is unaffected (byte-identical).

## Test plan
- New `TestRenderDocs_RenameNoFileLevelOrderChange` (pkg/diff) — a 3-doc set with a renamed middle doc: asserts the rename surfaces but no file-level "order changed" and no untouched neighbor leaks in. Confirmed it **fails** before the fix, passes after; runs for both `human` and `github` styles.
- Existing `TestRenderDocs_ContainerReorder` (in-resource list reorder) still passes — the kept signal.
- `gofmt` · `go vet` · `go test ./pkg/diff/` · `go test -race ./pkg/diff/` · `golangci-lint run ./pkg/diff/...` (0 issues).
- End-to-end repro on k8s-gitops confirmed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)