### PR TITLE
feat(producer): treat ObjectBucketClaim as a producer of its Secret + ConfigMap

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -113,24 +113,23 @@ func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResourc
 }
 
 // onRawProducerAdded returns a listener that indexes RawObject producers
-// (ExternalSecret, SealedSecret) into the shared producer index. Registered
-// with flush=true (via AddListener) so the index picks up any objects already
-// in the store at Start time and stays current as KS renders emit more — with
-// the post-kustomize-transform names a discovery-time file scan can't see.
+// (ExternalSecret, SealedSecret, ObjectBucketClaim) into the shared producer
+// index. Registered with flush=true (via AddListener) so the index picks up any
+// objects already in the store at Start time and stays current as KS renders
+// emit more — with the post-kustomize-transform names a discovery-time file
+// scan can't see.
 //
-// The index maps targetID → producer.Named() via manifest.ProducerTargetSecret
-// so the valuesFrom producer lookup answers in O(1) without a full-store scan.
+// The index maps each target → producer.Named() via manifest.ProducerTargets so
+// the valuesFrom producer lookup answers in O(1) without a full-store scan.
 func (c *Controller) onRawProducerAdded() store.Listener {
 	return func(_ manifest.NamedResource, payload any) {
 		raw, ok := payload.(*manifest.RawObject)
 		if !ok {
 			return
 		}
-		targetID, ok := manifest.ProducerTargetSecret(raw)
-		if !ok {
-			return
+		for _, targetID := range manifest.ProducerTargets(raw) {
+			c.producers.Record(targetID, raw.Named())
 		}
-		c.producers.Record(targetID, raw.Named())
 	}
 }
 

--- a/pkg/loader/selfproduce.go
+++ b/pkg/loader/selfproduce.go
@@ -243,21 +243,20 @@ func (b *selfProduceBuilder) recordConfigMap(cm *manifest.ConfigMap, baseNS, roo
 	b.idx.byID[id] = appendUniqueProducer(b.idx.byID[id], ks)
 }
 
-// recordProducer records the target Secret an ExternalSecret / SealedSecret
-// generates, re-keyed under the producer's effective namespace so it matches a
-// consumer's same-namespace lookup. Non-producer kinds and a nil index are
-// no-ops.
+// recordProducer records the target(s) a producer generates — the Secret an
+// ExternalSecret / SealedSecret materializes, or the Secret + ConfigMap an
+// ObjectBucketClaim's provisioner creates — each re-keyed under the producer's
+// effective namespace so it matches a consumer's same-namespace lookup.
+// Non-producer kinds and a nil index are no-ops.
 func (b *selfProduceBuilder) recordProducer(raw *manifest.RawObject, baseNS, rootNS string) {
-	target, ok := manifest.ProducerTargetSecret(raw)
-	if !ok {
-		return
+	for _, target := range manifest.ProducerTargets(raw) {
+		ns := cmp.Or(baseNS, target.Namespace, rootNS)
+		if ns == "" {
+			continue
+		}
+		target.Namespace = ns
+		b.producers.Record(target, raw.Named())
 	}
-	ns := cmp.Or(baseNS, target.Namespace, rootNS)
-	if ns == "" {
-		return
-	}
-	target.Namespace = ns
-	b.producers.Record(target, raw.Named())
 }
 
 func appendUniqueProducer(dst []manifest.NamedResource, v manifest.NamedResource) []manifest.NamedResource {

--- a/pkg/loader/selfproduce_test.go
+++ b/pkg/loader/selfproduce_test.go
@@ -100,7 +100,7 @@ func secretID(ns, name string) manifest.NamedResource {
 func TestBuildSelfProduceIndex_RecordsProducers(t *testing.T) {
 	dir := t.TempDir()
 	testutil.WriteFile(t, dir, "apps/kustomization.yaml",
-		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: secure\nresources:\n  - ./es.yaml\n  - ./sealed.yaml\n  - ./explicit.yaml\n")
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: secure\nresources:\n  - ./es.yaml\n  - ./sealed.yaml\n  - ./explicit.yaml\n  - ./obc.yaml\n")
 	// ExternalSecret, no namespace in file → inherits `secure`; explicit target.
 	testutil.WriteFile(t, dir, "apps/es.yaml",
 		"apiVersion: external-secrets.io/v1\nkind: ExternalSecret\nmetadata:\n  name: app-creds\nspec:\n  target:\n    name: app-values\n")
@@ -111,6 +111,10 @@ func TestBuildSelfProduceIndex_RecordsProducers(t *testing.T) {
 	// overrides it, exactly as kustomize does.
 	testutil.WriteFile(t, dir, "apps/explicit.yaml",
 		"apiVersion: external-secrets.io/v1\nkind: ExternalSecret\nmetadata:\n  name: own\n  namespace: ignored\nspec:\n  target:\n    name: own-values\n")
+	// ObjectBucketClaim: its provisioner materializes a Secret AND a ConfigMap
+	// both named after the claim, in the (transformer-resolved) namespace.
+	testutil.WriteFile(t, dir, "apps/obc.yaml",
+		"apiVersion: objectbucket.io/v1alpha1\nkind: ObjectBucketClaim\nmetadata:\n  name: media-bucket\nspec:\n  bucketName: media\n  storageClassName: ceph-bucket\n")
 
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{
@@ -121,10 +125,13 @@ func TestBuildSelfProduceIndex_RecordsProducers(t *testing.T) {
 	producers := &manifest.ProducerIndex{}
 	BuildSelfProduceIndex(s, dir, producers)
 
-	want := map[manifest.NamedResource]string{ // target Secret → producer name
+	want := map[manifest.NamedResource]string{ // target → producer name
 		secretID("secure", "app-values"): "app-creds",
 		secretID("secure", "db-secret"):  "db",
 		secretID("secure", "own-values"): "own",
+		// The OBC produces BOTH a Secret and a ConfigMap named after the claim.
+		secretID("secure", "media-bucket"):                                        "media-bucket",
+		{Kind: manifest.KindConfigMap, Namespace: "secure", Name: "media-bucket"}: "media-bucket",
 	}
 	for target, prodName := range want {
 		got, ok := producers.Producer(target)

--- a/pkg/manifest/producer.go
+++ b/pkg/manifest/producer.go
@@ -1,43 +1,55 @@
 package manifest
 
-import "sync"
+import (
+	"cmp"
+	"sync"
+)
 
-// ProducerTargetSecret returns the Secret that raw — an ExternalSecret
-// (external-secrets.io) or SealedSecret (bitnami-labs/sealed-secrets) — will
-// generate in-cluster, or (zero, false) when raw is not a recognised producer
-// kind. It is the single source of truth for producer classification:
-// extending coverage to a new generator kind means adding a case here.
+// ProducerTargets returns the in-cluster objects raw will generate live, or nil
+// when raw is not a recognised producer kind. It is the single source of truth
+// for producer classification: extending coverage to a new generator kind means
+// adding a case here.
 //
-// The target name comes from the producer's own declaration — ExternalSecret
-// spec.target.name, SealedSecret spec.template.metadata.name — defaulting to
-// metadata.name when unset, matching each controller's own defaulting. The
-// target Secret lands in the producer's namespace.
+//   - ExternalSecret (external-secrets.io) / SealedSecret
+//     (bitnami-labs/sealed-secrets): the one Secret each materializes —
+//     spec.target.name / spec.template.metadata.name, defaulting to
+//     metadata.name (matching each controller's own defaulting).
+//   - ObjectBucketClaim (objectbucket.io — Rook/Ceph's lib-bucket-provisioner):
+//     a Secret AND a ConfigMap, both named after the OBC. The Secret holds the
+//     S3 credentials (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY), the ConfigMap
+//     the bucket connection info (BUCKET_HOST / BUCKET_PORT / BUCKET_NAME); a
+//     consuming HelmRelease valuesFrom (or substituteFrom) references them by
+//     the claim's name and neither exists in the offline tree.
+//
+// Every target lands in the producer's namespace.
 //
 // Coverage caveat: this reads the producer's RAW declared name. A kustomize
-// namePrefix / nameSuffix / replacement that rewrites the generated Secret's
-// identity is NOT followed (kustomize does not register a nameReference
-// fieldSpec for spec.target.name), so producer-inference misses a transformed
-// target and the consumer falls back to fail-loud or --allow-missing-secrets.
-// Degraded-but-safe: never a false match.
-func ProducerTargetSecret(raw *RawObject) (NamedResource, bool) {
+// namePrefix / nameSuffix / replacement that rewrites the generated object's
+// identity is NOT followed (kustomize registers no nameReference fieldSpec for
+// these), so producer-inference misses a transformed target and the consumer
+// falls back to fail-loud or --allow-missing-secrets. Degraded-but-safe: never
+// a false match.
+func ProducerTargets(raw *RawObject) []NamedResource {
 	// Failed map asserts yield nil, and indexing nil yields the zero value, so
 	// the nested lookups need no explicit nil checks.
-	var name string
 	switch raw.Kind {
 	case "ExternalSecret":
 		target, _ := raw.Spec["target"].(map[string]any)
-		name, _ = target["name"].(string)
+		name, _ := target["name"].(string)
+		return []NamedResource{{Kind: KindSecret, Namespace: raw.Namespace, Name: cmp.Or(name, raw.Name)}}
 	case "SealedSecret":
 		tmpl, _ := raw.Spec["template"].(map[string]any)
 		meta, _ := tmpl["metadata"].(map[string]any)
-		name, _ = meta["name"].(string)
+		name, _ := meta["name"].(string)
+		return []NamedResource{{Kind: KindSecret, Namespace: raw.Namespace, Name: cmp.Or(name, raw.Name)}}
+	case "ObjectBucketClaim":
+		return []NamedResource{
+			{Kind: KindSecret, Namespace: raw.Namespace, Name: raw.Name},
+			{Kind: KindConfigMap, Namespace: raw.Namespace, Name: raw.Name},
+		}
 	default:
-		return NamedResource{}, false
+		return nil
 	}
-	if name == "" {
-		name = raw.Name // both controllers default the target to the CR's own name
-	}
-	return NamedResource{Kind: KindSecret, Namespace: raw.Namespace, Name: name}, true
 }
 
 // ProducerIndex maps a target resource — the Secret an ExternalSecret /

--- a/pkg/manifest/producer_test.go
+++ b/pkg/manifest/producer_test.go
@@ -1,55 +1,56 @@
 package manifest
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
-func TestProducerTargetSecret(t *testing.T) {
+func TestProducerTargets(t *testing.T) {
 	cases := []struct {
-		name     string
-		raw      *RawObject
-		wantOK   bool
-		wantName string
-		wantNS   string
+		name string
+		raw  *RawObject
+		want []NamedResource
 	}{
 		{
 			name: "ExternalSecret explicit target.name",
 			raw: &RawObject{Kind: "ExternalSecret", Namespace: "default", Name: "app-creds",
 				Spec: map[string]any{"target": map[string]any{"name": "app-values"}}},
-			wantOK: true, wantName: "app-values", wantNS: "default",
+			want: []NamedResource{{Kind: KindSecret, Namespace: "default", Name: "app-values"}},
 		},
 		{
-			name:   "ExternalSecret no target falls back to own name",
-			raw:    &RawObject{Kind: "ExternalSecret", Namespace: "staging", Name: "my-secret", Spec: map[string]any{}},
-			wantOK: true, wantName: "my-secret", wantNS: "staging",
+			name: "ExternalSecret no target falls back to own name",
+			raw:  &RawObject{Kind: "ExternalSecret", Namespace: "staging", Name: "my-secret", Spec: map[string]any{}},
+			want: []NamedResource{{Kind: KindSecret, Namespace: "staging", Name: "my-secret"}},
 		},
 		{
 			name: "SealedSecret template.metadata.name",
 			raw: &RawObject{Kind: "SealedSecret", Namespace: "prod", Name: "sealed",
 				Spec: map[string]any{"template": map[string]any{"metadata": map[string]any{"name": "sealed-db"}}}},
-			wantOK: true, wantName: "sealed-db", wantNS: "prod",
+			want: []NamedResource{{Kind: KindSecret, Namespace: "prod", Name: "sealed-db"}},
 		},
 		{
-			name:   "SealedSecret no template falls back to own name",
-			raw:    &RawObject{Kind: "SealedSecret", Namespace: "prod", Name: "sealed-db", Spec: map[string]any{}},
-			wantOK: true, wantName: "sealed-db", wantNS: "prod",
+			name: "SealedSecret no template falls back to own name",
+			raw:  &RawObject{Kind: "SealedSecret", Namespace: "prod", Name: "sealed-db", Spec: map[string]any{}},
+			want: []NamedResource{{Kind: KindSecret, Namespace: "prod", Name: "sealed-db"}},
 		},
 		{
-			name:   "non-producer kind",
-			raw:    &RawObject{Kind: "Certificate", Namespace: "default", Name: "tls"},
-			wantOK: false,
+			name: "ObjectBucketClaim produces a Secret and a ConfigMap named after the claim",
+			raw:  &RawObject{Kind: "ObjectBucketClaim", Namespace: "default", Name: "netbox-obc"},
+			want: []NamedResource{
+				{Kind: KindSecret, Namespace: "default", Name: "netbox-obc"},
+				{Kind: KindConfigMap, Namespace: "default", Name: "netbox-obc"},
+			},
+		},
+		{
+			name: "non-producer kind",
+			raw:  &RawObject{Kind: "Certificate", Namespace: "default", Name: "tls"},
+			want: nil,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, ok := ProducerTargetSecret(c.raw)
-			if ok != c.wantOK {
-				t.Fatalf("ok = %v, want %v", ok, c.wantOK)
-			}
-			if !c.wantOK {
-				return
-			}
-			want := NamedResource{Kind: KindSecret, Namespace: c.wantNS, Name: c.wantName}
-			if got != want {
-				t.Errorf("target = %v, want %v", got, want)
+			if got := ProducerTargets(c.raw); !slices.Equal(got, c.want) {
+				t.Errorf("targets = %v, want %v", got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Symptom

`flate test` on zariel/home-ops left one blocked: **`189 passed · 1 blocked by default/netbox-obc (not found)`**.

`netbox-obc` is an `ObjectBucketClaim`. Rook/Ceph's lib-bucket-provisioner materializes — live, in-cluster — a **Secret** and a **ConfigMap** both named after the claim (the Secret holds `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`, the ConfigMap the `BUCKET_HOST`/`PORT`/`NAME`). The netbox HelmRelease reads those creds via `valuesFrom`:

```yaml
valuesFrom:
  - targetPath: storages.default.OPTIONS.access_key
    kind: Secret
    name: netbox-obc
    valuesKey: AWS_ACCESS_KEY_ID
```

Neither object exists in the offline tree, so the HR blocked on the missing `Secret/netbox-obc` — exactly the situation flate already handles for ExternalSecret / SealedSecret.

## Fix

Treat `ObjectBucketClaim` as a producer, mirroring ES/SS:

- Generalize `manifest.ProducerTargetSecret` (one Secret) → **`ProducerTargets`** (every object a producer generates). ES/SS → `[Secret]`; OBC → `[Secret, ConfigMap]`, both named after the claim, in its namespace.
- Both recorders — the discovery-time producer scan (`loader.recordProducer`) and the HelmRelease render-time listener (`onRawProducerAdded`) — now record **every** target.
- A `valuesFrom` (or `substituteFrom`) Secret/ConfigMap backed by an OBC is then omitted as *producer-backed* rather than blocking. The producer index is already kind-aware and handles both Secret and ConfigMap.

## Verification

- **zariel/home-ops: `189 passed · 1 blocked` → `190 passed`** (the netbox HR now renders; its OBC-backed creds are omitted like any producer-backed valuesFrom Secret).
- **Biohazard** and **lunevans/talos-cluster** (no OBCs): `build all` **byte-identical** — the new case is inert where there are no OBCs.
- Tests: `ProducerTargets` table-test gains an OBC case (Secret + ConfigMap); `TestBuildSelfProduceIndex_RecordsProducers` asserts the discovery scan records both OBC targets under the transformer-resolved namespace.
- `gofmt` · `build` · `vet` · `go test ./...` · `-race` (manifest/loader/controllers) · `golangci-lint` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)