### PR TITLE
feat(kustomize): cross-run render cache validated by a recorded read-set

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -88,6 +88,12 @@ type commonFlags struct {
 	// previously-rendered manifests instead of re-running
 	// action.Install.RunWithContext.
 	helmRenderCacheMB int
+	// kustomizeRenderCacheMB caps the persistent on-disk kustomize render
+	// cache in megabytes. Default 1024; 0 disables. Plumbed through
+	// orchestrator.Config.KustomizeRenderCacheBytes into the TreeCache.
+	// Cross-process: a Kustomization whose source inputs are unchanged since
+	// a prior run skips krusty entirely.
+	kustomizeRenderCacheMB int
 }
 
 // bindCommon wires the flags every reconcile-running subcommand shares.
@@ -162,6 +168,11 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 	// CI runners where disk cost outweighs the rerun savings).
 	fs.IntVar(&f.helmRenderCacheMB, "helm-render-cache-mb", 1024,
 		"size of the persistent on-disk helm template-output cache in megabytes (0 disables)")
+	// 1 GiB default mirrors the helm render cache. Cross-process: a
+	// Kustomization whose source inputs are unchanged since a prior run skips
+	// krusty entirely. 0 disables (debugging the uncached path / disk-constrained CI).
+	fs.IntVar(&f.kustomizeRenderCacheMB, "kustomize-render-cache-mb", 1024,
+		"size of the persistent on-disk kustomize render cache in megabytes (0 disables)")
 }
 
 // skipResourceKinds delegates to helm.Options.SkipResourceKinds so
@@ -403,11 +414,12 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 			MaxWait:  c.sourceRetryMaxWait,
 			Jitter:   c.sourceRetryJitter,
 		},
-		GitDepth:               c.gitDepth,
-		AllowMissingSecrets:    c.allowMissingSecrets,
-		CacheDir:               c.resolveCacheRoot(),
-		HelmTemplateCacheBytes: int64(c.helmTemplateCacheMB) << 20,
-		HelmRenderCacheBytes:   int64(c.helmRenderCacheMB) << 20,
+		GitDepth:                  c.gitDepth,
+		AllowMissingSecrets:       c.allowMissingSecrets,
+		CacheDir:                  c.resolveCacheRoot(),
+		HelmTemplateCacheBytes:    int64(c.helmTemplateCacheMB) << 20,
+		HelmRenderCacheBytes:      int64(c.helmRenderCacheMB) << 20,
+		KustomizeRenderCacheBytes: int64(c.kustomizeRenderCacheMB) << 20,
 	}
 }
 

--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -81,6 +81,23 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 	}
 	sourceRoot = dr.root
 
+	// Cross-run render cache: a stored render whose recorded disk inputs still
+	// validate against the live tree reproduces the output exactly, so krusty is
+	// skipped entirely. The readSet (see readset.go) makes a hit sound even for
+	// `..`-escaping / transitive inputs a spec hash alone would miss.
+	key := renderKey(rawSpec, dr.root, subPath, applyIgnore)
+	if rc := cache.render; rc != nil && key != "" {
+		if snap, output, ok := rc.get(key); ok && snap.stillValid(dr.diskFS, dr.root) {
+			return output, nil
+		}
+	}
+	// On a miss, record this build's disk reads so the next run can validate it.
+	// A nil recorder (cache disabled or unkeyable) keeps the overlay byte-identical.
+	var rec *readSet
+	if cache.render != nil && key != "" {
+		rec = newReadSet(dr.root)
+	}
+
 	// Memory-over-disk overlay: source files are read from the secure on-disk
 	// FS rooted at sourceRoot (no real-FS reach beyond root; symlinks
 	// evaluated), while the merged kustomization.yaml + any pre-fetched remote
@@ -89,7 +106,7 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 	// gets its own overlay). Reading source from disk also sidesteps the
 	// in-memory fs's filename restriction, so trees with exotic names (spaces,
 	// etc.) render.
-	memFS := newOverlayFS(dr.diskFS)
+	memFS := newOverlayFS(dr.diskFS, rec)
 
 	subDir := filepath.Join(sourceRoot, subPath)
 	if info, statErr := os.Stat(subDir); statErr != nil || !info.IsDir() {
@@ -100,7 +117,8 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 	// resources: into the memory layer so the build only ever sees local files
 	// and never reaches the network (kustomize's git/HTTP fallback would
 	// otherwise run outside the fs sandbox). Scoped to subDir. See preflight.go.
-	if err := preflightRemoteResources(ctx, cache, memFS, subDir); err != nil {
+	injected, err := preflightRemoteResources(ctx, cache, memFS, subDir)
+	if err != nil {
 		return nil, err
 	}
 
@@ -115,6 +133,17 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 			return nil, ierr
 		}
 		ignore = m
+		// sourceignore.New → flux.LoadIgnorePatterns reads .sourceignore files
+		// directly off disk, OUTSIDE the recording overlay, so their content is
+		// invisible to the read-set — an in-place edit would otherwise stale-hit
+		// a cached render. Read each one back through the overlay so its content
+		// is recorded and a change invalidates the entry. Scoped to the
+		// auto-generate path (no in-tree kustomization), the matcher's only
+		// output-affecting consumer (scanManifests); a .sourceignore added or
+		// removed is already caught by the directory listings the build records.
+		if _, hasKust := kustomizationFileIn(memFS, subDir); rec != nil && !hasKust {
+			recordIgnoreFiles(memFS, subDir)
+		}
 	}
 
 	// Merge spec.patches/images/components/targetNamespace/namePrefix/nameSuffix
@@ -159,7 +188,48 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 	if err != nil {
 		return nil, fmt.Errorf("kustomize render %s: %w", subPath, err)
 	}
+	// Persist for the next run, unless the build consumed inputs the disk
+	// read-set can't validate: pre-fetched remote content (injected) or an
+	// unrepresentable read such as a Glob (rec.bypassed).
+	if rec != nil && !injected && !rec.bypassed() {
+		cache.render.put(key, rec.snapshot(), out)
+	}
 	return out, nil
+}
+
+// renderKey is the cross-run render-cache lookup key for a RenderFlux call: a
+// stable fingerprint of everything that determines the output BEFORE the source
+// tree's content is consulted (the read-set validates that content). The full
+// rawSpec is hashed — generateManifest's merge and the post-build
+// applyOwnerLabels/applyCommonMetadata all derive from it. Empty (caching off
+// for this render) when the spec can't be hashed.
+func renderKey(rawSpec map[string]any, sourceRoot, subPath string, applyIgnore bool) string {
+	return manifest.Fingerprint(struct {
+		Spec        map[string]any
+		SourceRoot  string
+		SubPath     string
+		ApplyIgnore bool
+	}{rawSpec, sourceRoot, subPath, applyIgnore})
+}
+
+// ignoreFileName is the in-tree source-controller exclusion file flux's
+// LoadIgnorePatterns reads (off-overlay) and recurses subdirectories for.
+const ignoreFileName = ".sourceignore"
+
+// recordIgnoreFiles reads every .sourceignore under subDir back through the
+// recording overlay so each one's content lands in the render cache's read-set
+// (flux loads them off-disk, bypassing the overlay — see RenderFlux). The
+// read-through's side effect is the recording; the returned bytes are discarded.
+func recordIgnoreFiles(memFS filesys.FileSystem, subDir string) {
+	_ = memFS.Walk(subDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == ignoreFileName {
+			_, _ = memFS.ReadFile(path)
+		}
+		return nil
+	})
 }
 
 // diskRoot holds the per-sourceRoot invariants RenderFlux reuses across every

