### PR TITLE
fix(cli): fold dependency cascades under their root cause on every surface

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -607,16 +607,37 @@ func scopedRunError(o *orchestrator.Orchestrator, res *orchestrator.Result, c *c
 		return runErr
 	}
 	extras := nonResourceRunErrors(runErr)
-	failed := make(map[manifest.NamedResource]store.StatusInfo, len(res.Failed))
-	for id, info := range res.Failed {
-		if c == nil || c.includeNamespace(o.Filter(), id.Namespace) {
-			failed[id] = info
-		}
-	}
+	failed, blocked := scopedFailures(o, res, c)
 	if len(failed) == 0 {
 		return errors.Join(extras...)
 	}
-	return errors.Join(aggregateScopedFailures(failed), errors.Join(extras...))
+	return errors.Join(aggregateScopedFailures(failed, blocked), errors.Join(extras...))
+}
+
+// scopedFailures projects res.Failed (and the matching res.Blocked subset) onto
+// c's namespace scope. Single-sourced so the machine-error builder
+// (aggregateScopedFailures) and the rendered report (reportFailures) can't drift
+// on what counts as in scope. Returns empty (non-nil) maps when there is no
+// orchestrator/result or nothing in scope.
+func scopedFailures(o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags) (
+	map[manifest.NamedResource]store.StatusInfo,
+	map[manifest.NamedResource][]manifest.NamedResource,
+) {
+	failed := map[manifest.NamedResource]store.StatusInfo{}
+	blocked := map[manifest.NamedResource][]manifest.NamedResource{}
+	if o == nil || res == nil {
+		return failed, blocked
+	}
+	for id, info := range res.Failed {
+		if c != nil && !c.includeNamespace(o.Filter(), id.Namespace) {
+			continue
+		}
+		failed[id] = info
+		if b := res.Blocked[id]; len(b) > 0 {
+			blocked[id] = b
+		}
+	}
+	return failed, blocked
 }
 
 // emitResult joins an emit-time error with the scoped run error so a
@@ -656,18 +677,7 @@ func (e reportedError) Unwrap() error { return e.err }
 // non-zero while run avoids printing it twice; otherwise err passes through.
 func reportFailures(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags, err error, elapsed time.Duration) error {
 	notes := drainLogNotes()
-	failed := map[manifest.NamedResource]store.StatusInfo{}
-	blocked := map[manifest.NamedResource][]manifest.NamedResource{}
-	if o != nil && res != nil {
-		for id, info := range res.Failed {
-			if c == nil || c.includeNamespace(o.Filter(), id.Namespace) {
-				failed[id] = info
-				if b := res.Blocked[id]; len(b) > 0 {
-					blocked[id] = b
-				}
-			}
-		}
-	}
+	failed, blocked := scopedFailures(o, res, c)
 	m := report.Build(failed, blocked, notes)
 	if m.Empty() {
 		return err
@@ -679,28 +689,44 @@ func reportFailures(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator
 	return reportedError{err}
 }
 
-// resourceAggregatePrefix is the leading text of the error
-// aggregateScopedFailures produces. nonResourceRunErrors uses it to tell
-// the per-resource failure aggregate apart from incidental run errors, so
-// both must reference this one constant or the classification silently
-// drifts.
-const resourceAggregatePrefix = "reconcile completed with "
-
-func aggregateScopedFailures(failed map[manifest.NamedResource]store.StatusInfo) error {
+// aggregateScopedFailures is the machine error value for a scoped failure set.
+// It enumerates the PRIMARY failures (root causes) one per line and tallies the
+// derived ones as "(+N blocked …)" rather than listing every cascade victim, so
+// the plain error a verb returns — printed by run() for get/diff, carried for
+// errors.Is / the non-zero exit on every verb — stays a concise root-cause
+// summary. build/test additionally render the styled report (see
+// reportFailures). Typed as *orchestrator.FailuresError so scopedRunError can
+// recognize and re-scope an aggregate that arrives as the run error.
+func aggregateScopedFailures(
+	failed map[manifest.NamedResource]store.StatusInfo,
+	blocked map[manifest.NamedResource][]manifest.NamedResource,
+) error {
 	msgs := make([]string, 0, len(failed))
+	nBlocked := 0
 	for id, info := range failed {
+		if len(blocked[id]) > 0 {
+			nBlocked++
+			continue
+		}
 		msgs = append(msgs, fmt.Sprintf("%s: %s", id, info.Message))
 	}
 	slices.Sort(msgs)
-	return fmt.Errorf("%s%d failure(s):\n  %s",
-		resourceAggregatePrefix, len(msgs), strings.Join(msgs, "\n  "))
+	msg := fmt.Sprintf("reconcile completed with %d failure(s)", len(msgs))
+	if len(msgs) > 0 {
+		msg += ":\n  " + strings.Join(msgs, "\n  ")
+	}
+	if nBlocked > 0 {
+		msg += fmt.Sprintf("\n  (+%d blocked by failed/missing dependencies)", nBlocked)
+	}
+	return &orchestrator.FailuresError{Count: len(msgs), Message: msg}
 }
 
 func nonResourceRunErrors(err error) []error {
 	var out []error
 	for _, leaf := range flattenErrors(err) {
-		if isResourceAggregateError(leaf) {
-			continue
+		var aggregate *orchestrator.FailuresError
+		if errors.As(leaf, &aggregate) {
+			continue // re-scoped + re-rendered from res.Failed, not carried verbatim
 		}
 		out = append(out, leaf)
 	}
@@ -722,10 +748,6 @@ func flattenErrors(err error) []error {
 		return flattenErrors(uw.Unwrap())
 	}
 	return []error{err}
-}
-
-func isResourceAggregateError(err error) bool {
-	return strings.HasPrefix(err.Error(), resourceAggregatePrefix)
 }
 
 func cmdContext(cmd *cobra.Command) context.Context {

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -145,7 +145,7 @@ func TestScopedRunError_FiltersOutsideNamespace(t *testing.T) {
 		},
 	}}
 
-	got := scopedRunError(o, res, &commonFlags{namespace: "media"}, aggregateScopedFailures(res.Failed))
+	got := scopedRunError(o, res, &commonFlags{namespace: "media"}, aggregateScopedFailures(res.Failed, nil))
 	if got == nil {
 		t.Fatal("expected scoped failure")
 	}
@@ -169,7 +169,7 @@ func TestScopedRunError_ReturnsNilWhenOnlyOutsideNamespaceFailed(t *testing.T) {
 		},
 	}}
 
-	if got := scopedRunError(o, res, &commonFlags{namespace: "media"}, aggregateScopedFailures(res.Failed)); got != nil {
+	if got := scopedRunError(o, res, &commonFlags{namespace: "media"}, aggregateScopedFailures(res.Failed, nil)); got != nil {
 		t.Fatalf("scopedRunError = %v, want nil", got)
 	}
 }
@@ -186,7 +186,7 @@ func TestScopedRunError_PreservesUnattributedRunError(t *testing.T) {
 		},
 	}}
 	panicErr := errors.New("1 task(s) panicked without per-resource attribution; check logs")
