### PR TITLE
feat(cli): root-cause failure report — collapse cascades, defer log noise

### DIFF
--- a/internal/cli/build.go
+++ b/internal/cli/build.go
@@ -106,7 +106,7 @@ func buildCmd(use string, aliases []string, short string, args cobra.PositionalA
 			// emitResult surfaces both an emit-time IO failure AND the
 			// partial-failure list — previously the emit error masked
 			// the run failures, so CI fixed the wrong thing.
-			return emitResult(emitErr, o, res, c, runErr)
+			return reportFailures(cmd.ErrOrStderr(), o, res, c, emitResult(emitErr, o, res, c, runErr), 0)
 		},
 	}
 	bindCommon(cmd.Flags(), c, format.OutputYAML, format.OutputJSON)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -461,8 +461,14 @@ func TestRun_TestAll_JoinsVisibleFailuresWithRunError(t *testing.T) {
 	if !strings.Contains(stdout, "✗") {
 		t.Errorf("stdout should still include failed test row:\n%s", stdout)
 	}
-	if !strings.Contains(stderr, "reconcile completed") {
-		t.Errorf("stderr should preserve scoped run error, got %q", stderr)
+	// The scoped failure surfaces in the styled root-cause report on stderr —
+	// the failing resource named with its real (primary) error, plus a verdict —
+	// not the old flat "reconcile completed with …" aggregate.
+	if !strings.Contains(stderr, "apps") || !strings.Contains(stderr, "kustomize build") {
+		t.Errorf("stderr should surface the failing resource and its error, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "failed") {
+		t.Errorf("stderr should include the failure verdict, got %q", stderr)
 	}
 }
 

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"runtime"
@@ -16,6 +17,8 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/home-operations/flate/internal/format"
+	"github.com/home-operations/flate/internal/report"
+	"github.com/home-operations/flate/internal/style"
 	"github.com/home-operations/flate/pkg/baseline"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/discovery"
@@ -622,6 +625,58 @@ func scopedRunError(o *orchestrator.Orchestrator, res *orchestrator.Result, c *c
 // error (and both nil to nil) via errors.Join's nil handling.
 func emitResult(emitErr error, o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags, runErr error) error {
 	return errors.Join(emitErr, scopedRunError(o, res, c, runErr))
+}
+
+// logBuffer is the process-wide deferred-log sink installed by setLogLevel; the
+// noisy Warn/Info chatter a failing run emits is held here and rendered in the
+// report footer instead of interleaving with output. nil only in tests that
+// bypass root setup.
+var logBuffer *deferSink
+
+// drainLogNotes returns and clears the buffered log lines (nil when unset).
+func drainLogNotes() []report.Note {
+	if logBuffer == nil {
+		return nil
+	}
+	return logBuffer.drain()
+}
+
+// reportedError marks an error whose human-facing report has already been
+// rendered to stderr, so run's top-level printer skips the plain reprint.
+type reportedError struct{ err error }
+
+func (e reportedError) Error() string { return e.err.Error() }
+func (e reportedError) Unwrap() error { return e.err }
+
+// reportFailures renders the styled root-cause report — real errors shown once,
+// cascaded failures folded under the root that caused them, and any deferred log
+// lines in a footer — to w, scoped to c's namespace filter. It always drains the
+// log buffer (so notes aren't lost even on a clean run). When something rendered
+// and err is non-nil, err is wrapped as reportedError so the caller still exits
+// non-zero while run avoids printing it twice; otherwise err passes through.
+func reportFailures(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags, err error, elapsed time.Duration) error {
+	notes := drainLogNotes()
+	failed := map[manifest.NamedResource]store.StatusInfo{}
+	blocked := map[manifest.NamedResource][]manifest.NamedResource{}
+	if o != nil && res != nil {
+		for id, info := range res.Failed {
+			if c == nil || c.includeNamespace(o.Filter(), id.Namespace) {
+				failed[id] = info
+				if b := res.Blocked[id]; len(b) > 0 {
+					blocked[id] = b
+				}
+			}
+		}
+	}
+	m := report.Build(failed, blocked, notes)
+	if m.Empty() {
+		return err
+	}
+	_ = m.Write(w, style.ColorEnabled(w), elapsed)
+	if err == nil {
+		return nil
+	}
+	return reportedError{err}
 }
 
 // resourceAggregatePrefix is the leading text of the error

--- a/internal/cli/defersink.go
+++ b/internal/cli/defersink.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"github.com/home-operations/flate/internal/report"
+	"github.com/home-operations/flate/internal/style"
+)
+
+// deferSink is a slog.Handler that holds back the chatter a failing run emits —
+// the scattered Warn/Info lines (chiefly "resource orphaned") that otherwise
+// interleave with, and bury, the final report — and hands them to the command
+// to render in a quiet footer instead. Error records (panics) always pass
+// through inline so a crash stays loud.
+//
+// One shared buffer backs every handler slog derives via WithAttrs/WithGroup, so
+// attribute-scoped loggers buffer into the same place. drain() returns the
+// collected notes (identical lines collapsed with a count) and stops buffering,
+// so anything logged afterwards passes straight through.
+type deferSink struct {
+	inner slog.Handler
+	buf   *noteBuffer
+}
+
+type noteBuffer struct {
+	mu     sync.Mutex
+	on     bool
+	order  []string
+	counts map[string]int
+}
+
+func newDeferSink(inner slog.Handler) *deferSink {
+	return &deferSink{inner: inner, buf: &noteBuffer{on: true, counts: map[string]int{}}}
+}
+
+func (d *deferSink) Enabled(ctx context.Context, l slog.Level) bool { return d.inner.Enabled(ctx, l) }
+
+func (d *deferSink) Handle(ctx context.Context, r slog.Record) error {
+	d.buf.mu.Lock()
+	buffering := d.buf.on
+	d.buf.mu.Unlock()
+	if !buffering || r.Level >= slog.LevelError {
+		return d.inner.Handle(ctx, r)
+	}
+	text := formatRecord(r)
+	d.buf.mu.Lock()
+	if _, seen := d.buf.counts[text]; !seen {
+		d.buf.order = append(d.buf.order, text)
+	}
+	d.buf.counts[text]++
+	d.buf.mu.Unlock()
+	return nil
+}
+
+func (d *deferSink) WithAttrs(as []slog.Attr) slog.Handler {
+	return &deferSink{inner: d.inner.WithAttrs(as), buf: d.buf}
+}
+
+func (d *deferSink) WithGroup(name string) slog.Handler {
+	return &deferSink{inner: d.inner.WithGroup(name), buf: d.buf}
+}
+
+// drain stops buffering and returns the collected notes in first-seen order.
+// Idempotent: a second call returns nothing.
+func (d *deferSink) drain() []report.Note {
+	d.buf.mu.Lock()
+	defer d.buf.mu.Unlock()
+	d.buf.on = false
+	notes := make([]report.Note, 0, len(d.buf.order))
+	for _, text := range d.buf.order {
+		notes = append(notes, report.Note{Text: text, Count: d.buf.counts[text]})
+	}
+	d.buf.order, d.buf.counts = nil, map[string]int{}
+	return notes
+}
+
+// formatRecord renders a buffered record as a single compact line: the message
+// followed by its attributes, each value truncated so a multi-line reason (e.g.
+// an orphan's cascaded dependency chain) can't reintroduce the wall of text the
+// footer exists to avoid.
+func formatRecord(r slog.Record) string {
+	var b strings.Builder
+	b.WriteString(r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Fprintf(&b, " %s=%s", a.Key, style.Truncate(oneLineValue(a.Value.String()), 80))
+		return true
+	})
+	return b.String()
+}
+
+func oneLineValue(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i]) + " …"
+	}
+	return s
+}

