### PR TITLE
feat(kustomize): name the paths that collide on a duplicate-resource-id build

### DIFF
--- a/pkg/kustomize/diagnose.go
+++ b/pkg/kustomize/diagnose.go
@@ -1,0 +1,94 @@
+package kustomize
+
+import (
+	"fmt"
+	"maps"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	fluxkustomize "github.com/fluxcd/pkg/kustomize"
+	kustypes "sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/yaml"
+)
+
+// dupDiagBuildLimit caps how many child paths the diagnostic rebuilds, so a
+// pathological aggregate can't turn one failed build into thousands. Only ever
+// reached on the failure path.
+const dupDiagBuildLimit = 256
+
+// duplicateProducers turns a krusty "already registered id" build failure into a
+// report naming every accumulated path that emits the colliding resource.
+//
+// An aggregate build — most often a Flux Kustomization whose spec.path has no
+// kustomization.yaml, so RenderFlux synthesizes one over the whole subtree —
+// merges every child into one build. kustomize then names only the colliding id
+// and the path it was re-added from, never the one that registered it first,
+// which makes a localized duplicate (a copy-paste namespace, a component pulled
+// in twice) hard to place.
+//
+// Each child builds cleanly on its own — the id only clashes once accumulated —
+// so rebuilding the directory entries one at a time and inverting
+// resource id → paths pinpoints every producer. It returns "" for any error
+// that isn't a duplicate id, or when the collision can't be attributed (it lives
+// within one entry, or against a leaf file), leaving the caller to surface the
+// raw error unchanged.
+//
+// kustomizationYAML is the merged kustomization RenderFlux already built for
+// subDir (absolute); subPath is the repo-relative spec.path, used to render
+// producer paths the reader can open.
+func duplicateProducers(buildErr error, memFS filesys.FileSystem, subDir, subPath string, kustomizationYAML []byte) string {
+	var kus kustypes.Kustomization
+	if !strings.Contains(buildErr.Error(), "already registered id") ||
+		yaml.Unmarshal(kustomizationYAML, &kus) != nil {
+		return ""
+	}
+
+	// Invert each child's resource ids into id → the paths that emit it.
+	pathsByID := map[string][]string{}
+	for _, entry := range kus.Resources {
+		dir := filepath.Join(subDir, entry)
+		if len(pathsByID) >= dupDiagBuildLimit || !memFS.IsDir(dir) {
+			continue
+		}
+		rel := "./" + path.Join(strings.TrimPrefix(subPath, "./"), entry)
+		for _, id := range buildIDs(memFS, dir) {
+			pathsByID[id] = append(pathsByID[id], rel)
+		}
+	}
+
+	// Keep only the ids two or more paths emit — the collisions the merged build
+	// rejects — then render them deterministically.
+	maps.DeleteFunc(pathsByID, func(_ string, paths []string) bool { return len(paths) < 2 })
+	if len(pathsByID) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("  duplicate resource(s) produced by multiple accumulated paths:")
+	for _, id := range slices.Sorted(maps.Keys(pathsByID)) {
+		fmt.Fprintf(&b, "\n    %s", id)
+		for _, p := range slices.Sorted(slices.Values(pathsByID[id])) {
+			fmt.Fprintf(&b, "\n      - %s", p)
+		}
+	}
+	return b.String()
+}
+
+// buildIDs builds one accumulation entry in isolation and returns the resource
+// ids it emits, or nil when the entry doesn't build on its own (it then can't be
+// a producer). BuildMutex guards krusty's process-global state — see flux.go.
+func buildIDs(memFS filesys.FileSystem, dir string) []string {
+	BuildMutex.Lock()
+	defer BuildMutex.Unlock()
+	rm, err := fluxkustomize.Build(memFS, dir)
+	if err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(rm.AllIds()))
+	for _, id := range rm.AllIds() {
+		ids = append(ids, id.String())
+	}
+	return ids
+}

