### PR TITLE
fix(discovery): alias a root Kustomization's self GitRepository when no remote matches

### DIFF
--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -2,6 +2,9 @@ package discovery
 
 import (
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
@@ -58,7 +61,10 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 }
 
 // aliasBootstrapSources resolves sources that real Flux would fetch
-// remotely but flate must satisfy from the working tree. Two passes:
+// remotely but flate must satisfy from the working tree. Two passes run
+// here; a third (overrideRootSourcesToWorkingTree) runs later in
+// discovery.Run once the parent index is built, and the caller folds all
+// three into one warnIfMultipleBootstrapAliases tally:
 //
 //  1. aliasMissingKustomizationSources — for every Kustomization
 //     whose sourceRef points at a Git/OCIRepository CR that isn't in
@@ -71,10 +77,10 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 //     override the artifact to the local checkout so the SOPS-decrypted
 //     remote fetch is avoided.
 //
-// Both passes alias to the same working tree, so the combined result
-// is logged at WARN when more than one source is aliased — multiple
-// remote shared-infra repos would silently render against the same
-// (wrong) tree.
+// All three passes alias to the same working tree, so the caller logs at
+// WARN when more than one source is aliased — multiple remote shared-infra
+// repos would silently render against the same (wrong) tree. Returns the
+// ids aliased here so the caller can fold pass 3's into that tally.
 //
 // All namespaces are aliased, not just `flux-system` (#199): the
 // convention of running Flux in a non-default namespace (e.g.
@@ -82,10 +88,114 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 // the-local-tree property is identical regardless. A typo'd sourceRef
 // silently renders against the working tree instead of failing fast —
 // trade-off inherited from the original `flux-system` path.
