### PR TITLE
refactor(test): consolidate `flate test` into one stdout report

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -461,14 +461,18 @@ func TestRun_TestAll_JoinsVisibleFailuresWithRunError(t *testing.T) {
 	if !strings.Contains(stdout, "✗") {
 		t.Errorf("stdout should still include failed test row:\n%s", stdout)
 	}
-	// The scoped failure surfaces in the styled root-cause report on stderr —
-	// the failing resource named with its real (primary) error, plus a verdict —
-	// not the old flat "reconcile completed with …" aggregate.
-	if !strings.Contains(stderr, "apps") || !strings.Contains(stderr, "kustomize build") {
-		t.Errorf("stderr should surface the failing resource and its error, got %q", stderr)
+	// `flate test` is one consolidated report on stdout: the failing resource
+	// named with its real (primary) error on its roster row, plus the verdict.
+	// The old separate stderr failure block — which double-printed failures and a
+	// second, differently-counted verdict — is gone.
+	if !strings.Contains(stdout, "apps") || !strings.Contains(stdout, "kustomize build") {
+		t.Errorf("stdout should surface the failing resource and its error, got %q", stdout)
 	}
-	if !strings.Contains(stderr, "failed") {
-		t.Errorf("stderr should include the failure verdict, got %q", stderr)
+	if !strings.Contains(stdout, "failed") {
+		t.Errorf("stdout should include the failure verdict, got %q", stdout)
+	}
+	if strings.Contains(stderr, "failed") {
+		t.Errorf("failures + verdict are consolidated on stdout; stderr must not carry a second verdict, got %q", stderr)
 	}
 }
 

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -82,16 +82,26 @@ func testCmd(use string, aliases []string, short string, args cobra.PositionalAr
 			// (colorprofile) honors NO_COLOR / CLICOLOR / TTY-ness; piped or
 			// redirected output stays plain.
 			color := style.ColorEnabled(cmd.OutOrStdout())
-			if err := report.Write(cmd.OutOrStdout(), color, elapsed); err != nil {
+			// One consolidated report on stdout: the per-resource roster (failures
+			// already appear inline on their rows), then render advisories
+			// (warnings) and deferred logs (notes), then a single verdict. No
+			// separate stderr failure block — that double-printed every failure and
+			// a second, differently-counted verdict.
+			warnings := scopedWarnings(o, res, c)
+			notes := drainLogNotes()
+			if err := report.Write(cmd.OutOrStdout(), warnings, notes, color, elapsed); err != nil {
 				return errors.Join(err, runErr)
 			}
 			final := runErr
 			if report.AnyFailed() {
 				final = errors.Join(errors.New("test failures detected"), runErr)
 			}
-			// Root-cause report (+ deferred-log footer) to stderr, replacing the
-			// flat aggregate; the per-resource table above stays on stdout.
-			return reportFailures(cmd.ErrOrStderr(), o, res, c, final, elapsed)
+			// The report is rendered; wrap so run's top-level printer doesn't
+			// reprint the error.
+			if final != nil {
+				return reportedError{final}
+			}
+			return nil
 		},
 	}
 	bindCommon(cmd.Flags(), c)

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -155,8 +155,8 @@ func sortedIDs(ids []manifest.NamedResource) []manifest.NamedResource {
 func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
 	doc := Document(
 		m.failuresBlock(color),
-		m.warningsBlock(color),
-		m.notesBlock(color),
+		WarningsBlock(m.Warnings, color),
+		NotesBlock(m.Notes, color),
 		m.verdictBlock(color, elapsed),
 	)
 	if doc == "" {
@@ -188,11 +188,13 @@ func (m Model) failuresBlock(color bool) string {
 	return strings.Join(rows, "\n")
 }
 
-// warningsBlock renders the advisory section: a header counting the warnings,
-// then one attributed line each (with an indented detail line when present).
-func (m Model) warningsBlock(color bool) string {
-	items := make([]string, 0, len(m.Warnings))
-	for _, wn := range m.Warnings {
+// WarningsBlock renders the advisory section: a header counting the warnings,
+// then one attributed line each (with an indented detail line when present), or
+// "" when there are none. Exported so the build/diff report and the `flate test`
+// roster surface advisories identically.
+func WarningsBlock(warnings []manifest.Warning, color bool) string {
+	items := make([]string, 0, len(warnings))
+	for _, wn := range warnings {
 		head := wn.Message
 		if wn.Resource != (manifest.NamedResource{}) {
 			head = wn.Resource.Kind + " " + wn.Resource.NamespacedName() + ": " + wn.Message
@@ -206,21 +208,22 @@ func (m Model) warningsBlock(color bool) string {
 		}
 		items = append(items, item)
 	}
-	return section(style.Warn(fmt.Sprintf("%s warnings (%d)", style.GlyphWarn, len(m.Warnings)), color), items)
+	return section(style.Warn(fmt.Sprintf("%s warnings (%d)", style.GlyphWarn, len(warnings)), color), items)
 }
 
-// notesBlock renders the operational-log section: a header counting the notes,
-// then one dim line each (collapsed identical lines carry a ×N suffix).
-func (m Model) notesBlock(color bool) string {
-	items := make([]string, 0, len(m.Notes))
-	for _, n := range m.Notes {
+// NotesBlock renders the operational-log section: a header counting the notes,
+// then one dim line each (collapsed identical lines carry a ×N suffix), or ""
+// when there are none. Shared by every footer-bearing surface.
+func NotesBlock(notes []Note, color bool) string {
+	items := make([]string, 0, len(notes))
+	for _, n := range notes {
 		line := n.Text
 		if n.Count > 1 {
 			line = fmt.Sprintf("%s (×%d)", line, n.Count)
 		}
 		items = append(items, style.Dim(line, color))
 	}
-	return section(style.Dim(fmt.Sprintf("notes (%d)", noteTotal(m.Notes)), color), items)
+	return section(style.Dim(fmt.Sprintf("notes (%d)", noteTotal(notes)), color), items)
 }
 
 // verdictBlock renders the "✗ N failed · M blocked   elapsed" line, or "" when

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -101,13 +101,22 @@ func (o Outcome) decorate() (glyph string, paint func(string, bool) string) {
 // reasonIndent aligns a failure's continuation lines beneath its row.
 const reasonIndent = "         "
 
-// Write renders the report as a roster block (one row per case, plus a folded
-// line per blocked root) followed by the verdict summary, composed through the
-// shared report.Document/report.Verdict toolkit so the test surface and the
-// build/diff failure report speak one spacing and verdict grammar. color gates
-// the ANSI codes — the caller decides based on the sink (see cli.test).
-func (r Report) Write(w io.Writer, color bool, elapsed time.Duration) error {
-	_, err := io.WriteString(w, report.Document(r.rosterBlock(color), r.verdict(color, elapsed)))
+// Write renders the whole `flate test` report to w as one document: the roster
+// (one row per case, plus a folded line per blocked root), then the render
+// advisories (warnings) and deferred operational logs (notes), then a single
+// verdict — composed through the shared report toolkit so the test surface and
+// the build/diff report speak one spacing and verdict grammar. Failures already
+// appear inline on their roster rows, so this is the complete picture: there is
+// no separate failure block to print elsewhere. color gates the ANSI codes — the
+// caller decides based on the sink (see cli.test).
+func (r Report) Write(w io.Writer, warnings []manifest.Warning, notes []report.Note, color bool, elapsed time.Duration) error {
+	doc := report.Document(
+		r.rosterBlock(color),
+		report.WarningsBlock(warnings, color),
+		report.NotesBlock(notes, color),
+		r.verdict(color, elapsed),
+	)
+	_, err := io.WriteString(w, doc)
 	return err
 }
 
@@ -221,6 +230,53 @@ func Run(j Job) Report {
 			}
 			rep.Cases = append(rep.Cases, c)
 		}
+	}
+	// Surface run failures whose kind isn't in the roster (e.g. a
+	// ResourceSet whose template won't parse, or a synthetic HelmChart) so a
+	// primary fault isn't silently dropped now that there's no separate
+	// build/diff failure block to catch it. The per-kind loop above already
+	// covered roster kinds; here we only add previously-unseen failed ids.
+	// Blocked-folded victims keep folding under their root; a failed id that
+	// is itself blocked joins the cascade rather than listing on its own row.
+	seen := make(map[manifest.NamedResource]bool, len(rep.Cases)+len(blocked))
+	for _, c := range rep.Cases {
+		seen[c.ID] = true
+	}
+	for id := range blocked {
+		seen[id] = true
+	}
+	extra := make([]manifest.NamedResource, 0)
+	for id := range j.Store.FailedResources() {
+		if seen[id] || id == manifest.BootstrapSourceID {
+			continue
+		}
+		// A synthetic HelmChart is internal plumbing flate materializes to
+		// drive an HR's chart fetch — never a first-class tested kind (absent
+		// from every `test` subcommand's roster). Its failure always re-surfaces
+		// inline on the consuming HR's row ("chart source … not ready: <err>"),
+		// so listing the hash-suffixed chart id again is pure duplication.
+		if id.Kind == manifest.KindHelmChart {
+			continue
+		}
+		if j.Name != "" && id.Name != j.Name {
+			continue
+		}
+		if j.Include != nil && !j.Include(id) {
+			continue
+		}
+		extra = append(extra, id)
+	}
+	slices.SortFunc(extra, func(a, b manifest.NamedResource) int { return a.Compare(b) })
+	for _, id := range extra {
+		rep.Matched++
+		c := classify(j.Store, id)
+		if c.Outcome == OutcomeBlocked {
+			rep.Blocked++
+			blocked[id] = j.Store.BlockedBy(id)
+			continue
+		}
+		rep.Failed++
+		rep.Cases = append(rep.Cases, c)
 	}
 	rep.BlockedRoots = blockedGroups(j.Store, blocked)
 	return rep

--- a/internal/testrunner/runner_test.go
+++ b/internal/testrunner/runner_test.go
@@ -21,7 +21,7 @@ func TestWrite_VerdictGlyphAndElapsed(t *testing.T) {
 	pass.AddObject(&manifest.Kustomization{Name: ok.Name, Namespace: ok.Namespace})
 	pass.UpdateStatus(ok, store.StatusReady, "")
 	var pb bytes.Buffer
-	if err := Run(Job{Store: pass}).Write(&pb, false, 1500*time.Millisecond); err != nil {
+	if err := Run(Job{Store: pass}).Write(&pb, nil, nil, false, 1500*time.Millisecond); err != nil {
 		t.Fatal(err)
 	}
 	if out := pb.String(); !strings.Contains(out, style.GlyphPass) || strings.Contains(out, style.GlyphFail) {
@@ -35,7 +35,7 @@ func TestWrite_VerdictGlyphAndElapsed(t *testing.T) {
 	fail.AddObject(&manifest.Kustomization{Name: bad.Name, Namespace: bad.Namespace})
 	fail.UpdateStatus(bad, store.StatusFailed, "boom")
 	var fb bytes.Buffer
-	_ = Run(Job{Store: fail}).Write(&fb, false, 0)
+	_ = Run(Job{Store: fail}).Write(&fb, nil, nil, false, 0)
 	if out := fb.String(); !strings.Contains(out, style.GlyphFail) {
 		t.Errorf("failing summary wants ✗:\n%s", out)
 	} else if strings.Contains(out, "0.0s") {
@@ -55,7 +55,7 @@ func TestRun_AllPass(t *testing.T) {
 		t.Errorf("expected 2 passed, got %+v", rep)
 	}
 	var b bytes.Buffer
-	if err := rep.Write(&b, false, 0); err != nil {
+	if err := rep.Write(&b, nil, nil, false, 0); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	if !strings.Contains(b.String(), "2 passed") {
@@ -138,7 +138,7 @@ func TestWrite_ShowsSkippedByDefault(t *testing.T) {
 	rep := Run(Job{Store: s})
 
 	var b bytes.Buffer
-	if err := rep.Write(&b, false, 0); err != nil {
+	if err := rep.Write(&b, nil, nil, false, 0); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	out := b.String()
@@ -165,7 +165,7 @@ func TestWrite_FailedNeverHidden(t *testing.T) {
 
 	rep := Run(Job{Store: s})
 	var b bytes.Buffer
-	if err := rep.Write(&b, false, 0); err != nil {
+	if err := rep.Write(&b, nil, nil, false, 0); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
 	if out := b.String(); !strings.Contains(out, "✗") || !strings.Contains(out, "broken") {
@@ -186,10 +186,10 @@ func TestWrite_Color(t *testing.T) {
 	rep := Run(Job{Store: s})
 
 	var colored, plain bytes.Buffer
-	if err := rep.Write(&colored, true, 0); err != nil {
+	if err := rep.Write(&colored, nil, nil, true, 0); err != nil {
 		t.Fatalf("Write(color): %v", err)
 	}
-	if err := rep.Write(&plain, false, 0); err != nil {
+	if err := rep.Write(&plain, nil, nil, false, 0); err != nil {
 		t.Fatalf("Write(plain): %v", err)
 	}
 	if !strings.Contains(colored.String(), "\x1b") {
@@ -233,7 +233,7 @@ func TestWrite_ReturnsWriterError(t *testing.T) {
 	want := errors.New("write failed")
 	rep := Report{Cases: []Case{{ID: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "ns", Name: "apps"}}}}
 
-	if err := rep.Write(errWriter{err: want}, false, 0); !errors.Is(err, want) {
+	if err := rep.Write(errWriter{err: want}, nil, nil, false, 0); !errors.Is(err, want) {
 		t.Fatalf("Write error = %v, want %v", err, want)
 	}
 }
@@ -278,7 +278,7 @@ func TestRun_BlockedFoldsUnderRoot(t *testing.T) {
 	}
 
 	var b bytes.Buffer
-	_ = rep.Write(&b, false, 0)
+	_ = rep.Write(&b, nil, nil, false, 0)
 	out := b.String()
 	if !strings.Contains(out, "1 blocked by flux-system/cluster-apps") {
 		t.Errorf("fold line missing:\n%s", out)
@@ -288,6 +288,78 @@ func TestRun_BlockedFoldsUnderRoot(t *testing.T) {
 	}
 	if strings.Contains(out, "media/plex") {
 		t.Errorf("blocked child must not appear as a row:\n%s", out)
+	}
+}
+
+// TestRun_SurfacesNonRosterFailure pins the consolidation contract: a run-time
+// failure whose kind isn't in the roster (here a ResourceSet whose template
+// won't parse) must still appear as a failed row and count in the verdict.
+// Before the single-report consolidation this failure lived only in the
+// now-dropped stderr block; the testrunner scans Store.FailedResources for any
+// failed id the per-kind loop didn't cover and lists it so no primary fault is
+// silently dropped.
+func TestRun_SurfacesNonRosterFailure(t *testing.T) {
+	s := store.New()
+	ks := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	rs := manifest.NamedResource{Kind: manifest.KindResourceSet, Namespace: "flux-system", Name: "broken-rs"}
+	s.AddObject(&manifest.Kustomization{Name: ks.Name, Namespace: ks.Namespace})
+	s.AddObject(&manifest.ResourceSet{Name: rs.Name, Namespace: rs.Namespace})
+	s.UpdateStatus(ks, store.StatusReady, "")
+	s.UpdateStatus(rs, store.StatusFailed, `parse template: function "nope" not defined`)
+
+	rep := Run(Job{Store: s})
+	if rep.Passed != 1 || rep.Failed != 1 {
+		t.Fatalf("want 1 passed (KS) + 1 failed (ResourceSet), got %+v", rep)
+	}
+	var found *Case
+	for i := range rep.Cases {
+		if rep.Cases[i].ID == rs {
+			found = &rep.Cases[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("ResourceSet failure not surfaced as a case: %+v", rep.Cases)
+	}
+	if found.Outcome != OutcomeFailed || !strings.Contains(found.Reason, "nope") {
+		t.Errorf("ResourceSet case = %+v, want failed with the parse error", found)
+	}
+	var b bytes.Buffer
+	_ = rep.Write(&b, nil, nil, false, 0)
+	if out := b.String(); !strings.Contains(out, "broken-rs") || !strings.Contains(out, "nope") {
+		t.Errorf("roster must show the non-roster failure inline:\n%s", out)
+	}
+}
+
+// TestRun_SkipsSyntheticHelmChartFailure pins the dedup half of the scan: a
+// synthetic HelmChart (internal plumbing flate materializes to fetch an HR's
+// chart) is never a first-class tested kind, and its failure always re-surfaces
+// on the consuming HR's own row. Listing the hash-suffixed chart id again would
+// be pure duplication, so the scan skips KindHelmChart.
+func TestRun_SkipsSyntheticHelmChartFailure(t *testing.T) {
+	s := store.New()
+	hr := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "nvidia", Name: "gpu-operator"}
+	chart := manifest.NamedResource{Kind: manifest.KindHelmChart, Namespace: "nvidia", Name: "nvidia-gpu-operator-16d855d"}
+	s.AddObject(&manifest.HelmRelease{Name: hr.Name, Namespace: hr.Namespace})
+	s.AddObject(&manifest.HelmChartSource{Name: chart.Name, Namespace: chart.Namespace})
+	s.UpdateStatus(hr, store.StatusFailed, "chart source HelmChart/nvidia/nvidia-gpu-operator-16d855d not ready: 404 Not Found")
+	s.UpdateStatus(chart, store.StatusFailed, "download chart: 404 Not Found")
+
+	rep := Run(Job{Store: s})
+	if rep.Failed != 1 {
+		t.Fatalf("want only the HR counted as failed, got %+v", rep)
+	}
+	for _, c := range rep.Cases {
+		if c.ID.Kind == manifest.KindHelmChart {
+			t.Errorf("synthetic HelmChart must not get its own row: %+v", c)
+		}
+	}
+	// Write renders only Cases (+ blocked folds), so the Case-level check above
+	// already guarantees no separate HelmChart row; confirm the consuming HR
+	// row still carries the chart error so the failure isn't lost.
+	var b bytes.Buffer
+	_ = rep.Write(&b, nil, nil, false, 0)
+	if out := b.String(); !strings.Contains(out, "gpu-operator") || !strings.Contains(out, "404") {
+		t.Errorf("the consuming HR row must still carry the chart error:\n%s", out)
 	}
 }
 
@@ -313,7 +385,7 @@ func TestRun_BlockedByMissingDep(t *testing.T) {
 		t.Fatalf("want the missing root marked Missing, got %+v", rep.BlockedRoots)
 	}
 	var b bytes.Buffer
-	_ = rep.Write(&b, false, 0)
+	_ = rep.Write(&b, nil, nil, false, 0)
 	if !strings.Contains(b.String(), "not found") {
 		t.Errorf("missing root should render (not found):\n%s", b.String())
 	}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -349,16 +349,18 @@ func TestE2E_DiffImagesRequiresBaselineWhenNoGit(t *testing.T) {
 }
 
 // TestE2E_BootstrapErrorSurfacesNotMasked pins the contract that
-// when discovery itself fails (e.g. a ResourceSet template that
-// fails to parse, a YAML schema rejection), the actual error reaches
-// the user instead of getting drowned under a wall of phantom
-// "FAILED (no status reported)" rows from the testrunner running on
-// a partial Store. Surfaced by tholinka/home-ops where an
-// unimplemented inputStrategy: Permute ResourceSet produced 247
-// generic failure rows instead of the actual message. Now that
-// Permute is implemented, the test triggers Bootstrap failure with
-// a malformed template — same code path through
-// runOrchestratorCfg's `res == nil` guard.
+// when a ResourceSet fails (here a template that won't parse), the
+// actual error reaches the user instead of getting drowned under a
+// wall of phantom "FAILED (no status reported)" rows. Surfaced by
+// tholinka/home-ops where an unimplemented inputStrategy: Permute
+// ResourceSet produced 247 generic failure rows instead of the actual
+// message.
+//
+// ResourceSet isn't a roster kind, so its run-time failure surfaces
+// through the testrunner's Store.FailedResources scan (see
+// testrunner.Run) as a single failed row carrying the real parse
+// error — never the phantom "no status reported" rows that a partial
+// Store would otherwise produce.
 func TestE2E_BootstrapErrorSurfacesNotMasked(t *testing.T) {
 	dir := t.TempDir()
 	// Minimal repo: one Kustomization + one ResourceSet whose template


### PR DESCRIPTION
## What

`flate test` printed **two** reports:

1. the pytest-style **roster + verdict** on stdout, and
2. a second **failure block on stderr** that re-listed every failure and appended its own verdict.

The two verdicts counted differently — the roster folds blocked cascades into a `blocked` tally, the stderr aggregate didn't — so a run showed the same failures twice under two disagreeing summaries. That redundancy reads as noise now that the roster already carries the `warnings` and `notes` sections inline.

This collapses `flate test` to **one report on stdout**:

```
  <full per-resource roster — every ✓ / ‒ / ✗ with inline reasons + blocked folds>

  ⚠ warnings (N)
    …

  notes (N)
    …

  ✗ 372 passed · 2 skipped · 7 failed · 8 blocked   4.9s   ← one verdict
```

The separate stderr failure block (and its second verdict) is dropped. `build`/`diff` keep their stderr root-cause report unchanged.

## Surfacing non-roster failures

The dropped stderr block was the *only* surface for a failure whose kind isn't in the roster — e.g. a `ResourceSet` whose template won't parse. To keep those from being silently lost, `testrunner.Run` now scans `Store.FailedResources()` for any failed id the per-kind loop didn't cover and lists it as a failed row (honoring the `Name`/`Include` filters, folding any that are themselves blocked under their root).

Synthetic `HelmChart`s are skipped: they're internal plumbing flate materializes to fetch an HR's chart, never a first-class tested kind, and the fetch error always re-surfaces on the consuming HR's own row (`chart source … not ready: <err>`) — a hash-suffixed second row would be pure duplication.

## Tests

- New `TestRun_SurfacesNonRosterFailure` — a failed `ResourceSet` appears as a failed roster row carrying its real parse error.
- New `TestRun_SkipsSyntheticHelmChartFailure` — a failed synthetic `HelmChart` gets no separate row; the consuming HR row still carries the chart error.
- `TestRun_TestAll_JoinsVisibleFailuresWithRunError` updated: failures + verdict now assert on **stdout**; stderr must not carry a second verdict.
- `TestE2E_BootstrapErrorSurfacesNotMasked` docstring corrected — the malformed-`ResourceSet` fixture is now a run-time failure surfaced through the scan, not the `res == nil` bootstrap path.

## Verification

- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race` (testrunner/cli/report/e2e) · `golangci-lint run ./...` → **0 issues**
- Visually confirmed on a real cluster (Biohazard): one consolidated report on stdout — full roster including non-roster failures, then warnings, then notes, then a single verdict — and a clean stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)