--- a/internal/cli/defersink_test.go
+++ b/internal/cli/defersink_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+)
+
+type captureHandler struct{ msgs *[]string }
+
+func (h captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h captureHandler) Handle(_ context.Context, r slog.Record) error {
+	*h.msgs = append(*h.msgs, r.Message)
+	return nil
+}
+func (h captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// TestDeferSink_BuffersWarnPassesError pins the footer mechanism: Warn/Info are
+// held back (and identical lines collapse with a count) while Error passes
+// through inline; after drain, buffering is off so later logs flow normally.
+func TestDeferSink_BuffersWarnPassesError(t *testing.T) {
+	var inline []string
+	sink := newDeferSink(captureHandler{&inline})
+	log := slog.New(sink)
+
+	log.Warn("resource orphaned", "id", "a")
+	log.Warn("resource orphaned", "id", "a") // identical → collapses
+	log.Info("note")
+	log.Error("boom") // inline
+
+	if len(inline) != 1 || inline[0] != "boom" {
+		t.Fatalf("only Error should pass through inline, got %v", inline)
+	}
+
+	notes := sink.drain()
+	if len(notes) != 2 {
+		t.Fatalf("drain = %+v, want 2 distinct notes", notes)
+	}
+	if notes[0].Count != 2 {
+		t.Errorf("identical warns should collapse with a count: %+v", notes[0])
+	}
+
+	log.Warn("after-drain")
+	if len(inline) != 2 || inline[1] != "after-drain" {
+		t.Errorf("post-drain logs should pass through inline, got %v", inline)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,6 +14,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -103,8 +104,25 @@ func run(version string, args []string, stdout, stderr io.Writer) int {
 	root.SetArgs(args)
 	root.SetOut(stdout)
 	root.SetErr(stderr)
-	if err := root.ExecuteContext(ctx); err != nil {
-		_, _ = io.WriteString(stderr, "flate error: "+err.Error()+"\n")
+	err := root.ExecuteContext(ctx)
+	// Flush any deferred log notes a command didn't already render (diff/get/
+	// cache, or a clean run) so nothing buffered is lost.
+	if logBuffer != nil {
+		for _, n := range logBuffer.drain() {
+			line := n.Text
+			if n.Count > 1 {
+				line = fmt.Sprintf("%s (×%d)", line, n.Count)
+			}
+			_, _ = io.WriteString(stderr, line+"\n")
+		}
+	}
+	if err != nil {
+		// reportFailures already rendered a styled report for this error; don't
+		// reprint it as a flat "flate error: …" line.
+		var reported reportedError
+		if !errors.As(err, &reported) {
+			_, _ = io.WriteString(stderr, "flate error: "+err.Error()+"\n")
+		}
 		return 1
 	}
 	return 0
@@ -129,6 +147,12 @@ func setLogLevel(lvl string, w io.Writer) error {
 	default:
 		return fmt.Errorf("invalid --log-level %q: must be one of debug, info, warn, error", lvl)
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(w, &slog.HandlerOptions{Level: l})))
+	// Wrap the text handler in a deferring sink so the Warn/Info chatter a
+	// failing run emits (chiefly "resource orphaned") is held back and rendered
+	// in the report footer instead of interleaving with output; Error records
+	// still pass straight through. Commands drain it via reportFailures; run
+	// flushes anything left so no note is lost.
+	logBuffer = newDeferSink(slog.NewTextHandler(w, &slog.HandlerOptions{Level: l}))
+	slog.SetDefault(slog.New(logBuffer))
 	return nil
 }

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -85,10 +85,13 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 			if err := report.Write(cmd.OutOrStdout(), color, elapsed); err != nil {
 				return errors.Join(err, runErr)
 			}
+			final := runErr
 			if report.AnyFailed() {
-				return errors.Join(errors.New("test failures detected"), runErr)
+				final = errors.Join(errors.New("test failures detected"), runErr)
 			}
-			return runErr
+			// Root-cause report (+ deferred-log footer) to stderr, replacing the
+			// flat aggregate; the per-resource table above stays on stdout.
+			return reportFailures(cmd.ErrOrStderr(), o, res, c, final, elapsed)
 		},
 	}
 	bindCommon(cmd.Flags(), c)

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -1,0 +1,225 @@
+// Package report turns a reconcile's failures into a compact, styled end-of-run
+// summary: the real (primary) errors shown once, every cascaded failure folded
+// under the root that caused it, and any deferred log lines in a quiet footer.
+// It exists so a single missing or failed dependency reads as one root cause
+// with a list of what it blocked — not a wall of nested, repeated
+// "dependencies failed: A: dependencies failed: B: …" chains.
+//
+// The model is built from orchestrator data (Result.Failed + Result.Blocked) and
+// is pure/deterministic; rendering is gated on a color bool so it is plain and
+// testable off a TTY. Styling reuses internal/style, the vocabulary the live
+// status bar and `flate test` report already speak.
+package report
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/home-operations/flate/internal/style"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// blockedSample bounds how many blocked/requiring ids are named inline per root
+// before collapsing the rest to "+N more", so a root that blocks a whole cluster
+// stays one readable line.
+const blockedSample = 6
+
+// Primary is a resource that failed on its own — a real render/template/build
+// error. Blocks lists the resources whose failure cascaded from it (sorted).
+type Primary struct {
+	ID     manifest.NamedResource
+	Msg    string
+	Blocks []manifest.NamedResource
+}
+
+// Missing is a dependency that never rendered (absent from the store) yet was
+// required by one or more resources — the other kind of root cause. RequiredBy
+// lists the resources blocked on it (sorted).
+type Missing struct {
+	ID         manifest.NamedResource
+	RequiredBy []manifest.NamedResource
+}
+
+// Note is one deferred log line for the footer, collapsed by identical text with
+// a repeat count.
+type Note struct {
+	Text  string
+	Count int
+}
+
+// Model is the partitioned, deterministic view the renderer consumes.
+type Model struct {
+	Primary []Primary
+	Missing []Missing
+	Notes   []Note
+}
+
+// Empty reports whether there is nothing to render.
+func (m Model) Empty() bool {
+	return len(m.Primary) == 0 && len(m.Missing) == 0 && len(m.Notes) == 0
+}
+
+// Build partitions failures into primary errors and root-grouped cascades.
+// failed is Result.Failed (sentinel-trimmed messages); blocked is Result.Blocked
+// (a failed id → the immediate deps that blocked it, empty for primaries); notes
+// are the deferred log lines for the footer.
+//
+// A blocked resource is folded into the root(s) it traces to: walking its
+// blockers until reaching a primary failure (a failed id that is not itself
+// blocked) or a missing id (absent from failed). Cascaded resources never get
+// their own line — they appear only in a root's Blocks / RequiredBy list.
+func Build(failed map[manifest.NamedResource]store.StatusInfo, blocked map[manifest.NamedResource][]manifest.NamedResource, notes []Note) Model {
+	// root id → resources that trace to it.
+	byRoot := map[manifest.NamedResource][]manifest.NamedResource{}
+	for id := range blocked {
+		for _, r := range rootsOf(id, blocked) {
+			byRoot[r] = append(byRoot[r], id)
+		}
+	}
+
+	var primary []Primary
+	var missing []Missing
+	for id, info := range failed {
+		if _, derived := blocked[id]; derived {
+			continue // cascaded — surfaced under its root, not on its own
+		}
+		primary = append(primary, Primary{ID: id, Msg: info.Message, Blocks: sortedIDs(byRoot[id])})
+	}
+	for root, reqs := range byRoot {
+		if _, isFailed := failed[root]; isFailed {
+			continue // root is a primary failure, already listed above
+		}
+		missing = append(missing, Missing{ID: root, RequiredBy: sortedIDs(reqs)})
+	}
+
+	slices.SortFunc(primary, func(a, b Primary) int { return a.ID.Compare(b.ID) })
+	slices.SortFunc(missing, func(a, b Missing) int { return a.ID.Compare(b.ID) })
+	return Model{Primary: primary, Missing: missing, Notes: notes}
+}
+
+// rootsOf resolves the root cause(s) of a blocked id by walking its blockers to
+// a primary failure or a missing id. Cycle-safe via a visited set.
+func rootsOf(id manifest.NamedResource, blocked map[manifest.NamedResource][]manifest.NamedResource) []manifest.NamedResource {
+	var out []manifest.NamedResource
+	seen := map[manifest.NamedResource]bool{id: true}
+	var walk func(manifest.NamedResource)
+	walk = func(n manifest.NamedResource) {
+		for _, dep := range blocked[n] {
+			if seen[dep] {
+				continue
+			}
+			seen[dep] = true
+			if _, derived := blocked[dep]; derived {
+				walk(dep) // dep is itself cascaded — keep climbing
+			} else {
+				out = append(out, dep) // primary failure or missing id — a root
+			}
+		}
+	}
+	walk(id)
+	return out
+}
+
+func sortedIDs(ids []manifest.NamedResource) []manifest.NamedResource {
+	out := slices.Clone(ids)
+	slices.SortFunc(out, manifest.NamedResource.Compare)
+	return slices.CompactFunc(out, func(a, b manifest.NamedResource) bool { return a.Compare(b) == 0 })
+}
+
+// Write renders the model to w. color gates ANSI styling; elapsed, when > 0,
+// closes the verdict line.
+func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
+	var b strings.Builder
+	b.WriteByte('\n')
+
+	for _, p := range m.Primary {
+		fmt.Fprintf(&b, "  %s  %s  %s",
+			style.Fail(style.GlyphFail, color),
+			style.Dim(p.ID.Kind, color),
+			p.ID.NamespacedName())
+		if msg := oneLine(p.Msg); msg != "" {
+			fmt.Fprintf(&b, "  %s", msg)
+		}
+		if len(p.Blocks) > 0 {
+			fmt.Fprintf(&b, "\n      %s", style.Dim("blocks "+summarize(p.Blocks), color))
+		}
+		b.WriteByte('\n')
+	}
+
+	for _, mr := range m.Missing {
+		fmt.Fprintf(&b, "  %s  %s  %s  %s\n      %s\n",
+			style.Fail(style.GlyphFail, color),
+			style.Dim(mr.ID.Kind, color),
+			mr.ID.NamespacedName(),
+			style.Fail("not found", color),
+			style.Dim("required by "+summarize(mr.RequiredBy), color))
+	}
+
+	if len(m.Notes) > 0 {
+		fmt.Fprintf(&b, "\n  %s\n", style.Dim(fmt.Sprintf("notes (%d)", noteTotal(m.Notes)), color))
+		for _, n := range m.Notes {
+			line := n.Text
+			if n.Count > 1 {
+				line = fmt.Sprintf("%s (×%d)", line, n.Count)
+			}
+			fmt.Fprintf(&b, "    %s\n", style.Dim(line, color))
+		}
+	}
+
+	// Verdict: failed = primary + missing roots; blocked = cascaded resources.
+	blockedCount := 0
+	for _, p := range m.Primary {
+		blockedCount += len(p.Blocks)
+	}
+	for _, mr := range m.Missing {
+		blockedCount += len(mr.RequiredBy)
+	}
+	failedCount := len(m.Primary) + len(m.Missing)
+	b.WriteString("\n  " + style.Fail(style.GlyphFail, color) + " " +
+		style.Fail(fmt.Sprintf("%d failed", failedCount), color))
+	if blockedCount > 0 {
+		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d blocked", blockedCount), color))
+	}
+	if elapsed > 0 {
+		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
+	}
+	b.WriteByte('\n')
+
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// summarize renders an id list as "a, b, c +N more", capped at blockedSample.
+func summarize(ids []manifest.NamedResource) string {
+	names := make([]string, 0, len(ids))
+	for _, id := range ids {
+		names = append(names, id.NamespacedName())
+	}
+	if len(names) <= blockedSample {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s +%d more", strings.Join(names[:blockedSample], ", "), len(names)-blockedSample)
+}
+
+// oneLine collapses a multi-line message to a single line so a primary failure
+// stays one row; helm/kustomize errors are often multi-line.
+func oneLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		return strings.TrimSpace(s[:i]) + " …"
+	}
+	return s
+}
+
+func noteTotal(notes []Note) int {
+	n := 0
+	for _, note := range notes {
+		n += cmp.Or(note.Count, 1)
+	}
+	return n
+}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -1,0 +1,103 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+func ks(name string) manifest.NamedResource {
+	return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+}
+
+func failed(ids ...manifest.NamedResource) map[manifest.NamedResource]store.StatusInfo {
+	m := map[manifest.NamedResource]store.StatusInfo{}
+	for _, id := range ids {
+		m[id] = store.StatusInfo{Status: store.StatusFailed, Message: id.Name + " boom"}
+	}
+	return m
+}
+
+// TestBuild_GroupsCascadeUnderRoots pins the core collapse: a real (primary)
+// failure and a missing dependency each surface once, with the resources that
+// cascaded from them folded into Blocks / RequiredBy — never on their own.
+func TestBuild_GroupsCascadeUnderRoots(t *testing.T) {
+	root, mid, leaf := ks("root"), ks("mid"), ks("leaf") // leaf → mid → root (primary)
+	missing := ks("missing")
+	dependent := ks("dependent") // dependent → missing (not found)
+
+	f := failed(root, mid, leaf, dependent) // missing is absent from the store
+	blocked := map[manifest.NamedResource][]manifest.NamedResource{
+		mid:       {root},
+		leaf:      {mid},
+		dependent: {missing},
+	}
+
+	m := Build(f, blocked, nil)
+
+	if len(m.Primary) != 1 || m.Primary[0].ID != root {
+		t.Fatalf("Primary = %+v, want only root", m.Primary)
+	}
+	// root's cascade is mid and leaf (transitively), folded under it and sorted.
+	if got := m.Primary[0].Blocks; len(got) != 2 || got[0] != leaf || got[1] != mid {
+		t.Errorf("root.Blocks = %+v, want sorted [leaf mid]", got)
+	}
+	if len(m.Missing) != 1 || m.Missing[0].ID != missing {
+		t.Fatalf("Missing = %+v, want only 'missing'", m.Missing)
+	}
+	if got := m.Missing[0].RequiredBy; len(got) != 1 || got[0] != dependent {
+		t.Errorf("missing.RequiredBy = %+v, want [dependent]", got)
+	}
+
+	var b bytes.Buffer
+	if err := m.Write(&b, false, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, want := range []string{"root", "blocks", "missing", "not found", "required by", "2 failed", "3 blocked"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered report missing %q:\n%s", want, out)
+		}
+	}
+	// Cascaded resources never get their own failure line.
+	for line := range strings.SplitSeq(out, "\n") {
+		if strings.Contains(line, "✗") && (strings.Contains(line, "leaf") || strings.Contains(line, "dependent")) {
+			t.Errorf("cascaded resource must not get its own failure line: %q", line)
+		}
+	}
+}
+
+// TestBuild_PrimaryOnly covers a lone real failure with nothing depending on it.
+func TestBuild_PrimaryOnly(t *testing.T) {
+	a := ks("a")
+	m := Build(failed(a), nil, nil)
+	if len(m.Primary) != 1 || len(m.Missing) != 0 || len(m.Primary[0].Blocks) != 0 {
+		t.Fatalf("want one primary with no blocks, got %+v", m)
+	}
+	if m.Empty() {
+		t.Error("a model with a failure is not empty")
+	}
+}
+
+// TestBuild_NotesOnly covers a clean run that only carries deferred log notes.
+func TestBuild_NotesOnly(t *testing.T) {
+	m := Build(nil, nil, []Note{{Text: "resource orphaned id=x", Count: 3}})
+	if len(m.Primary) != 0 || len(m.Missing) != 0 || m.Empty() {
+		t.Fatalf("notes-only model should be non-empty with no failures: %+v", m)
+	}
+	var b bytes.Buffer
+	_ = m.Write(&b, false, 0)
+	if out := b.String(); !strings.Contains(out, "notes (3)") || !strings.Contains(out, "×3") {
+		t.Errorf("notes footer missing or not collapsed:\n%s", out)
+	}
+}
+
+// TestBuild_Empty covers a clean run with nothing to show.
+func TestBuild_Empty(t *testing.T) {
+	if !Build(nil, nil, nil).Empty() {
+		t.Error("a clean run must produce an empty model")
+	}
+}

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -624,6 +624,16 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 				store.SkippedPrefix+" "+manifest.TrimSentinelPrefix(err.Error()))
 			return nil
 		}
