### PR TITLE
feat(source): opt-in SSRF egress guard for source fetches (#742)

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -47,6 +47,7 @@ type commonFlags struct {
 	skipCRDs            bool
 	skipSecrets         bool
 	allowMissingSecrets bool
+	restrictEgress      bool
 	skipKinds           []string
 	output              string
 	registryConfig      string
@@ -117,6 +118,11 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 			"that only materialize in the live cluster. Usually unnecessary: a missing Secret "+
 			"declared by an in-repo ExternalSecret/SealedSecret (with a static target name) is "+
 			"auto-skipped without this flag. cert/proxy secretRefs still fail loud.")
+	fs.BoolVar(&f.restrictEgress, "restrict-egress", false,
+		"block source fetches (kustomize remote resources/bases, Git/OCI/Helm/Bucket sources) to "+
+			"loopback, RFC1918, link-local, and cloud-metadata (169.254.169.254) addresses. Off by "+
+			"default — only enable when rendering UNTRUSTED input; trusted repos legitimately reach "+
+			"private/LAN hosts. A configured proxy and ssh:// git are not covered (operator-owned).")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")
 	// Commands with no -o variants (test) register no -o flag at all, so
 	// `-o anything` is an unknown flag rather than a rendered alternative.
@@ -416,6 +422,7 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 		},
 		GitDepth:                  c.gitDepth,
 		AllowMissingSecrets:       c.allowMissingSecrets,
+		RestrictEgress:            c.restrictEgress,
 		CacheDir:                  c.resolveCacheRoot(),
 		HelmTemplateCacheBytes:    int64(c.helmTemplateCacheMB) << 20,
 		HelmRenderCacheBytes:      int64(c.helmRenderCacheMB) << 20,

--- a/pkg/kustomize/preflight.go
+++ b/pkg/kustomize/preflight.go
@@ -19,6 +19,7 @@ import (
 	yaml "go.yaml.in/yaml/v4"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/ssrfguard"
 )
 
 // remoteFetchTimeout caps each pre-flight HTTP GET. Kustomize's
@@ -33,10 +34,16 @@ const remoteFetchTimeout = 5 * time.Second
 // URL endpoint.
 const remoteFetchMaxBytes = 64 << 20 // 64 MiB
 
-// remoteFetchClient is the package-level client used by the
-// pre-flight pass. Distinct from the helm/oci clients so resource-
-// fetch latency stays observable.
-var remoteFetchClient = &http.Client{Timeout: remoteFetchTimeout}
+// remoteFetchClient is the package-level client used by the pre-flight pass.
+// Distinct from the helm/oci clients so resource-fetch latency stays
+// observable. Its transport carries the SSRF egress guard (inert unless
+// ssrfguard.Restrict is enabled) so an untrusted kustomization can't drive a
+// fetch to a private/metadata address; redirects re-dial through the same guard.
+var remoteFetchClient = func() *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	ssrfguard.WrapTransport(tr)
+	return &http.Client{Timeout: remoteFetchTimeout, Transport: tr}
+}()
 
 // remoteResourcePrefix names the in-memory entries preflight writes beside a
 // kustomization for a pre-fetched remote resource: a `<prefix><hash>.yaml`

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/home-operations/flate/pkg/source/git/mirror"
 	"github.com/home-operations/flate/pkg/source/helmchart"
 	"github.com/home-operations/flate/pkg/source/oci"
+	"github.com/home-operations/flate/pkg/source/ssrfguard"
 	"github.com/home-operations/flate/pkg/store"
 	"github.com/home-operations/flate/pkg/task"
 )
