### PR TITLE
fix(source): reject file:// (non-https/ssh) git schemes under --restrict-egress

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -119,10 +119,12 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 			"declared by an in-repo ExternalSecret/SealedSecret (with a static target name) is "+
 			"auto-skipped without this flag. cert/proxy secretRefs still fail loud.")
 	fs.BoolVar(&f.restrictEgress, "restrict-egress", false,
-		"block source fetches (kustomize remote resources/bases, Git/OCI/Helm/Bucket sources) to "+
-			"loopback, RFC1918, link-local, and cloud-metadata (169.254.169.254) addresses. Off by "+
-			"default — only enable when rendering UNTRUSTED input; trusted repos legitimately reach "+
-			"private/LAN hosts. A configured proxy and ssh:// git are not covered (operator-owned).")
+		"untrusted-render guard: block source fetches (kustomize remote resources/bases, "+
+			"Git/OCI/Helm/Bucket sources) to loopback, RFC1918, link-local, and cloud-metadata "+
+			"(169.254.169.254) addresses, AND reject file:// / non-https-ssh GitRepository sources "+
+			"(no reading arbitrary in-pod repos). Off by default — only enable when rendering "+
+			"UNTRUSTED input; trusted repos legitimately reach private/LAN hosts and use local "+
+			"file:// self-sources. A configured proxy and ssh:// git egress are not covered (operator-owned).")
 	fs.StringSliceVar(&f.skipKinds, "skip-kinds", nil, "extra kinds to drop from rendered output")
 	// Commands with no -o variants (test) register no -o flag at all, so
 	// `-o anything` is an unknown flag rather than a rendered alternative.

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -76,14 +76,18 @@ type Config struct {
 	// refs let HelmReleases render with the remaining values.
 	AllowMissingSecrets bool
 
-	// RestrictEgress enables the SSRF egress guard for ALL source fetches
-	// (kustomize remote resources/bases + Git/OCI/Helm/Bucket sources):
-	// outbound dials to loopback/RFC1918/link-local/cloud-metadata addresses
-	// are refused. Off by default — flate normally renders TRUSTED repos that
-	// legitimately reach private/LAN hosts; a consumer rendering UNTRUSTED input
-	// (e.g. konflate fork mode) sets this. It is process-level (see
-	// pkg/source/ssrfguard): go-git installs its HTTPS transport process-wide,
-	// so a per-render git egress policy is impossible.
+	// RestrictEgress is the untrusted-render switch. It (1) enables the SSRF
+	// egress guard for ALL source fetches (kustomize remote resources/bases +
+	// Git/OCI/Helm/Bucket sources) — outbound dials to loopback/RFC1918/link-
+	// local/cloud-metadata addresses are refused — and (2) rejects GitRepository
+	// URLs whose transport is not https/ssh (file://, git://, http://, bare
+	// paths), so a fork-PR file:// source can't disclose an arbitrary in-pod
+	// repo (#743). Off by default — flate normally renders TRUSTED repos that
+	// legitimately reach private/LAN hosts and use local file:// self-sources;
+	// a consumer rendering UNTRUSTED input (e.g. konflate fork mode) sets this.
+	// The egress half is process-level (see pkg/source/ssrfguard): go-git
+	// installs its HTTPS transport process-wide, so a per-render git egress
+	// policy is impossible.
 	RestrictEgress bool
 
 	// RegistryConfig is the docker config.json used for OCI auth.
@@ -393,10 +397,11 @@ func New(cfg Config) (*Orchestrator, error) {
 	// payload <T>" from the single adapter site rather than from
 	// four nearly-identical type assertions.
 	gitFetcher := &git.Fetcher{
-		Cache:   cache,
-		Secrets: secretGet,
-		Mirrors: mirror.New(layout),
-		Depth:   cfg.GitDepth,
+		Cache:           cache,
+		Secrets:         secretGet,
+		Mirrors:         mirror.New(layout),
+		Depth:           cfg.GitDepth,
+		RestrictSchemes: cfg.RestrictEgress,
 	}
 	// Resolve kustomize remote git bases (resources: URLs carrying ?ref= or a
 	// git marker) through the same clone/mirror/ref-resolution machinery as

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -60,6 +60,17 @@ type Fetcher struct {
 	// recursion. The worktree materialization only needs the resolved
 	// tip's tree, which a shallow clone provides in full.
 	Depth int
+
+	// RestrictSchemes rejects GitRepository URLs whose transport is not
+	// https/ssh — file:// (local repo read), git:// (plaintext), http://,
+	// and bare paths. It is the untrusted-render guard for #743: a fork-PR
+	// GitRepository{ url: file:///some/path } would otherwise clone an
+	// arbitrary in-pod git repo and surface its manifests in the diff.
+	// Set from Config.RestrictEgress (the same --restrict-egress switch
+	// that arms the SSRF guard), so trusted renders keep file:// working
+	// (local fixtures, the synthetic self-source — which is pre-seeded and
+	// never reaches this fetch path anyway). Default false.
+	RestrictSchemes bool
 }
 
 // Fetch implements source.TypedFetcher[*manifest.GitRepository].
@@ -117,7 +128,7 @@ func (f *Fetcher) resolveTransport(repo *manifest.GitRepository) (transport.Auth
 // Supported transports: HTTPS (anonymous, basic, bearer), SSH (key
 // from SecretRef or ssh-agent), and file:// URLs.
 func (f *Fetcher) fetch(ctx context.Context, repo *manifest.GitRepository, auth transport.AuthMethod, proxy *source.ProxyConfig) (*store.SourceArtifact, error) {
-	if err := validateRepo(repo); err != nil {
+	if err := f.validateRepo(repo); err != nil {
 		return nil, err
 	}
 
@@ -225,15 +236,37 @@ func (f *Fetcher) cloneIntoSlot(ctx context.Context, repo *manifest.GitRepositor
 }
 
 // validateRepo guards the preconditions Fetch requires before touching
-// the network: a non-nil CR with a URL.
-func validateRepo(repo *manifest.GitRepository) error {
+// the network: a non-nil CR with a URL, and — when RestrictSchemes is on
+// (untrusted render) — a remote https/ssh transport rather than a
+// local/plaintext scheme.
+func (f *Fetcher) validateRepo(repo *manifest.GitRepository) error {
 	if repo == nil {
 		return errors.New("git repository is nil")
 	}
 	if repo.URL == "" {
 		return fmt.Errorf("%w: %s missing url", manifest.ErrInput, gitID(repo))
 	}
+	if f.RestrictSchemes && !gitSchemeAllowed(repo.URL) {
+		return fmt.Errorf("%w: %s url %q uses a scheme not allowed under --restrict-egress (only https:// and ssh:// remotes are permitted)",
+			manifest.ErrInput, gitID(repo), repo.URL)
+	}
 	return nil
+}
+
+// gitSchemeAllowed reports whether url uses a remote transport safe for an
+// untrusted render: https, ssh, or scp-style (user@host:path → SSH). It
+// blocks file:// (local repo read, #743), git:// (plaintext), http://, and
+// bare filesystem paths.
+func gitSchemeAllowed(url string) bool {
+	if strings.HasPrefix(url, "https://") || strings.HasPrefix(url, "ssh://") {
+		return true
+	}
+	// scp-style git@host:path carries no "://" scheme: a ':' before any '/'
+	// with a '@' in the host part. go-git routes this over SSH.
+	if i := strings.IndexAny(url, ":/"); i >= 0 && url[i] == ':' && strings.Contains(url[:i], "@") {
+		return true
+	}
+	return false
 }
 
 func effectiveNamedRef(ref manifest.GitRepositoryRef) string {

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,6 +49,75 @@ func TestFetcher_LocalFileURL(t *testing.T) {
 	}
 	if art2.Revision != sa.Revision {
 		t.Errorf("unchanged default ref revision changed: %s vs %s", sa.Revision, art2.Revision)
+	}
+}
+
+// TestFetcher_RestrictSchemesBlocksFileURL: with RestrictSchemes on (the
+// untrusted-render guard, #743), a file:// GitRepository is rejected before
+// any clone with an ErrInput-wrapped error naming the scheme; with it off
+// (the default) the same file:// source clones normally. Guards against a
+// fork-PR file:// source disclosing an arbitrary in-pod git repo.
+func TestFetcher_RestrictSchemesBlocksFileURL(t *testing.T) {
+	src := t.TempDir()
+	mustInitRepo(t, src)
+	repo := &manifest.GitRepository{
+		Name: "evil", Namespace: "flux-system",
+		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+	}
+
+	blocked := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir())), RestrictSchemes: true}
+	_, err := blocked.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatal("RestrictSchemes: true must reject a file:// GitRepository")
+	}
+	if !errors.Is(err, manifest.ErrInput) {
+		t.Errorf("error must wrap manifest.ErrInput; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "scheme not allowed") {
+		t.Errorf("error must name the rejected scheme; got %v", err)
+	}
+
+	allowed := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir()))} // RestrictSchemes defaults off
+	if _, err := allowed.Fetch(context.Background(), repo); err != nil {
+		t.Fatalf("RestrictSchemes off must allow file://: %v", err)
+	}
+}
+
+// TestFetcher_RestrictSchemesAllowsRemoteURLs: RestrictSchemes only blocks
+// local/plaintext schemes — an https:// or scp-style (git@host:path) URL
+// passes the validateRepo scheme check even when the guard is on. Asserted at
+// the validation layer to avoid a live clone of an unreachable remote.
+func TestFetcher_RestrictSchemesAllowsRemoteURLs(t *testing.T) {
+	f := &Fetcher{RestrictSchemes: true}
+	for _, url := range []string{"https://github.com/o/r", "ssh://git@github.com/o/r", "git@github.com:o/r.git"} {
+		repo := &manifest.GitRepository{
+			Name: "r", Namespace: "flux-system",
+			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: url},
+		}
+		if err := f.validateRepo(repo); err != nil {
+			t.Errorf("validateRepo(%q) under RestrictSchemes must pass: %v", url, err)
+		}
+	}
+}
+
+func TestGitSchemeAllowed(t *testing.T) {
+	cases := map[string]bool{
+		"https://github.com/o/r":    true,
+		"ssh://git@github.com/o/r":  true,
+		"git@github.com:o/r.git":    true, // scp-style → SSH
+		"user@host.xz:path/to/repo": true,
+		"file:///srv/repo":          false,
+		"git://github.com/o/r":      false,
+		"http://github.com/o/r":     false,
+		"/bare/local/path":          false,
+		"./relative":                false,
+		"ssh-but-not-scheme://x":    false, // not the ssh:// prefix
+		"":                          false,
+	}
+	for url, want := range cases {
+		if got := gitSchemeAllowed(url); got != want {
+			t.Errorf("gitSchemeAllowed(%q) = %v, want %v", url, got, want)
+		}
 	}
 }
 