-	runErr := errors.Join(aggregateScopedFailures(res.Failed), panicErr)
+	runErr := errors.Join(aggregateScopedFailures(res.Failed, nil), panicErr)
 
 	got := scopedRunError(o, res, &commonFlags{namespace: "media"}, runErr)
 	if got == nil {
@@ -211,7 +211,7 @@ func TestScopedRunError_CancellationStillFiltersHiddenFailures(t *testing.T) {
 			Message: "default failed",
 		},
 	}}
-	runErr := errors.Join(aggregateScopedFailures(res.Failed), context.Canceled)
+	runErr := errors.Join(aggregateScopedFailures(res.Failed, nil), context.Canceled)
 
 	got := scopedRunError(o, res, &commonFlags{namespace: "media"}, runErr)
 	if !errors.Is(got, context.Canceled) {
@@ -238,7 +238,7 @@ func TestScopedRunError_JoinsScopedAndUnattributed(t *testing.T) {
 		},
 	}}
 	panicErr := errors.New("1 task(s) panicked without per-resource attribution; check logs")
-	runErr := errors.Join(aggregateScopedFailures(res.Failed), panicErr)
+	runErr := errors.Join(aggregateScopedFailures(res.Failed, nil), panicErr)
 
 	got := scopedRunError(o, res, &commonFlags{namespace: "media"}, runErr)
 	if got == nil {
@@ -275,6 +275,36 @@ func TestOutputValue_Validates(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "must be one of: yaml, json") {
 		t.Errorf("error should name the accepted set: %q", err)
+	}
+}
+
+// TestAggregateScopedFailures_FoldsBlocked pins the concise machine error: it
+// enumerates only primary (root-cause) failures and tallies the blocked cascade
+// as a count, so get/diff print a root-cause summary rather than a wall of every
+// cascade victim. It is typed so scopedRunError can recognize and re-scope it.
+func TestAggregateScopedFailures_FoldsBlocked(t *testing.T) {
+	root := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	child := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "media", Name: "plex"}
+	failed := map[manifest.NamedResource]store.StatusInfo{
+		root:  {Status: store.StatusFailed, Message: "kustomize build boom"},
+		child: {Status: store.StatusFailed, Message: "dependencies failed: cluster-apps"},
+	}
+	blocked := map[manifest.NamedResource][]manifest.NamedResource{child: {root}}
+
+	err := aggregateScopedFailures(failed, blocked)
+	msg := err.Error()
+	if !strings.Contains(msg, "cluster-apps") || !strings.Contains(msg, "kustomize build boom") {
+		t.Errorf("primary failure should be enumerated: %q", msg)
+	}
+	if strings.Contains(msg, "media/plex") || strings.Contains(msg, "dependencies failed") {
+		t.Errorf("blocked cascade victim should be folded, not enumerated: %q", msg)
+	}
+	if !strings.Contains(msg, "1 blocked") {
+		t.Errorf("blocked count should be summarized: %q", msg)
+	}
+	var fe *orchestrator.FailuresError
+	if !errors.As(err, &fe) {
+		t.Errorf("aggregate must be a *orchestrator.FailuresError, got %T", err)
 	}
 }
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -57,6 +57,11 @@ type Model struct {
 	Primary []Primary
 	Missing []Missing
 	Notes   []Note
+	// Blocked is the count of distinct derived (cascaded) failures. It is the
+	// verdict's "N blocked" figure — distinct resources, not the sum of the
+	// per-root Blocks/RequiredBy lists, which can overlap when one resource
+	// traces to more than one root (e.g. a failed parent AND a missing dep).
+	Blocked int
 }
 
 // Empty reports whether there is nothing to render.
