### PR TITLE
fix(loader): don't let an external-sourced Kustomization claim the local tree

### DIFF
--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -185,7 +185,7 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	// children to that parent for `flate build` output. Without the
 	// file-path entry the RS would only learn its parent once the parent
 	// re-emitted it, racing the RS's own first render.
-	prefixes := loader.KSPathPrefixesWithCache(d.cfg.Store, repoRoot, cfg.ComponentCache)
+	prefixes := loader.KSPathPrefixesLocalOnly(d.cfg.Store, repoRoot, cfg.ComponentCache)
 	parentOf := loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindKustomization)
 	maps.Copy(parentOf, loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindHelmRelease))
 	maps.Copy(parentOf, loader.BuildParentIndexFromPrefixes(prefixes, d.cfg.Store, d.sourceFiles, manifest.KindResourceSet))

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -33,6 +33,67 @@ type KSPathPrefix struct {
 	Prefix string
 }
 
+// ExternalSourcedKSIDs returns the ids of Kustomizations whose sourceRef points
+// at a genuine EXTERNAL source rather than the working tree, so callers can keep
+// their spec.path from being resolved against the local checkout.
+//
+// flate renders the local tree. A KS sourced from the bootstrap/self source (or
+// a bare sourceRef, which anchors on the seeded BootstrapSourceID) renders that
+// local tree, so its spec.path legitimately claims local prefixes. But a KS
+// sourced from an in-tree GitRepository/OCIRepository CR that was NOT aliased to
+// the working tree — a private side-repo synced into the cluster, e.g.
+// `shelly-fleet` (ssh://…/shelly-fleet.git) with `path: ./kubernetes` — renders
+// THAT repo's tree, which flate can't see. Letting such a KS claim local
+// prefixes makes it the false structural parent/producer of everything beneath a
+// wide spec.path like ./kubernetes, so when its source soft-skips (missing auth
+// Secret) the skip cascades to the entire cluster (179 passed / 209 blocked on
+// lunevans/talos-cluster, issue #752).
+//
+// A source is "local" — excluded from the result — when: the sourceRef is bare
+// (→ BootstrapSourceID), the id IS BootstrapSourceID, the source carries a
+// working-tree artifact (aliased by discovery, LocalPath == repoRoot), or no
+// source object exists yet (a missing sourceRef that bootstrap aliasing
+// resolves). Only an in-tree, non-bootstrap, non-aliased source CR is external.
+func ExternalSourcedKSIDs(s *store.Store, repoRoot string) map[manifest.NamedResource]struct{} {
+	out := map[manifest.NamedResource]struct{}{}
+	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+		if ks.Path == "" || ks.SourceName == "" {
+			continue
+		}
+		src := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
+		if src == manifest.BootstrapSourceID {
+			continue
+		}
+		if art, ok := s.GetArtifact(src).(*store.SourceArtifact); ok && art.LocalPath == repoRoot {
+			continue
+		}
+		if s.GetObject(src) == nil {
+			continue
+		}
+		out[ks.Named()] = struct{}{}
+	}
+	return out
+}
+
+// KSPathPrefixesLocalOnly is KSPathPrefixesWithCache with external-sourced
+// Kustomizations' claims dropped (see ExternalSourcedKSIDs). Use this for the
+// parent index, orphan promotion, and any other local-tree path attribution so
+// an external-sourced KS never becomes the structural parent of local resources.
+func KSPathPrefixesLocalOnly(s *store.Store, repoRoot string, cache *manifest.ComponentCache) []KSPathPrefix {
+	all := KSPathPrefixesWithCache(s, repoRoot, cache)
+	external := ExternalSourcedKSIDs(s, repoRoot)
+	if len(external) == 0 {
+		return all
+	}
+	out := make([]KSPathPrefix, 0, len(all))
+	for _, p := range all {
+		if _, skip := external[p.ID]; !skip {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // KSPathPrefixesWithCache returns one or more entries per loaded
 // Kustomization with a non-empty spec.path. Each KS contributes:
 //

--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -16,6 +16,72 @@ func buildParentIndexForKindWithCache(s *store.Store, repoRoot string, sourceFil
 	return BuildParentIndexFromPrefixes(KSPathPrefixesWithCache(s, repoRoot, cache), s, sourceFiles, childKind)
 }
 
+// TestKSPathPrefixesLocalOnly_DropsExternalSourced pins issue #752
+// (lunevans/talos-cluster): a Kustomization sourced from a genuine external repo
+// (an in-tree GitRepository with no working-tree artifact) must not claim
+// local-tree path prefixes, even with a wide spec.path like ./kubernetes —
+// otherwise it becomes the false structural parent of the whole cluster and its
+// skip cascades. A bootstrap-sourced KS and an aliased (working-tree) source
+// keep their claims.
+func TestKSPathPrefixesLocalOnly_DropsExternalSourced(t *testing.T) {
+	repoRoot := "/repo" // no on-disk component reads will resolve; that's fine
+	s := store.New()
+
+	// Bootstrap-sourced root (sourceRef == BootstrapSourceID) — kept.
+	bootstrap := &manifest.Kustomization{
+		Name: "cluster-apps", Namespace: "flux-system",
+		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+	}
+	// Self/aliased source: an in-tree GitRepository with a working-tree artifact
+	// (URL-matched by discovery) — kept.
+	aliasedKS := &manifest.Kustomization{
+		Name: "self-apps", Namespace: "flux-system",
+		SourceKind: manifest.KindGitRepository, SourceName: "home-kubernetes", SourceNamespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/self"},
+	}
+	// External source: an in-tree GitRepository with NO working-tree artifact,
+	// claiming the WIDE ./kubernetes — must be dropped.
+	external := &manifest.Kustomization{
+		Name: "side-sync", Namespace: "flux-system",
+		SourceKind: manifest.KindGitRepository, SourceName: "side-repo", SourceNamespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes"},
+	}
+	s.AddObject(bootstrap)
+	s.AddObject(aliasedKS)
+	s.AddObject(external)
+	s.AddObject(&manifest.GitRepository{Name: "home-kubernetes", Namespace: "flux-system"})
+	s.AddObject(&manifest.GitRepository{Name: "side-repo", Namespace: "flux-system"})
+	// home-kubernetes is aliased to the working tree (LocalPath == repoRoot).
+	s.SetArtifact(
+		manifest.NamedResource{Kind: manifest.KindGitRepository, Namespace: "flux-system", Name: "home-kubernetes"},
+		&store.SourceArtifact{Kind: manifest.KindGitRepository, URL: "file://" + repoRoot, LocalPath: repoRoot},
+	)
+
+	ext := ExternalSourcedKSIDs(s, repoRoot)
+	if _, ok := ext[external.Named()]; !ok {
+		t.Errorf("external-sourced KS must be flagged; got %v", ext)
+	}
+	if _, ok := ext[bootstrap.Named()]; ok {
+		t.Errorf("bootstrap-sourced KS must NOT be flagged")
+	}
+	if _, ok := ext[aliasedKS.Named()]; ok {
+		t.Errorf("working-tree-aliased source must NOT be flagged")
+	}
+
+	prefixes := KSPathPrefixesLocalOnly(s, repoRoot, nil)
+	seen := map[manifest.NamedResource]bool{}
+	for _, p := range prefixes {
+		seen[p.ID] = true
+	}
+	if seen[external.Named()] {
+		t.Errorf("external-sourced KS claim must be dropped from the prefix index")
+	}
+	if !seen[bootstrap.Named()] || !seen[aliasedKS.Named()] {
+		t.Errorf("local-sourced KS claims must be retained; seen=%v", seen)
+	}
+}
+
 func TestBuildParentIndex_CrossTreeBasePattern(t *testing.T) {
 	// cluster-apps is the root with spec.path=./kubernetes/apps/main.
 	// karma lives at apps/main/observability/karma.yaml — under

--- a/pkg/loader/selfproduce.go
+++ b/pkg/loader/selfproduce.go
@@ -70,8 +70,16 @@ func BuildSelfProduceIndex(s *store.Store, repoRoot string, producers *manifest.
 		idx:       idx,
 		producers: producers,
 	}
+	// A KS sourced from a genuine external repo renders that repo's tree, not the
+	// local checkout — walking its spec.path against repoRoot would record it as
+	// producing local ConfigMaps/Secrets it doesn't own (and cascade its skip).
+	// See loader.ExternalSourcedKSIDs.
+	external := ExternalSourcedKSIDs(s, repoRoot)
 	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
 		if ks.Path == "" {
+			continue
+		}
+		if _, skip := external[ks.Named()]; skip {
 			continue
 		}
 		b.walkRoot(ks)

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -28,7 +28,7 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 	// the orchestrator side. Route through the shared component
 	// cache populated during Bootstrap so the per-KS component file
 	// reads are served from memory rather than re-stat'd here.
-	prefixes := loader.KSPathPrefixesWithCache(o.store, o.repoRoot, o.componentCache)
+	prefixes := loader.KSPathPrefixesLocalOnly(o.store, o.repoRoot, o.componentCache)
 	for id, info := range failed {
 		if !isReconcilableKind(id.Kind) {
 			continue

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -403,6 +403,76 @@ spec:
 	}
 }
 
+// TestE2E_ExternalSourcedWidePathDoesNotBlockCluster reproduces
+// lunevans/talos-cluster (issue #752): a "sync" Kustomization pulls a private
+// side-repo (an in-tree GitRepository flate can't fetch offline) and declares a
+// WIDE spec.path (./kubernetes) that, resolved against the LOCAL tree, covers the
+// whole cluster. flate must NOT treat that external-sourced KS as the structural
+// parent/producer of the local tree — otherwise its soft-skip (missing auth
+// Secret) cascades to every app ("179 passed · 209 blocked"). The sync KS itself
+// skips; everything else renders.
+func TestE2E_ExternalSourcedWidePathDoesNotBlockCluster(t *testing.T) {
+	dir := t.TempDir()
+	// Root entry: cluster-apps renders ./kubernetes/apps from the bootstrap
+	// source. Its file lives under ./kubernetes/flux, so the wide sync path
+	// ./kubernetes is its only structural ancestor — the trap.
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster.yaml", `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./kubernetes/apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/kustomization.yaml", "resources: [./app-a.yaml, ./sync.yaml]\n")
+	// A normal app sourced from the bootstrap tree — must pass.
+	testutil.WriteFile(t, dir, "kubernetes/apps/app-a.yaml", `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: app-a, namespace: default}
+spec:
+  path: ./kubernetes/apps/app-a
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/app-a/kustomization.yaml", "resources: [./cm.yaml]\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/app-a/cm.yaml", `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: app-a, namespace: default}
+data: {k: v}
+`)
+	// The trap: a sync KS with a WIDE path, sourced from an external private repo.
+	testutil.WriteFile(t, dir, "kubernetes/apps/sync.yaml", `---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: {name: side-repo, namespace: flux-system}
+spec:
+  url: ssh://git@github.com/someone/private-side-repo.git
+  ref: {branch: main}
+  secretRef: {name: side-repo-deploy}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: side-sync, namespace: flux-system}
+spec:
+  path: ./kubernetes
+  sourceRef: {kind: GitRepository, name: side-repo, namespace: flux-system}
+`)
+
+	// --allow-missing-secrets soft-skips the external source; a skip is not a
+	// failure so the run is clean (runCLI requires exit 0).
+	out := runCLI(t, "test", "all", "--path", dir, "--allow-missing-secrets")
+	if !strings.Contains(out, "app-a") || !strings.Contains(out, "passed") {
+		t.Errorf("a bootstrap-sourced app must render, not block, behind an external-sourced wide-path KS:\n%s", out)
+	}
+	if strings.Contains(out, "blocked") {
+		t.Errorf("an external-sourced wide-path KS must not parent (and block) the local tree:\n%s", out)
+	}
+	if !strings.Contains(out, "skipped") {
+		t.Errorf("the external-sourced sync KS (and its source) should skip:\n%s", out)
+	}
+}
+
 // TestE2E_ComponentChangePropagatesToAllConsumers — the fixture has
 // two apps (app-a, app-b) consuming components/shared; mutating the
 // shared component must show up in both consumers' diffs.


### PR DESCRIPTION
## Symptom

`flate test` on [lunevans/talos-cluster](https://github.com/LukeEvansTech/talos-cluster) reports **`179 passed · 1 skipped · 209 blocked`** — the exact signature from [#752](https://github.com/home-operations/flate/issues/752). The `GitRepository/home/shelly-fleet` source is correctly *skipped* (missing deploy-key Secret), but **209 unrelated resources block** with no root cause shown.

## Root cause

The repo has a `shelly-fleet-sync` Kustomization that syncs a **private side-repo** into the cluster:

```yaml
kind: Kustomization
metadata: {name: shelly-fleet-sync}
spec:
  path: ./kubernetes                      # the WHOLE tree
  sourceRef: {kind: GitRepository, name: shelly-fleet}   # an EXTERNAL repo
```

Real Flux renders `./kubernetes` from the **shelly-fleet repo's** tree. But flate resolves *every* KS's `spec.path` against the **local working tree** when building the parent index and the self-production index. So `shelly-fleet-sync` — with its wide `./kubernetes` path — became the false structural **parent/producer of the entire cluster**. When its external source soft-skipped, the skip cascaded to all 209 consumers.

Confirmed: narrowing that one KS's path to a leaf dir flips the run to `589 passed · 2 skipped`.

## Fix

A KS sourced from a genuine **external** repo renders that repo's tree, not ours — it must not claim local-tree path prefixes.

- `loader.ExternalSourcedKSIDs(store, repoRoot)` — a KS is external-sourced when its `sourceRef` resolves to an **in-tree Git/OCIRepository CR that discovery did NOT alias to the working tree** (no `LocalPath==repoRoot` artifact) and isn't the bootstrap source.
- `loader.KSPathPrefixesLocalOnly` drops those KSes' claims; the self-produce walk skips them.
- Wired into discovery (parent index + orphan promotion) and orchestrator finalize (orphan detection).

**Stays local (claims kept):** a bare `sourceRef` (→ `BootstrapSourceID`), the bootstrap id itself, and any working-tree-aliased source (the cluster pulling itself).

## Verification

| repo | before | after |
|---|---|---|
| **lunevans/talos-cluster** | `179 passed · 1 skipped · 209 blocked` | **`589 passed · 2 skipped`** ✅ |
| zariel/home-ops (`build all`) | — | **byte-identical** ✅ |
| Biohazard (`build all`) | — | **byte-identical** ✅ |

The `side-repo` and its `sync` KS correctly skip; the 209 false-blocks are gone. zariel and Biohazard are byte-identical because neither has an external-sourced KS, so the filter excludes nothing.

New tests: `TestKSPathPrefixesLocalOnly_DropsExternalSourced` (loader unit — bootstrap/aliased kept, external dropped) and `TestE2E_ExternalSourcedWidePathDoesNotBlockCluster` (the lunevans topology). `gofmt` · `build` · `vet` · `go test ./...` · `-race` · `golangci-lint` → 0 issues.

Closes #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)