### PR TITLE
fix(cli): detach the stdlib logger from the notes footer for determinism

### DIFF
--- a/internal/cli/logrouting_test.go
+++ b/internal/cli/logrouting_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"bytes"
+	"log"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSetLogLevel_StdlibLogDetachedFromNotes pins the determinism fix: Go's
+// slog↔log bridge (installed by slog.SetDefault) would otherwise route a
+// dependency's stdlib log.Printf — chiefly Helm's values-coalesce "destination
+// … is a table" warnings — into the notes footer. Those fire only when a chart
+// actually renders, so on a render-cache HIT they vanish, making the footer
+// differ between otherwise-identical runs (looks like a race). At non-debug
+// levels the stdlib logger is detached, so dependency chatter never reaches
+// notes; flate's own slog diagnostics still do. At debug it's reattached for
+// troubleshooting.
+func TestSetLogLevel_StdlibLogDetachedFromNotes(t *testing.T) {
+	saved := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(saved); log.SetOutput(os.Stderr) })
+
+	var sink bytes.Buffer
+	if err := setLogLevel("warn", &sink); err != nil {
+		t.Fatalf("setLogLevel(warn): %v", err)
+	}
+	log.Printf("warning: destination for x is a table. Ignoring non-table value") // dependency stdlib log
+	slog.Warn("resource orphaned", "id", "x")                                     // flate's own slog
+
+	var notes strings.Builder
+	for _, n := range drainLogNotes() {
+		notes.WriteString(n.Text)
+		notes.WriteByte('\n')
+	}
+	if got := notes.String(); strings.Contains(got, "is a table") {
+		t.Errorf("dependency stdlib log must NOT reach the notes footer at non-debug:\n%s", got)
+	}
+	if got := notes.String(); !strings.Contains(got, "resource orphaned") {
+		t.Errorf("flate's own slog Warn must still be captured as a note:\n%s", got)
+	}
+
+	// At debug the stdlib logger is reattached to the sink (visible for
+	// troubleshooting) rather than discarded.
+	var dbg bytes.Buffer
+	if err := setLogLevel("debug", &dbg); err != nil {
+		t.Fatalf("setLogLevel(debug): %v", err)
+	}
+	log.Printf("helm-coalesce-debug-line")
+	if !strings.Contains(dbg.String(), "helm-coalesce-debug-line") {
+		t.Errorf("at --log-level debug, stdlib log should reach the sink writer; got %q", dbg.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -154,5 +155,21 @@ func setLogLevel(lvl string, w io.Writer) error {
 	// flushes anything left so no note is lost.
 	logBuffer = newDeferSink(slog.NewTextHandler(w, &slog.HandlerOptions{Level: l}))
 	slog.SetDefault(slog.New(logBuffer))
+	// slog.SetDefault also reroutes the standard library `log` package through
+	// this handler. A dependency's log.Printf — chiefly Helm's values-coalesce
+	// "destination … is a table" warnings (chart/common/util/coalesce.go uses
+	// log.Printf, not slog) — would then land in the notes footer, but ONLY on a
+	// render-cache miss: a cache hit never re-runs the code that logs it, so the
+	// footer differs between otherwise-identical runs depending on cache state
+	// (looks like a race). flate's own diagnostics all use slog, never the
+	// stdlib logger, so detach `log` from the footer: discard it by default
+	// (notes stay deterministic and free of dependency render-noise), or pass it
+	// straight to the sink under --log-level debug, where determinism isn't
+	// promised and the dependency chatter aids troubleshooting.
+	if l <= slog.LevelDebug {
+		log.SetOutput(w)
+	} else {
+		log.SetOutput(io.Discard)
+	}
 	return nil
 }


### PR DESCRIPTION
## Symptom

`flate test` on lunevans/talos-cluster appeared to have a **race** — repeated runs flipped between `notes (1)` and `notes (5)`, the extra notes being Helm's `rook-ceph.csi` *"destination … is a table. Ignoring non-table value"* warnings.

## It's not a race — it's a cache-dependent footer

Across 150+ runs the **rendered YAML and verdict are fully deterministic** (`589 passed · 2 skipped`, warnings 8). What flipped was the **notes footer**, and strictly with cache state:

- `slog.SetDefault` (Go 1.21+) also reroutes the standard library **`log`** package through the installed handler.
- Helm's values-coalesce warnings come from `helm/v4 chart/common/util/coalesce.go` via **`log.Printf`** (stdlib `log`, not slog) → the slog↔log bridge → flate's `deferSink` → notes.
- They're emitted only when a chart actually renders. On a **render-cache hit** Helm never re-runs, so they're not re-emitted → `notes (1)`. On a **miss** → `notes (5)`.

So the footer differed between otherwise-identical runs depending on cache warmth. (Newly visible because #757 unblocked the rook-ceph render.)

## Fix

flate's own diagnostics use `slog` exclusively, never the stdlib logger — so detach `log` from the footer in `setLogLevel`:

- **non-debug:** `log.SetOutput(io.Discard)` — notes stay deterministic and free of dependency render-noise.
- **`--log-level debug`:** route stdlib `log` straight to the sink, where determinism isn't promised and the chatter aids troubleshooting.

## Verification

- lunevans/talos-cluster: **cold and warm `flate test all` are now byte-identical** (`notes (1)`, `589 passed · 2 skipped`); 3× cold + many warm all match.
- `--log-level debug` still surfaces the Helm coalesce warnings (4 lines).
- New `TestSetLogLevel_StdlibLogDetachedFromNotes` pins it: a stdlib `log.Printf` no longer reaches notes at non-debug; flate's own `slog.Warn` still does; debug reattaches.
- `gofmt` · `build` · `vet` · `go test ./...` · `-race` (cli) · `golangci-lint` → 0 issues. Rendered YAML unaffected (this only touches stdlib-log routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)