@@ -74,13 +79,7 @@ func (m Model) Empty() bool {
 // blocked) or a missing id (absent from failed). Cascaded resources never get
 // their own line — they appear only in a root's Blocks / RequiredBy list.
 func Build(failed map[manifest.NamedResource]store.StatusInfo, blocked map[manifest.NamedResource][]manifest.NamedResource, notes []Note) Model {
-	// root id → resources that trace to it.
-	byRoot := map[manifest.NamedResource][]manifest.NamedResource{}
-	for id := range blocked {
-		for _, r := range rootsOf(id, blocked) {
-			byRoot[r] = append(byRoot[r], id)
-		}
-	}
+	byRoot := Roots(blocked)
 
 	var primary []Primary
 	var missing []Missing
@@ -99,7 +98,23 @@ func Build(failed map[manifest.NamedResource]store.StatusInfo, blocked map[manif
 
 	slices.SortFunc(primary, func(a, b Primary) int { return a.ID.Compare(b.ID) })
 	slices.SortFunc(missing, func(a, b Missing) int { return a.ID.Compare(b.ID) })
-	return Model{Primary: primary, Missing: missing, Notes: notes}
+	return Model{Primary: primary, Missing: missing, Notes: notes, Blocked: len(blocked)}
+}
+
+// Roots inverts a blocked graph into root cause → the resources that trace to
+// it. blocked maps each derived failure to the immediate dependencies that
+// blocked it; a root is any id reached by walking those blockers that is not
+// itself blocked (a primary failure, or a dependency missing from the graph).
+// Shared by Build and the test runner so both fold a cascade under the same
+// root with identical walk semantics.
+func Roots(blocked map[manifest.NamedResource][]manifest.NamedResource) map[manifest.NamedResource][]manifest.NamedResource {
+	byRoot := map[manifest.NamedResource][]manifest.NamedResource{}
+	for id := range blocked {
+		for _, r := range rootsOf(id, blocked) {
+			byRoot[r] = append(byRoot[r], id)
+		}
+	}
+	return byRoot
 }
 
 // rootsOf resolves the root cause(s) of a blocked id by walking its blockers to
@@ -142,11 +157,9 @@ func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
 			style.Fail(style.GlyphFail, color),
 			style.Dim(p.ID.Kind, color),
 			p.ID.NamespacedName())
-		if msg := oneLine(p.Msg); msg != "" {
-			fmt.Fprintf(&b, "  %s", msg)
-		}
+		writeMessage(&b, p.Msg)
 		if len(p.Blocks) > 0 {
-			fmt.Fprintf(&b, "\n      %s", style.Dim("blocks "+summarize(p.Blocks), color))
+			fmt.Fprintf(&b, "\n%s%s", msgIndent, style.Dim("blocks "+summarize(p.Blocks), color))
 		}
 		b.WriteByte('\n')
 	}
@@ -171,19 +184,13 @@ func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
 		}
 	}
 
-	// Verdict: failed = primary + missing roots; blocked = cascaded resources.
-	blockedCount := 0
-	for _, p := range m.Primary {
-		blockedCount += len(p.Blocks)
-	}
-	for _, mr := range m.Missing {
-		blockedCount += len(mr.RequiredBy)
-	}
+	// Verdict: failed = primary + missing roots; blocked = distinct cascaded
+	// resources (m.Blocked, not the sum of per-root lists, which can overlap).
 	failedCount := len(m.Primary) + len(m.Missing)
 	b.WriteString("\n  " + style.Fail(style.GlyphFail, color) + " " +
 		style.Fail(fmt.Sprintf("%d failed", failedCount), color))
