### PR TITLE
refactor(report): one rendering toolkit for the test + build footers

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -153,20 +153,16 @@ func sortedIDs(ids []manifest.NamedResource) []manifest.NamedResource {
 // Write renders the model to w. color gates ANSI styling; elapsed, when > 0,
 // closes the verdict line.
 func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
-	blocks := nonEmpty(
+	doc := Document(
 		m.failuresBlock(color),
 		m.warningsBlock(color),
 		m.notesBlock(color),
 		m.verdictBlock(color, elapsed),
 	)
-	if len(blocks) == 0 {
+	if doc == "" {
 		return nil
 	}
-	// One spacing rule for the whole footer: a leading blank line parts it from
-	// preceding output, and a single blank line separates each section. Blocks
-	// carry no blank lines of their own, so there's no per-section newline
-	// bookkeeping to drift.
-	_, err := io.WriteString(w, "\n"+strings.Join(blocks, "\n\n")+"\n")
+	_, err := io.WriteString(w, doc)
 	return err
 }
 
@@ -232,19 +228,14 @@ func (m Model) notesBlock(color bool) string {
 // misleading red "✗ 0 failed". failed = primary + missing roots; blocked is the
 // distinct cascaded count (m.Blocked, not the sum of per-root lists).
 func (m Model) verdictBlock(color bool, elapsed time.Duration) string {
-	failedCount := len(m.Primary) + len(m.Missing)
-	if failedCount == 0 && m.Blocked == 0 {
+	failed := len(m.Primary) + len(m.Missing)
+	if failed == 0 && m.Blocked == 0 {
 		return ""
 	}
-	s := "  " + style.Fail(style.GlyphFail, color) + " " +
-		style.Fail(fmt.Sprintf("%d failed", failedCount), color)
-	if m.Blocked > 0 {
-		s += " · " + style.Dim(fmt.Sprintf("%d blocked", m.Blocked), color)
-	}
-	if elapsed > 0 {
-		s += "   " + style.Dim(style.Elapsed(elapsed), color)
-	}
-	return s
+	return Verdict(color, style.GlyphFail, style.Fail, elapsed,
+		Count{N: failed, Label: "failed", Paint: style.Fail},
+		Count{N: m.Blocked, Label: "blocked", Paint: style.Dim},
+	)
 }
 
 // section composes a titled footer block: the header line, then each item
@@ -270,6 +261,56 @@ func nonEmpty(blocks ...string) []string {
 		}
 	}
 	return out
+}
+
+// Document assembles a footer from section blocks: a leading blank line parts it
+// from preceding output, a single blank line separates each non-empty block, and
+// it ends with a newline. Returns "" when every block is empty, so the caller
+// writes nothing. Blocks carry no blank lines of their own — spacing lives here,
+// in one place, so there's no per-section newline bookkeeping to drift. Shared
+// by the build/diff failure report and the `flate test` roster.
+func Document(blocks ...string) string {
+	nz := nonEmpty(blocks...)
+	if len(nz) == 0 {
+		return ""
+	}
+	return "\n" + strings.Join(nz, "\n\n") + "\n"
+}
+
+// Count is one labeled tally in a Verdict line: N items, a noun, and the paint
+// that colors "<N> <Label>" (e.g. style.Fail for "failed").
+type Count struct {
+	N     int
+	Label string
+	Paint func(string, bool) string
+}
+
+// Verdict renders a one-line run summary: the lead glyph, then each count as
+// "<N> <Label>" joined by " · ", then a dim elapsed clock (omitted when zero).
+// The first count always shows (even at zero, e.g. "0 passed"); later counts
+// show only when non-zero. Returns "" when given no counts. Shared by the
+// build/diff failure report and the `flate test` roster so both speak one
+// verdict grammar.
+func Verdict(color bool, glyph string, paintGlyph func(string, bool) string, elapsed time.Duration, counts ...Count) string {
+	if len(counts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("  " + paintGlyph(glyph, color))
+	for i, c := range counts {
+		if i > 0 && c.N == 0 {
+			continue
+		}
+		sep := " "
+		if i > 0 {
+			sep = " · "
+		}
+		b.WriteString(sep + c.Paint(fmt.Sprintf("%d %s", c.N, c.Label), color))
+	}
+	if elapsed > 0 {
+		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
+	}
+	return b.String()
 }
 
 // summarize renders an id list as "a, b, c +N more", capped at blockedSample.

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -186,6 +187,51 @@ func TestBuild_BlockedCountsDistinctResources(t *testing.T) {
 	_ = m.Write(&b, false, 0)
 	if out := b.String(); !strings.Contains(out, "1 blocked") {
 		t.Errorf("verdict should count the dual-rooted resource once:\n%s", out)
+	}
+}
+
+// TestDocument pins the one spacing rule: a leading blank line, one blank line
+// between non-empty blocks, a trailing newline, and "" when all blocks are empty.
+func TestDocument(t *testing.T) {
+	cases := []struct {
+		name   string
+		blocks []string
+		want   string
+	}{
+		{"empty", []string{"", ""}, ""},
+		{"none", nil, ""},
+		{"single", []string{"a"}, "\na\n"},
+		{"two", []string{"a", "b"}, "\na\n\nb\n"},
+		{"drops empties between", []string{"a", "", "b"}, "\na\n\nb\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Document(tc.blocks...); got != tc.want {
+				t.Errorf("Document(%q) = %q, want %q", tc.blocks, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVerdict pins the shared verdict grammar: a lead glyph, the lead count
+// always shown (even at zero), later counts only when non-zero, joined by " · ",
+// and a trailing elapsed clock only when > 0.
+func TestVerdict(t *testing.T) {
+	pass := func(s string, _ bool) string { return s }
+	c := func(n int, label string) Count { return Count{N: n, Label: label, Paint: pass} }
+
+	if got := Verdict(false, "✓", pass, 0); got != "" {
+		t.Errorf("no counts = %q, want empty", got)
+	}
+	if got := Verdict(false, "✓", pass, 0, c(0, "passed")); got != "  ✓ 0 passed" {
+		t.Errorf("lead-at-zero = %q", got)
+	}
+	if got := Verdict(false, "✓", pass, 0,
+		c(2, "passed"), c(0, "skipped"), c(3, "failed")); got != "  ✓ 2 passed · 3 failed" {
+		t.Errorf("zero non-lead dropped = %q", got)
+	}
+	if got := Verdict(false, "✗", pass, 1500*time.Millisecond, c(1, "failed")); got != "  ✗ 1 failed   1.5s" {
+		t.Errorf("elapsed = %q", got)
 	}
 }
 

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -101,37 +101,41 @@ func (o Outcome) decorate() (glyph string, paint func(string, bool) string) {
 // reasonIndent aligns a failure's continuation lines beneath its row.
 const reasonIndent = "         "
 
-// Write renders the report: one row per case (status glyph, dimmed kind column,
-// namespace/name, dimmed reason) followed by a summary — an overall verdict
-// glyph, the colored counts, and a dim elapsed clock (omitted when zero). color
-// gates the ANSI codes — the caller decides based on the sink (see cli.test).
+// Write renders the report as a roster block (one row per case, plus a folded
+// line per blocked root) followed by the verdict summary, composed through the
+// shared report.Document/report.Verdict toolkit so the test surface and the
+// build/diff failure report speak one spacing and verdict grammar. color gates
+// the ANSI codes — the caller decides based on the sink (see cli.test).
 func (r Report) Write(w io.Writer, color bool, elapsed time.Duration) error {
+	_, err := io.WriteString(w, report.Document(r.rosterBlock(color), r.verdict(color, elapsed)))
+	return err
+}
+
+// rosterBlock renders one row per case (status glyph, dimmed kind column,
+// namespace/name, dimmed reason — a multi-line reason keeps its first line
+// inline and indents the rest) and one folded line per blocked root. Empty when
+// the run matched nothing, so Document drops it and only the verdict shows.
+func (r Report) rosterBlock(color bool) string {
 	kindW := 0
 	for _, c := range r.Cases {
 		kindW = max(kindW, len(c.ID.Kind))
 	}
-
-	var b strings.Builder
-	b.WriteByte('\n')
+	var rows []string
 	for _, c := range r.Cases {
 		glyph, paint := c.Outcome.decorate()
-		fmt.Fprintf(&b, "  %s  %s  %s",
+		var row strings.Builder
+		fmt.Fprintf(&row, "  %s  %s  %s",
 			paint(glyph, color),
 			style.Dim(fmt.Sprintf("%-*s", kindW, c.ID.Kind), color),
 			c.ID.NamespacedName())
-		// A single-line reason stays inline; a multi-line one (a kustomize
-		// build / helm template diagnostic) prints its first line inline and
-		// the rest indented beneath, so the detail survives instead of running
-		// the row off the right edge.
 		if lines := report.MessageLines(c.Reason); len(lines) > 0 {
-			fmt.Fprintf(&b, "  %s", style.Dim(lines[0], color))
+			fmt.Fprintf(&row, "  %s", style.Dim(lines[0], color))
 			for _, line := range lines[1:] {
-				fmt.Fprintf(&b, "\n%s%s", reasonIndent, style.Dim(line, color))
+				fmt.Fprintf(&row, "\n%s%s", reasonIndent, style.Dim(line, color))
 			}
 		}
-		b.WriteByte('\n')
+		rows = append(rows, row.String())
 	}
-
 	// Cascades fold under their root cause: one dim line per root, naming the
 	// count it blocks, in place of a per-resource row for each victim.
 	for _, g := range r.BlockedRoots {
@@ -139,36 +143,27 @@ func (r Report) Write(w io.Writer, color bool, elapsed time.Duration) error {
 		if g.Missing {
 			root += " (not found)"
 		}
-		fmt.Fprintf(&b, "  %s  %s\n",
+		rows = append(rows, fmt.Sprintf("  %s  %s",
 			style.Dim(style.GlyphBlocked, color),
-			style.Dim(fmt.Sprintf("%d blocked by %s", g.Count, root), color))
+			style.Dim(fmt.Sprintf("%d blocked by %s", g.Count, root), color)))
 	}
+	return strings.Join(rows, "\n")
+}
 
-	// Summary: a verdict glyph (green ✓ / red ✗) leads the colored counts —
-	// always the passed count; skipped/failed/blocked only when non-zero — and a
-	// dim elapsed clock closes it. An empty run still reads "✓ 0 passed".
-	verdict, paintVerdict := style.GlyphPass, style.Pass
+// verdict renders the summary line: a green ✓ when everything passed, a red ✗
+// when anything failed or blocked, leading the colored counts (passed always,
+// the rest only when non-zero) and the elapsed clock.
+func (r Report) verdict(color bool, elapsed time.Duration) string {
+	glyph, paint := style.GlyphPass, style.Pass
 	if r.Failed > 0 || r.Blocked > 0 {
-		verdict, paintVerdict = style.GlyphFail, style.Fail
+		glyph, paint = style.GlyphFail, style.Fail
 	}
-	b.WriteString("\n  " + paintVerdict(verdict, color) + " ")
-	b.WriteString(style.Pass(fmt.Sprintf("%d passed", r.Passed), color))
-	if r.Skipped > 0 {
-		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d skipped", r.Skipped), color))
-	}
-	if r.Failed > 0 {
-		b.WriteString(" · " + style.Fail(fmt.Sprintf("%d failed", r.Failed), color))
-	}
-	if r.Blocked > 0 {
-		b.WriteString(" · " + style.Dim(fmt.Sprintf("%d blocked", r.Blocked), color))
-	}
-	if elapsed > 0 {
-		b.WriteString("   " + style.Dim(style.Elapsed(elapsed), color))
-	}
-	b.WriteByte('\n')
-
-	_, err := io.WriteString(w, b.String())
-	return err
+	return report.Verdict(color, glyph, paint, elapsed,
+		report.Count{N: r.Passed, Label: "passed", Paint: style.Pass},
+		report.Count{N: r.Skipped, Label: "skipped", Paint: style.Dim},
+		report.Count{N: r.Failed, Label: "failed", Paint: style.Fail},
+		report.Count{N: r.Blocked, Label: "blocked", Paint: style.Dim},
+	)
 }
 
 // Run inspects the store and produces a Report. When j.Kinds is empty,


### PR DESCRIPTION
Stacked on #753 (base: `feat/result-warnings-stale-values`).

Follow-up to the footer work: the end-of-run output was hand-built by **two** renderers — `internal/testrunner` (`flate test` roster + verdict → stdout) and `internal/report` (build/diff failures + warnings + notes + verdict → stderr) — each managing its own `fmt.Fprintf` + per-section newlines. They duplicated the verdict grammar and the inter-section spacing, and that manual newline bookkeeping is what let the double-blank-line bug creep in.

## What

Extract the shared rendering vocabulary into `report`:
- **`Document(blocks…)`** — one spacing rule for any footer: a leading blank line, a single blank line between non-empty blocks, a trailing newline. Blocks carry no blank lines of their own, so there's no per-section newline to drift.
- **`Verdict(glyph, paint, elapsed, counts…)` + `Count`** — the `<glyph> N label · … elapsed` line; the lead count always shows, later counts only when non-zero.

`report.Model.Write` and `testrunner.Report.Write` now compose through these (plus the already-shared `report.MessageLines`).

## Why not one Model / not Bubbletea

- The two views are genuinely different — a full per-resource **roster** (every pass/skip/fail) vs. **failures-only** root-cause grouping — and they print to **different streams** (stdout vs stderr). Forcing them into one Model would be the wrong abstraction, so each view's rows stay local; only the verdict + spacing + message-splitting are shared.
- Bubbletea is for the *live* status bar (interactive event loop), which already uses it. The end-of-run summary is a static one-shot print, so the native tool is **lipgloss** layout / block composition — which is what `Document`/`Verdict` give us.

## Verification

- `flate test` / `flate build` render **byte-identically** to before on k8s-gitops (modulo the wall-clock in the verdict).
- New unit tests pin `Document` spacing and `Verdict` grammar; existing report + testrunner tests pass; full gate (build/vet/test/-race/lint) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)