### PR TITLE
feat(orchestrator): structured Result.Warnings channel + stale HelmRelease values (#744)

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -661,6 +661,25 @@ func scopedFailures(o *orchestrator.Orchestrator, res *orchestrator.Result, c *c
 	return failed, blocked
 }
 
+// scopedWarnings projects Result.Warnings onto c's namespace filter: a
+// resource-attributed advisory is kept only when its namespace is in scope;
+// render-global advisories (zero Resource) always pass. Mirrors scopedFailures
+// so the footer's warnings section honors --namespace like the failure list.
+func scopedWarnings(o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags) []manifest.Warning {
+	if o == nil || res == nil || len(res.Warnings) == 0 {
+		return nil
+	}
+	out := make([]manifest.Warning, 0, len(res.Warnings))
+	for _, w := range res.Warnings {
+		if w.Resource != (manifest.NamedResource{}) && c != nil &&
+			!c.includeNamespace(o.Filter(), w.Resource.Namespace) {
+			continue
+		}
+		out = append(out, w)
+	}
+	return out
+}
+
 // emitResult joins an emit-time error with the scoped run error so a
 // partial render still surfaces both the IO/format failure and any
 // per-resource reconcile failures. A nil emitErr collapses to just the run
@@ -699,7 +718,7 @@ func (e reportedError) Unwrap() error { return e.err }
 func reportFailures(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags, err error, elapsed time.Duration) error {
 	notes := drainLogNotes()
 	failed, blocked := scopedFailures(o, res, c)
-	m := report.Build(failed, blocked, notes)
+	m := report.Build(failed, blocked, scopedWarnings(o, res, c), notes)
 	if m.Empty() {
 		return err
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -56,7 +56,11 @@ type Note struct {
 type Model struct {
 	Primary []Primary
 	Missing []Missing
-	Notes   []Note
+	// Warnings are non-fatal render advisories (Result.Warnings) — rendered in
+	// their own footer section above operational Notes. Distinct from failures
+	// (the render succeeded) and from Notes (operational slog lines).
+	Warnings []manifest.Warning
+	Notes    []Note
 	// Blocked is the count of distinct derived (cascaded) failures. It is the
 	// verdict's "N blocked" figure — distinct resources, not the sum of the
 	// per-root Blocks/RequiredBy lists, which can overlap when one resource
@@ -66,7 +70,7 @@ type Model struct {
 
 // Empty reports whether there is nothing to render.
 func (m Model) Empty() bool {
-	return len(m.Primary) == 0 && len(m.Missing) == 0 && len(m.Notes) == 0
+	return len(m.Primary) == 0 && len(m.Missing) == 0 && len(m.Warnings) == 0 && len(m.Notes) == 0
 }
 
 // Build partitions failures into primary errors and root-grouped cascades.
@@ -78,7 +82,7 @@ func (m Model) Empty() bool {
 // blockers until reaching a primary failure (a failed id that is not itself
 // blocked) or a missing id (absent from failed). Cascaded resources never get
 // their own line — they appear only in a root's Blocks / RequiredBy list.
-func Build(failed map[manifest.NamedResource]store.StatusInfo, blocked map[manifest.NamedResource][]manifest.NamedResource, notes []Note) Model {
+func Build(failed map[manifest.NamedResource]store.StatusInfo, blocked map[manifest.NamedResource][]manifest.NamedResource, warnings []manifest.Warning, notes []Note) Model {
 	byRoot := Roots(blocked)
 
 	var primary []Primary
@@ -98,7 +102,7 @@ func Build(failed map[manifest.NamedResource]store.StatusInfo, blocked map[manif
 
 	slices.SortFunc(primary, func(a, b Primary) int { return a.ID.Compare(b.ID) })
 	slices.SortFunc(missing, func(a, b Missing) int { return a.ID.Compare(b.ID) })
-	return Model{Primary: primary, Missing: missing, Notes: notes, Blocked: len(blocked)}
+	return Model{Primary: primary, Missing: missing, Warnings: warnings, Notes: notes, Blocked: len(blocked)}
 }
 
 // Roots inverts a blocked graph into root cause → the resources that trace to
@@ -149,57 +153,123 @@ func sortedIDs(ids []manifest.NamedResource) []manifest.NamedResource {
 // Write renders the model to w. color gates ANSI styling; elapsed, when > 0,
 // closes the verdict line.
 func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
-	var b strings.Builder
-	b.WriteByte('\n')
+	blocks := nonEmpty(
+		m.failuresBlock(color),
+		m.warningsBlock(color),
+		m.notesBlock(color),
+		m.verdictBlock(color, elapsed),
+	)
+	if len(blocks) == 0 {
+		return nil
+	}
+	// One spacing rule for the whole footer: a leading blank line parts it from
+	// preceding output, and a single blank line separates each section. Blocks
+	// carry no blank lines of their own, so there's no per-section newline
+	// bookkeeping to drift.
+	_, err := io.WriteString(w, "\n"+strings.Join(blocks, "\n\n")+"\n")
+	return err
+}
 
+// failuresBlock renders the root-cause rows: each primary failure (its inline
+// message and the resources it blocks) followed by each missing dependency.
+func (m Model) failuresBlock(color bool) string {
+	var rows []string
 	for _, p := range m.Primary {
-		fmt.Fprintf(&b, "  %s  %s  %s",
-			style.Fail(style.GlyphFail, color),
-			style.Dim(p.ID.Kind, color),
-			p.ID.NamespacedName())
-		writeMessage(&b, p.Msg)
+		row := fmt.Sprintf("  %s  %s  %s",
+			style.Fail(style.GlyphFail, color), style.Dim(p.ID.Kind, color), p.ID.NamespacedName()) +
+			messageTail(p.Msg)
 		if len(p.Blocks) > 0 {
-			fmt.Fprintf(&b, "\n%s%s", msgIndent, style.Dim("blocks "+summarize(p.Blocks), color))
+			row += "\n" + msgIndent + style.Dim("blocks "+summarize(p.Blocks), color)
 		}
-		b.WriteByte('\n')
+		rows = append(rows, row)
 	}
-
 	for _, mr := range m.Missing {
-		fmt.Fprintf(&b, "  %s  %s  %s  %s\n%s%s\n",
-			style.Fail(style.GlyphFail, color),
-			style.Dim(mr.ID.Kind, color),
-			mr.ID.NamespacedName(),
-			style.Fail("not found", color),
-			msgIndent,
-			style.Dim("required by "+summarize(mr.RequiredBy), color))
+		rows = append(rows, fmt.Sprintf("  %s  %s  %s  %s\n%s%s",
+			style.Fail(style.GlyphFail, color), style.Dim(mr.ID.Kind, color), mr.ID.NamespacedName(),
+			style.Fail("not found", color), msgIndent,
+			style.Dim("required by "+summarize(mr.RequiredBy), color)))
 	}
+	return strings.Join(rows, "\n")
+}
 
-	if len(m.Notes) > 0 {
-		fmt.Fprintf(&b, "\n  %s\n", style.Dim(fmt.Sprintf("notes (%d)", noteTotal(m.Notes)), color))
-		for _, n := range m.Notes {
-			line := n.Text
-			if n.Count > 1 {
-				line = fmt.Sprintf("%s (×%d)", line, n.Count)
-			}
-			fmt.Fprintf(&b, "    %s\n", style.Dim(line, color))
+// warningsBlock renders the advisory section: a header counting the warnings,
+// then one attributed line each (with an indented detail line when present).
+func (m Model) warningsBlock(color bool) string {
+	items := make([]string, 0, len(m.Warnings))
+	for _, wn := range m.Warnings {
+		head := wn.Message
+		if wn.Resource != (manifest.NamedResource{}) {
+			head = wn.Resource.Kind + " " + wn.Resource.NamespacedName() + ": " + wn.Message
 		}
+		if wn.Count > 1 {
+			head = fmt.Sprintf("%s (×%d)", head, wn.Count)
+		}
+		item := style.Warn(head, color)
+		if len(wn.Detail) > 0 {
+			item += "\n      " + style.Dim(strings.Join(wn.Detail, ", "), color)
+		}
+		items = append(items, item)
 	}
+	return section(style.Warn(fmt.Sprintf("%s warnings (%d)", style.GlyphWarn, len(m.Warnings)), color), items)
+}
 
-	// Verdict: failed = primary + missing roots; blocked = distinct cascaded
-	// resources (m.Blocked, not the sum of per-root lists, which can overlap).
+// notesBlock renders the operational-log section: a header counting the notes,
+// then one dim line each (collapsed identical lines carry a ×N suffix).
+func (m Model) notesBlock(color bool) string {
+	items := make([]string, 0, len(m.Notes))
+	for _, n := range m.Notes {
+		line := n.Text
+		if n.Count > 1 {
+			line = fmt.Sprintf("%s (×%d)", line, n.Count)
+		}
+		items = append(items, style.Dim(line, color))
+	}
+	return section(style.Dim(fmt.Sprintf("notes (%d)", noteTotal(m.Notes)), color), items)
+}
+
+// verdictBlock renders the "✗ N failed · M blocked   elapsed" line, or "" when
+// nothing failed — a clean run carrying only advisories shows just those, not a
+// misleading red "✗ 0 failed". failed = primary + missing roots; blocked is the
+// distinct cascaded count (m.Blocked, not the sum of per-root lists).
+func (m Model) verdictBlock(color bool, elapsed time.Duration) string {
 	failedCount := len(m.Primary) + len(m.Missing)
-	b.WriteString("\n  " + style.Fail(style.GlyphFail, color) + " " +
-		style.Fail(fmt.Sprintf("%d failed", failedCount), color))
+	if failedCount == 0 && m.Blocked == 0 {
+		return ""
+	}
+	s := "  " + style.Fail(style.GlyphFail, color) + " " +
+		style.Fail(fmt.Sprintf("%d failed", failedCount), color)
 	if m.Blocked > 0 {
-		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d blocked", m.Blocked), color))
+		s += " · " + style.Dim(fmt.Sprintf("%d blocked", m.Blocked), color)
 	}
 	if elapsed > 0 {
-		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
+		s += "   " + style.Dim(style.Elapsed(elapsed), color)
 	}
-	b.WriteByte('\n')
+	return s
+}
 
-	_, err := io.WriteString(w, b.String())
-	return err
+// section composes a titled footer block: the header line, then each item
+// indented beneath it. Returns "" (an empty block Write drops) when no items.
+func section(header string, items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("  " + header)
+	for _, it := range items {
+		b.WriteString("\n    " + it)
+	}
+	return b.String()
+}
+
+// nonEmpty returns the non-empty blocks, in order.
+func nonEmpty(blocks ...string) []string {
+	out := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		if b != "" {
+			out = append(out, b)
+		}
+	}
+	return out
 }
 
 // summarize renders an id list as "a, b, c +N more", capped at blockedSample.
@@ -218,20 +288,22 @@ func summarize(ids []manifest.NamedResource) string {
 // line) under the message column.
 const msgIndent = "         "
 
-// writeMessage appends a primary failure's message to its resource header line:
-// the first line follows inline; any continuation lines print indented beneath.
+// messageTail renders a primary failure's message as it trails the resource
+// header line: the first line inline, any continuation lines indented beneath.
 // Multi-line build/template diagnostics — notably the duplicate-id producer
 // attribution from pkg/kustomize — survive intact instead of being truncated to
-// their first line.
-func writeMessage(b *strings.Builder, msg string) {
+// their first line. Returns "" for an empty message.
+func messageTail(msg string) string {
 	lines := MessageLines(msg)
 	if len(lines) == 0 {
-		return
+		return ""
 	}
+	var b strings.Builder
 	b.WriteString("  " + lines[0])
 	for _, line := range lines[1:] {
 		b.WriteString("\n" + msgIndent + line)
 	}
+	return b.String()
 }
 
 // MessageLines splits a stored failure message into trimmed, non-empty lines.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -36,7 +36,7 @@ func TestBuild_GroupsCascadeUnderRoots(t *testing.T) {
 		dependent: {missing},
 	}
 
-	m := Build(f, blocked, nil)
+	m := Build(f, blocked, nil, nil)
 
 	if len(m.Primary) != 1 || m.Primary[0].ID != root {
 		t.Fatalf("Primary = %+v, want only root", m.Primary)
@@ -73,7 +73,7 @@ func TestBuild_GroupsCascadeUnderRoots(t *testing.T) {
 // TestBuild_PrimaryOnly covers a lone real failure with nothing depending on it.
 func TestBuild_PrimaryOnly(t *testing.T) {
 	a := ks("a")
-	m := Build(failed(a), nil, nil)
+	m := Build(failed(a), nil, nil, nil)
 	if len(m.Primary) != 1 || len(m.Missing) != 0 || len(m.Primary[0].Blocks) != 0 {
 		t.Fatalf("want one primary with no blocks, got %+v", m)
 	}
@@ -84,7 +84,7 @@ func TestBuild_PrimaryOnly(t *testing.T) {
 
 // TestBuild_NotesOnly covers a clean run that only carries deferred log notes.
 func TestBuild_NotesOnly(t *testing.T) {
-	m := Build(nil, nil, []Note{{Text: "resource orphaned id=x", Count: 3}})
+	m := Build(nil, nil, nil, []Note{{Text: "resource orphaned id=x", Count: 3}})
 	if len(m.Primary) != 0 || len(m.Missing) != 0 || m.Empty() {
 		t.Fatalf("notes-only model should be non-empty with no failures: %+v", m)
 	}
@@ -97,8 +97,45 @@ func TestBuild_NotesOnly(t *testing.T) {
 
 // TestBuild_Empty covers a clean run with nothing to show.
 func TestBuild_Empty(t *testing.T) {
-	if !Build(nil, nil, nil).Empty() {
+	if !Build(nil, nil, nil, nil).Empty() {
 		t.Error("a clean run must produce an empty model")
+	}
+}
+
+// TestWrite_WarningsSection: a clean run carrying only render advisories renders
+// a "warnings" section (attributed + detail) and NO red "✗ 0 failed" verdict.
+func TestWrite_WarningsSection(t *testing.T) {
+	hr := manifest.NamedResource{Kind: "HelmRelease", Namespace: "default", Name: "app"}
+	warns := []manifest.Warning{
+		{Resource: hr, Category: manifest.WarnStaleValues, Message: "values not defined by the chart schema", Detail: []string{"image.tagg", "oldKey"}},
+		{Category: manifest.WarnEmptyScan, Message: "no Flux objects found"}, // global
+	}
+	m := Build(nil, nil, warns, nil)
+	if m.Empty() {
+		t.Fatal("a model with warnings is not empty")
+	}
+	var b bytes.Buffer
+	if err := m.Write(&b, false, 0); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, want := range []string{"warnings (2)", "HelmRelease default/app: values not defined", "image.tagg, oldKey", "no Flux objects found"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("warnings section missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "failed") {
+		t.Errorf("a warnings-only run must not render a failure verdict:\n%s", out)
+	}
+}
+
+// TestWrite_WarningCount: a deduped warning renders its repeat count.
+func TestWrite_WarningCount(t *testing.T) {
+	warns := []manifest.Warning{{Category: manifest.WarnPathConfig, Message: "same root", Count: 4}}
+	var b bytes.Buffer
+	_ = Build(nil, nil, warns, nil).Write(&b, false, 0)
+	if out := b.String(); !strings.Contains(out, "×4") {
+		t.Errorf("warning repeat count not rendered:\n%s", out)
 	}
 }
 
@@ -113,7 +150,7 @@ func TestWrite_PrimaryMessageIsMultiLine(t *testing.T) {
 			"duplicate resource(s) produced by multiple accumulated paths:\n  - ./one\n  - ./two"},
 	}
 	var b bytes.Buffer
-	if err := Build(f, nil, nil).Write(&b, false, 0); err != nil {
+	if err := Build(f, nil, nil, nil).Write(&b, false, 0); err != nil {
 		t.Fatal(err)
 	}
 	out := b.String()
@@ -134,7 +171,7 @@ func TestBuild_BlockedCountsDistinctResources(t *testing.T) {
 		dual: {root, missing}, // blocked by a failed parent AND a missing dep
 	}
 
-	m := Build(f, blocked, nil)
+	m := Build(f, blocked, nil, nil)
 	if m.Blocked != 1 {
 		t.Errorf("Blocked = %d, want 1 distinct blocked resource", m.Blocked)
 	}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -26,16 +26,18 @@ const (
 	GlyphFail    = "✗"
 	GlyphSkip    = "‒"
 	GlyphBlocked = "⊘"
+	GlyphWarn    = "⚠"
 )
 
 // Semantic styles, by ANSI base color (0-7) so they downsample cleanly on
 // 16-color terminals: 1 red, 2 green, 6 cyan; faint and bold carry no hue.
 var (
-	greenStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
-	redStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
-	cyanStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
-	boldStyle  = lipgloss.NewStyle().Bold(true)
-	faintStyle = lipgloss.NewStyle().Faint(true)
+	greenStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	redStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	cyanStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	yellowStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	boldStyle   = lipgloss.NewStyle().Bold(true)
+	faintStyle  = lipgloss.NewStyle().Faint(true)
 )
 
 // ColorEnabled reports whether w should receive ANSI styling. colorprofile.Detect
@@ -59,6 +61,9 @@ func Pass(s string, color bool) string { return render(greenStyle, s, color) }
 
 // Fail renders s as a failure (red) when color is on, else verbatim.
 func Fail(s string, color bool) string { return render(redStyle, s, color) }
+
+// Warn renders s as an advisory (yellow) when color is on, else verbatim.
+func Warn(s string, color bool) string { return render(yellowStyle, s, color) }
 
 // Skip renders s as skipped/secondary (faint) when color is on, else verbatim.
 func Skip(s string, color bool) string { return render(faintStyle, s, color) }

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -270,6 +270,18 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	if err != nil {
 		return err
 	}
+	// #744: flag top-level release values no chart template references — a key
+	// renamed/removed when the chart was upgraded silently does nothing, so the
+	// override is a stale no-op. Advisory only; rides Result.Warnings to the
+	// footer + konflate. See StaleValuePaths.
+	if stale := c.Helm.StaleValuePaths(ctx, hr, hr.Values); len(stale) > 0 {
+		c.Store.AddWarning(manifest.Warning{
+			Resource: id,
+			Category: manifest.WarnStaleValues,
+			Message:  "values not used by the chart",
+			Detail:   stale,
+		})
+	}
 	// Render-output pipeline: flatten List wrappers first so the
 	// post-render passes stamp the items, then apply commonMetadata and
 	// origin labels (origin last so it wins on key collisions), then drop

--- a/pkg/helm/stalevalues.go
+++ b/pkg/helm/stalevalues.go
@@ -1,0 +1,181 @@
+package helm
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	chart "helm.sh/helm/v4/pkg/chart/v2"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// StaleValuePaths returns the top-level release-value keys a HelmRelease supplies
+// that NO chart template references — the #744 signal that an override has gone
+// stale (a key renamed/removed when the chart was upgraded silently does
+// nothing) or was never consumed.
+//
+// It measures actual consumption, not schema shape: it scans every template in
+// the chart and its (sub)charts for a `.Values.<key>` reference (dotted, or a
+// quoted "<key>" for index/pluck/hasKey/dig forms). A key referenced nowhere is
+// reported. This is what a values.schema.json can't tell us — real charts ship
+// incomplete, open schemas that permit (but never consume) extra keys, so a
+// dead key like a renamed override passes schema validation untouched.
+//
+// Top-level only, and deliberately conservative to avoid false positives:
+//   - Keys addressed to a subchart (a dependency name/alias) or Helm's shared
+//     "global" are always treated as used — the subchart consumes them.
+//   - If the chart accesses `.Values` opaquely — ranges/dumps the whole map
+//     (toYaml .Values), binds it to a variable, or indexes it with a non-literal
+//     key — we can't statically prove any key unused, so we report NOTHING.
+//
+// Schema-independent and advisory only: fail-open (nil) on a load error or a
+// chart with no templates. The controller surfaces the result as a
+// manifest.Warning; this function never logs or fails a render.
+func (c *Client) StaleValuePaths(ctx context.Context, hr *manifest.HelmRelease, values map[string]any) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	loaded, err := c.LoadChart(ctx, hr)
+	if err != nil || loaded.Chart == nil {
+		return nil
+	}
+	return unreferencedValuePaths(chartTemplateText(loaded.Chart), values, knownTopLevelKeys(loaded.Chart))
+}
+
+// unreferencedValuePaths returns the sorted top-level value keys absent from the
+// template source, skipping the always-used allowlist. It is pure and fail-open:
+// empty source or any opaque whole-.Values access yields nil (never a misleading
+// warning).
+func unreferencedValuePaths(src string, values map[string]any, allow map[string]struct{}) []string {
+	if src == "" || opaqueValuesAccess(src) {
+		return nil
+	}
+	var out []string
+	for k := range values {
+		if _, ok := allow[k]; ok {
+			continue
+		}
+		if !valuesKeyReferenced(src, k) {
+			out = append(out, k)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// knownTopLevelKeys are release top-level keys always treated as used,
+// regardless of the parent chart's templates: Helm's shared "global" key, and
+// every declared dependency's name/alias (values addressed to a subchart nest
+// under these and are consumed by the subchart, not the parent).
+func knownTopLevelKeys(ch *chart.Chart) map[string]struct{} {
+	allow := map[string]struct{}{"global": {}}
+	if ch == nil {
+		return allow
+	}
+	if ch.Metadata != nil {
+		for _, d := range ch.Metadata.Dependencies {
+			if d == nil {
+				continue
+			}
+			if d.Name != "" {
+				allow[d.Name] = struct{}{}
+			}
+			if d.Alias != "" {
+				allow[d.Alias] = struct{}{}
+			}
+		}
+	}
+	for _, sub := range ch.Dependencies() {
+		if n := sub.Name(); n != "" {
+			allow[n] = struct{}{}
+		}
+	}
+	return allow
+}
+
+// chartTemplateText concatenates every template (including _helpers.tpl and
+// NOTES.txt) of ch and its subcharts. Subchart templates are included because a
+// parent that passes context to a common/library chart has its values consumed
+// there — so a `.Values.<key>` reference anywhere in the tree counts.
+func chartTemplateText(ch *chart.Chart) string {
+	var b strings.Builder
+	var add func(*chart.Chart)
+	add = func(c *chart.Chart) {
+		if c == nil {
+			return
+		}
+		for _, f := range c.Templates {
+			if f != nil {
+				b.Write(f.Data)
+				b.WriteByte('\n')
+			}
+		}
+		for _, sub := range c.Dependencies() {
+			add(sub)
+		}
+	}
+	add(ch)
+	return b.String()
+}
+
+// opaqueValuesAccess reports whether src reads `.Values` in a way that could
+// consume an arbitrary key without naming it — ranging or dumping the whole map
+// (range .Values, toYaml .Values), binding it to a variable (:= .Values),
+// passing it to a template (include "x" .Values), or indexing it with a
+// non-literal key (index .Values $k). When true, no key can be proven unused, so
+// the caller reports nothing.
+//
+// The test is structural: every `.Values` token whose next non-space byte is
+// neither `.` (a field selector, .Values.foo) nor `"` (a literal index,
+// `.Values "foo"` / `index .Values "foo"`) accesses the map as a whole.
+func opaqueValuesAccess(src string) bool {
+	const tok = ".Values"
+	for i := 0; ; {
+		j := strings.Index(src[i:], tok)
+		if j < 0 {
+			return false
+		}
+		next := i + j + len(tok)
+		for next < len(src) && (src[next] == ' ' || src[next] == '\t') {
+			next++
+		}
+		if next >= len(src) {
+			return true
+		}
+		if c := src[next]; c != '.' && c != '"' {
+			return true
+		}
+		i += j + len(tok)
+	}
+}
+
+// valuesKeyReferenced reports whether src names top-level value key — either as
+// a dotted field `.Values.<key>` (with a trailing identifier boundary, so
+// `.Values.foobar` doesn't satisfy "foo") or as a quoted "<key>" token (the
+// index/pluck/hasKey/dig forms). The quoted check is intentionally broad: a
+// spurious match only suppresses a warning (a false negative), never invents one.
+func valuesKeyReferenced(src, key string) bool {
+	if strings.Contains(src, `"`+key+`"`) {
+		return true
+	}
+	needle := ".Values." + key
+	for i := 0; ; {
+		j := strings.Index(src[i:], needle)
+		if j < 0 {
+			return false
+		}
+		end := i + j + len(needle)
+		if end >= len(src) || !isIdentByte(src[end]) {
+			return true
+		}
+		i += j + len(needle)
+	}
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
+}

--- a/pkg/helm/stalevalues_test.go
+++ b/pkg/helm/stalevalues_test.go
@@ -1,0 +1,162 @@
+package helm
+
+import (
+	"slices"
+	"testing"
+)
+
+// allow is the default top-level allowlist for walker tests (no chart deps).
+func allow(keys ...string) map[string]struct{} {
+	m := map[string]struct{}{}
+	for _, k := range keys {
+		m[k] = struct{}{}
+	}
+	return m
+}
+
+func vals(keys ...string) map[string]any {
+	m := map[string]any{}
+	for _, k := range keys {
+		m[k] = true
+	}
+	return m
+}
+
+func TestUnreferencedValuePaths(t *testing.T) {
+	cases := []struct {
+		name   string
+		src    string
+		values map[string]any
+		allow  map[string]struct{}
+		want   []string
+	}{
+		{
+			name:   "key no template references is flagged",
+			src:    "data:\n  g: {{ .Values.greeting }}\n  r: {{ .Values.replicas }}\n",
+			values: vals("greeting", "replicas", "oldKey"),
+			want:   []string{"oldKey"},
+		},
+		{
+			name:   "all keys referenced",
+			src:    "{{ .Values.greeting }}{{ .Values.replicas }}",
+			values: vals("greeting", "replicas"),
+			want:   nil,
+		},
+		{
+			name:   "quoted index access counts as a reference",
+			src:    `{{ index .Values "greeting" }}{{ if hasKey .Values "extra" }}x{{ end }}`,
+			values: vals("greeting", "extra", "gone"),
+			want:   []string{"gone"},
+		},
+		{
+			name:   "nested field reference marks the top-level key used",
+			src:    "{{ .Values.image.repository }}:{{ .Values.image.tag }}",
+			values: vals("image", "stale"),
+			want:   []string{"stale"},
+		},
+		{
+			name:   "identifier boundary: .Values.foobar does not satisfy foo",
+			src:    "{{ .Values.foobar }}",
+			values: vals("foo"),
+			want:   []string{"foo"},
+		},
+		{
+			name:   "allowlisted global + dependency are never flagged",
+			src:    "{{ .Values.greeting }}",
+			values: vals("greeting", "global", "mariadb"),
+			allow:  allow("global", "mariadb"),
+			want:   nil,
+		},
+		{
+			name:   "opaque toYaml .Values bails (reports nothing)",
+			src:    "config.yaml: |\n  {{- toYaml .Values | nindent 4 }}",
+			values: vals("anything", "more"),
+			want:   nil,
+		},
+		{
+			name:   "opaque range over whole .Values bails",
+			src:    "{{- range $k, $v := .Values }}{{ $k }}{{- end }}",
+			values: vals("anything"),
+			want:   nil,
+		},
+		{
+			name:   "opaque bind of whole .Values bails",
+			src:    "{{- $v := .Values }}{{ $v.anything }}",
+			values: vals("anything"),
+			want:   nil,
+		},
+		{
+			name:   "opaque pass of .Values to include bails",
+			src:    `{{ include "lib.all" .Values }}`,
+			values: vals("anything"),
+			want:   nil,
+		},
+		{
+			name:   "passing whole context (.) to include is NOT opaque — .Values.x still resolves",
+			src:    `{{ include "lib.all" . }}{{ define "lib.all" }}{{ .Values.greeting }}{{ end }}`,
+			values: vals("greeting", "gone"),
+			want:   []string{"gone"},
+		},
+		{
+			name:   "multiple unreferenced keys returned sorted",
+			src:    "{{ .Values.keep }}",
+			values: vals("keep", "zeta", "alpha"),
+			want:   []string{"alpha", "zeta"},
+		},
+		{
+			name:   "empty template source reports nothing",
+			src:    "",
+			values: vals("anything"),
+			want:   nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			al := tc.allow
+			if al == nil {
+				al = allow()
+			}
+			got := unreferencedValuePaths(tc.src, tc.values, al)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("unreferencedValuePaths = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpaqueValuesAccess(t *testing.T) {
+	cases := map[string]bool{
+		"{{ .Values.foo }}":              false, // field selector
+		`{{ index .Values "foo" }}`:      false, // literal index
+		"{{ toYaml .Values }}":           true,  // whole-map dump
+		"{{- range .Values }}{{ end }}":  true,  // range whole map
+		"{{ $v := .Values }}":            true,  // bind whole map
+		`{{ include "x" .Values }}`:      true,  // passed to a template
+		"{{ .Values | toYaml }}":         true,  // piped whole map
+		"{{ index .Values $key }}":       true,  // non-literal index
+		"no values here":                 false,
+		"{{ .Values }}":                  true, // bare at brace
+		"{{ .Values.a }}{{ .Values.b }}": false,
+	}
+	for src, want := range cases {
+		if got := opaqueValuesAccess(src); got != want {
+			t.Errorf("opaqueValuesAccess(%q) = %v, want %v", src, got, want)
+		}
+	}
+}
+
+func TestValuesKeyReferenced(t *testing.T) {
+	src := `{{ .Values.greeting }} {{ index .Values "weird-key" }} {{ .Values.image.tag }}`
+	cases := map[string]bool{
+		"greeting":  true,  // dotted
+		"weird-key": true,  // quoted (not a valid Go field, accessed via index)
+		"image":     true,  // dotted prefix of .Values.image.tag
+		"greet":     false, // boundary: not .Values.greet<boundary>
+		"absent":    false,
+	}
+	for key, want := range cases {
+		if got := valuesKeyReferenced(src, key); got != want {
+			t.Errorf("valuesKeyReferenced(%q) = %v, want %v", key, got, want)
+		}
+	}
+}

--- a/pkg/manifest/warning.go
+++ b/pkg/manifest/warning.go
@@ -1,0 +1,56 @@
+package manifest
+
+import "cmp"
+
+// Warning is a non-fatal render advisory: a user-actionable signal ABOUT the
+// rendered output that flate surfaces at end-of-run and that a library consumer
+// (e.g. konflate, which reads orchestrator.Result) can present in a PR diff.
+//
+// It is distinct from a failure (which blocks a resource and lands in
+// Result.Failed) and from operational/diagnostic logs (submodule skips, cache
+// resets, best-effort loader parse errors) which stay as plain slog lines — a
+// Warning means "the render succeeded, but you probably want to look at this".
+//
+// Producers record Warnings on the Store; the orchestrator collects them into
+// Result.Warnings. Consumers filter on the stable Category code rather than
+// parsing Message.
+type Warning struct {
+	// Resource is the object the warning concerns. The zero value means the
+	// warning is render-global (not tied to one object), e.g. an empty --path
+	// scan or a --path/--path-orig misconfiguration.
+	Resource NamedResource
+	// Category is a stable machine-readable code (one of the Warn* constants).
+	// Consumers switch/filter on this; it never carries free text.
+	Category string
+	// Message is a one-line human-readable summary for the footer.
+	Message string
+	// Detail is an optional structured payload — e.g. the dotted value key paths
+	// a WarnStaleValues advisory lists.
+	Detail []string
+	// Count is the number of times an identical warning was emitted, set by the
+	// collector's de-duplication (1 for a unique warning).
+	Count int
+}
+
+// Warning category codes. Stable identifiers a consumer filters on.
+const (
+	// WarnStaleValues: a HelmRelease sets top-level values no chart template
+	// references (#744). Detail = the unused keys.
+	WarnStaleValues = "StaleValues"
+	// WarnEmptyScan: no Flux Kustomization/HelmRelease objects were found under
+	// --path (likely a wrong path). Render-global.
+	WarnEmptyScan = "EmptyScan"
+	// WarnPathConfig: a --path / --path-orig misconfiguration (same root, or no
+	// detected changes). Render-global.
+	WarnPathConfig = "PathConfig"
+)
+
+// CompareWarning orders warnings deterministically by category, then resource,
+// then message — so the footer and Result.Warnings are stable across runs.
+func CompareWarning(a, b Warning) int {
+	return cmp.Or(
+		cmp.Compare(a.Category, b.Category),
+		a.Resource.Compare(b.Resource),
+		cmp.Compare(a.Message, b.Message),
+	)
+}

--- a/pkg/orchestrator/changefilter.go
+++ b/pkg/orchestrator/changefilter.go
@@ -90,8 +90,11 @@ func (o *Orchestrator) computeChangeSet(repoRoot string) (*change.Set, error) {
 	// against itself producing an empty change set. Skip filter build so
 	// the user's `--path-orig` typo doesn't silently render zero output.
 	if origRoot == repoRoot {
-		slog.Warn("--path and --path-orig resolve to the same root; ignoring --path-orig",
-			"resolved_path", repoRoot)
+		o.store.AddWarning(manifest.Warning{
+			Category: manifest.WarnPathConfig,
+			Message:  "--path and --path-orig resolve to the same root; ignoring --path-orig",
+			Detail:   []string{repoRoot},
+		})
 		return nil, nil
 	}
 	cs, err := change.Detect(origRoot, repoRoot)
@@ -100,7 +103,10 @@ func (o *Orchestrator) computeChangeSet(repoRoot string) (*change.Set, error) {
 	}
 	slog.Debug("changed-only mode", "baseline", origRoot, "current", repoRoot, "changed_files", cs.Len())
 	if cs.Len() == 0 {
-		slog.Warn("no changes detected between --path and --path-orig — output will be empty; verify both paths reference distinct snapshots")
+		o.store.AddWarning(manifest.Warning{
+			Category: manifest.WarnPathConfig,
+			Message:  "no changes detected between --path and --path-orig — output will be empty; verify both paths reference distinct snapshots",
+		})
 	}
 	return cs, nil
 }

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -186,11 +186,14 @@ func (o *Orchestrator) logSummary(failed map[manifest.NamedResource]store.Status
 		"kustomizations", ksCount,
 		"helm_releases", hrCount,
 		"failed", len(failed))
-	// Surface a clear warning when the scan turned up nothing — covers
+	// Surface a clear advisory when the scan turned up nothing — covers
 	// the "typo'd --path that happens to be an empty directory" case
 	// where flate would otherwise look like a silent success.
 	if ksCount == 0 && hrCount == 0 {
-		slog.Warn("no Flux Kustomization or HelmRelease objects found under --path; check the path is correct")
+		o.store.AddWarning(manifest.Warning{
+			Category: manifest.WarnEmptyScan,
+			Message:  "no Flux Kustomization or HelmRelease objects found under --path; check the path is correct",
+		})
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -339,6 +339,16 @@ type Result struct {
 	// derived failures under their root cause by walking these edges to a primary
 	// failure or a missing id, instead of surfacing every cascaded failure.
 	Blocked map[manifest.NamedResource][]manifest.NamedResource
+	// Warnings are non-fatal render advisories — the render succeeded, but the
+	// operator probably wants to look at these (e.g. a HelmRelease pinning
+	// values the chart's schema no longer defines, an empty --path scan). Each
+	// carries a stable Category code a consumer filters on rather than parsing
+	// the message, an optional Resource (zero = render-global), and optional
+	// structured Detail. Sorted deterministically; nil (not empty) when none.
+	// Distinct from Failed (which blocks a resource) and from operational logs
+	// (submodule skips, cache resets) which stay on stderr. A consumer like
+	// konflate surfaces these alongside the diff.
+	Warnings []manifest.Warning
 }
 
 // New constructs an Orchestrator. It allocates the Store and TaskService

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -200,6 +200,9 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 		// per-id ReplaceEdges during Run); snapshot it for blast-radius consumers.
 		DependsOn: o.depGraph.Edges(),
 		Blocked:   map[manifest.NamedResource][]manifest.NamedResource{},
+		// Render advisories collected by producers during Run (HR stale values,
+		// empty scan, …). Nil when none, sorted deterministically by the store.
+		Warnings: o.store.Warnings(),
 	}
 	// Apply --skip-secrets / --skip-crds / --skip-kinds uniformly here
 	// so embedders calling Render see consistent Result.Manifests

--- a/pkg/orchestrator/warnings_test.go
+++ b/pkg/orchestrator/warnings_test.go
@@ -1,0 +1,105 @@
+package orchestrator
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestRender_StaleValuesWarning is the konflate-facing contract: a HelmRelease
+// pinning a value no chart template references surfaces as a structured
+// Result.Warnings entry (Category WarnStaleValues, attributed to the HR, Detail
+// = the unused keys) — not just a log line. A sibling HR on a chart that
+// consumes .Values wholesale (toYaml) produces no warning.
+func TestRender_StaleValuesWarning(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "hr.yaml", `apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: app
+  namespace: apps
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: charts/app
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  values:
+    greeting: hi
+    oldUnusedKey: true
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opaque
+  namespace: apps
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: charts/opaque
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  values:
+    greeting: hi
+    oldUnusedKey: true
+`)
+	// appchart names .Values.greeting → flate flags the unreferenced oldUnusedKey.
+	testutil.WriteFile(t, dir, "charts/app/Chart.yaml", "apiVersion: v2\nname: app\nversion: 0.1.0\n")
+	testutil.WriteFile(t, dir, "charts/app/values.yaml", "greeting: hi\n")
+	testutil.WriteFile(t, dir, "charts/app/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\ndata:\n  g: {{ .Values.greeting | quote }}\n")
+	// opaquechart dumps .Values wholesale → detection must stay silent.
+	testutil.WriteFile(t, dir, "charts/opaque/Chart.yaml", "apiVersion: v2\nname: opaque\nversion: 0.1.0\n")
+	testutil.WriteFile(t, dir, "charts/opaque/values.yaml", "greeting: hi\n")
+	testutil.WriteFile(t, dir, "charts/opaque/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\ndata:\n  v: |\n    {{- toYaml .Values | nindent 4 }}\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if len(res.Failed) != 0 {
+		t.Fatalf("advisory must not fail the render; Failed=%v", res.Failed)
+	}
+
+	app := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "apps", Name: "app"}
+	opaque := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "apps", Name: "opaque"}
+
+	var got *manifest.Warning
+	for i := range res.Warnings {
+		w := res.Warnings[i]
+		if w.Resource == opaque {
+			t.Errorf("a chart consuming .Values wholesale must not warn; got %+v", w)
+		}
+		if w.Resource == app && w.Category == manifest.WarnStaleValues {
+			got = &res.Warnings[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("missing StaleValues warning for %s; Warnings=%+v", app, res.Warnings)
+	}
+	if !slices.Equal(got.Detail, []string{"oldUnusedKey"}) {
+		t.Errorf("warning Detail = %v, want [oldUnusedKey]", got.Detail)
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -126,6 +126,15 @@ type Store struct {
 	// listenerSet has its own internal mutex so the shard locks don't
 	// serialize listener registration.
 	listeners [numEventKinds + 1]*listenerSet
+
+	// warn collects render advisories (manifest.Warning) for Result.Warnings.
+	// Kept off the shards: warnings are low-volume, some are render-global
+	// (zero NamedResource) so they can't shard by id, and the orchestrator
+	// reads them once at finalize. Its own mutex keeps advisory writes off the
+	// shard locks' hot path. See warning.go.
+	warnMu    sync.Mutex
+	warnOrder []manifest.Warning
+	warnIndex map[string]int // dedupKey → index into warnOrder (Count bump)
 }
 
 // New constructs an empty Store.

--- a/pkg/store/warning.go
+++ b/pkg/store/warning.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// AddWarning records a render advisory for Result.Warnings. Identical warnings
+// (same resource, category, message, and detail) collapse into one entry whose
+// Count is incremented — so a producer that fires the same advisory N times
+// (e.g. across retries) surfaces once with "(×N)". Producers leave Count unset
+// (the zero value normalizes to 1); it exists for the collector's tally.
+// Concurrency-safe via a dedicated mutex, off the shard locks' hot path.
+func (s *Store) AddWarning(w manifest.Warning) {
+	if w.Count <= 0 {
+		w.Count = 1
+	}
+	w.Detail = slices.Clone(w.Detail) // defensive: caller can't mutate stored state
+	key := warningKey(w)
+
+	s.warnMu.Lock()
+	defer s.warnMu.Unlock()
+	if i, ok := s.warnIndex[key]; ok {
+		s.warnOrder[i].Count += w.Count
+		return
+	}
+	if s.warnIndex == nil {
+		s.warnIndex = make(map[string]int)
+	}
+	s.warnIndex[key] = len(s.warnOrder)
+	s.warnOrder = append(s.warnOrder, w)
+}
+
+// Warnings returns a deterministically-sorted copy of the collected advisories
+// (by category, then resource, then message — see manifest.CompareWarning), or
+// nil when none were recorded. The orchestrator copies this into
+// Result.Warnings at finalize.
+func (s *Store) Warnings() []manifest.Warning {
+	s.warnMu.Lock()
+	defer s.warnMu.Unlock()
+	if len(s.warnOrder) == 0 {
+		return nil
+	}
+	out := make([]manifest.Warning, len(s.warnOrder))
+	for i, w := range s.warnOrder {
+		w.Detail = slices.Clone(w.Detail)
+		out[i] = w
+	}
+	slices.SortFunc(out, manifest.CompareWarning)
+	return out
+}
+
+// warningKey is the identity used to collapse repeat warnings. Fields (and
+// Detail elements) are NUL-joined — a byte that can't appear in a resource id,
+// category, message, or dotted value path — so distinct warnings never collide
+// (e.g. Detail ["a,b"] and ["a","b"] stay separate).
+func warningKey(w manifest.Warning) string {
+	return w.Resource.String() + "\x00" + w.Category + "\x00" + w.Message + "\x00" + strings.Join(w.Detail, "\x00")
+}

--- a/pkg/store/warning_test.go
+++ b/pkg/store/warning_test.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+func hrID(name string) manifest.NamedResource {
+	return manifest.NamedResource{Kind: "HelmRelease", Namespace: "default", Name: name}
+}
+
+// TestWarnings_Empty: a fresh store reports nil (not empty slice) — matching
+// the nil-when-empty convention Result.Warnings consumers rely on.
+func TestWarnings_Empty(t *testing.T) {
+	if got := New().Warnings(); got != nil {
+		t.Fatalf("Warnings() on empty store = %v, want nil", got)
+	}
+}
+
+// TestAddWarning_DedupAndCount: identical advisories collapse and accumulate a
+// Count; a differing field (detail here) is a distinct entry.
+func TestAddWarning_DedupAndCount(t *testing.T) {
+	s := New()
+	w := manifest.Warning{Resource: hrID("app"), Category: manifest.WarnStaleValues,
+		Message: "values not defined by the chart schema", Detail: []string{"a", "b"}}
+	s.AddWarning(w)
+	s.AddWarning(w) // identical → Count bump
+	s.AddWarning(manifest.Warning{Resource: hrID("app"), Category: manifest.WarnStaleValues,
+		Message: "values not defined by the chart schema", Detail: []string{"c"}}) // distinct detail
+
+	got := s.Warnings()
+	if len(got) != 2 {
+		t.Fatalf("want 2 distinct warnings, got %d: %+v", len(got), got)
+	}
+	var first manifest.Warning
+	for _, w := range got {
+		if slices.Equal(w.Detail, []string{"a", "b"}) {
+			first = w
+		}
+	}
+	if first.Count != 2 {
+		t.Errorf("identical warning Count = %d, want 2", first.Count)
+	}
+}
+
+// TestAddWarning_DetailCollision: two warnings whose Detail elements would
+// collide under a naive comma-join ([a,b] vs [a","b]) stay distinct entries.
+func TestAddWarning_DetailCollision(t *testing.T) {
+	s := New()
+	base := manifest.Warning{Resource: hrID("app"), Category: manifest.WarnStaleValues, Message: "m"}
+	w1 := base
+	w1.Detail = []string{"a,b"}
+	w2 := base
+	w2.Detail = []string{"a", "b"}
+	s.AddWarning(w1)
+	s.AddWarning(w2)
+	if got := s.Warnings(); len(got) != 2 {
+		t.Fatalf("distinct Detail must not collide; want 2 warnings, got %d: %+v", len(got), got)
+	}
+}
+
+// TestWarnings_Sorted: output is ordered by (category, resource, message),
+// independent of insertion order — deterministic for the footer + Result.
+func TestWarnings_Sorted(t *testing.T) {
+	s := New()
+	s.AddWarning(manifest.Warning{Category: manifest.WarnStaleValues, Resource: hrID("z"), Message: "m"})
+	s.AddWarning(manifest.Warning{Category: manifest.WarnEmptyScan, Message: "scan"})
+	s.AddWarning(manifest.Warning{Category: manifest.WarnStaleValues, Resource: hrID("a"), Message: "m"})
+
+	got := s.Warnings()
+	want := []string{manifest.WarnEmptyScan, manifest.WarnStaleValues, manifest.WarnStaleValues}
+	for i, w := range got {
+		if w.Category != want[i] {
+			t.Fatalf("order[%d] category = %q, want %q (%+v)", i, w.Category, want[i], got)
+		}
+	}
+	// Within WarnStaleValues, resource "a" precedes "z".
+	if got[1].Resource.Name != "a" || got[2].Resource.Name != "z" {
+		t.Errorf("resource tiebreak wrong: %q then %q", got[1].Resource.Name, got[2].Resource.Name)
+	}
+}
+
+// TestAddWarning_DefensiveCopy: mutating the caller's Detail slice after Add
+// does not change stored state, and the returned slice is a copy.
+func TestAddWarning_DefensiveCopy(t *testing.T) {
+	s := New()
+	detail := []string{"x"}
+	s.AddWarning(manifest.Warning{Category: manifest.WarnStaleValues, Resource: hrID("app"), Message: "m", Detail: detail})
+	detail[0] = "MUTATED"
+
+	got := s.Warnings()
+	if len(got) != 1 || got[0].Detail[0] != "x" {
+		t.Fatalf("stored detail aliased caller slice: %+v", got)
+	}
+	got[0].Detail[0] = "ALSO_MUTATED" // mutating the returned copy must not affect the store
+	if again := s.Warnings(); again[0].Detail[0] != "x" {
+		t.Errorf("Warnings() returned aliased internal slice: %q", again[0].Detail[0])
+	}
+}
+
+// TestAddWarning_Concurrent: concurrent producers don't race (run with -race)
+// and every emission is accounted for via Count.
+func TestAddWarning_Concurrent(t *testing.T) {
+	s := New()
+	const goroutines, each = 8, 50
+	var wg sync.WaitGroup
+	for range goroutines {
+		wg.Go(func() {
+			for range each {
+				s.AddWarning(manifest.Warning{Category: manifest.WarnStaleValues,
+					Resource: hrID("shared"), Message: "m", Detail: []string{"k"}})
+			}
+		})
+	}
+	wg.Wait()
+	got := s.Warnings()
+	if len(got) != 1 {
+		t.Fatalf("want 1 deduped warning, got %d", len(got))
+	}
+	if got[0].Count != goroutines*each {
+		t.Errorf("Count = %d, want %d", got[0].Count, goroutines*each)
+	}
+}

--- a/test/e2e/stalevalues_test.go
+++ b/test/e2e/stalevalues_test.go
@@ -1,0 +1,38 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestE2E_StaleValuesWarning exercises #744 end-to-end: a HelmRelease pins a
+// value (`oldUnusedKey`) that no chart template references. The render still
+// succeeds (advisory only), and the unused key surfaces in the stderr warnings
+// footer attributed to that HR — while a sibling on a chart that consumes
+// .Values wholesale (toYaml) stays silent.
+func TestE2E_StaleValuesWarning(t *testing.T) {
+	stdout, stderr, code := runCLIBuffers("build", "hr", "--path", copyTree(t, testdataPath(t, "stalevalues")))
+
+	if code != 0 {
+		t.Fatalf("stale-value detection is advisory and must not fail the render; exit=%d\nstderr:\n%s", code, stderr)
+	}
+	// The unused key is flagged, attributed to the HR whose chart names its values.
+	for _, want := range []string{"warnings", "apps/app", "oldUnusedKey"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		}
+	}
+	// The opaque-chart sibling pins the same key but must NOT warn (we can't
+	// prove it unused when the chart reads .Values wholesale).
+	if strings.Contains(stderr, "apps/opaque") {
+		t.Errorf("a chart that consumes .Values wholesale must not produce a stale-value warning:\n%s", stderr)
+	}
+	// Referenced values are never reported.
+	if strings.Contains(stderr, "greeting") || strings.Contains(stderr, "replicas") {
+		t.Errorf("referenced values must not appear in the warnings footer:\n%s", stderr)
+	}
+	// Rendered output is unaffected — both HRs produce their ConfigMaps.
+	if !strings.Contains(stdout, "app-cm") || !strings.Contains(stdout, "opaque-cm") {
+		t.Errorf("rendered HR output missing:\n%s", stdout)
+	}
+}

--- a/testdata/stalevalues/charts/appchart/Chart.yaml
+++ b/testdata/stalevalues/charts/appchart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: appchart
+description: chart whose templates name each value they consume (#744 E2E — stale key detected)
+version: 0.1.0
+appVersion: "1.0"

--- a/testdata/stalevalues/charts/appchart/templates/configmap.yaml
+++ b/testdata/stalevalues/charts/appchart/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+  namespace: {{ .Release.Namespace }}
+data:
+  greeting: {{ .Values.greeting | quote }}
+  replicas: "{{ .Values.replicas }}"

--- a/testdata/stalevalues/charts/appchart/values.yaml
+++ b/testdata/stalevalues/charts/appchart/values.yaml
@@ -1,0 +1,2 @@
+greeting: hi
+replicas: 1

--- a/testdata/stalevalues/charts/opaquechart/Chart.yaml
+++ b/testdata/stalevalues/charts/opaquechart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: opaquechart
+description: chart that consumes .Values wholesale (toYaml) — detection must stay silent
+version: 0.1.0
+appVersion: "1.0"

--- a/testdata/stalevalues/charts/opaquechart/templates/configmap.yaml
+++ b/testdata/stalevalues/charts/opaquechart/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cm
+  namespace: {{ .Release.Namespace }}
+data:
+  # Dumps the whole values map — flate can't prove any key unused, so it stays silent.
+  values.yaml: |
+    {{- toYaml .Values | nindent 4 }}

--- a/testdata/stalevalues/charts/opaquechart/values.yaml
+++ b/testdata/stalevalues/charts/opaquechart/values.yaml
@@ -1,0 +1,1 @@
+greeting: hi

--- a/testdata/stalevalues/cluster/helmreleases.yaml
+++ b/testdata/stalevalues/cluster/helmreleases.yaml
@@ -1,0 +1,48 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://example.test/cluster.git
+---
+# appchart's templates name each value they read (.Values.greeting/.replicas),
+# so flate flags oldUnusedKey — a value no template references (#744).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: app
+  namespace: apps
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: charts/appchart
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  values:
+    greeting: hello-from-helm
+    replicas: 3
+    oldUnusedKey: true
+---
+# opaquechart consumes .Values wholesale (toYaml), so flate can't prove any key
+# unused and stays silent — even for the same oldUnusedKey.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opaque
+  namespace: apps
+spec:
+  interval: 10m
+  chart:
+    spec:
+      chart: charts/opaquechart
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+  values:
+    greeting: hello-from-helm
+    oldUnusedKey: true


### PR DESCRIPTION
Closes #744.

## What

Two layers, one cohesive change:

1. **A structured `Result.Warnings` channel.** Render advisories were unstructured — scattered `slog.Warn` calls swept by the CLI `deferSink` into a free-text notes footer, invisible to a library consumer and carrying no resource attribution. Now they ride a typed `manifest.Warning{Resource, Category, Message, Detail, Count}` recorded on the `Store` (dedup + count, deterministic sort) and surfaced as `orchestrator.Result.Warnings` at finalize — exactly how `Result.Failed`/`Blocked` already flow from the store. konflate reads it the same way it reads `Result.DependsOn`, filtering on the stable `Category` code. The CLI renders a dedicated yellow **warnings** footer section (the `deferSink` stays for operational logs; a clean run with only advisories no longer prints a red "✗ 0 failed").

2. **#744 — detect HelmRelease values the chart doesn't use.** Flag top-level release-supplied keys that **no chart template references**.

## How the detector works (and why this approach)

It measures **actual consumption**, not schema shape. For each top-level key a HelmRelease sets, it scans every template in the chart and its subcharts for a `.Values.<key>` reference (dotted, or a quoted `"<key>"` for `index`/`pluck`/`hasKey`/`dig` forms). A key referenced nowhere is reported.

A `values.schema.json` *can't* tell us this: real charts ship incomplete, **open** schemas (`additionalProperties` absent) that permit but never consume extra keys — so a renamed/removed override passes schema validation untouched and silently does nothing. (An earlier schema-based revision of this PR was abandoned for exactly this reason: it false-positived on valid-but-unschematized keys like cilium's `loadBalancer.algorithm`.)

Top-level only, and deliberately conservative to keep false positives at zero:
- Keys addressed to a subchart (a dependency name/alias) or Helm's shared `global` are always treated as used.
- If a chart reads `.Values` **opaquely** — ranges/dumps the whole map (`toYaml .Values`), binds it to a variable, passes it to a template, or indexes it with a non-literal key — we can't statically prove any key unused, so it reports **nothing**.

## Producers on the channel

The #744 detector (HR controller), plus the previously-`slog`-only **empty `--path` scan** and **`--path`/`--path-orig` misconfig** advisories (migrated, so they no longer double-render).

## Verification

- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race` (manifest/store/helm/orchestrator/controllers/report) · `golangci-lint` → clean.
- Unit tests: the consumption walker (referenced/unreferenced, quoted index, nested-field, identifier boundary, every opaque-access form, allowlist), the store collector (dedup+count, deterministic sort, defensive copy, `-race` concurrency, NUL-key collision), the report footer + verdict gating.
- Orchestrator contract test asserts `res.Warnings` carries the attributed `StaleValues` advisory; e2e asserts the stderr footer + that an opaque-chart sibling stays silent.
- **Real clusters — zero false positives, and it caught five genuinely dead overrides:** an added `hi` on external-secrets, a renamed cilium `enableTunnelBIGTCP`, a misplaced alertmanager `route` (belongs under `config:`), an envoy-gateway `resources`, and an upstream-removed volsync `kube-rbac-proxy-resources`. **stdout byte-identical to `main`** on both (advisories are stderr/Result only).

## Notes

Advisory only — never fails a render, never touches stdout YAML. Three remaining render-advisory producers (bootstrap-alias, ResourceSet-provider-empty, loader parse) live in leaf packages and are a clean fast-follow once they take a warnings sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)