-func (d *discoverer) aliasBootstrapSources(repoRoot string) {
+func (d *discoverer) aliasBootstrapSources(repoRoot string) []manifest.NamedResource {
 	aliased := d.aliasMissingKustomizationSources(repoRoot)
 	aliased = append(aliased, d.overrideSelfReferentialGitRepositories(repoRoot)...)
-	warnIfMultipleBootstrapAliases(aliased, repoRoot)
+	return aliased
+}
+
+// overrideRootSourcesToWorkingTree is pass 3, the no-URL-match fallback. When
+// passes 1–2 left a *root* Kustomization's in-tree GitRepository source
+// un-aliased — because the working tree has no .git remote, the caller supplied
+// no SelfURLs, or the declared spec.url simply doesn't normalize-match either —
+// alias that source to the working tree anyway. A root KS (one no other KS's
+// spec.path covers, i.e. absent from parentOf) pulls the cluster's own repo by
+// the flux-bootstrap convention, so its source IS the working tree: flate
+// renders the KS's spec.path from the local checkout, and the auth secret real
+// Flux needs only to FETCH that repo is irrelevant and must not block the run
+// (issue #752). Without this an in-tree bootstrap GitRepository at a non-default
+// id whose URL can't be matched falls through to a real fetch, fails on the
+// (SOPS-wiped / out-of-band) deploy-key Secret, and cascades every consumer to
+// blocked.
+//
+// Four guards keep this from silently rendering an external private repo
+// against the wrong files:
+//   - no-URL-signal: this runs ONLY when the working tree exposes no remotes
+//     and the caller supplied no SelfURLs. When remotes DO exist but none
+//     matched, an unmatched in-tree GitRepository is a genuine external source
+//     (shared-infra), not the cluster pulling itself — the URL match is the
+//     authoritative signal and we defer to it. Pinned by
+//     TestRun_LeavesUnmatchedInTreeGitRepository.
+//   - root-only: a source referenced solely by a non-root tenant KS is never
+//     touched (parentOf membership ⇒ skip).
+//   - already-handled: a source with an artifact (pass 1/2 URL match, or the
+//     seeded BootstrapSourceID) is left untouched, so a URL-matched checkout —
+//     the common CI case — stays byte-identical.
+//   - local-content: the root KS's spec.path must resolve to a directory inside
+//     the working tree. A root pointing at a path this tree doesn't contain is
+//     an external source flate can't satisfy offline — leave it to fail loud.
+//
+// Returns the ids aliased so the caller folds them into the multi-alias WARN.
+func (d *discoverer) overrideRootSourcesToWorkingTree(repoRoot string, parentOf map[manifest.NamedResource]manifest.NamedResource) []manifest.NamedResource {
+	// Only fall back to topology when there's no URL signal at all. With remotes
+	// (or SelfURLs) present, pass 2's URL match is authoritative — an unmatched
+	// source is external, not self, and must not be aliased to this tree.
+	if len(d.selfRemotes(repoRoot)) > 0 {
+		return nil
+	}
+	var overridden []manifest.NamedResource
+	seen := map[manifest.NamedResource]struct{}{}
+	for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
+		if _, hasParent := parentOf[ks.Named()]; hasParent {
+			continue // not a root — its source resolves through its parent's tree
+		}
+		src := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
+		// GitRepository only. A committed OCIRepository is, by overwhelming
+		// convention, an EXTERNAL artifact pull (an app/chart registry), not the
+		// cluster's own tree — its missing pull Secret should soft-skip, not be
+		// aliased away (locked by TestOrchestrator_AllowMissingSecretsPropagates).
+		// A genuine OCI *bootstrap* source (flux-operator publishing the repo as an
+		// OCI artifact) is operator-created and absent from the tree, so pass 1
+		// already aliases it; there's no safe topological signal that distinguishes
+		// a committed self OCI source from an external one (no URL match is possible
+		// for oci://), so pass 3 stays Git-only.
+		if src.Kind != manifest.KindGitRepository || src.Name == "" {
+			continue
+		}
+		if _, done := seen[src]; done {
+			continue
+		}
+		seen[src] = struct{}{}
+		// During discovery only aliasing sets a source artifact, so a non-nil
+		// artifact means pass 1/2 (or the seed) already handled this id — never
+		// clobber it, keeping the URL-matched path byte-identical.
+		if d.cfg.Store.GetArtifact(src) != nil {
+			continue
+		}
+		// Must be a real in-tree GitRepository; a missing source is pass 1's job.
+		if _, ok := d.cfg.Store.GetObject(src).(*manifest.GitRepository); !ok {
+			continue
+		}
+		if !rootPathInTree(repoRoot, ks.Path) {
+			continue
+		}
+		d.cfg.Store.SetArtifact(src, &store.SourceArtifact{
+			Kind: manifest.KindGitRepository,
+			URL:  "file://" + repoRoot, LocalPath: repoRoot,
+		})
+		d.cfg.Store.UpdateStatus(src, store.StatusReady, "bootstrap alias (root Kustomization source)")
+		slog.Debug("discovery: aliased root Kustomization source to working tree (no URL match)",
+			"id", src.String(), "rootKS", ks.Named().String(), "localPath", repoRoot)
+		overridden = append(overridden, src)
+	}
+	return overridden
+}
+
+// rootPathInTree reports whether a Kustomization spec.path resolves to an
+// existing directory inside repoRoot. Empty path or one that escapes the tree
+// (`..`) ↦ false: a bare-sourceRef root is anchored on the already-seeded
+// BootstrapSourceID, and an escaping path is never a self-pull we can satisfy.
+func rootPathInTree(repoRoot, specPath string) bool {
+	if specPath == "" {
+		return false
+	}
+	clean := filepath.Join(repoRoot, filepath.FromSlash(strings.TrimPrefix(specPath, "./")))
+	rel, err := filepath.Rel(repoRoot, clean)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	info, err := os.Stat(clean)
+	return err == nil && info.IsDir()
 }
 
 // aliasMissingKustomizationSources is pass 1. It walks every loaded

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -150,7 +150,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	if err := d.loadManifests(ctx, repoRoot); err != nil {
 		return nil, err
 	}
-	d.aliasBootstrapSources(repoRoot)
+	aliased := d.aliasBootstrapSources(repoRoot)
 	d.applyNamespaces(repoRoot)
 	// Resolve bare ${VAR} in Kustomization dependsOn against the
 	// cluster's postBuild substitute values, now that the full KS set is
@@ -189,6 +189,14 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	parentOf := loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindKustomization)
 	maps.Copy(parentOf, loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease))
 	maps.Copy(parentOf, loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindResourceSet))
+	// Pass 3 of bootstrap aliasing (deferred to here because it needs the
+	// parent index to tell a root Kustomization from a nested one): alias a
+	// root KS's in-tree GitRepository source to the working tree when no URL
+	// match aliased it, so a missing deploy-key Secret on the cluster's own
+	// source doesn't cascade every consumer to blocked (#752). Folded into the
+	// same multi-alias WARN as passes 1–2.
+	aliased = append(aliased, d.overrideRootSourcesToWorkingTree(repoRoot, parentOf)...)
+	warnIfMultipleBootstrapAliases(aliased, repoRoot)
 	// Orphan promotion: every Existence entry whose file path is NOT
 	// under any KS spec.path will never reach the Store through KS
 	// render emission. Promote it now so standalone CRs (loose HR

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -440,6 +440,241 @@ spec:
 	}
 }
 