--- a/pkg/kustomize/diagnose_test.go
+++ b/pkg/kustomize/diagnose_test.go
@@ -1,0 +1,116 @@
+package kustomize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+)
+
+// fluxKS is a minimal Flux Kustomization spec for driving RenderFlux against a
+// subPath; the auto-generate path keys off the directory, not these fields.
+func fluxKS() map[string]any {
+	return map[string]any{
+		"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+		"kind":       "Kustomization",
+		"metadata":   map[string]any{"name": "apps", "namespace": "flux-system"},
+		"spec":       map[string]any{"path": "./apps"},
+	}
+}
+
+// cmChild writes apps/<name>/{kustomization.yaml,cm.yaml} producing a ConfigMap
+// named cmName in namespace ns — so two children sharing (cmName, ns) clash only
+// once a parent accumulates them, mirroring the real cluster-apps case.
+func cmChild(t *testing.T, root, name, ns, cmName string) {
+	t.Helper()
+	dir := "apps/" + name
+	testutil.WriteFile(t, root, dir+"/kustomization.yaml", "namespace: "+ns+"\nresources:\n- cm.yaml\n")
+	testutil.WriteFile(t, root, dir+"/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: "+cmName+"}\ndata: {k: v}\n")
+}
+
+// TestRenderFlux_DuplicateID_NamesProducers is the repro: two children emit the
+// same id, the auto-generated parent accumulates both and fails, and the error
+// now names BOTH producing paths (sorted) instead of just the one kustomize hit.
+func TestRenderFlux_DuplicateID_NamesProducers(t *testing.T) {
+	root := t.TempDir()
+	cmChild(t, root, "a", "shared", "dup")
+	cmChild(t, root, "b", "shared", "dup")
+	// No apps/kustomization.yaml → RenderFlux synthesizes one over a + b.
+
+	_, err := RenderFlux(context.Background(), NewTreeCache(), root, false, "apps", fluxKS())
+	if err == nil {
+		t.Fatal("expected a duplicate-id build failure")
+	}
+	s := err.Error()
+	for _, want := range []string{
+		"already registered id",
+		"duplicate resource(s) produced by multiple accumulated paths",
+		"./apps/a",
+		"./apps/b",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("error missing %q:\n%s", want, s)
+		}
+	}
+	if strings.Index(s, "./apps/a") > strings.Index(s, "./apps/b") {
+		t.Errorf("producer paths must be sorted (a before b):\n%s", s)
+	}
+}
+
+// TestRenderFlux_DistinctIDs_NoDiagnostic confirms a healthy aggregate renders
+// without ever running the diagnostic.
+func TestRenderFlux_DistinctIDs_NoDiagnostic(t *testing.T) {
+	root := t.TempDir()
+	cmChild(t, root, "a", "shared", "a-cm")
+	cmChild(t, root, "b", "shared", "b-cm")
+
+	out, err := RenderFlux(context.Background(), NewTreeCache(), root, false, "apps", fluxKS())
+	if err != nil {
+		t.Fatalf("RenderFlux: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("empty render")
+	}
+}
+
+// TestRenderFlux_NonDuplicateError_Unannotated confirms a build failure that
+// isn't a duplicate id is surfaced verbatim — the diagnostic stays out of it.
+func TestRenderFlux_NonDuplicateError_Unannotated(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, "apps/a/kustomization.yaml", "resources:\n- missing.yaml\n")
+
+	_, err := RenderFlux(context.Background(), NewTreeCache(), root, false, "apps", fluxKS())
+	if err == nil {
+		t.Fatal("expected a build failure")
+	}
+	if strings.Contains(err.Error(), "duplicate resource(s) produced") {
+		t.Errorf("a non-duplicate error must not carry the diagnostic:\n%s", err)
+	}
+}
+
+// TestRenderFlux_DuplicateID_Unattributable_FallsBack confirms graceful
+// fallback: when the collision is between two leaf files of one kustomization
+// (no directory producer to attribute), the raw error stands unchanged.
+func TestRenderFlux_DuplicateID_Unattributable_FallsBack(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, "apps/kustomization.yaml",
+		"namespace: shared\nresources:\n- one.yaml\n- two.yaml\n")
+	testutil.WriteFile(t, root, "apps/one.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: dup}\ndata: {k: v}\n")
+	testutil.WriteFile(t, root, "apps/two.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: dup}\ndata: {k: v}\n")
+
+	_, err := RenderFlux(context.Background(), NewTreeCache(), root, false, "apps", fluxKS())
+	if err == nil {
+		t.Fatal("expected a duplicate-id build failure")
+	}
+	s := err.Error()
+	if !strings.Contains(s, "already registered id") {
+		t.Errorf("expected the raw duplicate-id error:\n%s", s)
+	}
+	if strings.Contains(s, "duplicate resource(s) produced") {
+		t.Errorf("a file-level dup is unattributable; diagnostic must stay silent:\n%s", s)
+	}
+}

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -137,7 +137,14 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 		return fluxkustomize.Build(memFS, subDir)
 	}()
 	if err != nil {
-		return nil, fmt.Errorf("kustomize build %s: %w", subPath, err)
+		built := fmt.Errorf("kustomize build %s: %w", subPath, err)
+		// On a duplicate-resource-id failure, name every accumulated path that
+		// emits the colliding resource so a localized duplicate is locatable
+		// (no-op for any other error — see duplicateProducers).
+		if attr := duplicateProducers(err, memFS, subDir, subPath, data); attr != "" {
+			return nil, fmt.Errorf("%w\n%s", built, attr)
+		}
+		return nil, built
 	}
 	// Owner labels first so user-supplied spec.commonMetadata wins on a key
 	// collision. Matches kustomize-controller's ordering: SetOwnerLabels runs at


