### PR TITLE
perf(cache): compress render cache with zstd instead of gzip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.15.0
 	github.com/homeport/dyff v1.12.0
+	github.com/klauspost/compress v1.18.6
 	github.com/minio/minio-go/v7 v7.2.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -124,7 +125,6 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect

--- a/internal/diskcache/store.go
+++ b/internal/diskcache/store.go
@@ -1,11 +1,8 @@
 package diskcache
 
 import (
-	"bytes"
 	"cmp"
-	"compress/gzip"
 	"errors"
-	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -13,16 +10,31 @@ import (
 	"sync"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
+
 	"github.com/home-operations/flate/pkg/source/atomic"
 )
 
-// Store is a persistent, cross-process disk cache of gzip-compressed byte
+// zstdEncoder and zstdDecoder are process-lifetime singletons. zstd's EncodeAll
+// and DecodeAll are safe for concurrent use, so every Store shares one of each
+// rather than allocating a codec per call (the idiomatic, near-zero-allocation
+// usage). SpeedDefault compresses flate's rendered-manifest payloads ~2x smaller
+// than gzip while compressing ~8x and decompressing ~3.5x faster, at one
+// allocation per call instead of gzip's 20-30 — see the codec benchmark in the
+// PR that introduced this. NewWriter/NewReader cannot error with nil options, so
+// the errors are discarded; both live for the process and are never closed.
+var (
+	zstdEncoder, _ = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.SpeedDefault))
+	zstdDecoder, _ = zstd.NewReader(nil)
+)
+
+// Store is a persistent, cross-process disk cache of zstd-compressed byte
 // payloads keyed by a content hash. Both render caches sit on it: the helm
 // template-output cache (pkg/helm) stores rendered manifest bytes directly; the
 // kustomize render cache (pkg/kustomize) stores a framed read-set + output and
 // owns that framing on top. The Store owns everything below the value: the
-// sharded on-disk layout, gzip, atomic writes, and the single-flight mtime-LRU
-// sweep that bounds total bytes.
+// sharded on-disk layout, zstd compression, atomic writes, and the single-flight
+// mtime-LRU sweep that bounds total bytes.
 //
 // Layout under root:
 //
@@ -30,7 +42,7 @@ import (
 //
 // where <hex> is the full hex-encoded sha256 cache key. The two-char shard
 // avoids one giant directory (mkdir scan / readdir cost balloons past ~100k
-// entries on common filesystems). Contents are gzip(payload).
+// entries on common filesystems). Contents are zstd(payload).
 //
 // Concurrency: Get is unsynchronized — the filesystem already serialises
 // atomic-rename writes against partial reads. Put is likewise unsynchronized;
@@ -97,15 +109,12 @@ func (s *Store) Get(key string) ([]byte, bool) {
 		}
 		return nil, false
 	}
-	gz, err := gzip.NewReader(bytes.NewReader(raw))
+	out, err := zstdDecoder.DecodeAll(raw, nil)
 	if err != nil {
-		slog.Debug("disk render cache: gunzip header", "path", p, "err", err)
-		return nil, false
-	}
-	defer func() { _ = gz.Close() }()
-	out, err := io.ReadAll(gz)
-	if err != nil {
-		slog.Debug("disk render cache: gunzip body", "path", p, "err", err)
+		// A decode failure is a clean miss: a torn write, or an entry left by a
+		// prior build that used a different codec (the format rolls forward by
+		// re-rendering, never by a flag day).
+		slog.Debug("disk render cache: decompress", "path", p, "err", err)
 		return nil, false
 	}
 	// Touch the file so LRU eviction by mtime treats this entry as fresh.
@@ -116,7 +125,7 @@ func (s *Store) Get(key string) ([]byte, bool) {
 	return out, true
 }
 
-// Put gzip-encodes payload and atomically writes it to the sharded path.
+// Put zstd-compresses payload and atomically writes it to the sharded path.
 // Subsequent reads either observe the previous complete file or the new one —
 // never a partial. After the write we kick a background sweep (single-flight via
 // sweepGate) so the fast path doesn't block on directory walks.