--- a/pkg/kustomize/generate_test.go
+++ b/pkg/kustomize/generate_test.go
@@ -24,7 +24,7 @@ func testOverlayFS(t *testing.T, root string) filesys.FileSystem {
 	if err != nil {
 		t.Fatalf("secure fs: %v", err)
 	}
-	return newOverlayFS(disk)
+	return newOverlayFS(disk, nil)
 }
 
 // These tests pin flate's in-memory generateManifest to flux's real on-disk

--- a/pkg/kustomize/gitbase_test.go
+++ b/pkg/kustomize/gitbase_test.go
@@ -111,7 +111,7 @@ func TestPreflightGitBase_RewritesToDirectory(t *testing.T) {
 
 	cache := newPreflightCache(t)
 	withFakeGitBase(cache, worktree, nil)
-	if err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 
@@ -160,7 +160,7 @@ func TestPreflightGitBase_DoesNotHTTPGetGitURL(t *testing.T) {
 
 	cache := newPreflightCache(t)
 	withFakeGitBase(cache, worktree, nil)
-	if err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 
@@ -244,7 +244,7 @@ func TestPreflightGitBase_SourceTreeImmutable(t *testing.T) {
 // base surfaces a clear error rather than silently HTTP-GETting the URL.
 func TestPreflightGitBase_NilFetcherErrors(t *testing.T) {
 	fsys := memFSWith(t, map[string]string{"kustomization.yaml": "resources:\n  - https://github.com/o/r?ref=v1\n"})
-	err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, ".")
+	_, err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, ".")
 	if err == nil {
 		t.Fatal("expected error when no git fetcher is wired")
 	}
@@ -270,7 +270,7 @@ func TestPreflightGitBase_EachKSGetsOwnCopy(t *testing.T) {
 	var calls atomic.Int32
 	cache := newPreflightCache(t)
 	withFakeGitBase(cache, worktree, &calls)
-	if err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 

--- a/pkg/kustomize/overlayfs.go
+++ b/pkg/kustomize/overlayfs.go
@@ -14,6 +14,13 @@ package kustomize
 // also sidesteps the in-memory fs's filename restriction for exotic source
 // names like spaces). The disk layer is a secure FS, so disk reads stay
 // confined to the source root.
+//
+// When a non-nil *readSet is threaded in, every read served from the DISK layer
+// is recorded (file content, directory listing, or probed-path kind) so the
+// render cache can validate a later run by replaying those reads. Memory-layer
+// reads are not recorded: the generated kustomization.yaml is captured by the
+// cache key, and remote-resource builds bypass the cache entirely. With a nil
+// readSet the methods are byte-identical to the uninstrumented overlay.
 
 import (
 	"os"
@@ -23,14 +30,16 @@ import (
 )
 
 // newOverlayFS returns a filesystem that reads from disk and writes to memory.
-func newOverlayFS(disk filesys.FileSystem) filesys.FileSystem {
-	return overlayFS{disk: disk, memory: filesys.MakeFsInMemory()}
+// rec, when non-nil, records disk-layer reads for render-cache validation.
+func newOverlayFS(disk filesys.FileSystem, rec *readSet) filesys.FileSystem {
+	return overlayFS{disk: disk, memory: filesys.MakeFsInMemory(), rec: rec}
 }
 
 // overlayFS layers an in-memory filesystem over a read-only disk filesystem.
 type overlayFS struct {
 	disk   filesys.FileSystem
 	memory filesys.FileSystem
+	rec    *readSet // nil disables recording (and keeps reads byte-identical)
 }
 
 // Write operations: memory only.
@@ -41,14 +50,48 @@ func (fs overlayFS) MkdirAll(path string) error               { return fs.memory
 func (fs overlayFS) RemoveAll(path string) error              { return fs.memory.RemoveAll(path) }
 func (fs overlayFS) WriteFile(path string, d []byte) error    { return fs.memory.WriteFile(path, d) }
 
-// Read operations: memory first, then disk.
+// Read operations: memory first, then disk. Disk reads are recorded.
 
-func (fs overlayFS) Exists(path string) bool { return fs.memory.Exists(path) || fs.disk.Exists(path) }
-func (fs overlayFS) IsDir(path string) bool  { return fs.memory.IsDir(path) || fs.disk.IsDir(path) }
+// recordProbe records the disk-layer node kind of a path that was only probed
+// (existence / type checked, not read or listed). diskExists is the already-
+// computed disk.Exists result so the common path adds at most one IsDir stat.
+func (fs overlayFS) recordProbe(path string, diskExists bool) {
+	if fs.rec == nil {
+		return
+	}
+	isDir := diskExists && fs.disk.IsDir(path)
+	fs.rec.recordNode(path, diskKind(diskExists, isDir))
+}
+
+func (fs overlayFS) Exists(path string) bool {
+	if fs.memory.Exists(path) {
+		return true
+	}
+	e := fs.disk.Exists(path)
+	fs.recordProbe(path, e)
+	return e
+}
+
+func (fs overlayFS) IsDir(path string) bool {
+	if fs.memory.IsDir(path) {
+		return true
+	}
+	d := fs.disk.IsDir(path)
+	if fs.rec != nil {
+		fs.rec.recordNode(path, diskKind(d || fs.disk.Exists(path), d))
+	}
+	return d
+}
 
 func (fs overlayFS) Open(path string) (filesys.File, error) {
 	if fs.memory.Exists(path) {
 		return fs.memory.Open(path)
+	}
+	if fs.rec != nil {
+		// Open streams content the recorder can't observe; re-read once to hash
+		// it (rare — krusty Opens at most a handful of files per build).
+		b, err := fs.disk.ReadFile(path)
+		fs.rec.recordFile(path, b, err)
 	}
 	return fs.disk.Open(path)
 }
@@ -57,7 +100,11 @@ func (fs overlayFS) ReadFile(path string) ([]byte, error) {
 	if fs.memory.Exists(path) {
 		return fs.memory.ReadFile(path)
 	}
-	return fs.disk.ReadFile(path)
+	b, err := fs.disk.ReadFile(path)
+	if fs.rec != nil {
+		fs.rec.recordFile(path, b, err)
+	}
+	return b, err
 }
 
 // CleanedAbs resolves memory paths against the memory layer (so added files —
@@ -67,14 +114,24 @@ func (fs overlayFS) CleanedAbs(path string) (filesys.ConfirmedDir, string, error
 	if fs.memory.Exists(path) {
 		return fs.memory.CleanedAbs(path)
 	}
-	return fs.disk.CleanedAbs(path)
+	d, s, err := fs.disk.CleanedAbs(path)
+	fs.recordProbe(path, err == nil)
+	return d, s, err
 }
 
 func (fs overlayFS) ReadDir(path string) ([]string, error) {
+	if entries, err := fs.disk.ReadDir(path); err == nil && fs.rec != nil {
+		fs.rec.recordDir(path, entries)
+	}
 	return mergeFSResults(fs.memory.ReadDir(path))(fs.disk.ReadDir(path))
 }
 
 func (fs overlayFS) Glob(pattern string) ([]string, error) {
+	// Glob results aren't a single path we can replay soundly; disable caching
+	// for any build that globs rather than risk a stale hit.
+	if fs.rec != nil {
+		fs.rec.markBypass()
+	}
 	return mergeFSResults(fs.memory.Glob(pattern))(fs.disk.Glob(pattern))
 }
 
@@ -104,6 +161,14 @@ func (fs overlayFS) Walk(path string, walkFn filepath.WalkFunc) error {
 		}
 		if _, ok := visited[p]; ok {
 			return nil
+		}
+		// Record each disk directory entered so an added/removed sibling
+		// invalidates the cached render (file content is recorded via ReadFile
+		// when the walk body reads it).
+		if fs.rec != nil && info != nil && info.IsDir() {
+			if entries, derr := fs.disk.ReadDir(p); derr == nil {
+				fs.rec.recordDir(p, entries)
+			}
 		}
 		return walkFn(p, info, err)
 	})

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -63,10 +63,13 @@ const remoteResourcePrefix = ".flate-remote-"
 // On a fetch failure (timeout, 4xx, 5xx, DNS, connection refused) preflight
 // returns the error immediately, so the KS controller surfaces it as a real
 // reconcile failure rather than a silent missing resource.
-func preflightRemoteResources(ctx context.Context, cache *TreeCache, memFS filesys.FileSystem, subPath string) error {
-	return memFS.Walk(subPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
+// The injected return reports whether any remote resource or git base was
+// pre-fetched into the in-memory layer. When true the build reads inputs the
+// disk read-set can't capture, so RenderFlux must not cache that render.
+func preflightRemoteResources(ctx context.Context, cache *TreeCache, memFS filesys.FileSystem, subPath string) (injected bool, err error) {
+	walkErr := memFS.Walk(subPath, func(path string, info os.FileInfo, werr error) error {
+		if werr != nil {
+			return werr
 		}
 		if info.IsDir() {
 			// Skip a git base materialized by a prior resources: entry — its
@@ -80,8 +83,13 @@ func preflightRemoteResources(ctx context.Context, cache *TreeCache, memFS files
 		if !slices.Contains(manifest.KustomizeBuilderFilenames, filepath.Base(path)) {
 			return nil
 		}
-		return rewriteURLResources(ctx, cache, memFS, path)
+		changed, rerr := rewriteURLResources(ctx, cache, memFS, path)
+		if changed {
+			injected = true
+		}
+		return rerr
 	})
+	return injected, walkErr
 }
 
 // rewriteURLResources rewrites URL entries in one kustomization file via
@@ -92,10 +100,10 @@ func preflightRemoteResources(ctx context.Context, cache *TreeCache, memFS files
 //
 // Returns the first fetch failure encountered so the caller can fail the
 // Kustomization's reconcile rather than silently dropping the missing resource.
-func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.FileSystem, ksFile string) error {
+func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.FileSystem, ksFile string) (bool, error) {
 	body, err := memFS.ReadFile(ksFile)
 	if err != nil {
-		return err
+		return false, err
 	}
 	// Fast path: a resource is rewritten only when its scalar carries an
 	// http://|https:// scheme — every trigger (isHTTPURL, and isGitRemoteBase
@@ -105,7 +113,7 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 	// is provably a no-op. Skipping it for the common (local-only) kustomization
 	// avoids a yaml.Unmarshal of every kustomization file on every render.
 	if !containsHTTPFold(body) {
-		return nil
+		return false, nil
 	}
 	var doc yaml.Node
 	if err := yaml.Unmarshal(body, &doc); err != nil {
@@ -114,11 +122,11 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 		// kustomize will load them via its own parser, and if any carry URL
 		// resources we fall back to kustomize's own fetch path. Better to
 		// render imperfectly than fail loud on a doc kustomize itself handles.
-		return nil
+		return false, nil
 	}
 	resourcesNode := findMappingValue(&doc, "resources")
 	if resourcesNode == nil || resourcesNode.Kind != yaml.SequenceNode || len(resourcesNode.Content) == 0 {
-		return nil
+		return false, nil
 	}
 	changed := false
 	dir := filepath.Dir(ksFile)
@@ -133,7 +141,7 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 		if spec, ok := isGitRemoteBase(entry.Value); ok {
 			localDir, fetchErr := fetchGitBase(ctx, cache, memFS, dir, spec)
 			if fetchErr != nil {
-				return fmt.Errorf("remote git base %s: %w", entry.Value, fetchErr)
+				return false, fmt.Errorf("remote git base %s: %w", entry.Value, fetchErr)
 			}
 			setPlainScalar(entry, localDir)
 			changed = true
@@ -144,19 +152,19 @@ func rewriteURLResources(ctx context.Context, cache *TreeCache, memFS filesys.Fi
 		}
 		localFile, fetchErr := fetchRemoteResource(ctx, cache, memFS, dir, entry.Value)
 		if fetchErr != nil {
-			return fmt.Errorf("remote resource %s: %w", entry.Value, fetchErr)
+			return false, fmt.Errorf("remote resource %s: %w", entry.Value, fetchErr)
 		}
 		setPlainScalar(entry, "./"+localFile)
 		changed = true
 	}
 	if !changed {
-		return nil
+		return false, nil
 	}
 	out, err := yaml.Marshal(&doc)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return memFS.WriteFile(ksFile, out)
+	return true, memFS.WriteFile(ksFile, out)
 }
 
 // setPlainScalar rewrites node to a plain (unquoted, untagged) string scalar

--- a/pkg/kustomize/preflight_test.go
+++ b/pkg/kustomize/preflight_test.go
@@ -62,7 +62,7 @@ func TestPreflightRemoteResources_RewritesSuccessfulFetch(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	fsys := memFSWith(t, map[string]string{"kustomization.yaml": "resources:\n  - " + srv.URL + "/foo.yaml\n"})
-	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 
@@ -102,7 +102,7 @@ func TestPreflightRemoteResources_PropagatesFailure(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	fsys := memFSWith(t, map[string]string{"kustomization.yaml": "resources:\n  - " + srv.URL + "/missing.yaml\n"})
-	err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, ".")
+	_, err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, ".")
 	if err == nil {
 		t.Fatal("expected error on 404; got nil (preflight would silently swallow the failure)")
 	}
@@ -119,7 +119,7 @@ func TestPreflightRemoteResources_PropagatesFailure(t *testing.T) {
 func TestPreflightRemoteResources_IgnoresLocalEntries(t *testing.T) {
 	body := "resources:\n  - ./local.yaml\n  - ../shared/cm.yaml\n"
 	fsys := memFSWith(t, map[string]string{"kustomization.yaml": body})
-	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 	got, _ := fsys.ReadFile("kustomization.yaml")
@@ -141,7 +141,7 @@ func TestPreflightRemoteResources_WalksNestedKustomizations(t *testing.T) {
 		"kustomization.yaml":              "resources:\n  - ./components/x\n",
 		"components/x/kustomization.yaml": "resources:\n  - " + srv.URL + "/nested.yaml\n",
 	})
-	if err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 	body, _ := fsys.ReadFile("components/x/kustomization.yaml")
@@ -201,7 +201,7 @@ func TestPreflightRemoteResources_HonorsAlternateFilenames(t *testing.T) {
 	for _, name := range []string{"kustomization.yml", "Kustomization"} {
 		t.Run(name, func(t *testing.T) {
 			fsys := memFSWith(t, map[string]string{name: "resources:\n  - " + srv.URL + "/x.yaml\n"})
-			if err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
+			if _, err := preflightRemoteResources(context.Background(), newPreflightCache(t), fsys, "."); err != nil {
 				t.Fatalf("preflight: %v", err)
 			}
 			body, _ := fsys.ReadFile(name)
@@ -235,7 +235,7 @@ func TestPreflightRemoteResources_FetchesEachURLOnce(t *testing.T) {
 	})
 
 	cache := newPreflightCache(t)
-	if err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
 		t.Fatalf("preflight: %v", err)
 	}
 	if hits != 1 {
@@ -250,7 +250,7 @@ func TestPreflightRemoteResources_FetchesEachURLOnce(t *testing.T) {
 	// A second preflight against the same cache (production runs one preflight
 	// per RenderFlux) must NOT re-fetch.
 	fsys2 := memFSWith(t, map[string]string{"kustomization.yaml": "resources:\n  - " + srv.URL + "/shared.yaml\n"})
-	if err := preflightRemoteResources(context.Background(), cache, fsys2, "."); err != nil {
+	if _, err := preflightRemoteResources(context.Background(), cache, fsys2, "."); err != nil {
 		t.Fatalf("second preflight: %v", err)
 	}
 	if hits != 1 {
@@ -297,7 +297,7 @@ resources:
 namespace: my-app
 `
 	fsys := memFSWith(t, map[string]string{"kustomization.yaml": original})
-	if err := rewriteURLResources(context.Background(), newPreflightCache(t), fsys, "kustomization.yaml"); err != nil {
+	if _, err := rewriteURLResources(context.Background(), newPreflightCache(t), fsys, "kustomization.yaml"); err != nil {
 		t.Fatalf("rewriteURLResources: %v", err)
 	}
 

--- a/pkg/kustomize/readset.go
+++ b/pkg/kustomize/readset.go
@@ -1,0 +1,232 @@
+package kustomize
+
+// readset.go records exactly which on-disk inputs a single RenderFlux build
+// reads, so a later run can validate a cached render by replaying those reads:
+// if every recorded file's content, every listed directory's entries, and every
+// probed path's node kind still match, the build's inputs are unchanged and the
+// cached output is still valid. Because the transitive input set is captured
+// from the build's *actual* reads (not guessed from the spec), it is sound
+// across the cases a naive subtree hash misses — `..`-escaping resources,
+// transitive components, and files added to or removed from an auto-scanned
+// directory.
+//
+// Only disk-layer reads are recorded. The in-memory overlay holds the generated
+// kustomization.yaml — already captured by the cache key, which hashes the Flux
+// spec — and, in the uncacheable remote-resource case, pre-fetched content (that
+// build bypasses the cache; see RenderFlux). An unexpected read the recorder
+// can't represent sets bypass, disabling caching for that render rather than
+// risking a stale hit.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// nodeKind classifies a probed path so a dir↔file↔absent transition the build
+// would observe cannot slip through as a stale hit.
+type nodeKind uint8
+
+const (
+	kindAbsent nodeKind = iota
+	kindFile
+	kindDir
+)
+
+func diskKind(exists, isDir bool) nodeKind {
+	switch {
+	case !exists:
+		return kindAbsent
+	case isDir:
+		return kindDir
+	default:
+		return kindFile
+	}
+}
+
+// readSet accumulates a build's disk reads. Safe for the concurrent access a
+// single krusty build performs through the overlay.
+type readSet struct {
+	root string // source root; recorded paths are stored relative to it
+
+	mu     sync.Mutex
+	files  map[string]string   // relpath -> sha256(content), or "" when the read errored
+	dirs   map[string]string   // relpath -> sha256(sorted child names)
+	nodes  map[string]nodeKind // relpath -> kind, for paths only probed (not read/listed)
+	bypass bool                // an uninstrumentable read occurred — do not cache
+}
+
+func newReadSet(root string) *readSet {
+	return &readSet{
+		root:  root,
+		files: map[string]string{},
+		dirs:  map[string]string{},
+		nodes: map[string]nodeKind{},
+	}
+}
+
+// rel converts an absolute path the overlay saw into a slash-relative path under
+// root. A path outside root (shouldn't happen under the secure FS) is reported
+// not-ok so the caller can bypass.
+func (rs *readSet) rel(abs string) (string, bool) {
+	r, err := filepath.Rel(rs.root, abs)
+	if err != nil || r == ".." || strings.HasPrefix(r, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return filepath.ToSlash(r), true
+}
+
+func (rs *readSet) recordFile(abs string, content []byte, readErr error) {
+	rel, ok := rs.rel(abs)
+	if !ok {
+		rs.markBypass()
+		return
+	}
+	h := ""
+	if readErr == nil {
+		sum := sha256.Sum256(content)
+		h = hex.EncodeToString(sum[:])
+	}
+	rs.mu.Lock()
+	rs.files[rel] = h
+	rs.mu.Unlock()
+}
+
+func (rs *readSet) recordDir(abs string, entries []string) {
+	rel, ok := rs.rel(abs)
+	if !ok {
+		rs.markBypass()
+		return
+	}
+	sorted := append([]string(nil), entries...)
+	sort.Strings(sorted)
+	sum := sha256.Sum256([]byte(strings.Join(sorted, "\x00")))
+	rs.mu.Lock()
+	rs.dirs[rel] = hex.EncodeToString(sum[:])
+	rs.mu.Unlock()
+}
+
+func (rs *readSet) recordNode(abs string, kind nodeKind) {
+	rel, ok := rs.rel(abs)
+	if !ok {
+		rs.markBypass()
+		return
+	}
+	rs.mu.Lock()
+	rs.nodes[rel] = kind
+	rs.mu.Unlock()
+}
+
+func (rs *readSet) markBypass() {
+	rs.mu.Lock()
+	rs.bypass = true
+	rs.mu.Unlock()
+}
+
+func (rs *readSet) bypassed() bool {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	return rs.bypass
+}
+
+// fileEntry / nodeEntry are the serialized, sorted snapshot the disk cache
+// stores beside a render's output. Slices (not maps) so the encoding is
+// deterministic.
+type fileEntry struct {
+	Path string `json:"p"`
+	Hash string `json:"h"`
+}
+type nodeEntry struct {
+	Path string   `json:"p"`
+	Kind nodeKind `json:"k"`
+}
+
+// readSetSnapshot is the cache-stored, deterministic form of a readSet.
+type readSetSnapshot struct {
+	Files []fileEntry `json:"files"`
+	Dirs  []fileEntry `json:"dirs"`
+	Nodes []nodeEntry `json:"nodes"`
+}
+
+// snapshot freezes the recorder into its deterministic serialized form.
+func (rs *readSet) snapshot() readSetSnapshot {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	snap := readSetSnapshot{
+		Files: make([]fileEntry, 0, len(rs.files)),
+		Dirs:  make([]fileEntry, 0, len(rs.dirs)),
+		Nodes: make([]nodeEntry, 0, len(rs.nodes)),
+	}
+	for p, h := range rs.files {
+		snap.Files = append(snap.Files, fileEntry{Path: p, Hash: h})
+	}
+	for p, h := range rs.dirs {
+		snap.Dirs = append(snap.Dirs, fileEntry{Path: p, Hash: h})
+	}
+	for p, k := range rs.nodes {
+		// A bare node bit is redundant when the same path was recorded as a read
+		// file or listed dir (those validate strictly already).
+		if _, isFile := rs.files[p]; isFile {
+			continue
+		}
+		if _, isDir := rs.dirs[p]; isDir {
+			continue
+		}
+		snap.Nodes = append(snap.Nodes, nodeEntry{Path: p, Kind: k})
+	}
+	sort.Slice(snap.Files, func(i, j int) bool { return snap.Files[i].Path < snap.Files[j].Path })
+	sort.Slice(snap.Dirs, func(i, j int) bool { return snap.Dirs[i].Path < snap.Dirs[j].Path })
+	sort.Slice(snap.Nodes, func(i, j int) bool { return snap.Nodes[i].Path < snap.Nodes[j].Path })
+	return snap
+}
+
+// diskReader is the read subset of filesys.FileSystem a snapshot replays
+// against to validate a cached render.
+type diskReader interface {
+	ReadFile(path string) ([]byte, error)
+	ReadDir(path string) ([]string, error)
+	Exists(path string) bool
+	IsDir(path string) bool
+}
+
+// stillValid replays the snapshot against the live disk under root: a cache HIT
+// iff every recorded file still hashes the same, every recorded directory still
+// lists the same children, and every probed path is still the same kind. Any
+// edit, add, or delete krusty would have observed flips one of these, forcing a
+// re-render — so a HIT provably reproduces the cached output.
+func (snap readSetSnapshot) stillValid(disk diskReader, root string) bool {
+	for _, f := range snap.Files {
+		b, err := disk.ReadFile(filepath.Join(root, filepath.FromSlash(f.Path)))
+		if (err != nil) != (f.Hash == "") {
+			return false // file appeared or vanished since recording
+		}
+		if err == nil {
+			sum := sha256.Sum256(b)
+			if hex.EncodeToString(sum[:]) != f.Hash {
+				return false // content changed
+			}
+		}
+	}
+	for _, d := range snap.Dirs {
+		entries, err := disk.ReadDir(filepath.Join(root, filepath.FromSlash(d.Path)))
+		if err != nil {
+			return false
+		}
+		sorted := append([]string(nil), entries...)
+		sort.Strings(sorted)
+		sum := sha256.Sum256([]byte(strings.Join(sorted, "\x00")))
+		if hex.EncodeToString(sum[:]) != d.Hash {
+			return false // a child was added or removed
+		}
+	}
+	for _, n := range snap.Nodes {
+		abs := filepath.Join(root, filepath.FromSlash(n.Path))
+		if diskKind(disk.Exists(abs), disk.IsDir(abs)) != n.Kind {
+			return false // a probed path appeared, vanished, or changed file↔dir
+		}
+	}
+	return true
+}

--- a/pkg/kustomize/readset_test.go
+++ b/pkg/kustomize/readset_test.go
@@ -1,0 +1,128 @@
+package kustomize
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+)
+
+// fakeDisk is a minimal diskReader over in-memory maps keyed by absolute path.
+type fakeDisk struct {
+	files map[string][]byte
+	dirs  map[string][]string
+}
+
+func (f fakeDisk) ReadFile(p string) ([]byte, error) {
+	b, ok := f.files[p]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return b, nil
+}
+
+func (f fakeDisk) ReadDir(p string) ([]string, error) {
+	e, ok := f.dirs[p]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return e, nil
+}
+
+func (f fakeDisk) Exists(p string) bool {
+	if _, ok := f.files[p]; ok {
+		return true
+	}
+	_, ok := f.dirs[p]
+	return ok
+}
+
+func (f fakeDisk) IsDir(p string) bool { _, ok := f.dirs[p]; return ok }
+
+// recordAgainst replays a build's reads against disk into a fresh readSet — the
+// recorder side, mirroring what the instrumented overlay does during a render.
+func recordAgainst(root string, disk fakeDisk, files, dirs, probed []string) readSetSnapshot {
+	rs := newReadSet(root)
+	for _, rel := range files {
+		abs := filepath.Join(root, rel)
+		b, err := disk.ReadFile(abs)
+		rs.recordFile(abs, b, err)
+	}
+	for _, rel := range dirs {
+		abs := filepath.Join(root, rel)
+		e, _ := disk.ReadDir(abs)
+		rs.recordDir(abs, e)
+	}
+	for _, rel := range probed {
+		abs := filepath.Join(root, rel)
+		rs.recordNode(abs, diskKind(disk.Exists(abs), disk.IsDir(abs)))
+	}
+	return rs.snapshot()
+}
+
+func TestReadSet_HitAndInvalidation(t *testing.T) {
+	const root = "/src/app"
+	base := func() fakeDisk {
+		return fakeDisk{
+			files: map[string][]byte{
+				"/src/app/kustomization.yaml": []byte("resources: [a.yaml]\n"),
+				"/src/app/a.yaml":             []byte("kind: ConfigMap\n"),
+				"/src/app/b.yaml":             []byte("kind: Secret\n"),
+			},
+			dirs: map[string][]string{"/src/app": {"kustomization.yaml", "a.yaml", "b.yaml"}},
+		}
+	}
+	// A build that read the kustomization + a.yaml, listed the dir, and probed a
+	// (missing) optional component.
+	snap := recordAgainst(root, base(),
+		[]string{"kustomization.yaml", "a.yaml"},
+		[]string{"."},
+		[]string{"comp"},
+	)
+
+	t.Run("unchanged tree is a hit", func(t *testing.T) {
+		if !snap.stillValid(base(), root) {
+			t.Error("identical tree must validate (cache hit)")
+		}
+	})
+
+	t.Run("editing a recorded file misses", func(t *testing.T) {
+		d := base()
+		d.files["/src/app/a.yaml"] = []byte("kind: ConfigMap\ndata: {x: y}\n")
+		if snap.stillValid(d, root) {
+			t.Error("an edit to a recorded input must invalidate (cache miss)")
+		}
+	})
+
+	t.Run("editing an UNREAD file stays a hit (granularity)", func(t *testing.T) {
+		d := base()
+		d.files["/src/app/b.yaml"] = []byte("kind: Secret\nstringData: {k: v}\n")
+		if !snap.stillValid(d, root) {
+			t.Error("b.yaml was never read by this build; editing it must NOT invalidate")
+		}
+	})
+
+	t.Run("adding a file to the listed dir misses", func(t *testing.T) {
+		d := base()
+		d.dirs["/src/app"] = []string{"kustomization.yaml", "a.yaml", "b.yaml", "c.yaml"}
+		d.files["/src/app/c.yaml"] = []byte("kind: Service\n")
+		if snap.stillValid(d, root) {
+			t.Error("a new file in the auto-scanned dir must invalidate")
+		}
+	})
+
+	t.Run("deleting a recorded file misses", func(t *testing.T) {
+		d := base()
+		delete(d.files, "/src/app/a.yaml")
+		if snap.stillValid(d, root) {
+			t.Error("deleting a recorded input must invalidate")
+		}
+	})
+
+	t.Run("a probed-absent component appearing misses", func(t *testing.T) {
+		d := base()
+		d.dirs["/src/app/comp"] = []string{"kustomization.yaml"}
+		if snap.stillValid(d, root) {
+			t.Error("an optional component that materialized must invalidate")
+		}
+	})
+}

--- a/pkg/kustomize/render_cache.go
+++ b/pkg/kustomize/render_cache.go
@@ -1,0 +1,215 @@
+package kustomize
+
+// render_cache.go persists kustomize render output across `flate` invocations,
+// giving kustomize the cross-run cache helm already has. Each entry pairs the
+// rendered YAML with the readSet snapshot of the disk inputs that produced it
+// (see readset.go); RenderFlux validates a candidate by replaying that snapshot
+// against the live tree, so a hit provably reproduces a fresh render. Layout,
+// gzip framing, atomic writes, and the single-flight LRU sweep mirror
+// pkg/helm/render_cache_disk.go.
+
+import (
+	"bytes"
+	"cmp"
+	"compress/gzip"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"log/slog"
+	"math"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/home-operations/flate/internal/diskcache"
+	"github.com/home-operations/flate/pkg/source/atomic"
+)
+
+// renderCache is a disk-backed, content-validated kustomize render cache. A nil
+// *renderCache is the "disabled" sentinel: every method no-ops / misses, so call
+// sites need not guard the wiring.
+type renderCache struct {
+	root  string
+	limit int64 // total disk bytes; <=0 disables caching
+
+	sweepGate diskcache.Gate
+	rootOnce  sync.Once
+}
+
+// newRenderCache returns a cache rooted at root with the supplied byte cap, or
+// nil (disabled) for an empty root or non-positive limit. The root is created
+// lazily on the first Put.
+func newRenderCache(root string, limitBytes int64) *renderCache {
+	if root == "" || limitBytes <= 0 {
+		return nil
+	}
+	return &renderCache{root: root, limit: limitBytes}
+}
+
+// pathFor shards by the first two key chars so no directory balloons past ~16k
+// peers — readdir stays cheap even for caches in the millions.
+func (c *renderCache) pathFor(key string) string {
+	if len(key) < 2 {
+		return filepath.Join(c.root, "00", key)
+	}
+	return filepath.Join(c.root, key[:2], key)
+}
+
+// get returns the cached snapshot + output for key, or ok=false on any miss
+// (including I/O / decode errors, surfaced at Debug). A nil receiver misses.
+func (c *renderCache) get(key string) (snap readSetSnapshot, output []byte, ok bool) {
+	if c == nil {
+		return readSetSnapshot{}, nil, false
+	}
+	p := c.pathFor(key)
+	raw, err := os.ReadFile(p) //nolint:gosec // path derived from sha256 hex of caller-controlled key
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Debug("kustomize render cache: read", "path", p, "err", err)
+		}
+		return readSetSnapshot{}, nil, false
+	}
+	snap, output, err = decodeEntry(raw)
+	if err != nil {
+		slog.Debug("kustomize render cache: decode", "path", p, "err", err)
+		return readSetSnapshot{}, nil, false
+	}
+	// Bump mtime so the LRU sweep treats this entry as freshly used.
+	now := nowFn()
+	_ = os.Chtimes(p, now, now) //nolint:gosec // path derived from sha256 hex of caller-controlled key
+	return snap, output, true
+}
+
+// put stores snapshot + output under key. A nil receiver no-ops.
+func (c *renderCache) put(key string, snap readSetSnapshot, output []byte) {
+	if c == nil {
+		return
+	}
+	payload, err := encodeEntry(snap, output)
+	if err != nil {
+		slog.Debug("kustomize render cache: encode", "err", err)
+		return
+	}
+	c.rootOnce.Do(func() {
+		if err := os.MkdirAll(c.root, 0o750); err != nil {
+			slog.Debug("kustomize render cache: mkdir root", "root", c.root, "err", err)
+		}
+	})
+	p := c.pathFor(key)
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		slog.Debug("kustomize render cache: mkdir shard", "dir", filepath.Dir(p), "err", err)
+		return
+	}
+	// syncDir=false: a miss is cheap to re-derive, so trade durability for write
+	// throughput (mirrors the helm render cache).
+	if err := atomic.WriteFile(p, payload, 0o600, false); err != nil {
+		slog.Debug("kustomize render cache: write", "path", p, "err", err)
+		return
+	}
+	if c.sweepGate.TryAcquire() {
+		go c.sweep()
+	}
+}
+
+// encodeEntry frames the entry as gzip( uint32(len(snapshotJSON)) | snapshotJSON
+// | rawOutput ). Output stays raw (not base64) so gzip compresses it as text.
+func encodeEntry(snap readSetSnapshot, output []byte) ([]byte, error) {
+	js, err := json.Marshal(snap)
+	if err != nil {
+		return nil, err
+	}
+	if len(js) > math.MaxUint32 {
+		return nil, errors.New("read-set snapshot too large to frame")
+	}
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(js))) //nolint:gosec // bounded by the MaxUint32 check above
+	if _, err := gw.Write(hdr[:]); err != nil {
+		return nil, err
+	}
+	if _, err := gw.Write(js); err != nil {
+		return nil, err
+	}
+	if _, err := gw.Write(output); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func decodeEntry(raw []byte) (readSetSnapshot, []byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	if err != nil {
+		return readSetSnapshot{}, nil, err
+	}
+	defer func() { _ = gz.Close() }()
+	plain, err := io.ReadAll(gz)
+	if err != nil {
+		return readSetSnapshot{}, nil, err
+	}
+	if len(plain) < 4 {
+		return readSetSnapshot{}, nil, errors.New("entry too short")
+	}
+	n := binary.BigEndian.Uint32(plain[:4])
+	if int(n) > len(plain)-4 {
+		return readSetSnapshot{}, nil, errors.New("entry header length out of range")
+	}
+	var snap readSetSnapshot
+	if err := json.Unmarshal(plain[4:4+n], &snap); err != nil {
+		return readSetSnapshot{}, nil, err
+	}
+	output := plain[4+n:]
+	return snap, output, nil
+}
+
+// sweep totals the cache and evicts oldest-by-mtime entries until within limit.
+// Single-flight via sweepGate; errors are best-effort (logged at Debug).
+func (c *renderCache) sweep() {
+	defer c.sweepGate.Release()
+	var (
+		entries []diskcache.Entry
+		total   int64
+	)
+	walkErr := filepath.WalkDir(c.root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return nil
+		}
+		entries = append(entries, diskcache.Entry{Path: path, Size: info.Size(), MTime: info.ModTime().UnixNano()})
+		total += info.Size()
+		return nil
+	})
+	if walkErr != nil {
+		slog.Debug("kustomize render cache: sweep walk", "root", c.root, "err", walkErr)
+	}
+	diskcache.EvictOldest(entries, total, c.limit,
+		func(a, b diskcache.Entry) int {
+			return cmp.Or(cmp.Compare(a.MTime, b.MTime), cmp.Compare(a.Path, b.Path))
+		},
+		func(e diskcache.Entry) error {
+			if err := os.Remove(e.Path); err != nil {
+				slog.Debug("kustomize render cache: sweep remove", "path", e.Path, "err", err)
+				return err
+			}
+			return nil
+		},
+	)
+}
+
+// nowFn is the wall-clock for Get's mtime bump; tests rebind it.
+var nowFn = time.Now

--- a/pkg/kustomize/render_cache_test.go
+++ b/pkg/kustomize/render_cache_test.go
@@ -1,0 +1,144 @@
+package kustomize
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var demoRawSpec = map[string]any{
+	"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+	"kind":       "Kustomization",
+	"metadata":   map[string]any{"name": "demo", "namespace": "flux-system"},
+	"spec":       map[string]any{"path": "./"},
+}
+
+// TestRenderFlux_CacheHitMissInvalidate is the end-to-end soundness gate for the
+// cross-run render cache: a populated entry is a real hit (returns the stored
+// bytes, krusty skipped — proven by tampering the cached output), and editing a
+// recorded input invalidates it so the re-render reflects the change.
+func TestRenderFlux_CacheHitMissInvalidate(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"kustomization.yaml": "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - cm.yaml\n",
+		"cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  k: v1\n",
+	})
+	cache := NewTreeCache()
+	cache.SetRenderCache(t.TempDir(), 1<<30)
+	ctx := context.Background()
+
+	out1, err := RenderFlux(ctx, cache, root, false, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	if !strings.Contains(string(out1), "k: v1") {
+		t.Fatalf("first render missing data; got %s", out1)
+	}
+
+	// Prove the next call is a real HIT (returns stored bytes, skips krusty) by
+	// tampering the cached output and confirming it comes back verbatim.
+	dr, err := cache.diskRootFor(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := renderKey(demoRawSpec, dr.root, ".", false)
+	snap, _, ok := cache.render.get(key)
+	if !ok {
+		t.Fatal("first render did not populate the cache")
+	}
+	cache.render.put(key, snap, []byte("SENTINEL\n"))
+	out2, err := RenderFlux(ctx, cache, root, false, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if string(out2) != "SENTINEL\n" {
+		t.Errorf("expected a cache hit returning the stored bytes; got a re-render:\n%s", out2)
+	}
+
+	// Editing a recorded input must invalidate: the cache misses, krusty re-runs,
+	// and the fresh output reflects the change (never the stale sentinel).
+	if err := os.WriteFile(filepath.Join(root, "cm.yaml"),
+		[]byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  k: v2\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out3, err := RenderFlux(ctx, cache, root, false, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("post-edit render: %v", err)
+	}
+	if string(out3) == "SENTINEL\n" {
+		t.Fatal("edit did not invalidate the cache (stale hit — unsound)")
+	}
+	if !strings.Contains(string(out3), "k: v2") {
+		t.Errorf("re-render should reflect the edit; got %s", out3)
+	}
+}
+
+// TestRenderFlux_SourceignoreContentInvalidates is the regression for the
+// adversarially-found stale hit: .sourceignore is loaded off-disk (outside the
+// recording overlay), so an in-place edit that changes which resources an
+// auto-generated kustomization includes must still invalidate the cache.
+func TestRenderFlux_SourceignoreContentInvalidates(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"a.yaml":        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a\n",
+		"b.yaml":        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: b\n",
+		".sourceignore": "# excludes nothing yet\n",
+	})
+	cache := NewTreeCache()
+	cache.SetRenderCache(t.TempDir(), 1<<30)
+	ctx := context.Background()
+
+	out1, err := RenderFlux(ctx, cache, root, true /* applyIgnore */, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	if !strings.Contains(string(out1), "name: a") || !strings.Contains(string(out1), "name: b") {
+		t.Fatalf("first render should include both a and b; got %s", out1)
+	}
+
+	// Edit .sourceignore IN PLACE to exclude b.yaml — filenames and every .yaml's
+	// content are unchanged, so only the off-overlay .sourceignore bytes differ.
+	if err := os.WriteFile(filepath.Join(root, ".sourceignore"), []byte("b.yaml\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out2, err := RenderFlux(ctx, cache, root, true, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if strings.Contains(string(out2), "name: b") {
+		t.Error("STALE HIT: a .sourceignore edit excluding b.yaml did not invalidate the cache")
+	}
+	if !strings.Contains(string(out2), "name: a") {
+		t.Errorf("re-render should still include a; got %s", out2)
+	}
+}
+
+// TestRenderFlux_DisabledCacheUnchanged pins that a TreeCache with no render
+// cache renders identically to one with the cache — the cache only memoizes, it
+// never changes output.
+func TestRenderFlux_DisabledCacheUnchanged(t *testing.T) {
+	files := map[string]string{
+		"kustomization.yaml": "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - cm.yaml\n",
+		"cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  k: v1\n",
+	}
+	ctx := context.Background()
+
+	rootA := writeTree(t, files)
+	plain := NewTreeCache()
+	outPlain, err := RenderFlux(ctx, plain, rootA, false, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("plain render: %v", err)
+	}
+
+	rootB := writeTree(t, files)
+	cached := NewTreeCache()
+	cached.SetRenderCache(t.TempDir(), 1<<30)
+	outCached, err := RenderFlux(ctx, cached, rootB, false, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("cached render: %v", err)
+	}
+	if string(outPlain) != string(outCached) {
+		t.Errorf("render cache changed output:\nplain:\n%s\ncached:\n%s", outPlain, outCached)
+	}
+}

--- a/pkg/kustomize/tree.go
+++ b/pkg/kustomize/tree.go
@@ -41,10 +41,23 @@ type TreeCache struct {
 	// pkg/source/git (import cycle). nil ⇒ a git-base resource fails with a
 	// clear error. See gitbase.go.
 	gitBase GitBaseFetcher
+
+	// render is the cross-run, content-validated kustomize render cache (see
+	// render_cache.go). nil ⇒ disabled; every render rebuilds. Set once at
+	// construction via SetRenderCache.
+	render *renderCache
 }
 
 // NewTreeCache constructs an empty render cache.
 func NewTreeCache() *TreeCache { return &TreeCache{} }
+
+// SetRenderCache enables the cross-run render cache, persisting under dir with a
+// capBytes disk cap (<=0 or empty dir disables it). The orchestrator calls this
+// once at construction; embedders/tests may leave it unset for an always-render
+// TreeCache.
+func (c *TreeCache) SetRenderCache(dir string, capBytes int64) {
+	c.render = newRenderCache(dir, capBytes)
+}
 
 // SetGitBaseFetcher wires the git-clone capability used to resolve remote git
 // bases referenced from a kustomization's resources:. The orchestrator calls

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -138,6 +138,13 @@ type Config struct {
 	// The CLI flag `--helm-render-cache-mb` exposes this in MB
 	// units; embedders pass bytes directly.
 	HelmRenderCacheBytes int64
+
+	// KustomizeRenderCacheBytes caps the persistent on-disk kustomize
+	// render cache. Cross-process reuse: a Kustomization whose recorded
+	// disk inputs are unchanged since a prior run skips krusty entirely
+	// (see pkg/kustomize/render_cache.go). <= 0 disables it. The CLI flag
+	// `--kustomize-render-cache-mb` exposes this in MB; embedders pass bytes.
+	KustomizeRenderCacheBytes int64
 }
 
 // Orchestrator wires controllers and drives reconciliation.
@@ -347,6 +354,9 @@ func New(cfg Config) (*Orchestrator, error) {
 	// render derives a private in-memory filesystem (no disk staging). Nothing
 	// to clean up on Stop.
 	treeCache := kustomize.NewTreeCache()
+	if cfg.KustomizeRenderCacheBytes > 0 {
+		treeCache.SetRenderCache(layout.RenderKustomizeCache(), cfg.KustomizeRenderCacheBytes)
+	}
 
 	st := store.New()
 	ts := task.NewBounded(cfg.Concurrency)

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -68,6 +68,13 @@ const (
 	// is gzipped rendered manifest bytes. Cross-process safe via atomic
 	// rename; eviction is mtime-LRU bounded by the caller's byte cap.
 	RenderHelmCacheDir = "render/helm"
+	// RenderKustomizeCacheDir holds the persisted kustomize render-output
+	// cache: `<root>/render/kustomize/<hex[:2]>/<hex>` where <hex> is the
+	// sha256 render key; content is gzipped {read-set snapshot + rendered
+	// bytes}. An entry is reused only when its recorded disk inputs still
+	// validate (see pkg/kustomize/render_cache.go) — same cross-process /
+	// mtime-LRU machinery as the helm render cache.
+	RenderKustomizeCacheDir = "render/kustomize"
 )
 
 // pathSep is the platform separator as a string, used by join so it can
@@ -156,3 +163,7 @@ func (l Layout) HelmTmp() string { return join(l.Root, HelmTmpDir) }
 // the first two hex chars of the cache key; the disk layer in
 // pkg/helm owns the layout below this root.
 func (l Layout) RenderHelmCache() string { return join(l.Root, RenderHelmCacheDir) }
+
+// RenderKustomizeCache is the root of the persisted kustomize render cache; the
+// disk layer in pkg/kustomize owns the sharded layout below it.
+func (l Layout) RenderKustomizeCache() string { return join(l.Root, RenderKustomizeCacheDir) }


### PR DESCRIPTION
## What

Gives kustomize the cross-run cache helm already has. A Kustomization whose **source inputs are unchanged** since a prior run skips krusty entirely — warm `build all` drops **~25–30%** (k8s-gitops 0.44 s → 0.33 s, and steadier), the dev-loop win the [perf deep-dive](https://github.com/home-operations/flate/pull/729) identified as the only remaining structural lever (helm renders were already cached; this was the missing piece, profiled at ~240 ms + 121 MB `CopyYNode`/run).

## Why a read-set, not a content hash

A kustomization's input set is only knowable **by building it** — `..`-escaping resources, transitive components, files added to an auto-scanned dir. So a subtree/content hash is **unsound** (that's why the package doc deferred render caching). Instead this **records exactly which disk inputs each build reads** and **validates a cached render by replaying them**:

- `readset.go` — `{file→sha256(content), dir→sha256(entries), probed→nodeKind}`; `stillValid(disk, root)` replays it → HIT iff all still match. Sound across edit / add / delete / rename / file↔dir flip.
- `overlayfs.go` — the memory-over-disk FS feeds the recorder on every **disk-served** read (memory reads = the generated kustomization.yaml = key-determined; remote-injected builds bypass).
- `render_cache.go` — disk cache mirroring `pkg/helm/render_cache_disk.go` (gzip, sharded, atomic write, mtime-LRU sweep), storing `{snapshot + output}`.
- `flux.go` — `key = Fingerprint(rawSpec + sourceRoot + subPath + applyIgnore)`; get-hit + `stillValid` → return cached output (skip `BuildMutex`+`Build`+`AsYaml`); miss → build with a recording overlay, then `put` unless `injected` (preflight fetched remote content) or `bypassed` (Glob).
- `--kustomize-render-cache-mb` (default 1 GiB) → `Config` → `TreeCache`.

## Adversarial verification

Because a silent stale hit is the worst failure mode, the whole feature was run through an **8-agent adversarial pass** across 4 lenses (read-surface completeness, memory/bypass holes, key/invalidation, cross-run portability/integrity). It found **exactly one** real false-hit — an in-place `.sourceignore` edit, since flux loads `.sourceignore` off-disk *outside* the recording overlay. **Fixed** by reading each `.sourceignore` back through the overlay on the auto-generate path, with a regression test (`TestRenderFlux_SourceignoreContentInvalidates`). No other hole survived verification.

## Verification

- `gofmt` · `go vet` · `go test ./...` · `-race` on touched pkgs · `golangci-lint run` → **0 issues**.
- Integration test proves a **real hit** (tampered cached bytes returned → krusty skipped) and that **edits invalidate**; unit tests prove the read-set catches edit/add/delete/appear, and that an *unread* file edit stays a hit (granularity).
- **Byte-equivalence**: `flate build all` STDOUT byte-identical to `main` on `/Users/buroa/k8s-gitops` and a 5k-object repo, **both cold (populate) and warm (hit)**.
- **Determinism**: 10–15× warm runs identical; 220 cache entries populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)