--- a/pkg/source/git/remotebase.go
+++ b/pkg/source/git/remotebase.go
@@ -43,6 +43,13 @@ func (f *Fetcher) FetchRemoteBase(ctx context.Context, repoURL, ref string) (*st
 	if repoURL == "" {
 		return nil, fmt.Errorf("%w: remote git base missing url", manifest.ErrInput)
 	}
+	// Defense-in-depth for #743: an untrusted render only reaches here via an
+	// https kustomize ?ref= base today (see isGitRemoteBase), but gate the
+	// scheme anyway so a future broadening can't smuggle a file:// base past it.
+	if f.RestrictSchemes && !gitSchemeAllowed(repoURL) {
+		return nil, fmt.Errorf("%w: remote git base %q uses a scheme not allowed under --restrict-egress (only https:// and ssh:// remotes are permitted)",
+			manifest.ErrInput, repoURL)
+	}
 	refLabel := cmp.Or(ref, "HEAD")
 
 	// Per-(url, ref) slot, anonymous (authID ""). The ref label is


### PR DESCRIPTION
Closes #743 — the third finding from onedr0p's [konflate](https://github.com/onedr0p/konflate) security audit, same untrusted-fork-PR threat model as #741/#742.

## The vulnerability

go-git's pure-Go transport accepts the `file://` scheme, and `validateRepo` accepted any non-empty URL. A consumer rendering **untrusted** input (a fork PR, e.g. konflate's `KONFLATE_RENDER_FORK_PRS=true`) is therefore exposed: a fork can add a

```yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: GitRepository
metadata: { name: evil, namespace: flux-system }
spec:
  url: file:///some/in-pod/repo
```

referenced by a Kustomization. flate then clones that arbitrary local repo — another source's cache mirror, any repo on the pod filesystem — and surfaces its manifests in the rendered diff (read-only disclosure; no RCE). Disclosure is already public.

## The fix

Gate it behind the **existing** untrusted-render switch — `--restrict-egress` / `Config.RestrictEgress`, the #742 SSRF toggle. It now *also* rejects `GitRepository` URLs whose transport is not `https`/`ssh` (`file://`, `git://`, `http://`, bare paths). One switch konflate sets covers all three findings: symlink confinement (#741, always-on), SSRF egress block (#742), and now local-scheme block (#743).

### Why a per-Fetcher field, not a process global

Unlike the SSRF guard (forced process-global by go-git installing its HTTPS transport process-wide), the scheme check is plain input validation, so it's a clean per-`Fetcher.RestrictSchemes` field — no go-git coupling, and existing `file://` fixtures keep working with a default-off `Fetcher` (no test-global to reset).

### `file://` stays legitimate for trusted use

The synthetic self-source `GitRepository` that bootstrap rewrites to `file://<repoRoot>` is **pre-seeded with an artifact and never reaches this fetch path**, so `build all --restrict-egress` renders a self-sourced cluster byte-identically to without the flag (verified on a real cluster, 69k lines identical). `FetchRemoteBase` gets the same guard as defense-in-depth.

## Verification

- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race ./pkg/source/git/...` · `golangci-lint run` → clean.
- New unit tests: `file://` rejected (ErrInput, names the scheme) when on / clones when off; `https`/`ssh`/scp-style pass even when on; `gitSchemeAllowed` table.
- **Real repro** (built binary, fork-style cluster with a `file://` GitRepository → victim repo): without the flag the victim's ConfigMap leaks into the render; with `--restrict-egress` the fetch fails with `url "file://…" uses a scheme not allowed under --restrict-egress` and nothing leaks.
- **Critical safety**: `build all --restrict-egress` on a self-sourced cluster is byte-identical to without the flag (pre-seeded self-source bypasses the gate).
- **OFF-parity**: no-flag output byte-identical to `main` across two production clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)