### PR TITLE
fix(kustomize): confine remote-git-base symlinks to the base root (#741)

### DIFF
--- a/pkg/kustomize/copytree.go
+++ b/pkg/kustomize/copytree.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/home-operations/flate/pkg/source/safepath"
 )
 
 // skipStageDir reports whether a directory base name is excluded when a source
@@ -17,16 +19,36 @@ func skipStageDir(base string) bool {
 }
 
 // walkSourceFiles walks root and invokes visit(rel, body) for every regular
-// file (symlinks dereferenced; dangling and irregular entries skipped silently),
-// descending all directories except those skipStageDir excludes. rel is
-// relative to root, using the OS separator. Used to copy a cloned git base into
-// a render's in-memory fs (see copyDirIntoFS).
+// file (symlinks dereferenced but confined to root — issue #741; dangling,
+// escaping, and irregular entries skipped silently), descending all directories
+// except those skipStageDir excludes. rel is relative to root, using the OS
+// separator. Used to copy a cloned git base into a render's in-memory fs (see
+// copyDirIntoFS).
 func walkSourceFiles(root string, visit func(rel string, body []byte) error) error {
-	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	// A remote git base is untrusted: a fork PR can plant a symlink like
+	// creds.yaml -> /proc/self/environ in the fetched worktree, and this copy
+	// reads through symlinks. Resolve the base root once (Abs mirrors flux's
+	// isSecurePath; EvalSymlinks is load-bearing because cache/temp dirs sit
+	// under symlinked prefixes like /var -> /private/var) so each link's real
+	// target can be confined to it. The main source path gets this for free from
+	// the secure on-disk FS (MakeFsOnDiskSecure); this copy walks the real tree
+	// and must enforce containment itself. The confinement is sound only because
+	// gittree.Materialize writes blob bytes via WriteFile and links via
+	// os.Symlink, never os.Link — so a regular-file walk entry can never be a
+	// hardlink to a host file (which would bypass the symlink check).
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	rootResolved, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return err
+	}
+	return filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		rel, err := filepath.Rel(root, path)
+		rel, err := filepath.Rel(absRoot, path)
 		if err != nil {
 			return err
 		}
@@ -39,8 +61,24 @@ func walkSourceFiles(root string, visit func(rel string, body []byte) error) err
 			}
 			return nil
 		}