@@ -140,19 +149,11 @@ func (s *Store) Put(key string, payload []byte) {
 		return
 	}
 
-	var buf bytes.Buffer
-	// Default gzip level — rendered manifests are mostly text and compress 4-6x;
-	// the CPU cost of level=DefaultCompression vs. BestSpeed is dominated by the
-	// render we just skipped.
-	gw := gzip.NewWriter(&buf)
-	if _, err := gw.Write(payload); err != nil {
-		slog.Debug("disk render cache: gzip write", "path", p, "err", err)
-		return
-	}
-	if err := gw.Close(); err != nil {
-		slog.Debug("disk render cache: gzip close", "path", p, "err", err)
-		return
-	}
+	// EncodeAll with the shared encoder is allocation-light and needs no
+	// Close; rendered manifests are repetitive text that zstd packs ~2x tighter
+	// than gzip, and the compress cost is dominated by the render we just
+	// skipped on this (miss) path anyway.
+	comp := zstdEncoder.EncodeAll(payload, nil)
 
 	// syncDir=false: a render cache miss is cheap to re-derive on the next
 	// invocation, so we trade durability for write throughput. Mirrors
@@ -161,7 +162,7 @@ func (s *Store) Put(key string, payload []byte) {
 	// atomic.WriteFile removes its staged tmpfile on any error path (see
 	// pkg/source/atomic/file.go's committed-bool defer guard), so a failed Put
 	// can't leak partial state into the cache root.
-	if err := atomic.WriteFile(p, buf.Bytes(), 0o600, false); err != nil {
+	if err := atomic.WriteFile(p, comp, 0o600, false); err != nil {
 		slog.Debug("disk render cache: write", "path", p, "err", err)
 		return
 	}

--- a/internal/diskcache/store_test.go
+++ b/internal/diskcache/store_test.go
@@ -2,12 +2,14 @@ package diskcache
 
 import (
 	"bytes"
-	"compress/gzip"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/klauspost/compress/zstd"
 )
 
 // sweepBlocking forces a synchronous eviction pass. Test affordance — production
@@ -26,7 +28,7 @@ func (s *Store) sweepBlocking() {
 }
 
 // TestStore_RoundTrip pins the basic put-then-get path: payload bytes survive
-// gzip + atomic rename + read intact. The load-bearing assertion is
+// zstd + atomic rename + read intact. The load-bearing assertion is
 // byte-identity — a single corrupted byte would be silently observed by every
 // downstream consumer.
 func TestStore_RoundTrip(t *testing.T) {
@@ -64,7 +66,7 @@ func TestStore_PutShardsByHexPrefix(t *testing.T) {
 		t.Fatalf("expected file at %s, got %v", want, err)
 	}
 	if info.Size() == 0 {
-		t.Fatalf("file at %s is empty; Put should have written gzipped bytes", want)
+		t.Fatalf("file at %s is empty; Put should have written compressed bytes", want)
 	}
 }
 
@@ -103,17 +105,19 @@ func TestStore_DisabledOnEmptyRoot(t *testing.T) {
 // TestStore_SweepEvictsOldestByMtime pins the LRU-by-mtime eviction policy: with
 // three entries totaling more than the limit, the sweep removes the oldest until
 // total ≤ limit. The fixed per-entry mtimes (manually Chtimes-d after the write)
-// make the expected eviction order deterministic across filesystems.
+// make the expected eviction order deterministic across filesystems. Payloads are
+// incompressible so the on-disk size is codec-independent (~1 KB each), keeping
+// the eviction math from depending on how well the codec packs the bytes.
 func TestStore_SweepEvictsOldestByMtime(t *testing.T) {
 	dir := t.TempDir()
-	s := NewStore(dir, 50) // 50 bytes total
+	s := NewStore(dir, 1500) // ~1.5 entries fit; the sweep must drop the oldest two
 	keys := []string{
 		strings.Repeat("1", 64),
 		strings.Repeat("2", 64),
 		strings.Repeat("3", 64),
 	}
 	for i, k := range keys {
-		s.Put(k, []byte(strings.Repeat("x", 1024)))
+		s.Put(k, incompressible(1024, uint64(i+1)))
 		// Stagger mtimes so the sort key is unambiguous. Older entries get
 		// earlier timestamps.
 		p := s.pathFor(k)
@@ -191,38 +195,123 @@ func TestStore_GetBumpsMtime(t *testing.T) {
 	}
 }
 
-// TestStore_ReadsExternallyWrittenGzip pins the on-disk wire format: a file that
-// is simply gzip(payload) at the sharded path is a valid Store entry. This is
-// what guarantees a warm cache written by a prior binary stays readable across
-// an upgrade — the format is gzip(payload), nothing more.
-func TestStore_ReadsExternallyWrittenGzip(t *testing.T) {
+// TestStore_ReadsExternallyWrittenZstd pins the on-disk wire format: a file that
+// is simply zstd(payload) at the sharded path is a valid Store entry — the format
+// is zstd(payload), nothing more.
+func TestStore_ReadsExternallyWrittenZstd(t *testing.T) {
 	dir := t.TempDir()
 	s := NewStore(dir, 1<<20)
 	key := strings.Repeat("f", 64)
 	payload := []byte("hello: world\n")
 
-	// Write gzip(payload) by hand at the sharded path — no Store.Put involved.
+	// Write zstd(payload) by hand at the sharded path — no Store.Put involved.
 	p := s.pathFor(key)
 	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	var buf bytes.Buffer
-	gw := gzip.NewWriter(&buf)
-	if _, err := gw.Write(payload); err != nil {
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := gw.Close(); err != nil {
+	if err := os.WriteFile(p, enc.EncodeAll(payload, nil), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p, buf.Bytes(), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	_ = enc.Close()
 
 	got, ok := s.Get(key)
 	if !ok {
-		t.Fatalf("Store must read an externally-written gzip(payload) entry")
+		t.Fatalf("Store must read an externally-written zstd(payload) entry")
 	}
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("wire-format read mismatch:\nwant: %q\ngot:  %q", payload, got)
+	}
+}
+
+// TestStore_RejectsForeignCodec pins the format-roll-forward behavior: an entry
+// in some other codec (here gzip, the prior format) is a clean miss, not a
+// panic or a garbage hit — so a stale cache simply re-renders.
+func TestStore_RejectsForeignCodec(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir, 1<<20)
+	key := strings.Repeat("9", 64)
+	p := s.pathFor(key)
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// 0x1f 0x8b is the gzip magic — not zstd's 0x28 0xb5 0x2f 0xfd.
+	if err := os.WriteFile(p, []byte{0x1f, 0x8b, 0x08, 0x00, 0x00}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := s.Get(key); ok || got != nil {
+		t.Fatalf("a foreign-codec entry must miss cleanly; got (%v, %v)", got, ok)
+	}
+}
+
+// incompressible returns n high-entropy bytes (an LCG's top byte) that neither
+// gzip nor zstd can pack down, so a test's on-disk size math is codec-independent.
+// seed varies the stream per entry.
+func incompressible(n int, seed uint64) []byte {
+	b := make([]byte, n)
+	x := seed
+	for i := range b {
+		x = x*6364136223846793005 + 1442695040888963407
+		b[i] = byte(x >> 56)
+	}
+	return b
+}
+
+// syntheticManifests returns a payload shaped like flate's real cache values:
+// repetitive rendered Kubernetes YAML (~tens of KB), which compresses heavily.
+func syntheticManifests(docs int) []byte {
+	var b strings.Builder
+	for i := range docs {
+		fmt.Fprintf(&b, `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config-%d
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/name: app-%d
+    app.kubernetes.io/instance: app-%d
+    kustomize.toolkit.fluxcd.io/name: apps
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+data:
+  KEY_ONE: "value-one-%d"
+  KEY_TWO: "value-two-%d"
+  CONFIG: |
+    server.host=example.local
+    server.port=8080
+    log.level=info
+`, i, i, i, i, i)
+	}
+	return []byte(b.String())
+}
+
+// BenchmarkStore_Put / _Get guard the codec on a representative payload so a
+// future codec change is measured, not guessed. Put covers the cache-miss
+// (compress) path; Get covers the warm-hit (decompress) path.
+func BenchmarkStore_Put(b *testing.B) {
+	s := NewStore(b.TempDir(), 1<<30)
+	payload := syntheticManifests(200)
+	key := strings.Repeat("a", 64)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	for b.Loop() {
+		s.Put(key, payload)
+	}
+}
+
+func BenchmarkStore_Get(b *testing.B) {
+	s := NewStore(b.TempDir(), 1<<30)
+	payload := syntheticManifests(200)
+	key := strings.Repeat("a", 64)
+	s.Put(key, payload)
+	b.SetBytes(int64(len(payload)))
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, ok := s.Get(key); !ok {
+			b.Fatal("expected hit")
+		}
 	}
 }

--- a/pkg/helm/template_cache.go
+++ b/pkg/helm/template_cache.go
@@ -88,8 +88,8 @@ func newTemplateCache(limitBytes int64, disk *diskcache.Store) *templateCache {
 //
 // On an in-memory miss with a wired disk layer, Get reads through to
 // disk and promotes the hit back into the LRU so subsequent same-
-// process Gets stay fast. Cross-process disk hits incur a gunzip read
-// (cheap vs. the helm render they avoid).
+// process Gets stay fast. Cross-process disk hits incur a decompress
+// read (cheap vs. the helm render they avoid).
 func (c *templateCache) Get(key string) (string, bool) {
 	if c == nil {
 		return "", false
@@ -141,7 +141,7 @@ func (c *templateCache) Put(key, value string) {
 	c.putLocked(key, value)
 	c.mu.Unlock()
 	// Write through to the disk layer outside the in-memory lock so
-	// the gzip + atomic-write doesn't hold off concurrent Gets. Put
+	// the compress + atomic-write doesn't hold off concurrent Gets. Put
 	// no-ops on a nil disk receiver.
 	if c.disk != nil {
 		c.disk.Put(key, []byte(value))

--- a/pkg/kustomize/render_cache.go
+++ b/pkg/kustomize/render_cache.go
@@ -8,8 +8,8 @@ package kustomize
 //
 // renderCache is the kustomize-domain layer: the read-set framing (encodeFrame /
 // decodeFrame) on top of the shared diskcache.Store, which owns the sharded
-// layout, gzip, atomic writes, and the mtime-LRU sweep. helm's render cache sits
-// on the same Store with a plain-bytes value instead of a frame.
+// layout, zstd compression, atomic writes, and the mtime-LRU sweep. helm's
+// render cache sits on the same Store with a plain-bytes value instead of a frame.
 
 import (
 	"encoding/binary"
@@ -73,8 +73,8 @@ func (c *renderCache) put(key string, snap readSetSnapshot, output []byte) {
 }
 
 // encodeFrame frames the entry as uint32(len(snapshotJSON)) | snapshotJSON |
-// rawOutput. The Store gzips this plain frame on write (and gunzips on read), so
-// the output stays raw here — gzip compresses it as text.
+// rawOutput. The Store compresses this plain frame on write (and decompresses on
+// read), so the output stays raw here — zstd compresses it as text.
 func encodeFrame(snap readSetSnapshot, output []byte) ([]byte, error) {
 	js, err := json.Marshal(snap)
 	if err != nil {
@@ -90,7 +90,7 @@ func encodeFrame(snap readSetSnapshot, output []byte) ([]byte, error) {
 	return buf, nil
 }
 
-// decodeFrame is the inverse of encodeFrame over the Store's already-gunzipped
+// decodeFrame is the inverse of encodeFrame over the Store's already-decompressed
 // bytes: read the 4-byte length header, unmarshal that many bytes as the
 // snapshot JSON, and return the remainder as the rendered output.
 func decodeFrame(plain []byte) (readSetSnapshot, []byte, error) {

--- a/pkg/source/cacheroot/layout.go
+++ b/pkg/source/cacheroot/layout.go
@@ -65,13 +65,13 @@ const (
 	// RenderHelmCacheDir holds the persisted helm template-output
 	// cache. Entries are sharded `<root>/render/helm/<hex[:2]>/<hex>`
 	// where <hex> is the full sha256 of the template-cache key. Content
-	// is gzipped rendered manifest bytes. Cross-process safe via atomic
-	// rename; eviction is mtime-LRU bounded by the caller's byte cap.
+	// is zstd-compressed rendered manifest bytes. Cross-process safe via
+	// atomic rename; eviction is mtime-LRU bounded by the caller's byte cap.
 	RenderHelmCacheDir = "render/helm"
 	// RenderKustomizeCacheDir holds the persisted kustomize render-output
 	// cache: `<root>/render/kustomize/<hex[:2]>/<hex>` where <hex> is the
-	// sha256 render key; content is gzipped {read-set snapshot + rendered
-	// bytes}. An entry is reused only when its recorded disk inputs still
+	// sha256 render key; content is zstd-compressed {read-set snapshot +
+	// rendered bytes}. An entry is reused only when its recorded disk inputs still
 	// validate (see pkg/kustomize/render_cache.go) — same cross-process /
 	// mtime-LRU machinery as the helm render cache.
 	RenderKustomizeCacheDir = "render/kustomize"


### PR DESCRIPTION
## What

The shared `diskcache.Store` inherited gzip from the helm render cache (#733 preserved the format); it was never weighed against zstd. It should be zstd — and `klauspost/compress` is already in the module graph (pulled in by helm v4, minio-go, flux-operator), so this is a **pure-Go codec swap at zero new dependency cost** (promoted indirect → direct).

## Benchmark (real cache corpus: 278 entries, ~43 MB rendered-manifest plaintext)

| codec | size vs gzip | encode | decode | allocs/op |
|---|---|---|---|---|
| gzip | — | 1,280 µs | 238 µs | 23 / 34 |
| **zstd** | **−48%** | **157 µs** | **66 µs** | **1 / 1** |

zstd wins on every axis. The Store shares one process-lifetime encoder + decoder (`EncodeAll`/`DecodeAll` are concurrency-safe), so each call allocates **once** instead of gzip's 20–34 — and the code is simpler (no `Writer.Close`/`Reader`+`ReadAll`).

## End-to-end (k8s-gitops, zariel/home-ops)

- **Cache footprint 35–47% smaller** (k8s 3.5→1.9 MB, zariel 2.8→1.8 MB).
- **Warm `build all` wall-clock unchanged** (within noise, best-of-5) — being honest: the codec is a small fraction of the warm build, so its faster decode doesn't move the end-to-end number. The wins are the **footprint** and the **near-zero allocations**, which ease the GC pressure that dominates flate's warm profile.
- **STDOUT byte-identical** to gzip, cold and warm.

## Format roll-forward

The on-disk format changes (zstd magic, not gzip), so the first run after upgrade re-renders and rewrites each entry. The Store treats a foreign-codec or torn entry as a clean miss (`TestStore_RejectsForeignCodec`), so the format rolls forward by re-rendering — never a flag day. STDOUT is unaffected throughout.

## Verification

- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race ./internal/diskcache/...` · `golangci-lint` → 0 issues.
- Replaced the throwaway corpus benchmark with a permanent synthetic `BenchmarkStore_Put`/`_Get` regression guard; the eviction test now uses incompressible payloads so its size math is codec-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