+		// A DependencyFailedError means the body never ran — the Require gate
+		// failed because a dependency failed or was missing. Record the
+		// structured blockers so the failure report can group this derived
+		// failure under its root cause instead of reprinting the nested chain.
+		// Any other error is a primary failure (its own render/template/build)
+		// and leaves the blocked set empty.
+		var depErr *manifest.DependencyFailedError
+		if errors.As(err, &depErr) {
+			s.SetBlocked(id, depErr.Failed)
+		}
 		s.UpdateStatus(id, store.StatusFailed, err.Error())
 		return nil
 	}

--- a/pkg/kustomize/generate.go
+++ b/pkg/kustomize/generate.go
@@ -323,12 +323,42 @@ func scanManifests(fsys filesys.FileSystem, base string, ignore *sourceignore.Ma
 			}
 		}()
 		if _, err := rf.SliceFromBytes(contents); err != nil {
+			// A kustomize Kustomization/Component config decodes as a resource
+			// without metadata.name and fails cryptically. The usual cause is a
+			// misnamed kustomization file (e.g. "kustomzation.yaml"), which the
+			// scan then treats as a resource — say so plainly instead.
+			if kind := kustomizeConfigKind(contents); kind != "" {
+				return fmt.Errorf("%s: looks like a misnamed kustomization file (kind %s); rename it to %s or remove it",
+					path, kind, konfig.DefaultKustomizationFileName())
+			}
 			return fmt.Errorf("failed to decode Kubernetes YAML from %s: %w", path, err)
 		}
 		paths = append(paths, path)
 		return nil
 	})
 	return paths, err