+		readPath := path
 		if d.Type()&fs.ModeSymlink != 0 {
-			info, serr := os.Stat(path)
+			// Resolve the full link chain and require the real target to stay
+			// inside the base root, then read that resolved path directly (not
+			// back through the link, so there is no re-follow). An escaping link
+			// is skipped silently — erroring would leak host-path existence to
+			// the attacker via render success/failure.
+			target, terr := filepath.EvalSymlinks(path)
+			if terr != nil {
+				if errors.Is(terr, fs.ErrNotExist) {
+					return nil // dangling — skip
+				}
+				return terr
+			}
+			if !safepath.Contains(rootResolved, target) {
+				return nil // escapes the base root — skip
+			}
+			info, serr := os.Stat(target)
 			if serr != nil {
 				if errors.Is(serr, fs.ErrNotExist) {
 					return nil
@@ -50,10 +88,11 @@ func walkSourceFiles(root string, visit func(rel string, body []byte) error) err
 			if !info.Mode().IsRegular() {
 				return nil
 			}
+			readPath = target
 		} else if !d.Type().IsRegular() {
 			return nil
 		}
-		body, rerr := os.ReadFile(path) //nolint:gosec // path is a walk result under root
+		body, rerr := os.ReadFile(readPath) //nolint:gosec // symlink targets are confined to root via safepath.Contains; regular entries are walk results under root
 		if rerr != nil {
 			return rerr
 		}

--- a/pkg/kustomize/copytree_test.go
+++ b/pkg/kustomize/copytree_test.go
@@ -3,6 +3,7 @@ package kustomize
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -79,5 +80,49 @@ func TestWalkSourceFiles_FollowsLiveSymlink(t *testing.T) {
 	}
 	if got := collectWalk(t, src)["alias.yaml"]; got != "kind: ConfigMap\n" {
 		t.Errorf("symlink target lost; got %q", got)
+	}
+}
+
+// TestWalkSourceFiles_RejectsSymlinkEscape is the #741 regression: a remote git
+// base is untrusted, so a symlink whose target escapes the base root (e.g.
+// creds.yaml -> /proc/self/environ) must NOT be read through — its host bytes
+// must never reach the render fs. In-root symlinks and regular files are
+// unaffected.
+func TestWalkSourceFiles_RejectsSymlinkEscape(t *testing.T) {
+	// An outside-root "host file" with distinctive bytes.
+	outside := t.TempDir()
+	const sentinel = "SECRET-HOST-BYTES\n"
+	hostFile := filepath.Join(outside, "host-secret.yaml")
+	if err := os.WriteFile(hostFile, []byte(sentinel), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "real.yaml"), []byte("kind: ConfigMap\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// In-tree symlink — must still be dereferenced (confine, not skip-all).
+	if err := os.Symlink(filepath.Join(src, "real.yaml"), filepath.Join(src, "alias.yaml")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+	// Escaping symlink — must be dropped.
+	if err := os.Symlink(hostFile, filepath.Join(src, "creds.yaml")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	got := collectWalk(t, src)
+	if got["real.yaml"] != "kind: ConfigMap\n" {
+		t.Errorf("regular file missing/wrong: %q", got["real.yaml"])
+	}
+	if got["alias.yaml"] != "kind: ConfigMap\n" {
+		t.Errorf("in-tree symlink should still be dereferenced; got %q", got["alias.yaml"])
+	}
+	if body, ok := got["creds.yaml"]; ok {
+		t.Errorf("symlink escaping the base root must be skipped; got %q", body)
+	}
+	for rel, body := range got {
+		if strings.Contains(body, sentinel) {
+			t.Fatalf("host-file bytes exfiltrated via %q: %q", rel, body)
+		}
 	}
 }

--- a/pkg/kustomize/gitbase_test.go
+++ b/pkg/kustomize/gitbase_test.go
@@ -281,3 +281,41 @@ func TestPreflightGitBase_EachKSGetsOwnCopy(t *testing.T) {
 		}
 	}
 }
+
+// TestPreflightGitBase_SymlinkEscapeNotMaterialized is the #741 end-to-end
+// regression: a fork-PR-controlled remote base whose worktree contains a symlink
+// pointing at a host file (here a valid ConfigMap so it WOULD render unfixed)
+// must not have that host content copied into the render fs. Legit base files
+// are still materialized; only the escaping symlink is dropped.
+func TestPreflightGitBase_SymlinkEscapeNotMaterialized(t *testing.T) {
+	// A host file OUTSIDE the base root, shaped as a valid manifest so an
+	// unfixed copy would surface it straight into the rendered diff.
+	outside := t.TempDir()
+	const sentinel = "host-secret-exfil"
+	hostFile := filepath.Join(outside, "host.yaml")
+	testutil.WriteFileAt(t, hostFile, "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+sentinel+"\n")
+
+	worktree := fakeWorktree(t, map[string]string{
+		"kustomization.yaml": "resources:\n  - ./cm.yaml\n  - ./creds.yaml\n",
+		"cm.yaml":            "apiVersion: v1\nkind: ConfigMap\nmetadata: {name: base}\n",
+	})
+	// The attacker's symlink: a referenced resource whose target escapes the base.
+	if err := os.Symlink(hostFile, filepath.Join(worktree, "creds.yaml")); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	fsys := memFSWith(t, map[string]string{"kustomization.yaml": "resources:\n  - https://example.com/o/r?ref=v1\n"})
+	cache := newPreflightCache(t)
+	withFakeGitBase(cache, worktree, nil)
+	if _, err := preflightRemoteResources(context.Background(), cache, fsys, "."); err != nil {
+		t.Fatalf("preflight: %v", err)
+	}
+
+	wantDir := remoteResourcePrefix + urlHash("https://example.com/o/r@v1")
+	if !fsys.Exists(filepath.Join(wantDir, "cm.yaml")) {
+		t.Error("legit base resource should still be materialized")
+	}
+	if fsys.Exists(filepath.Join(wantDir, "creds.yaml")) {
+		t.Fatal("symlink escaping the base root must NOT be materialized into the render fs (#741)")
+	}
+}

--- a/pkg/source/safepath/safepath.go
+++ b/pkg/source/safepath/safepath.go
@@ -69,3 +69,13 @@ func SafeJoin(base, rel string, rejectAbsolute bool) (string, error) {
 func isEscaped(rel string) bool {
 	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
+
+// Contains reports whether target lies within root. Both must already be
+// absolute and symlink-resolved by the caller; Contains is pure (no I/O) and
+// only does the algebraic containment check (filepath.Rel + the same `..`-prefix
+// test SafeJoin uses). root == target counts as contained. Used by the kustomize
+// remote-base copy to confine a symlink's resolved target to the base root.
+func Contains(root, target string) bool {
+	rel, err := filepath.Rel(root, target)
+	return err == nil && !isEscaped(rel)
+}

--- a/pkg/source/safepath/safepath_test.go
+++ b/pkg/source/safepath/safepath_test.go
@@ -144,6 +144,35 @@ func TestSafeJoin_ForwardSlashNormalization(t *testing.T) {
 	}
 }
 
+// TestContains exercises the pure containment check the kustomize remote-base
+// copy uses to confine a symlink's resolved target to the base root. Both args
+// are absolute, symlink-resolved paths; only the algebraic check is tested.
+func TestContains(t *testing.T) {
+	t.Parallel()
+	root := filepath.Join(string(filepath.Separator), "base", "root")
+	cases := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{name: "file directly inside", target: filepath.Join(root, "a.yaml"), want: true},
+		{name: "nested inside", target: filepath.Join(root, "sub", "a.yaml"), want: true},
+		{name: "root itself", target: root, want: true},
+		{name: "parent escape", target: filepath.Join(root, "..", "secret"), want: false},
+		{name: "absolute outside", target: filepath.Join(string(filepath.Separator), "etc", "passwd"), want: false},
+		// /base/rootx must NOT count as inside /base/root (prefix-boundary case).
+		{name: "sibling prefix not contained", target: root + "x" + string(filepath.Separator) + "a.yaml", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := safepath.Contains(root, tc.target); got != tc.want {
+				t.Errorf("Contains(%q, %q) = %v; want %v", root, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
 // assertUnderBase verifies that path is strictly inside base (or equal to base).
 func assertUnderBase(t *testing.T, base, path, rel string) {
 	t.Helper()


### PR DESCRIPTION
Closes #741.

## The vulnerability

A Flux Kustomization referencing a **remote git base** could read arbitrary host files into the rendered output via a symlink. [`walkSourceFiles`](pkg/kustomize/copytree.go) — the routine that copies a fetched base into the render FS (reached only via `fetchGitBase` → `copyDirIntoFS`) — followed a symlink entry with `os.Stat` + `os.ReadFile` **through** the link, with no check that the resolved target stayed inside the base root. A fork-PR-controlled base containing `creds.yaml -> /proc/self/environ` (or a serviceaccount token, a mounted config, another repo's cache mirror) had the target's bytes copied beside the kustomization and, if they parsed as a manifest, surfaced in the rendered diff — an exfiltration channel.

**Reachable only when a consumer renders untrusted input** (e.g. konflate with `KONFLATE_RENDER_FORK_PRS=true`). The main source tree and Flux `GitRepository` sources are **unaffected** — they read through fluxcd `MakeFsOnDiskSecure`, which already confines symlinks to root.

## The fix — confine the copy path the same way the secure FS does

- New pure `safepath.Contains(root, target)`, reusing the package's existing `isEscaped` idiom.
- In `walkSourceFiles`: resolve the base root once (`filepath.Abs` + `EvalSymlinks` — `Abs` mirrors flux's `isSecurePath`, `EvalSymlinks` is load-bearing because cache/temp dirs sit under symlinked prefixes like `/var → /private/var`). For each symlink, resolve the full chain, require the real target to stay within root, and read the **resolved target directly** (no re-follow / TOCTOU). An escaping link is **skipped silently** — erroring would leak host-path existence via render success/failure.

**Confine, not skip-all**: in-root symlinks still resolve (matching the secure FS and the existing `FollowsLiveSymlink` behaviour), so output is byte-identical for legitimate input. The confinement holds only because `gittree.Materialize` writes blob bytes + `os.Symlink` and never `os.Link` (so a regular-file walk entry can't be a hardlink to a host file) — documented in a comment so a future worktree-source change can't silently reopen it.

## Verification

- Unit regression (`TestWalkSourceFiles_RejectsSymlinkEscape`): in-tree symlink still dereferenced; an outside-root symlink dropped, its sentinel bytes never collected. End-to-end (`TestPreflightGitBase_SymlinkEscapeNotMaterialized`): a fake worktree symlink → host file is not materialized into the render FS. **Both fail on the pre-fix code with the exact exfiltration** (`host-file bytes exfiltrated via "creds.yaml"`) and pass after. Plus a `safepath.Contains` table test (prefix-boundary `/base/root` vs `/base/rootx`, `root==target`, escapes).
- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race ./pkg/kustomize/... ./pkg/source/safepath/...` · `golangci-lint` (gosec accepts the updated `//nolint`) → 0 issues.
- `flate build all` STDOUT **byte-identical to main** on k8s-gitops and zariel (the fix is a no-op for legitimate input).

Disclosure is already public (filed by the maintainer); whether to additionally publish a GitHub Security Advisory / request a CVE is the maintainers' call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