-	if blockedCount > 0 {
-		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d blocked", blockedCount), color))
+	if m.Blocked > 0 {
+		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d blocked", m.Blocked), color))
 	}
 	if elapsed > 0 {
 		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
@@ -206,14 +213,37 @@ func summarize(ids []manifest.NamedResource) string {
 	return fmt.Sprintf("%s +%d more", strings.Join(names[:blockedSample], ", "), len(names)-blockedSample)
 }
 
-// oneLine collapses a multi-line message to a single line so a primary failure
-// stays one row; helm/kustomize errors are often multi-line.
-func oneLine(s string) string {
-	s = strings.TrimSpace(s)
-	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
-		return strings.TrimSpace(s[:i]) + " …"
+// msgIndent aligns a primary failure's continuation lines (and its "blocks …"
+// line) under the message column.
+const msgIndent = "         "
+
+// writeMessage appends a primary failure's message to its resource header line:
+// the first line follows inline; any continuation lines print indented beneath.
+// Multi-line build/template diagnostics — notably the duplicate-id producer
+// attribution from pkg/kustomize — survive intact instead of being truncated to
+// their first line.
+func writeMessage(b *strings.Builder, msg string) {
+	lines := MessageLines(msg)
+	if len(lines) == 0 {
+		return
 	}
-	return s
+	b.WriteString("  " + lines[0])
+	for _, line := range lines[1:] {
+		b.WriteString("\n" + msgIndent + line)
+	}
+}
+
+// MessageLines splits a stored failure message into trimmed, non-empty lines.
+// Shared with the test runner so a multi-line build/template diagnostic renders
+// the same way on both surfaces.
+func MessageLines(s string) []string {
+	var out []string
+	for line := range strings.SplitSeq(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 func noteTotal(notes []Note) int {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -101,3 +101,66 @@ func TestBuild_Empty(t *testing.T) {
 		t.Error("a clean run must produce an empty model")
 	}
 }
+
+// TestWrite_PrimaryMessageIsMultiLine pins that a multi-line primary message (a
+// kustomize duplicate-id diagnostic) renders every line — the producer
+// attribution must survive intact rather than being truncated to the first
+// line, which is exactly the detail that tells the user what to fix.
+func TestWrite_PrimaryMessageIsMultiLine(t *testing.T) {
+	a := ks("a")
+	f := map[manifest.NamedResource]store.StatusInfo{
+		a: {Status: store.StatusFailed, Message: "may not add resource with an already registered id: X\n" +
+			"duplicate resource(s) produced by multiple accumulated paths:\n  - ./one\n  - ./two"},
+	}
+	var b bytes.Buffer
+	if err := Build(f, nil, nil).Write(&b, false, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, want := range []string{"already registered id: X", "produced by multiple accumulated paths", "- ./one", "- ./two"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("multi-line primary message missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestBuild_BlockedCountsDistinctResources pins that a resource blocked by two
+// independent roots (a failed parent AND a missing dependency) counts once in
+// the verdict, even though it folds under both roots' lists.
+func TestBuild_BlockedCountsDistinctResources(t *testing.T) {
+	root, missing, dual := ks("root"), ks("missing"), ks("dual")
+	f := failed(root, dual) // missing is absent from the store
+	blocked := map[manifest.NamedResource][]manifest.NamedResource{
+		dual: {root, missing}, // blocked by a failed parent AND a missing dep
+	}
+
+	m := Build(f, blocked, nil)
+	if m.Blocked != 1 {
+		t.Errorf("Blocked = %d, want 1 distinct blocked resource", m.Blocked)
+	}
+	if len(m.Primary) != 1 || len(m.Primary[0].Blocks) != 1 {
+		t.Errorf("root should fold dual once: %+v", m.Primary)
+	}
+	if len(m.Missing) != 1 || len(m.Missing[0].RequiredBy) != 1 {
+		t.Errorf("missing should fold dual once: %+v", m.Missing)
+	}
+
+	var b bytes.Buffer
+	_ = m.Write(&b, false, 0)
+	if out := b.String(); !strings.Contains(out, "1 blocked") {
+		t.Errorf("verdict should count the dual-rooted resource once:\n%s", out)
+	}
+}
+
+// TestRoots_WalksTransitiveChainToTrueRoot pins the shared grouping the test
+// runner reuses: a leaf folds under the primary at the top of its blocker chain.
+func TestRoots_WalksTransitiveChainToTrueRoot(t *testing.T) {
+	root, mid, leaf := ks("root"), ks("mid"), ks("leaf")
+	byRoot := Roots(map[manifest.NamedResource][]manifest.NamedResource{
+		mid:  {root},
+		leaf: {mid},
+	})
+	if got := byRoot[root]; len(got) != 2 {
+		t.Fatalf("root should gather mid and leaf, got %+v", got)
+	}
+}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -22,9 +22,10 @@ import (
 // Status glyphs shared across surfaces: a passing/success mark, a failure mark,
 // and a skipped/secondary dash. Pair with Pass/Fail/Skip for color.
 const (
-	GlyphPass = "✓"
-	GlyphFail = "✗"
-	GlyphSkip = "‒"
+	GlyphPass    = "✓"
+	GlyphFail    = "✗"
+	GlyphSkip    = "‒"
+	GlyphBlocked = "⊘"
 )
 
 // Semantic styles, by ANSI base color (0-7) so they downsample cleanly on

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/home-operations/flate/internal/report"
 	"github.com/home-operations/flate/internal/style"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -42,6 +43,10 @@ const (
 	OutcomePassed Outcome = iota
 	OutcomeSkipped
 	OutcomeFailed
+	// OutcomeBlocked is a resource that failed only because a dependency
+	// failed or was missing — the body never ran. These are folded under
+	// their root cause rather than listed per-resource (see Report.Write).
+	OutcomeBlocked
 )
 
 // Case is one Kustomization (or HelmRelease) result.
@@ -51,17 +56,34 @@ type Case struct {
 	Reason  string
 }
 
+// BlockedGroup folds the resources that cascaded from one root cause into a
+// single reported line: Count resources blocked by Root. Missing is true when
+// Root was never loaded (a dependency that does not exist), false when Root is a
+// failure reported elsewhere in the table.
+type BlockedGroup struct {
+	Root    manifest.NamedResource
+	Count   int
+	Missing bool
+}
+
 // Report is the aggregate outcome.
 type Report struct {
 	Cases   []Case
 	Passed  int
 	Skipped int
 	Failed  int
-	Matched int
+	// Blocked counts resources folded under a root cause (not listed as
+	// Cases); BlockedRoots names those roots with their tallies.
+	Blocked      int
+	BlockedRoots []BlockedGroup
+	Matched      int
 }
 
-// AnyFailed reports whether any case failed.
-func (r Report) AnyFailed() bool { return r.Failed > 0 }
+// AnyFailed reports whether the run should be considered failed: a primary
+// failure, or a cascade blocked on one. A broken dependency that blocks
+// everything downstream must still flip the exit code even if nothing reported
+// a primary failure in scope.
+func (r Report) AnyFailed() bool { return r.Failed > 0 || r.Blocked > 0 }
 
 // decorate maps an outcome to its leading glyph and the style renderer that
 // colors it. Glyphs render in both modes (any UTF-8 sink); only color is gated.
@@ -75,6 +97,9 @@ func (o Outcome) decorate() (glyph string, paint func(string, bool) string) {
 		return style.GlyphSkip, style.Skip
 	}
 }
+
+// reasonIndent aligns a failure's continuation lines beneath its row.
+const reasonIndent = "         "
 
 // Write renders the report: one row per case (status glyph, dimmed kind column,
 // namespace/name, dimmed reason) followed by a summary — an overall verdict
@@ -94,17 +119,36 @@ func (r Report) Write(w io.Writer, color bool, elapsed time.Duration) error {
 			paint(glyph, color),
 			style.Dim(fmt.Sprintf("%-*s", kindW, c.ID.Kind), color),
 			c.ID.NamespacedName())
-		if c.Reason != "" {
-			fmt.Fprintf(&b, "  %s", style.Dim(c.Reason, color))
+		// A single-line reason stays inline; a multi-line one (a kustomize
+		// build / helm template diagnostic) prints its first line inline and
+		// the rest indented beneath, so the detail survives instead of running
+		// the row off the right edge.
+		if lines := report.MessageLines(c.Reason); len(lines) > 0 {
+			fmt.Fprintf(&b, "  %s", style.Dim(lines[0], color))
+			for _, line := range lines[1:] {
+				fmt.Fprintf(&b, "\n%s%s", reasonIndent, style.Dim(line, color))
+			}
 		}
 		b.WriteByte('\n')
 	}
 
+	// Cascades fold under their root cause: one dim line per root, naming the
+	// count it blocks, in place of a per-resource row for each victim.
+	for _, g := range r.BlockedRoots {
+		root := g.Root.NamespacedName()
+		if g.Missing {
+			root += " (not found)"
+		}
+		fmt.Fprintf(&b, "  %s  %s\n",
+			style.Dim(style.GlyphBlocked, color),
+			style.Dim(fmt.Sprintf("%d blocked by %s", g.Count, root), color))
+	}
+
 	// Summary: a verdict glyph (green ✓ / red ✗) leads the colored counts —
-	// always the passed count; skipped/failed only when non-zero — and a dim
-	// elapsed clock closes it. An empty run still reads "✓ 0 passed".
+	// always the passed count; skipped/failed/blocked only when non-zero — and a
+	// dim elapsed clock closes it. An empty run still reads "✓ 0 passed".
 	verdict, paintVerdict := style.GlyphPass, style.Pass
-	if r.Failed > 0 {
+	if r.Failed > 0 || r.Blocked > 0 {
 		verdict, paintVerdict = style.GlyphFail, style.Fail
 	}
 	b.WriteString("\n  " + paintVerdict(verdict, color) + " ")
@@ -114,6 +158,9 @@ func (r Report) Write(w io.Writer, color bool, elapsed time.Duration) error {
 	}
 	if r.Failed > 0 {
 		b.WriteString(" · " + style.Fail(fmt.Sprintf("%d failed", r.Failed), color))
+	}
+	if r.Blocked > 0 {
+		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d blocked", r.Blocked), color))
 	}
 	if elapsed > 0 {
 		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
@@ -133,6 +180,9 @@ func Run(j Job) Report {
 		kinds = []string{manifest.KindKustomization, manifest.KindHelmRelease}
 	}
 	var rep Report
+	// id → its immediate blockers, accumulated across kinds so a cross-kind
+	// cascade still resolves to one root in blockedGroups.
+	blocked := map[manifest.NamedResource][]manifest.NamedResource{}
 	for _, kind := range kinds {
 		objs := j.Store.ListObjects(kind)
 		slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
@@ -166,13 +216,33 @@ func Run(j Job) Report {
 				rep.Passed++
 			case OutcomeSkipped:
 				rep.Skipped++
-			case OutcomeFailed:
+			case OutcomeBlocked:
+				// Folded under its root cause, not listed per-resource.
+				rep.Blocked++
+				blocked[id] = j.Store.BlockedBy(id)
+				continue
+			default: // OutcomeFailed
 				rep.Failed++
 			}
 			rep.Cases = append(rep.Cases, c)
 		}
 	}
+	rep.BlockedRoots = blockedGroups(j.Store, blocked)
 	return rep
+}
+
+// blockedGroups inverts the blocked graph (id → its immediate blockers) into one
+// BlockedGroup per root cause, sorted by root, using the same root-resolution as
+// the build/diff report so a cascade folds identically on every surface.
+func blockedGroups(s *store.Store, blocked map[manifest.NamedResource][]manifest.NamedResource) []BlockedGroup {
+	byRoot := report.Roots(blocked)
+	groups := make([]BlockedGroup, 0, len(byRoot))
+	for root, ids := range byRoot {
+		_, known := s.GetStatus(root)
+		groups = append(groups, BlockedGroup{Root: root, Count: len(ids), Missing: !known})
+	}
+	slices.SortFunc(groups, func(a, b BlockedGroup) int { return a.Root.Compare(b.Root) })
+	return groups
 }
 
 func classify(s *store.Store, id manifest.NamedResource) Case {
@@ -181,6 +251,13 @@ func classify(s *store.Store, id manifest.NamedResource) Case {
 	case !ok:
 		return Case{ID: id, Outcome: OutcomeFailed, Reason: "no status reported"}
 	case info.Status == store.StatusFailed:
+		// A failure with recorded blockers never ran its body — it's blocked by
+		// a failed/missing dependency, not a primary fault. Fold it under the
+		// root cause (Report.Write) rather than reprinting the nested
+		// "dependencies failed:" chain on its own row.
+		if len(s.BlockedBy(id)) > 0 {
+			return Case{ID: id, Outcome: OutcomeBlocked}
+		}
 		// Strip the `flux error: input error:` sentinel chain so the
 		// `flate test` table shows the actual cause rather than two
 		// layers of bureaucracy. Same treatment the orchestrator gives

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -245,3 +245,76 @@ type errWriter struct {
 func (w errWriter) Write(_ []byte) (int, error) {
 	return 0, w.err
 }
+
+// TestRun_BlockedFoldsUnderRoot pins the cascade fold: a failure with recorded
+// blockers classifies as Blocked (not Failed), is kept out of the per-resource
+// rows, and folds under its root in BlockedRoots — the verdict counting it as
+// blocked, the run still non-zero.
+func TestRun_BlockedFoldsUnderRoot(t *testing.T) {
+	s := store.New()
+	root := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	child := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "media", Name: "plex"}
+	s.AddObject(&manifest.Kustomization{Name: root.Name, Namespace: root.Namespace})
+	s.AddObject(&manifest.Kustomization{Name: child.Name, Namespace: child.Namespace})
+	s.UpdateStatus(root, store.StatusFailed, "kustomize build boom") // primary
+	s.UpdateStatus(child, store.StatusFailed, "dependencies failed: cluster-apps")
+	s.SetBlocked(child, []manifest.NamedResource{root})
+
+	rep := Run(Job{Store: s})
+	if rep.Failed != 1 || rep.Blocked != 1 {
+		t.Fatalf("want 1 failed (root) + 1 blocked (child), got %+v", rep)
+	}
+	if !rep.AnyFailed() {
+		t.Error("a blocked cascade must flip the run to failed")
+	}
+	for _, c := range rep.Cases {
+		if c.ID == child {
+			t.Errorf("blocked child must not get its own case row: %+v", c)
+		}
+	}
+	if len(rep.BlockedRoots) != 1 || rep.BlockedRoots[0].Root != root ||
+		rep.BlockedRoots[0].Count != 1 || rep.BlockedRoots[0].Missing {
+		t.Fatalf("want one BlockedGroup{root, count 1, not missing}, got %+v", rep.BlockedRoots)
+	}
+
+	var b bytes.Buffer
+	_ = rep.Write(&b, false, 0)
+	out := b.String()
+	if !strings.Contains(out, "1 blocked by flux-system/cluster-apps") {
+		t.Errorf("fold line missing:\n%s", out)
+	}
+	if !strings.Contains(out, "1 failed") || !strings.Contains(out, "1 blocked") {
+		t.Errorf("verdict should separate failed and blocked:\n%s", out)
+	}
+	if strings.Contains(out, "media/plex") {
+		t.Errorf("blocked child must not appear as a row:\n%s", out)
+	}
+}
+
+// TestRun_BlockedByMissingDep covers a resource blocked on a dependency that was
+// never loaded: the root folds with a "(not found)" marker and counts as blocked
+// even though no primary failure exists, keeping the run non-zero.
+func TestRun_BlockedByMissingDep(t *testing.T) {
+	s := store.New()
+	child := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "volsync-system", Name: "kopiur-repository"}
+	missing := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "kopiur-system", Name: "kopiur"}
+	s.AddObject(&manifest.Kustomization{Name: child.Name, Namespace: child.Namespace})
+	s.UpdateStatus(child, store.StatusFailed, "dependencies failed: kopiur")
+	s.SetBlocked(child, []manifest.NamedResource{missing})
+
+	rep := Run(Job{Store: s})
+	if rep.Failed != 0 || rep.Blocked != 1 {
+		t.Fatalf("want 0 failed + 1 blocked, got %+v", rep)
+	}
+	if !rep.AnyFailed() {
+		t.Error("a blocked-only run must still be non-zero")
+	}
+	if len(rep.BlockedRoots) != 1 || !rep.BlockedRoots[0].Missing {
+		t.Fatalf("want the missing root marked Missing, got %+v", rep.BlockedRoots)
+	}
+	var b bytes.Buffer
+	_ = rep.Write(&b, false, 0)
+	if !strings.Contains(b.String(), "not found") {
+		t.Errorf("missing root should render (not found):\n%s", b.String())
+	}
+}

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -40,9 +40,21 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 		if !ok {
 			continue
 		}
-		if _, ok := loader.LongestParent(prefixes, file, id); ok {
-			out[id] = info.Message
+		parent, ok := loader.LongestParent(prefixes, file, id)
+		if !ok {
+			continue
 		}
+		// A covering parent that itself FAILED emitted nothing, so every child
+		// under its spec.path looks unreferenced — but these are blocked
+		// cascade victims, not stale unwired files. Leave them Failed (with the
+		// BlockedBy the dependency gate recorded) so the report folds them under
+		// the root cause instead of demoting each to a quiet "orphaned" warning.
+		// A child under a parent that SUCCEEDED but still didn't emit it is the
+		// genuine orphan this detection exists for.
+		if _, parentFailed := failed[parent]; parentFailed {
+			continue
+		}
+		out[id] = info.Message
 	}
 	return out
 }
@@ -197,6 +209,18 @@ func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]sto
 	}
 }
 
+// FailuresError aggregates per-resource reconcile failures into one error. Its
+// identity (recovered with errors.As) — not its message text — is how the CLI
+// tells the resource-failure aggregate apart from incidental run errors (a
+// panic, a cancellation) when it re-scopes failures to a namespace filter and
+// re-renders them. Count is the number of failures aggregated.
+type FailuresError struct {
+	Count   int
+	Message string
+}
+
+func (e *FailuresError) Error() string { return e.Message }
+
 func (o *Orchestrator) aggregateFailures(failed map[manifest.NamedResource]store.StatusInfo) error {
 	msgs := make([]string, 0, len(failed))
 	for id, info := range sanitizeFailed(failed) {
@@ -207,8 +231,10 @@ func (o *Orchestrator) aggregateFailures(failed map[manifest.NamedResource]store
 		}
 	}
 	slices.Sort(msgs) // deterministic ordering across runs
-	return fmt.Errorf("reconcile completed with %d failure(s):\n  %s",
-		len(msgs), strings.Join(msgs, "\n  "))
+	return &FailuresError{
+		Count:   len(msgs),
+		Message: fmt.Sprintf("reconcile completed with %d failure(s):\n  %s", len(msgs), strings.Join(msgs, "\n  ")),
+	}
 }
 
 // sanitizeFailed returns a copy of the failure map with each entry's

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -114,6 +114,46 @@ func TestDetectOrphans_NonReconcilableKindsIgnored(t *testing.T) {
 	}
 }
 
+// TestDetectOrphans_ParentFailedIsCascadeNotOrphan pins the cascade/orphan
+// discriminator: when a child's covering parent itself FAILED (so it emitted
+// nothing, making every child under its spec.path look unreferenced), the child
+// is a blocked cascade victim — NOT an orphan. Demoting it would drop it from
+// the failure set and let the report/test runner score a broken tree as passing.
+// Only a child under a parent that SUCCEEDED is a genuine orphan.
+func TestDetectOrphans_ParentFailedIsCascadeNotOrphan(t *testing.T) {
+	parent := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+	}
+	child := &manifest.Kustomization{
+		Name: "plex", Namespace: "media",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps/media/plex/app"},
+	}
+
+	o := &Orchestrator{
+		store:    store.New(),
+		rendered: newRenderedSet(),
+		sourceFiles: map[manifest.NamedResource]string{
+			parent.Named(): "kubernetes/flux/cluster/ks.yaml",
+			child.Named():  "kubernetes/apps/media/plex/ks.yaml",
+		},
+	}
+	o.store.AddObject(parent)
+	o.store.AddObject(child)
+
+	failed := map[manifest.NamedResource]store.StatusInfo{
+		parent.Named(): {Status: store.StatusFailed, Message: "kustomize build boom"}, // the build that emitted nothing
+		child.Named():  {Status: store.StatusFailed, Message: "dependencies failed: cluster-apps"},
+	}
+	orphans := o.detectOrphans(failed)
+	if _, ok := orphans[child.Named()]; ok {
+		t.Errorf("child under a FAILED covering parent is a cascade victim, not an orphan: %+v", orphans)
+	}
+	if len(orphans) != 0 {
+		t.Errorf("expected no orphans when the covering parent failed, got %+v", orphans)
+	}
+}
+
 // TestOrchestrator_WithFetcherAfterBootstrapPanics pins the
 // contract that WithFetcher MUST be called before Bootstrap. A
 // late swap would silently miss any source CR discovery already


### PR DESCRIPTION
## Problem

On a repo with one real fault — `flux-system/cluster-apps` fails its kustomize build on a duplicate `Alert/alertmanager.volsync-system` id — flate produced three bad outputs:

- `flate build all` printed a **76-line `notes (76)` wall** of `resource orphaned … reason=dependencies failed: …cluster-apps…`.
- `flate test all` reported a **false green: `112 passed · 1 failed`** — the broken Kustomizations counted as *passed*.
- The report's primary line ended in `…`, having **truncated away the [#726](https://github.com/home-operations/flate/pull/726) dup-id diagnostic** that names which paths collide — the one detail that says what to fix.

### One misclassification, three symptoms

When a parent Kustomization fails its build it emits nothing, so every child under its `spec.path` looks unreferenced. `detectOrphans` demoted all of them to `Ready` "orphans", deleting them from the failure set and logging each as a `slog.Warn`. They never reached the root-cause grouping introduced in [#728](https://github.com/home-operations/flate/pull/728) — so they flooded the deferred-log footer, and `flate test` (reading store status) scored a broken tree as passing.

## Fix

**An orphan is only an orphan if its covering parent *succeeded*.** A child under a *failed* parent is a blocked cascade victim — keep it `Failed` (with the `BlockedBy` the dependency gate recorded) so it folds under its root cause on every surface.

- **orchestrator** — `detectOrphans` skips a child whose covering parent is itself failed.
- **report** — render the full multi-line primary message (the dup-id producer attribution survives); share the root-grouping via `report.Roots`; count *distinct* blocked resources so the verdict doesn't double-count a resource that traces to two roots (e.g. a failed parent **and** a missing dep).
- **testrunner** — first-class `OutcomeBlocked`: blocked resources fold into one `⊘ N blocked by <root>` line per root instead of a per-resource row; the verdict gains a blocked term and a blocked-only run still exits non-zero.
- **cli** — single namespace-scoping pass (`scopedFailures`) shared by the report and the machine error; the machine error enumerates only primary failures and tallies `(+N blocked …)` so `get`/`diff` stay concise; a typed `orchestrator.FailuresError` replaces the fragile `"reconcile completed with "` string-prefix classification.

## Result (k8s-gitops)

`build all` — real error once with the full dup-id attribution, cascade folded, no notes wall:
```
  ✗  Kustomization  flux-system/cluster-apps  kustomize build …: may not add resource with an already registered id: Alert…/alertmanager.volsync-system
         duplicate resource(s) produced by multiple accumulated paths:
         Alert…/alertmanager.volsync-system
         - ./kubernetes/apps/kopiur-system
         - ./kubernetes/apps/volsync-system
         …
         blocks actions-runner-system/actions-runner-controller, …, cert-manager/cert-manager +70 more
  ✗  Kustomization  kopiur-system/kopiur  not found
      required by volsync-system/kopiur-repository

  ✗ 2 failed · 76 blocked
```

`test all` — false green corrected, cascade folded:
```
  ⊘  76 blocked by flux-system/cluster-apps
  ⊘  1 blocked by kopiur-system/kopiur (not found)

  ✗ 36 passed · 1 failed · 76 blocked   0.1s
```

## Verification

- `gofmt` clean · `go build` · `go vet` · `go test ./...` · `-race` on touched packages · `golangci-lint run` → **0 issues**.
- New unit tests: cascade/orphan discriminator, multi-line primary message, distinct-blocked counting, the test-runner fold (failed-parent + missing-dep), the folded typed machine error.
- **Byte-equivalence**: `flate build all` STDOUT byte-identical to `main` on `/Users/buroa/k8s-gitops` (439 B) and a 5k-object repo (3,190,543 B) — only stderr/status/the test table change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)