+}
+
+// kustomizeConfigKind reports the kustomize config kind (Kustomization or
+// Component) when b is a kustomize.config.k8s.io document, else "". The resource
+// scan uses it to recognize a misnamed kustomization file — which would
+// otherwise fail to decode as a Kubernetes object on the missing metadata.name —
+// and report it clearly.
+func kustomizeConfigKind(b []byte) string {
+	var head struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+	}
+	if err := yaml.Unmarshal(b, &head); err != nil {
+		return ""
+	}
+	if !strings.HasPrefix(head.APIVersion, "kustomize.config.k8s.io/") {
+		return ""
+	}
+	if head.Kind == "Kustomization" || head.Kind == "Component" {
+		return head.Kind
+	}
+	return ""
 }
 
 // decodeTypedSlice reads a nested []any field and converts each element into T

--- a/pkg/kustomize/misnamed_test.go
+++ b/pkg/kustomize/misnamed_test.go
@@ -1,0 +1,33 @@
+package kustomize
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+)
+
+// TestRenderFlux_MisnamedKustomization confirms a misspelled kustomization file
+// (a kustomize config the auto-generate scan would otherwise try to decode as a
+// resource and fail on "missing metadata.name") yields an actionable error
+// naming the file and the rename, instead of the cryptic decode error.
+func TestRenderFlux_MisnamedKustomization(t *testing.T) {
+	root := t.TempDir()
+	testutil.WriteFile(t, root, "app/kustomzation.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n- cm.yaml\n")
+	testutil.WriteFile(t, root, "app/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata: {name: x}\ndata: {k: v}\n")
+
+	_, err := RenderFlux(context.Background(), NewTreeCache(), root, false, "app", fluxKS())
+	if err == nil {
+		t.Fatal("expected an error for the misnamed kustomization file")
+	}
+	s := err.Error()
+	if !strings.Contains(s, "misnamed kustomization") || !strings.Contains(s, "kustomzation.yaml") {
+		t.Errorf("want an actionable misnamed-kustomization hint naming the file, got: %v", err)
+	}
+	if !strings.Contains(s, "kustomization.yaml") {
+		t.Errorf("error should point at the correct filename: %v", err)
+	}
+}

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -120,6 +120,7 @@ func (o *Orchestrator) cascadeParentFailures(failed map[manifest.NamedResource]s
 		}
 		msg := fmt.Sprintf("parent %s failed: %s", parent.String(), parentInfo.Message)
 		o.store.UpdateStatus(child, store.StatusFailed, msg)