+// TestRun_AliasesRootSourceWithoutRemotes covers the no-URL-signal fallback
+// (pass 3): when the working tree exposes no git remote and the caller supplied
+// no SelfURLs, pass 2's URL match can't fire, so an in-tree GitRepository that
+// is a *root* Kustomization's source — the cluster pulling itself, e.g. a
+// `.git`-less checkout or extracted tree — is aliased to the working tree. This
+// stops its (irrelevant, fetch-only) deploy-key secret from cascading every
+// consumer to blocked (#752).
+func TestRun_AliasesRootSourceWithoutRemotes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// No .git/config here: selfRemotes() is empty, so the URL match can't fire
+	// and pass 3's topology fallback is the only thing that can alias the source.
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "flux", "cluster.yaml"), `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-kubernetes
+  namespace: flux-system
+spec:
+  url: ssh://git@github.com/example/home-ops.git
+  ref:
+    branch: main
+  secretRef:
+    name: github-deploy-key
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster
+  namespace: flux-system
+spec:
+  path: ./k8s/apps
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  interval: 1h
+`)
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "apps", "kustomization.yaml"), "resources: []\n")
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	id := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "home-kubernetes"}
+	art, ok := st.GetArtifact(id).(*store.SourceArtifact)
+	if !ok {
+		t.Fatalf("root-KS source must be aliased to the working tree; got artifact %v", st.GetArtifact(id))
+	}
+	if !strings.HasPrefix(art.URL, "file://") {
+		t.Errorf("expected a file:// working-tree alias; got %q", art.URL)
+	}
+	if info, ok := st.GetStatus(id); !ok || info.Status != store.StatusReady {
+		t.Errorf("aliased source must be Ready; got ok=%v info=%+v", ok, info)
+	}
+}
+
+// TestRun_LeavesRootOCISourceWithoutRemotes pins that pass 3 stays GitRepository
+// only: a committed OCIRepository that is a root Kustomization's source is, by
+// convention, an external artifact pull, not the cluster's own tree — even with
+// no remotes it must NOT be aliased (its missing pull Secret soft-skips via
+// --allow-missing-secrets instead; see TestOrchestrator_AllowMissingSecretsPropagates).
+func TestRun_LeavesRootOCISourceWithoutRemotes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "flux", "cluster.yaml"), `---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: private-app
+  namespace: flux-system
+spec:
+  url: oci://ghcr.io/upstream/private-app
+  ref:
+    tag: latest
+  secretRef:
+    name: ghcr-pull
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster
+  namespace: flux-system
+spec:
+  path: ./k8s/apps
+  sourceRef:
+    kind: OCIRepository
+    name: private-app
+  interval: 1h
+`)
+	testutil.WriteFileAt(t, filepath.Join(dir, "k8s", "apps", "kustomization.yaml"), "resources: []\n")
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	id := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "private-app"}
+	if st.GetArtifact(id) != nil {
+		t.Errorf("a committed OCIRepository source must NOT be aliased to the working tree (it's an external pull)")
+	}
+}
+
+// TestRun_LeavesRootSourceWithMissingLocalPath pins pass 3's local-content
+// guard: even with no remotes, a root Kustomization whose spec.path is NOT a
+// directory inside the working tree is an external source flate can't satisfy
+// offline — its GitRepository must be left to fail loud, never aliased to (and
+// rendered against) the wrong tree.
+func TestRun_LeavesRootSourceWithMissingLocalPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	testutil.WriteFileAt(t, filepath.Join(dir, "cluster.yaml"), `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: shared-infra
+  namespace: flux-system
+spec:
+  url: https://github.com/upstream/shared-infra.git
+  ref:
+    branch: main
+  secretRef:
+    name: deploy-key
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster
+  namespace: flux-system
+spec:
+  path: ./not-in-this-tree
+  sourceRef:
+    kind: GitRepository
+    name: shared-infra
+  interval: 1h
+`)
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	id := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "shared-infra"}
+	if st.GetArtifact(id) != nil {
+		t.Errorf("a root source whose spec.path isn't local must NOT be aliased to the working tree")
+	}
+}
+
+// TestRun_LeavesNonRootSourceWithoutRemotes pins pass 3's root-only guard: a
+// GitRepository referenced solely by a NON-root tenant Kustomization (one a
+// parent KS's spec.path covers) is a genuine external source, never the
+// cluster's own — it must not be aliased even when there are no remotes.
+func TestRun_LeavesNonRootSourceWithoutRemotes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Root entry KS lives outside ./apps and pulls the cluster itself.
+	testutil.WriteFileAt(t, filepath.Join(dir, "clusters", "cluster.yaml"), `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: home-kubernetes
+  namespace: flux-system
+spec:
+  url: ssh://git@github.com/example/home-ops.git
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster
+  namespace: flux-system
+spec:
+  path: ./apps
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  interval: 1h
+`)
+	// app-x lives UNDER ./apps (so cluster is its parent → non-root) and pulls
+	// a separate external private repo.
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "app-x.yaml"), `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: ext-private
+  namespace: flux-system
+spec:
+  url: https://github.com/upstream/ext-private.git
+  ref:
+    branch: main
+  secretRef:
+    name: ext-key
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-x
+  namespace: default
+spec:
+  path: ./apps/x
+  sourceRef:
+    kind: GitRepository
+    name: ext-private
+    namespace: flux-system
+  interval: 1h
+`)
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "kustomization.yaml"), "resources: [./app-x.yaml]\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "x", "kustomization.yaml"), "resources: []\n")
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: dir, Store: st, WipeSecrets: true,
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The root's own source is aliased (the fix); the non-root tenant's external
+	// source is not.
+	root := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "home-kubernetes"}
+	if st.GetArtifact(root) == nil {
+		t.Errorf("root-KS source should be aliased to the working tree")
+	}
+	ext := manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "ext-private"}
+	if st.GetArtifact(ext) != nil {
+		t.Errorf("an external source referenced only by a non-root KS must NOT be aliased")
+	}
+}
+
 // TestRun_ComponentGeneratorMaterializesCM mirrors home-operations/flate
 // issue #396: a Flux Kustomization references a kustomize Component
 // whose configMapGenerator produces cluster-settings. Without the

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -403,6 +403,105 @@ spec:
 	}
 }
 
