### PR TITLE
refactor(kustomize): tidy the render-cache read path after #731/#733

### DIFF
--- a/pkg/kustomize/overlayfs.go
+++ b/pkg/kustomize/overlayfs.go
@@ -120,10 +120,11 @@ func (fs overlayFS) CleanedAbs(path string) (filesys.ConfirmedDir, string, error
 }
 
 func (fs overlayFS) ReadDir(path string) ([]string, error) {
-	if entries, err := fs.disk.ReadDir(path); err == nil && fs.rec != nil {
+	entries, err := fs.disk.ReadDir(path)
+	if err == nil && fs.rec != nil {
 		fs.rec.recordDir(path, entries)
 	}
-	return mergeFSResults(fs.memory.ReadDir(path))(fs.disk.ReadDir(path))
+	return mergeFSResults(fs.memory.ReadDir(path))(entries, err)
 }
 
 func (fs overlayFS) Glob(pattern string) ([]string, error) {

--- a/pkg/kustomize/readset.go
+++ b/pkg/kustomize/readset.go
@@ -18,12 +18,13 @@ package kustomize
 // risking a stale hit.
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"cmp"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
+
+	"github.com/home-operations/flate/pkg/manifest"
 )
 
 // nodeKind classifies a probed path so a dir↔file↔absent transition the build
@@ -45,6 +46,15 @@ func diskKind(exists, isDir bool) nodeKind {
 	default:
 		return kindFile
 	}
+}
+
+// hashEntries is the order-independent digest of a directory's child names. The
+// record side (recordDir) and the validate side (stillValid) must agree
+// byte-for-byte, so both go through this one definition.
+func hashEntries(entries []string) string {
+	sorted := slices.Clone(entries)
+	slices.Sort(sorted)
+	return manifest.SHA256Hex([]byte(strings.Join(sorted, "\x00")))
 }
 
 // readSet accumulates a build's disk reads. Safe for the concurrent access a
@@ -87,8 +97,7 @@ func (rs *readSet) recordFile(abs string, content []byte, readErr error) {
 	}
 	h := ""
 	if readErr == nil {
-		sum := sha256.Sum256(content)
-		h = hex.EncodeToString(sum[:])
+		h = manifest.SHA256Hex(content)
 	}
 	rs.mu.Lock()
 	rs.files[rel] = h
@@ -101,11 +110,9 @@ func (rs *readSet) recordDir(abs string, entries []string) {
 		rs.markBypass()
 		return
 	}
-	sorted := append([]string(nil), entries...)
-	sort.Strings(sorted)
-	sum := sha256.Sum256([]byte(strings.Join(sorted, "\x00")))
+	h := hashEntries(entries)
 	rs.mu.Lock()
-	rs.dirs[rel] = hex.EncodeToString(sum[:])
+	rs.dirs[rel] = h
 	rs.mu.Unlock()
 }
 
@@ -177,9 +184,9 @@ func (rs *readSet) snapshot() readSetSnapshot {
 		}
 		snap.Nodes = append(snap.Nodes, nodeEntry{Path: p, Kind: k})
 	}
-	sort.Slice(snap.Files, func(i, j int) bool { return snap.Files[i].Path < snap.Files[j].Path })
-	sort.Slice(snap.Dirs, func(i, j int) bool { return snap.Dirs[i].Path < snap.Dirs[j].Path })
-	sort.Slice(snap.Nodes, func(i, j int) bool { return snap.Nodes[i].Path < snap.Nodes[j].Path })
+	slices.SortFunc(snap.Files, func(a, b fileEntry) int { return cmp.Compare(a.Path, b.Path) })
+	slices.SortFunc(snap.Dirs, func(a, b fileEntry) int { return cmp.Compare(a.Path, b.Path) })
+	slices.SortFunc(snap.Nodes, func(a, b nodeEntry) int { return cmp.Compare(a.Path, b.Path) })
 	return snap
 }
 
@@ -203,11 +210,8 @@ func (snap readSetSnapshot) stillValid(disk diskReader, root string) bool {
 		if (err != nil) != (f.Hash == "") {
 			return false // file appeared or vanished since recording
 		}
-		if err == nil {
-			sum := sha256.Sum256(b)
-			if hex.EncodeToString(sum[:]) != f.Hash {
-				return false // content changed
-			}
+		if err == nil && manifest.SHA256Hex(b) != f.Hash {
+			return false // content changed
 		}
 	}
 	for _, d := range snap.Dirs {
@@ -215,10 +219,7 @@ func (snap readSetSnapshot) stillValid(disk diskReader, root string) bool {
 		if err != nil {
 			return false
 		}
-		sorted := append([]string(nil), entries...)
-		sort.Strings(sorted)
-		sum := sha256.Sum256([]byte(strings.Join(sorted, "\x00")))
-		if hex.EncodeToString(sum[:]) != d.Hash {
+		if hashEntries(entries) != d.Hash {
 			return false // a child was added or removed
 		}
 	}


### PR DESCRIPTION
## What

A review pass over the render-cache subsystem shipped in [#731](https://github.com/home-operations/flate/pull/731) / [#733](https://github.com/home-operations/flate/pull/733) surfaced two concrete cleanups (four review lenses, each finding adversarially verified against the byte-equivalence and minimal-implementation constraints; gzip-pooling and "stale comment" suggestions were correctly rejected as speculative or inaccurate).

### 1. `overlayFS.ReadDir` read the disk twice

```go
if entries, err := fs.disk.ReadDir(path); err == nil && fs.rec != nil { // call #1 — runs even when rec == nil
    fs.rec.recordDir(path, entries)
}
return mergeFSResults(fs.memory.ReadDir(path))(fs.disk.ReadDir(path))      // call #2
```

The if-init ran `fs.disk.ReadDir` unconditionally (the `fs.rec != nil` guard only gates the `recordDir` call), then the merge re-read the same directory — a redundant syscall on **every** directory read, including when caching is disabled. Now read once and reuse; the recorded read-set and the merged listing derive from the same listing (also closes a tiny TOCTOU window).

### 2. `readset.go` dedup + modernize

- The `sha256.Sum256 → hex.EncodeToString` idiom (4×) → the canonical `manifest.SHA256Hex`.
- The duplicated `clone + sort + join + hash` directory digest (in `recordDir` **and** `stillValid`) → one `hashEntries` helper, so the record side and validate side — which *must* agree byte-for-byte — hash through a single definition.
- `sort.Slice` → `slices.SortFunc`/`cmp.Compare`, `append([]T(nil),…)` → `slices.Clone`, matching house style (slices helpers used in 31 files). Drops the `crypto/sha256`, `encoding/hex`, and `sort` imports.

## Verification

- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race ./pkg/kustomize/...` · `golangci-lint` → 0 issues.
- **`flate build all` STDOUT byte-identical to `main`** on k8s-gitops and zariel, cold + warm; warm re-run deterministic; warm timing flat (~0.37s / ~0.77s).
- The read-set snapshot + directory digests are byte-identical, so a cache written by the prior binary still validates (cross-cache read verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