+		o.store.SetBlocked(child, []manifest.NamedResource{parent})
 		failed[child] = store.StatusInfo{Status: store.StatusFailed, Message: msg}
 		slog.Debug("cascaded parent failure to child",
 			"child", child.String(),

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -310,6 +310,13 @@ type Result struct {
 	// render filters, so an id here may have no entry in Manifests when its kind
 	// was skipped.
 	DependsOn map[manifest.NamedResource][]manifest.NamedResource
+	// Blocked maps a failed resource to the immediate dependencies that blocked
+	// it — present only for failures that are purely derived (the resource's own
+	// reconcile never ran because a dependency failed or was missing), absent for
+	// primary failures (a real render/template/build error). A consumer groups
+	// derived failures under their root cause by walking these edges to a primary
+	// failure or a missing id, instead of surfacing every cascaded failure.
+	Blocked map[manifest.NamedResource][]manifest.NamedResource
 }
 
 // New constructs an Orchestrator. It allocates the Store and TaskService

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -199,6 +199,7 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 		// The dependsOn graph is fully populated by now (Bootstrap's rebuild +
 		// per-id ReplaceEdges during Run); snapshot it for blast-radius consumers.
 		DependsOn: o.depGraph.Edges(),
+		Blocked:   map[manifest.NamedResource][]manifest.NamedResource{},
 	}
 	// Apply --skip-secrets / --skip-crds / --skip-kinds uniformly here
 	// so embedders calling Render see consistent Result.Manifests