@@ -74,6 +75,16 @@ type Config struct {
 	// resources mark Ready with a "skipped:" reason; omitted valuesFrom
 	// refs let HelmReleases render with the remaining values.
 	AllowMissingSecrets bool
+
+	// RestrictEgress enables the SSRF egress guard for ALL source fetches
+	// (kustomize remote resources/bases + Git/OCI/Helm/Bucket sources):
+	// outbound dials to loopback/RFC1918/link-local/cloud-metadata addresses
+	// are refused. Off by default — flate normally renders TRUSTED repos that
+	// legitimately reach private/LAN hosts; a consumer rendering UNTRUSTED input
+	// (e.g. konflate fork mode) sets this. It is process-level (see
+	// pkg/source/ssrfguard): go-git installs its HTTPS transport process-wide,
+	// so a per-render git egress policy is impossible.
+	RestrictEgress bool
 
 	// RegistryConfig is the docker config.json used for OCI auth.
 	RegistryConfig string
@@ -332,6 +343,10 @@ func New(cfg Config) (*Orchestrator, error) {
 	if cfg.Path == "" {
 		return nil, errors.New("orchestrator: path is required")
 	}
+
+	// Arm (or disarm) the process-global SSRF egress guard before any fetcher
+	// transport dials. Inert by default; see Config.RestrictEgress.
+	ssrfguard.Restrict(cfg.RestrictEgress)
 
 	layout := cacheroot.New(cmp.Or(cfg.CacheDir, cacheroot.Default()))
 	helmClientOpts := helm.ClientOptions{

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -2,6 +2,7 @@ package helmchart
 
 import (
 	"fmt"
+	"net/http"
 
 	"helm.sh/helm/v4/pkg/getter"
 
@@ -45,62 +46,29 @@ func (f *Fetcher) helmRepoAuthOptions(r *manifest.HelmRepository) ([]getter.Opti
 	return opts, nil
 }
 
-// helmRepoTLSOptions resolves spec.certSecretRef into helm getter options.
-// The Secret carries one or both of (tls.crt, tls.key) for client-cert auth
-// plus optional ca.crt. Each present file is materialized to a temp file
-// (helm getter v4's WithTLSClientConfig takes paths) removed by cleanup.
-func (f *Fetcher) helmRepoTLSOptions(r *manifest.HelmRepository) ([]getter.Option, func(), error) {
-	noCleanup := func() {}
+// helmRepoTransport builds a per-repo guarded HTTP transport when a
+// HelmRepository sets spec.certSecretRef, returning nil for the common
+// no-custom-TLS case (httpGet's package-default guarded transport then applies).
+// The transport carries client-cert / CA TLS resolved via source.ResolveCertSecret
+// (the canonical cross-kind cert helper — same error sentinels as git/OCI/bucket,
+// incl. the --allow-missing-secrets case) AND the SSRF egress guard
+// (source.NewHTTPTransport wraps it). It is passed to helm's getter via
+// getter.WithTransport, the only way to apply BOTH flate's dial guard and the
+// repo's TLS — helm's getter treats WithTransport and WithTLSClientConfig as
+// mutually exclusive. DisableCompression mirrors helm's own getter transport
+// (chart tarballs are already compressed).
+func (f *Fetcher) helmRepoTransport(r *manifest.HelmRepository) (*http.Transport, error) {
 	if r.CertSecretRef == nil {
-		return nil, noCleanup, nil
+		return nil, nil
 	}
-	if f.secrets == nil {
-		// certSecretRef carries TLS trust material — an unwired SecretGetter
-		// is a wiring bug, not a missing-in-cluster secret. Fail loud (no
-		// ErrMissingSecret wrap, which --allow-missing-secrets would soft-skip):
-		// silently dropping TLS material is a security downgrade. Mirrors
-		// source.ResolveCertSecret, the canonical cross-kind cert helper.
-		return nil, noCleanup, fmt.Errorf("%s references certSecretRef but no SecretGetter is wired", helmID(r))
+	tlsCfg, err := source.ResolveCertSecret(f.secrets, r.Namespace, "HelmRepository", helmID(r), r.CertSecretRef)
+	if err != nil {
+		return nil, err
 	}
-	sec := f.secrets(r.Namespace, r.CertSecretRef.Name)
-	if sec == nil {
-		// A genuinely-absent secret IS the --allow-missing-secrets case
-		// (cert materialized live, not in git) — same sentinel git/oci/bucket
-		// use via source.ResolveCertSecret.
-		return nil, noCleanup, source.MissingSecretErr("HelmRepository", r.Namespace, r.Name, r.CertSecretRef.Name, "not found")
+	tr, err := source.NewHTTPTransport(tlsCfg, nil)
+	if err != nil {
+		return nil, err
 	}
-
-	// Scope the materialized PEM files under the fetcher's per-fetch
-	// tmpDir; helm's getter only reads them. cleanup removes every file
-	// a successful write registered (see source.TempFiles).
-	tf := source.NewTempFiles(f.tmpDir)
-	cleanup := tf.Cleanup
-
-	// Materialize tls.crt / tls.key / ca.crt in the order WithTLSClientConfig
-	// takes them; a missing/empty key yields no file (path stays "").
-	var paths [3]string
-	for i, key := range [3]string{"tls.crt", "tls.key", "ca.crt"} {
-		p, err := tf.Write("helm-tls-*.pem", source.StringFromSecret(sec, key))
-		if err != nil {
-			cleanup()
-			return nil, noCleanup, err
-		}
-		paths[i] = p
-	}
-	if paths == [3]string{} {
-		cleanup()
-		// A secret present but carrying none of the TLS keys is malformed
-		// config — fail loud (no ErrMissingSecret wrap), like BuildTLSConfig.
-		return nil, noCleanup, fmt.Errorf("%s: certSecretRef %s/%s contains none of tls.crt / tls.key / ca.crt",
-			helmID(r), r.Namespace, r.CertSecretRef.Name)
-	}
-	// A client cert needs both halves; reject a half-pair rather than feed
-	// helm a cert without its key (or vice versa). Matches source.BuildTLSConfig,
-	// which the OCI/Bucket paths enforce via ResolveCertSecret.
-	if (paths[0] == "") != (paths[1] == "") {
-		cleanup()
-		return nil, noCleanup, fmt.Errorf("%s: certSecretRef %s/%s must provide both tls.crt and tls.key (or neither)",
-			helmID(r), r.Namespace, r.CertSecretRef.Name)
-	}
-	return []getter.Option{getter.WithTLSClientConfig(paths[0], paths[1], paths[2])}, cleanup, nil
+	tr.DisableCompression = true
+	return tr, nil
 }

--- a/pkg/source/helmchart/auth_test.go
+++ b/pkg/source/helmchart/auth_test.go
@@ -1,84 +1,96 @@
 package helmchart
 
 import (
-	"path/filepath"
+	"errors"
 	"testing"
 
+	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
-// tlsPEMFiles returns the helm-tls-*.pem files the fetcher materialized
-// under its tmpDir.
-func tlsPEMFiles(t *testing.T, tmpDir string) []string {
-	t.Helper()
-	matches, err := filepath.Glob(filepath.Join(tmpDir, "helm-tls-*.pem"))
+// TestHelmRepoTransport_NoCertRef: a repo without certSecretRef returns no
+// per-repo transport (nil) — httpGet's package-default guarded transport
+// applies. That default must carry the egress guard's dial hook.
+func TestHelmRepoTransport_NoCertRef(t *testing.T) {
+	r := httpRepo("https://charts.example")
+	f := newHTTPFetcherWithSecrets(t, r, nil)
+
+	tr, err := f.helmRepoTransport(r)
 	if err != nil {
-		t.Fatalf("glob: %v", err)
+		t.Fatalf("helmRepoTransport: %v", err)
 	}
-	return matches
-}
-
-// TestHelmRepoTLSOptions_MaterializesPresentKeys checks that
-// helmRepoTLSOptions writes exactly the present TLS keys to temp files
-// (the empty-content keys produce no file), and that cleanup removes
-// them — exercising the source.TempFiles dedup through its helm caller.
-func TestHelmRepoTLSOptions_MaterializesPresentKeys(t *testing.T) {
-	cases := []struct {
-		name      string
-		data      map[string]any
-		wantFiles int
-	}{
-		{"all-three", map[string]any{"tls.crt": "CRT", "tls.key": "KEY", "ca.crt": "CA"}, 3},
-		{"cert-and-key", map[string]any{"tls.crt": "CRT", "tls.key": "KEY"}, 2},
-		{"ca-only", map[string]any{"ca.crt": "CA"}, 1},
+	if tr != nil {
+		t.Fatalf("no certSecretRef should yield a nil per-repo transport, got %v", tr)
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			r := httpRepo("https://charts.example")
-			r.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
-			data := tc.data
-			f := newHTTPFetcherWithSecrets(t, r, func(_, _ string) *manifest.Secret {
-				return &manifest.Secret{StringData: data}
-			})
-
-			opts, cleanup, err := f.helmRepoTLSOptions(r)
-			if err != nil {
-				t.Fatalf("helmRepoTLSOptions: %v", err)
-			}
-			if len(opts) != 1 {
-				t.Fatalf("opts = %d, want 1 (WithTLSClientConfig)", len(opts))
-			}
-			files := tlsPEMFiles(t, f.tmpDir)
-			if len(files) != tc.wantFiles {
-				t.Fatalf("materialized %d PEM file(s), want %d", len(files), tc.wantFiles)
-			}
-			cleanup()
-			if remaining := tlsPEMFiles(t, f.tmpDir); len(remaining) != 0 {
-				t.Fatalf("cleanup left %d PEM file(s)", len(remaining))
-			}
-		})
+	if helmGuardedTransport.DialContext == nil {
+		t.Fatal("the default helm transport must be egress-guarded (DialContext set)")
 	}
 }
 
-// TestHelmRepoTLSOptions_NoneFailsLoud pins that a certSecretRef Secret
-// carrying none of tls.crt/tls.key/ca.crt is malformed config and fails
-// loud (no ErrMissingSecret wrap, no files left behind).
-func TestHelmRepoTLSOptions_NoneFailsLoud(t *testing.T) {
+// TestHelmRepoTransport_CertSecretYieldsGuardedTransport: a certSecretRef with
+// CA material yields a non-nil transport that is BOTH egress-guarded
+// (DialContext set) and TLS-configured (RootCAs from the CA), passed to helm via
+// WithTransport. Uses a real CA PEM so source.BuildTLSConfig accepts it.
+func TestHelmRepoTransport_CertSecretYieldsGuardedTransport(t *testing.T) {
+	r := httpRepo("https://charts.example")
+	r.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+	f := newHTTPFetcherWithSecrets(t, r, func(_, _ string) *manifest.Secret {
+		return &manifest.Secret{StringData: map[string]any{"ca.crt": testutil.SelfSignedCA(t)}}
+	})
+
+	tr, err := f.helmRepoTransport(r)
+	if err != nil {
+		t.Fatalf("helmRepoTransport: %v", err)
+	}
+	if tr == nil {
+		t.Fatal("certSecretRef should yield a per-repo transport")
+	}
+	if tr.DialContext == nil {
+		t.Error("per-repo helm transport must be egress-guarded (DialContext set)")
+	}
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.RootCAs == nil {
+		t.Error("certSecretRef CA must populate the transport's RootCAs")
+	}
+}
+
+// TestHelmRepoTransport_MissingSecretIsSoftSkippable: an absent certSecretRef
+// Secret surfaces the shared missing-secret sentinel (so --allow-missing-secrets
+// covers it), matching git/OCI/bucket via source.ResolveCertSecret.
+func TestHelmRepoTransport_MissingSecretIsSoftSkippable(t *testing.T) {
+	r := httpRepo("https://charts.example")
+	r.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
+	f := newHTTPFetcherWithSecrets(t, r, func(_, _ string) *manifest.Secret { return nil })
+
+	tr, err := f.helmRepoTransport(r)
+	if err == nil {
+		t.Fatal("expected an error for an absent certSecretRef Secret")
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("missing certSecretRef Secret must be the ErrMissingSecret sentinel; got %v", err)
+	}
+	if tr != nil {
+		t.Errorf("transport = %v, want nil on error", tr)
+	}
+}
+
+// TestHelmRepoTransport_MalformedFailsLoud: a present Secret carrying none of
+// tls.crt/tls.key/ca.crt is malformed config and fails LOUD (not the
+// soft-skippable missing-secret sentinel).
+func TestHelmRepoTransport_MalformedFailsLoud(t *testing.T) {
 	r := httpRepo("https://charts.example")
 	r.CertSecretRef = &manifest.LocalObjectReference{Name: "tls"}
 	f := newHTTPFetcherWithSecrets(t, r, func(_, _ string) *manifest.Secret {
 		return &manifest.Secret{StringData: map[string]any{"unrelated": "x"}}
 	})
 
-	opts, cleanup, err := f.helmRepoTLSOptions(r)
-	defer cleanup()
+	tr, err := f.helmRepoTransport(r)
 	if err == nil {
 		t.Fatal("expected a loud error for a TLS secret with none of the keys")
 	}
-	if opts != nil {
-		t.Fatalf("opts = %v, want nil on error", opts)
+	if errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("a malformed (key-less) TLS secret must fail loud, not as ErrMissingSecret; got %v", err)
 	}
-	if files := tlsPEMFiles(t, f.tmpDir); len(files) != 0 {
-		t.Fatalf("error path left %d PEM file(s) behind", len(files))
+	if tr != nil {
+		t.Errorf("transport = %v, want nil on error", tr)
 	}
 }

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"slices"
@@ -14,6 +15,7 @@ import (
 	repo "helm.sh/helm/v4/pkg/repo/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -27,12 +29,16 @@ func (f *Fetcher) fetchHTTPChart(ctx context.Context, r *manifest.HelmRepository
 	if err != nil {
 		return nil, err
 	}
-	tlsOpts, cleanup, err := f.helmRepoTLSOptions(r)
+	tr, err := f.helmRepoTransport(r)
 	if err != nil {
 		return nil, err
 	}
-	defer cleanup()
-	allOpts := slices.Concat(authOpts, tlsOpts)
+	allOpts := authOpts
+	if tr != nil {
+		// Custom-CA repo: override httpGet's default guarded transport with one
+		// that also carries this repo's TLS (last WithTransport wins).
+		allOpts = append(slices.Clone(authOpts), getter.WithTransport(tr))
+	}
 
 	res, err := f.resolveChart(ctx, r, chartName, version, allOpts)
 	if err != nil {
@@ -228,6 +234,18 @@ func absChartURL(base, urlStr string) (string, error) {
 // tests can shrink it; mutate only before a run starts to stay race-clean.
 var helmHTTPTimeout = 120 * time.Second
 
+// helmGuardedTransport is the default transport for every helm HTTP repo fetch:
+// the SSRF egress guard (source.NewHTTPTransport) with compression disabled to
+// match helm's own getter transport (chart tarballs are already compressed). A
+// custom-CA repo overrides it per-fetch (see helmRepoTransport). Built once; the
+// guard's blocking is gated by the process-global toggle, so this is inert
+// unless ssrfguard.Restrict is enabled.
+var helmGuardedTransport = func() *http.Transport {
+	tr, _ := source.NewHTTPTransport(nil, nil) // nil/nil never errors
+	tr.DisableCompression = true
+	return tr
+}()
+
 // httpGet fetches url with helm's HTTP getter and the given options. Callers
 // wrap the error with their own context (index fetch vs chart download).
 func httpGet(url string, opts []getter.Option) (*bytes.Buffer, error) {
@@ -235,10 +253,14 @@ func httpGet(url string, opts []getter.Option) (*bytes.Buffer, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Prepend the liveness timeout so a caller-supplied WithTimeout (none
-	// today) still overrides it — getter applies options in order, last
-	// write wins. source.WithRetry layers attempts on top.
-	opts = append([]getter.Option{getter.WithTimeout(helmHTTPTimeout)}, opts...)
+	// Prepend the liveness timeout AND the default guarded transport so EVERY
+	// helm HTTP fetch (index.yaml + chart .tgz) is egress-guarded. A caller-
+	// supplied WithTransport (the custom-CA path) still overrides, since getter
+	// applies options in order, last write wins. source.WithRetry layers attempts.
+	opts = append([]getter.Option{
+		getter.WithTimeout(helmHTTPTimeout),
+		getter.WithTransport(helmGuardedTransport),
+	}, opts...)
 	return g.Get(url, opts...)
 }
 

--- a/pkg/source/ssrfguard/ssrfguard.go
+++ b/pkg/source/ssrfguard/ssrfguard.go
@@ -1,0 +1,172 @@
+// Package ssrfguard is an opt-in SSRF egress guard for flate's outbound source
+// fetches. When flate renders UNTRUSTED input (e.g. konflate rendering a fork
+// PR), a fork can place attacker-chosen URLs in the tree — kustomize remote
+// resources/bases and GitRepository/OCIRepository/HelmRepository/Bucket
+// spec.url — which flate would otherwise fetch server-side from inside the
+// cluster, reaching cloud metadata (169.254.169.254), in-cluster services, and
+// RFC1918/loopback hosts.
+//
+// The guard installs a net.Dialer.Control hook on every fetch transport (via
+// WrapTransport, wired into source.NewHTTPTransport, the helm getter, and the
+// kustomize remote-fetch client). Control runs at dial time, AFTER DNS
+// resolution, for every connection INCLUDING redirect targets, so one hook
+// closes both DNS-rebinding and redirect SSRF without a CheckRedirect.
+//
+// It is OFF by default and gated by a single process-global toggle (Restrict):
+// flate normally renders TRUSTED repos that legitimately fetch from private/LAN
+// hosts (self-hosted Gitea, in-cluster registries), so an always-on private
+// block would break the common case. A consumer rendering untrusted input
+// (konflate fork mode, or the `flate --restrict-egress` flag) turns it on. The
+// toggle is process-global, not per-render, because go-git v5 installs its HTTPS
+// transport on a process-global protocol map with no per-clone hook — so a
+// per-render git egress policy is impossible, and a process-global toggle is the
+// honest model. Set it once at process init; last writer wins.
+//
+// Boundaries (deliberately NOT covered):
+//   - A configured HTTP proxy is a trust boundary the operator owns: with
+//     Transport.Proxy set, the dial (and thus Control) sees the proxy IP, not
+//     the CONNECT target.
+//   - SSH git (ssh://) dials via ssh.Dial, outside this HTTP transport; SSH to a
+//     metadata/RFC1918 endpoint is implausible and out of scope.
+//   - This blocks reaching INTERNAL addresses; full egress-deny (incl. public
+//     hosts) is the consumer's NetworkPolicy job.
+package ssrfguard
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// restrict is the process-global on/off toggle, read at dial time by control.
+var restrict atomic.Bool
+
+// Restrict enables or disables the egress guard process-wide. The orchestrator
+// sets it from Config.RestrictEgress; tests reset it. Safe for concurrent use,
+// but it is a single process-level setting (last writer wins) — see the package
+// doc on why per-render is not possible.
+func Restrict(on bool) { restrict.Store(on) }
+
+// Restricted reports whether the guard is currently enabled.
+func Restricted() bool { return restrict.Load() }
+
+// Ranges netip.Addr.IsPrivate does NOT cover but that are not legitimate fetch
+// targets: carrier-grade NAT, the IETF protocol-assignments /24 (holds
+// 192.0.0.192), and the benchmarking range. Plus the IPv6 transition prefixes
+// that can embed a private/metadata IPv4 (NAT64 is realistic on DNS64 clusters —
+// flate's deployment target).
+var (
+	cgnat       = netip.MustParsePrefix("100.64.0.0/10")
+	ietfProto   = netip.MustParsePrefix("192.0.0.0/24")
+	benchmark   = netip.MustParsePrefix("198.18.0.0/15")
+	nat64       = netip.MustParsePrefix("64:ff9b::/96")
+	sixToFour   = netip.MustParsePrefix("2002::/16")
+	teredo      = netip.MustParsePrefix("2001::/32")
+	broadcastV4 = netip.AddrFrom4([4]byte{255, 255, 255, 255})
+)
+
+// Blocked reports whether a resolved address must not be dialed. It is pure (no
+// I/O) and is the unit-testable core of the guard. The standard SSRF set
+// (loopback, RFC1918+ULA, link-local incl. 169.254.169.254, multicast,
+// unspecified) plus the ranges and IPv6-embedded-IPv4 forms net/netip misses.
+func Blocked(a netip.Addr) bool {
+	a = a.Unmap()
+	switch {
+	case !a.IsValid(),
+		a.IsLoopback(),
+		a.IsPrivate(),          // RFC1918 + IPv6 ULA fc00::/7
+		a.IsLinkLocalUnicast(), // 169.254.0.0/16 + fe80::/10
+		a.IsLinkLocalMulticast(),
+		a.IsMulticast(),
+		a.IsUnspecified(),
+		a == broadcastV4,
+		a.Is4() && a.As4()[0] == 0, // 0.0.0.0/8 "this network"
+		cgnat.Contains(a), ietfProto.Contains(a), benchmark.Contains(a):
+		return true
+	}
+	return embeddedV4Blocked(a)
+}
+
+// embeddedV4Blocked extracts the IPv4 address embedded in an IPv6 transition
+// address (NAT64, 6to4, Teredo, or deprecated v4-compatible) and re-checks it,
+// so e.g. a DNS64 cluster resolving an attacker host to 64:ff9b::a9fe:a9fe
+// (= 169.254.169.254) is still blocked. Returns false for plain IPv6.
+func embeddedV4Blocked(a netip.Addr) bool {
+	if !a.Is6() {
+		return false
+	}
+	b := a.As16()
+	var v4 netip.Addr
+	switch {
+	case nat64.Contains(a):
+		v4 = netip.AddrFrom4([4]byte(b[12:16]))
+	case sixToFour.Contains(a):
+		v4 = netip.AddrFrom4([4]byte(b[2:6]))
+	case teredo.Contains(a):
+		v4 = netip.AddrFrom4([4]byte{^b[12], ^b[13], ^b[14], ^b[15]})
+	case isV4Compatible(b):
+		v4 = netip.AddrFrom4([4]byte(b[12:16]))
+	default:
+		return false
+	}
+	return Blocked(v4)
+}
+
+// isV4Compatible matches the deprecated ::a.b.c.d form: the top 96 bits are zero
+// and the low 32 are non-zero (:: and ::1 are already handled as unspecified /
+// loopback, and ::ffff:a.b.c.d is unmapped to IPv4 before this point).
+func isV4Compatible(b [16]byte) bool {
+	for _, x := range b[:12] {
+		if x != 0 {
+			return false
+		}
+	}
+	return b[12]|b[13]|b[14]|b[15] != 0
+}
+
+// blockedError is the dial error returned for a guarded address.
+type blockedError struct {
+	address string
+	reason  string
+}
+
+func (e *blockedError) Error() string {
+	if e.reason != "" {
+		return fmt.Sprintf("egress to %s blocked: %s", e.address, e.reason)
+	}
+	return fmt.Sprintf("egress to %s blocked by --restrict-egress (private/loopback/link-local/metadata address)", e.address)
+}
+
+// control is the net.Dialer.Control hook. When the guard is off it is a no-op
+// (the dial proceeds, behaviorally identical to an unguarded transport). When on
+// it rejects a dial to a Blocked address. address is the already-resolved
+// ip:port for each connection attempt.
+func control(_, address string, _ syscall.RawConn) error {
+	if !restrict.Load() {
+		return nil
+	}
+	ap, err := netip.ParseAddrPort(address)
+	if err != nil {
+		return &blockedError{address: address, reason: err.Error()}
+	}
+	if Blocked(ap.Addr()) {
+		return &blockedError{address: address}
+	}
+	return nil
+}
+
+// WrapTransport installs the guard's Control hook on tr's dialer. It mirrors
+// http.DefaultTransport's dialer settings (Timeout/KeepAlive) so that with the
+// guard off the transport behaves identically to an unwrapped one. Idempotent
+// and safe to call on every transport flate builds.
+func WrapTransport(tr *http.Transport) {
+	tr.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		Control:   control,
+	}).DialContext
+}

--- a/pkg/source/ssrfguard/ssrfguard_test.go
+++ b/pkg/source/ssrfguard/ssrfguard_test.go
@@ -1,0 +1,102 @@
+package ssrfguard_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/source/ssrfguard"
+)
+
+// TestBlocked is the pure classifier matrix — the unit-testable core of the
+// guard. No network, so it is parallel-safe and independent of the process-
+// global toggle.
+func TestBlocked(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		// --- must block: loopback ---
+		{"127.0.0.1", true},
+		{"127.5.6.7", true},
+		{"::1", true},
+		// --- must block: cloud metadata / link-local (every encoding) ---
+		{"169.254.169.254", true},
+		{"::ffff:169.254.169.254", true}, // IPv4-mapped IPv6
+		{"64:ff9b::a9fe:a9fe", true},     // NAT64 (DNS64)
+		{"2002:a9fe:a9fe::", true},       // 6to4
+		{"::a9fe:a9fe", true},            // deprecated v4-compatible
+		{"fe80::1", true},                // IPv6 link-local
+		// --- must block: RFC1918 + ULA ---
+		{"10.0.0.5", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"fc00::1", true},
+		{"fd12:3456::1", true},
+		// --- must block: ranges netip misses ---
+		{"100.64.0.1", true},      // CGNAT
+		{"198.18.0.1", true},      // benchmark
+		{"192.0.0.192", true},     // IETF protocol assignments
+		{"255.255.255.255", true}, // broadcast
+		{"0.0.0.0", true},         // unspecified / this-network
+		{"0.1.2.3", true},         // 0.0.0.0/8
+		{"224.0.0.1", true},       // multicast
+		// --- must allow: public ---
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"140.82.112.3", false}, // github.com-ish
+		{"2606:4700:4700::1111", false},
+		{"64:ff9b::808:808", false}, // NAT64 wrapping a PUBLIC v4 (8.8.8.8) — allowed
+	}
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			t.Parallel()
+			a, err := netip.ParseAddr(tc.addr)
+			if err != nil {
+				t.Fatalf("parse %q: %v", tc.addr, err)
+			}
+			if got := ssrfguard.Blocked(a); got != tc.want {
+				t.Errorf("Blocked(%s) = %v; want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWrapTransport_GatesDialByToggle is the end-to-end block proof: a guarded
+// client GETs an httptest server (which binds to 127.0.0.1, a blocked address).
+// With the guard ON the dial is rejected before connecting; with it OFF the
+// request succeeds — proving both the dial-time block and the opt-in default.
+// NOT parallel: it flips the process-global toggle (reset via Cleanup).
+func TestWrapTransport_GatesDialByToggle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { ssrfguard.Restrict(false) })
+
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	ssrfguard.WrapTransport(tr)
+	client := &http.Client{Transport: tr}
+
+	// Guard ON: the loopback dial must be refused with the block error.
+	ssrfguard.Restrict(true)
+	if _, err := client.Get(srv.URL); err == nil {
+		t.Fatal("guard ON: expected the loopback dial to be blocked, got success")
+	} else if !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("guard ON: expected a block error, got %v", err)
+	}
+
+	// Guard OFF (default): the same request must succeed.
+	ssrfguard.Restrict(false)
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("guard OFF: expected success, got %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("guard OFF: status %d", resp.StatusCode)
+	}
+}

--- a/pkg/source/transport.go
+++ b/pkg/source/transport.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 	"time"
+
+	"github.com/home-operations/flate/pkg/source/ssrfguard"
 )
 
 // ResponseHeaderTimeout bounds how long an HTTP source fetch (git over HTTPS,
@@ -45,5 +47,10 @@ func NewHTTPTransport(tlsCfg *tls.Config, proxy *ProxyConfig) (*http.Transport, 
 		}
 		tr.Proxy = http.ProxyURL(u)
 	}
+	// Install the SSRF egress guard's dial Control on every source-fetch
+	// transport (git/OCI/bucket here; helm + kustomize wrap their own clients
+	// the same way). A no-op unless ssrfguard.Restrict is enabled, so untrusted
+	// renders are guarded while trusted renders keep reaching private/LAN hosts.
+	ssrfguard.WrapTransport(tr)
 	return tr, nil
 }


### PR DESCRIPTION
Closes #742.

## The vulnerability

Rendering **untrusted input** (e.g. konflate fork PRs) could drive flate to issue server-side HTTP(S) requests to attacker-chosen URLs — cloud metadata (`169.254.169.254`), in-cluster `*.svc`, RFC1918, loopback — with no IP guard and redirects followed. Confirmed **all five** fetch paths honor attacker-controlled URLs from the rendered tree: kustomize `resources:` (HTTP + git bases) **and** `GitRepository`/`OCIRepository`/`HelmRepository`/`Bucket` `spec.url` — so the guard covers all of them (a fork can't bypass via a source CR).

## The guard — `pkg/source/ssrfguard` (opt-in, default off)

A `net.Dialer.Control` hook that, when enabled, refuses dials to loopback / RFC1918+ULA / link-local (incl. `169.254.169.254`, `fe80::`) / CGNAT / unspecified / broadcast — **plus** the IPv6 transition forms that embed a blocked IPv4 (NAT64 `64:ff9b::`, 6to4, Teredo, v4-compat; DNS64/NAT64 is common in clusters). `Control` fires at **dial time, post-DNS, per-connection including redirects**, so one hook closes DNS-rebinding *and* redirect SSRF — no `CheckRedirect`.

**Opt-in, default off**: flate normally renders *trusted* repos that legitimately reach private/LAN hosts (self-hosted Gitea, in-cluster registries); a consumer rendering untrusted input opts in via `--restrict-egress` (CLI) or `Config.RestrictEgress` (konflate fork mode).

## Wiring (small, because the factory is shared)

- **`source.NewHTTPTransport`** (git anon + custom-CA, OCI, bucket): one `ssrfguard.WrapTransport` call.
- **helm**: passes the guarded transport via `getter.WithTransport` — which also let the helm-repo TLS path **drop its temp-file materialization** and unify on `source.ResolveCertSecret` (a net cleanup).
- **kustomize** `remoteFetchClient`: wraps its own transport.
- **toggle**: a single process-global atomic (`ssrfguard.Restrict`) flipped from `Config.RestrictEgress`. Process-global because go-git v5 installs its HTTPS transport process-wide with no per-clone hook — a per-render git egress policy is impossible, so this is the honest model.

**Documented boundaries (out of scope, in flag help):** a configured HTTP proxy is an operator-owned trust boundary (Control sees the proxy IP, not the CONNECT target); `ssh://` git dials outside the HTTP transport.

## Verification

- **Real repro**: a kustomization `resources: [http://169.254.169.254/...]` rendered **with `--restrict-egress`** is refused **at dial**, fast — `egress to 169.254.169.254:80 blocked by --restrict-egress`. **Without** the flag the fetch is attempted (`no route to host`), proving the opt-in default.
- **Pure `Blocked()` matrix**: every encoding of the metadata IP (`169.254.169.254`, `::ffff:…`, NAT64 `64:ff9b::a9fe:a9fe`, 6to4 `2002:a9fe:a9fe::`, `::a9fe:a9fe`), all RFC1918/ULA/CGNAT/broadcast/`0.0.0.0` → blocked; public `8.8.8.8`/`2606:4700::`/`64:ff9b::808:808` (NAT64-to-public) → allowed. Plus a `WrapTransport` dial-block integration test.
- `gofmt` · `go build` · `go vet` · `go test ./...` · `-race` · `golangci-lint` → 0 issues.
- **OFF-parity / byte-equivalence**: `flate build all` without the flag is **byte-identical to main** on k8s-gitops and zariel (the OFF dialer mirrors `http.DefaultTransport`'s settings).

konflate enables `Config.RestrictEgress` for fork renders (with a default-deny-egress NetworkPolicy as the consumer-side compensating control). Disclosure is already public; a Security Advisory is the maintainers' call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