+// TestE2E_BootstrapSelfSourceSecretDoesNotBlock reproduces the home-ops
+// pattern behind issue #752: a bootstrap GitRepository points at the cluster's
+// own repo and carries a deploy-key secretRef that only exists out-of-band
+// (created by `flux bootstrap`, never committed). When flate renders a tree
+// with no matching git remote — a `.git`-less checkout or extracted tree — that
+// fetch-only secret is irrelevant, so it must NOT cascade every consumer to
+// blocked. Discovery aliases the root Kustomization's source to the working
+// tree (pass 3) and the run is clean.
+func TestE2E_BootstrapSelfSourceSecretDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	// No .git: the URL match can't fire, so only the root-KS topology fallback
+	// can recognize home-kubernetes as the cluster pulling itself.
+	testutil.WriteFile(t, dir, "clusters/cluster.yaml", `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: home-kubernetes, namespace: flux-system}
+spec:
+  url: ssh://git@github.com/example/home-ops.git
+  ref: {branch: main}
+  secretRef: {name: github-deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster, namespace: flux-system}
+spec:
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: home-kubernetes}
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources: [./cm.yaml]\n")
+	testutil.WriteFile(t, dir, "apps/cm.yaml", `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: demo, namespace: default}
+data: {hello: world}
+`)
+
+	// runCLI requires a clean (exit 0) run — the whole point of the fix.
+	out := runCLI(t, "test", "all", "--path", dir)
+	if strings.Contains(out, "github-deploy-key") || strings.Contains(out, "not found") {
+		t.Errorf("bootstrap deploy-key secret must be irrelevant (source aliased to the tree); got:\n%s", out)
+	}
+	if strings.Contains(out, "blocked") {
+		t.Errorf("nothing should be blocked on the aliased bootstrap source; got:\n%s", out)
+	}
+}
+
+// TestE2E_SkippedSourcePropagatesSkipNotBlock locks the issue-#752 contract for
+// a genuinely-external source: when a private GitRepository referenced by a
+// non-root app is soft-skipped (--allow-missing-secrets), the consuming
+// Kustomization must report SKIPPED, not blocked, and the run must stay clean
+// (exit 0). Pins the DAG engine's skip-propagation so it can't regress.
+func TestE2E_SkippedSourcePropagatesSkipNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "clusters/cluster.yaml", `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	// app-x (under ./apps, so non-root) pulls a separate external private repo
+	// whose deploy-key Secret is absent.
+	testutil.WriteFile(t, dir, "apps/app-x.yaml", `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: ext-private, namespace: flux-system}
+spec:
+  url: ssh://git@example.com/other/repo.git
+  ref: {branch: main}
+  secretRef: {name: ext-deploy-key}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: app-x, namespace: default}
+spec:
+  path: ./apps/x
+  sourceRef: {kind: GitRepository, name: ext-private, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "apps/kustomization.yaml", "resources: [./app-x.yaml]\n")
+	testutil.WriteFile(t, dir, "apps/x/kustomization.yaml", "resources: [./cm.yaml]\n")
+	testutil.WriteFile(t, dir, "apps/x/cm.yaml", `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: x-config, namespace: default}
+data: {k: v}
+`)
+
+	// Clean exit: a skip is not a failure. (The skipped source + consumer show
+	// on stdout; runCLI asserts exit 0.)
+	out := runCLI(t, "test", "all", "--path", dir, "--allow-missing-secrets")
+	if !strings.Contains(out, "app-x") || !strings.Contains(out, "skipped") {
+		t.Errorf("consumer of a skipped source must report skipped; got:\n%s", out)
+	}
+	if strings.Contains(out, "blocked") {
+		t.Errorf("a skipped source must propagate skip, not block its consumers; got:\n%s", out)
+	}
+}
+
 // TestE2E_ComponentChangePropagatesToAllConsumers — the fixture has
 // two apps (app-a, app-b) consuming components/shared; mutating the
 // shared component must show up in both consumers' diffs.


### PR DESCRIPTION
## Symptom

`flate test` on a repo whose bootstrap `GitRepository` carries a deploy-key `secretRef` (the `flux bootstrap` / self-pull pattern) reports **everything blocked** whenever there's no working-tree git remote to match the source URL against — a `.git`-less checkout, an extracted tree, or no `Config.SelfURLs`:

```
✗  GitRepository  flux-system/home-kubernetes  ... secret flux-system/github-deploy-key not found
⊘  93 blocked by flux-system/home-kubernetes
✗ 51 passed · 1 failed · 93 blocked
```

The deploy-key Secret exists only to *fetch the remote* — which flate never does for a self source; it renders from the working tree. So the secret is irrelevant, yet it cascades every consumer to blocked.

## Root cause

Discovery already aliases such a source to the working tree, but **only on a URL match** (`overrideSelfReferentialGitRepositories`, pass 2) against a `.git` remote or `Config.SelfURLs`. With no URL signal at all, pass 1 (missing sources) skips it (it's in-tree) and pass 2 can't fire → the in-tree `GitRepository` falls through to a real fetch → fails on the absent secret → consumers block.

## Fix

A third aliasing pass that runs **only when there's no URL signal** (`selfRemotes` empty): alias an in-tree `GitRepository` that is a **root** Kustomization's source — one no other KS's `spec.path` covers (absent from `parentOf`) — to the working tree. Four guards keep it from ever rendering an external repo against the wrong files:

| guard | prevents |
|---|---|
| **no-URL-signal** | when remotes exist but none match, the URL match is authoritative → unmatched source stays external (pinned by `TestRun_LeavesUnmatchedInTreeGitRepository`) |
| **root-only** | a source referenced solely by a non-root tenant KS is untouched |
| **already-handled** | a URL-matched / pass-1 / seeded source is never re-aliased → `.git` checkouts stay byte-identical |
| **local-content** | the root KS's `spec.path` must resolve to a directory inside the tree |

**Scoped to `GitRepository`.** A *committed* `OCIRepository` is, by convention, an external artifact pull whose missing pull Secret should soft-skip — not be aliased (locked by `TestOrchestrator_AllowMissingSecretsPropagates`); a genuine OCI-*bootstrap* source is operator-created and absent, already handled by pass 1. (An earlier draft extended pass 3 to OCI and the existing #190 test correctly caught the regression.)

## On #752

This closes the **bootstrap** case of [#752](https://github.com/home-operations/flate/issues/752) (a `Ready` source has nothing to skip/block). The **general** skip-propagation — a genuinely-external skipped source's consumers blocking instead of skipping — turned out to **already work** in the current DAG engine, so rather than add dead code, `TestE2E_SkippedSourcePropagatesSkipNotBlock` locks it so it can't regress.

## Verification

- **User repro:** the `.git`-less tree goes `51 passed / 1 failed / 93 blocked` → **`189 passed / 1 blocked`** (the lone block an unrelated `ObjectBucketClaim`), no flags.
- **Byte-equivalence:** zariel/home-ops and Biohazard **with** `.git` render byte-identically (`build all`) before/after — pass 3 no-ops when remotes exist.
- New: 4 discovery unit tests (alias-without-remotes, the OCI/non-root/missing-path guards) + 2 e2e tests (the bootstrap scenario + the #752 skip regression).
- `gofmt` · `go build` · `go vet` · `go test ./...` · `go test -race` (discovery/controllers/orchestrator/e2e) · `golangci-lint run ./...` → **0 issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)