@@ -239,6 +240,13 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 	// changes.
 	maps.Copy(res.Failed, sanitizeFailed(o.store.FailedResources()))
 	maps.Copy(res.Orphans, o.orphans)
+	// Tag the derived (dependency-blocked) failures so a consumer can collapse
+	// the cascade under its root cause. A failure with no blockers is primary.
+	for id := range res.Failed {
+		if b := o.store.BlockedBy(id); len(b) > 0 {
+			res.Blocked[id] = b
+		}
+	}
 	return res, runErr
 }
 

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -319,3 +319,24 @@ func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 	}
 	return out
 }
+
+// SetBlocked records that id failed only because the given dependencies failed
+// or were missing — the structured form of a DependencyFailedError, captured at
+// the failure sink. The failure report uses it to group derived failures under
+// their root cause instead of reprinting nested "dependencies failed: …" chains.
+// A defensive copy is stored so the caller's slice can't mutate store state.
+func (s *Store) SetBlocked(id manifest.NamedResource, deps []manifest.NamedResource) {
+	sh := s.shardFor(id)
+	sh.mu.Lock()
+	sh.blocked[id] = append([]manifest.NamedResource(nil), deps...)
+	sh.mu.Unlock()
+}
+
+// BlockedBy returns the immediate dependencies that blocked id (set via
+// SetBlocked), or nil when id failed on its own — i.e. a primary failure.
+func (s *Store) BlockedBy(id manifest.NamedResource) []manifest.NamedResource {
+	sh := s.shardFor(id)
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	return append([]manifest.NamedResource(nil), sh.blocked[id]...)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -46,6 +46,12 @@ type shard struct {
 	objects    map[manifest.NamedResource]manifest.BaseManifest
 	conditions map[manifest.NamedResource][]Condition
 	artifacts  map[manifest.NamedResource]Artifact
+	// blocked records, for a resource that failed only because a dependency
+	// failed or was missing, the immediate dependency ids responsible — the
+	// structured form of a DependencyFailedError, captured at the failure sink
+	// so the failure report can group derived failures under their root cause
+	// instead of reprinting nested "dependencies failed: …" chains.
+	blocked map[manifest.NamedResource][]manifest.NamedResource
 
 	// byName mirrors the per-shard slice of the Store-wide secondary
 	// index. Keyed by Kind first so a single GetByName lookup is two
@@ -59,6 +65,7 @@ func newShard() *shard {
 		objects:    make(map[manifest.NamedResource]manifest.BaseManifest),
 		conditions: make(map[manifest.NamedResource][]Condition),
 		artifacts:  make(map[manifest.NamedResource]Artifact),
+		blocked:    make(map[manifest.NamedResource][]manifest.NamedResource),
 		byName:     make(map[string]map[string]manifest.BaseManifest),
 	}
 }


### PR DESCRIPTION
## Problem

A repo with a few mistakes made `flate test`/`build` *bomb out with a ton of errors*: one missing/failed dependency exploded into a wall of nested, repeated `dependencies failed: A: dependencies failed: B: … dependency not found` lines; 21 scattered `slog.Warn` sites (chiefly `"resource orphaned"`) flooded the stream interleaved with the report; and the final output was an unstyled flat `reconcile completed with N failure(s): …` string. Hard to see what *actually* broke.

## What it does now

The same failure now renders as:

```
  ✗  HelmRelease  nvidia/nvidia-gpu-operator  chart download 404: helm.ngc.nvidia.com/charts/gpu-operator-v26.3.1.tgz
  ✗  Kustomization  flux-system/1-core-monitoring-deps  not found
      required by flux-system/1-core-monitoring-grafana-app, flux-system/1-core-monitoring-kps-app, flux-system/1-core-monitoring-kps-external

  notes (13)
    resource orphaned id=Kustomization/networking/envoy-gateway
    loader: file failed to parse path=ansible/site.yaml (×12)

  ✗ 2 failed · 3 blocked   1.2s
```

Real errors once; the cascade folded under its root; log noise in a quiet footer; a clean verdict.

## How

- **Classify structurally.** In the DAG a `Require` gate fails *before* the body runs, so a failure with a dependency blocker is purely derived. Captured at the failure sink (`errors.As` `*DependencyFailedError` → `store.SetBlocked`) and the structural-parent cascade, exposed as `orchestrator.Result.Blocked`.
- **Collapse the cascade** (`internal/report`). Partition into *primary* (real render/template/build error) vs *blocked*; fold each blocked resource under the root it traces to — a primary failure or a *missing* dependency. Roots shown once with what they block / are required by; cascaded resources never get their own line; nested chains never reprinted.
- **Defer the noise** (`internal/cli/defersink.go`). A buffering `slog.Handler` holds Warn/Info during the run (Error passes through inline); the report renders them in a `notes` footer, identical lines collapsed with a count. No need to touch the 21 log sites.
- **Render styled**, reusing `internal/style` (the `flate test` vocabulary); a sentinel error lets the top-level printer skip the flat reprint. Plain + grouped off a TTY (CI/pipes).
- **Bonus:** a misnamed kustomization file (e.g. `kustomzation.yaml`) now reports *"looks like a misnamed kustomization file; rename it to kustomization.yaml"* instead of the cryptic "missing metadata.name".

## Scope / not in scope
Per discussion: group blocked failures under their root cause; one combined PR. The `flate test` per-resource table (stdout) is unchanged and complementary; the root-cause report goes to stderr, replacing the flat aggregate.

## Test plan
- New: `internal/report` (partition + transitive root grouping + missing-dep root + render); `defersink` (buffer Warn/Info, pass Error, drain→passthrough, collapse); misnamed-kustomization; updated `cli_test` for the styled report.
- `gofmt` · `go vet ./...` · `go test ./...` · `-race` on touched pkgs · `golangci-lint` (0 issues).
- **Byte-equivalence:** `build all` stdout byte-identical to `main` on k8s-gitops and zariel (3,190,543 B) — all changes are stderr/logging/classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)