### PR DESCRIPTION
## Symptom

Adding one misconfigured app made `flate build` (and everything downstream) fail with a wall of cascade errors. The root error — a kustomize duplicate-resource-id from the synthesized `cluster-apps` build — was *legitimate* (flux rejects it too), but it only named the colliding id and **one** of the two paths involved:

```
kustomize build ./kubernetes/apps: ... may not add resource with an already
registered id: Alert.v1beta3.notification.toolkit.fluxcd.io/alertmanager.volsync-system
```

So a localized copy-paste (a `kustomization.yaml` with the wrong `namespace:`, pulling in `../../components/alerts` a second time) read as a cryptic, hard-to-place failure. flate is a pre-merge dev tool — it should point at the actual cause.

## What

When a Flux Kustomization's `spec.path` has no `kustomization.yaml`, flate (like kustomize-controller) synthesizes one accumulating the whole subtree into a single build. On the **duplicate-id** failure of that build, flate now rebuilds each immediate accumulation entry on its own (each builds cleanly — the id only clashes once merged), inverts `resource id → producing paths`, and appends the paths that emit each colliding id:

```
  duplicate resource(s) produced by multiple accumulated paths:
    ConfigMap.v1.[noGrp]/alertmanager.volsync-system
      - ./kubernetes/apps/kopiur-system
      - ./kubernetes/apps/volsync-system
```

- **Failure-path only.** The diagnostic gates on the krusty `already registered id` error and runs nothing otherwise — zero cost on a successful render. Rebuilds are bounded (`dupDiagBuildLimit`) so a pathological aggregate can't blow up.
- **Graceful fallback.** Returns nothing — leaving the raw error untouched — when the collision can't be attributed (a dup within one entry, or against a leaf file). Never worse than before.
- **Scope (as requested):** only the producer attribution. No change to the cascade/orphan reporting or warning scope.

## How

`pkg/kustomize/diagnose.go` — `duplicateProducers` parses the merged kustomization, rebuilds each directory `resources:` entry via the same `fluxkustomize.Build` under `BuildMutex`, and reports ids emitted by ≥2 paths (sorted, deterministic). Hooked into `RenderFlux`'s build-error path in `flux.go` as a single clean call. ids use `resid.ResId.String()`, which matches the krusty error verbatim.

## Test plan
- `pkg/kustomize/diagnose_test.go`: the repro (two children → both producers named, sorted); healthy aggregate (diagnostic never runs); non-duplicate build error (surfaced verbatim); unattributable file-level dup (falls back to the raw error).
- `gofmt` · `go build ./...` · `go vet` · `go test ./pkg/kustomize/` · `go test -race ./pkg/kustomize/` · `golangci-lint run ./pkg/kustomize/...` (0 issues).
- **Byte-equivalence:** `flate build all` on `/Users/buroa/k8s-gitops` is byte-identical to `main` (change is strictly inside the build-failure branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)