### PR TITLE
refactor: tidy the root-cause failure-output internals

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -718,7 +718,7 @@ func aggregateScopedFailures(
 	if nBlocked > 0 {
 		msg += fmt.Sprintf("\n  (+%d blocked by failed/missing dependencies)", nBlocked)
 	}
-	return &orchestrator.FailuresError{Count: len(msgs), Message: msg}
+	return &orchestrator.FailuresError{Message: msg}
 }
 
 func nonResourceRunErrors(err error) []error {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -143,7 +143,7 @@ func rootsOf(id manifest.NamedResource, blocked map[manifest.NamedResource][]man
 func sortedIDs(ids []manifest.NamedResource) []manifest.NamedResource {
 	out := slices.Clone(ids)
 	slices.SortFunc(out, manifest.NamedResource.Compare)
-	return slices.CompactFunc(out, func(a, b manifest.NamedResource) bool { return a.Compare(b) == 0 })
+	return slices.Compact(out) // NamedResource is a comparable struct; sorted ⇒ dups adjacent
 }
 
 // Write renders the model to w. color gates ANSI styling; elapsed, when > 0,
@@ -165,11 +165,12 @@ func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
 	}
 
 	for _, mr := range m.Missing {
-		fmt.Fprintf(&b, "  %s  %s  %s  %s\n      %s\n",
+		fmt.Fprintf(&b, "  %s  %s  %s  %s\n%s%s\n",
 			style.Fail(style.GlyphFail, color),
 			style.Dim(mr.ID.Kind, color),
 			mr.ID.NamespacedName(),
 			style.Fail("not found", color),
+			msgIndent,
 			style.Dim("required by "+summarize(mr.RequiredBy), color))
 	}
 

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -15,9 +15,11 @@ import (
 // detectOrphans returns the subset of failed resources that are
 // "orphans" — Kustomizations/HelmReleases whose source files sit
 // under another Kustomization's spec.path but were never emitted by
-// that parent's render output. Such files exist on disk but Flux
-// would never see them, so flate downgrades the failure to a
-// warning rather than gating the test on stale local files.
+// that parent's render output, AND whose covering parent itself
+// succeeded. Such files exist on disk but Flux would never see them,
+// so flate downgrades the failure to a warning rather than gating the
+// test on stale local files. A child under a parent that FAILED is a
+// blocked cascade victim, not an orphan — it stays failed (see below).
 func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.StatusInfo) map[manifest.NamedResource]string {
 	out := make(map[manifest.NamedResource]string)
 	// Use repoRoot (not cfg.Path) so KSPathPrefixes' component
@@ -213,11 +215,8 @@ func (o *Orchestrator) logResourceFailures(failed map[manifest.NamedResource]sto
 // identity (recovered with errors.As) — not its message text — is how the CLI
 // tells the resource-failure aggregate apart from incidental run errors (a
 // panic, a cancellation) when it re-scopes failures to a namespace filter and
-// re-renders them. Count is the number of failures aggregated.
-type FailuresError struct {
-	Count   int
-	Message string
-}
+// re-renders them.
+type FailuresError struct{ Message string }
 
 func (e *FailuresError) Error() string { return e.Message }
 
@@ -231,10 +230,8 @@ func (o *Orchestrator) aggregateFailures(failed map[manifest.NamedResource]store
 		}
 	}
 	slices.Sort(msgs) // deterministic ordering across runs
-	return &FailuresError{
-		Count:   len(msgs),
-		Message: fmt.Sprintf("reconcile completed with %d failure(s):\n  %s", len(msgs), strings.Join(msgs, "\n  ")),
-	}
+	return &FailuresError{Message: fmt.Sprintf("reconcile completed with %d failure(s):\n  %s",
+		len(msgs), strings.Join(msgs, "\n  "))}
 }
 
 // sanitizeFailed returns a copy of the failure map with each entry's

--- a/pkg/store/status.go
+++ b/pkg/store/status.go
@@ -328,7 +328,7 @@ func (s *Store) FailedResources() map[manifest.NamedResource]StatusInfo {
 func (s *Store) SetBlocked(id manifest.NamedResource, deps []manifest.NamedResource) {
 	sh := s.shardFor(id)
 	sh.mu.Lock()
-	sh.blocked[id] = append([]manifest.NamedResource(nil), deps...)
+	sh.blocked[id] = slices.Clone(deps)
 	sh.mu.Unlock()
 }
 
@@ -338,5 +338,5 @@ func (s *Store) BlockedBy(id manifest.NamedResource) []manifest.NamedResource {
 	sh := s.shardFor(id)
 	sh.mu.RLock()
 	defer sh.mu.RUnlock()
-	return append([]manifest.NamedResource(nil), sh.blocked[id]...)
+	return slices.Clone(sh.blocked[id])
 }


### PR DESCRIPTION
A cleanup pass over the now-stable failure-output code shipped in [#728](https://github.com/home-operations/flate/pull/728) and [#729](https://github.com/home-operations/flate/pull/729). **No behavior change** — `flate build all` stdout is byte-identical on both fixture repos (k8s-gitops, 2.4 MB; a 5k-object repo, 3.19 MB); the only rendered difference is a cosmetic stderr alignment fix.

### Changes

- **report** — align the `Missing` "required by" continuation to the same `msgIndent` the primary "blocks" line uses (was a hardcoded 6-space literal vs. 9); replace `sortedIDs`' `CompactFunc` closure with `slices.Compact` (`NamedResource` is a comparable struct, so sorted ⇒ dups adjacent).
- **store** — `slices.Clone` over the `append([]T(nil), …)` idiom in the two `SetBlocked`/`BlockedBy` defensive copies.
- **orchestrator** — drop `FailuresError.Count`: it was never read, and the two builders set it with *different* meanings (total vs. primary-only count). Keep just the `Message` identity that `errors.As` keys on. Document `detectOrphans`' parent-succeeded discriminator in the function doc.

### Deliberately left alone

`Primary`/`Missing` stay as distinct types (they model two genuinely different root-cause kinds and render differently); the orchestrator's eager failure-aggregate string stays eager (failure path, not hot); `noteTotal`'s count guard stays. No manufactured churn.

### Verification

`gofmt` · `go build` · `go vet` · `go test ./...` · `-race` on touched packages · `golangci-lint run` → **0 issues**. Existing tests cover the touched paths unchanged (behavior-preserving). Byte-equivalence confirmed on both repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)