### PR TITLE
refactor: cleanup sweep pass 1 — idiom, dedup, drop a needless clone (post-v0.4.5)

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -764,8 +764,7 @@ func aggregateScopedFailures(
 func nonResourceRunErrors(err error) []error {
 	var out []error
 	for _, leaf := range flattenErrors(err) {
-		var aggregate *orchestrator.FailuresError
-		if errors.As(leaf, &aggregate) {
+		if _, ok := errors.AsType[*orchestrator.FailuresError](leaf); ok {
 			continue // re-scoped + re-rendered from res.Failed, not carried verbatim
 		}
 		out = append(out, leaf)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -108,14 +108,12 @@ func run(version string, args []string, stdout, stderr io.Writer) int {
 	err := root.ExecuteContext(ctx)
 	// Flush any deferred log notes a command didn't already render (diff/get/
 	// cache, or a clean run) so nothing buffered is lost.
-	if logBuffer != nil {
-		for _, n := range logBuffer.drain() {
-			line := n.Text
-			if n.Count > 1 {
-				line = fmt.Sprintf("%s (×%d)", line, n.Count)
-			}
-			_, _ = io.WriteString(stderr, line+"\n")
+	for _, n := range drainLogNotes() {
+		line := n.Text
+		if n.Count > 1 {
+			line = fmt.Sprintf("%s (×%d)", line, n.Count)
 		}
+		_, _ = io.WriteString(stderr, line+"\n")
 	}
 	if err != nil {
 		// reportFailures already rendered a styled report for this error; don't

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -153,7 +153,7 @@ func caseRow(c Case, kindW int, color bool) string {
 // the rest only when non-zero) and the elapsed clock.
 func (r Report) verdict(color bool, elapsed time.Duration) string {
 	glyph, paint := style.GlyphPass, style.Pass
-	if r.Failed > 0 || len(r.Blocked) > 0 {
+	if r.AnyFailed() {
 		glyph, paint = style.GlyphFail, style.Fail
 	}
 	return report.Verdict(color, glyph, paint, elapsed,

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -296,7 +295,7 @@ func gitCacheKey(repo *manifest.GitRepository, refLabel string) string {
 	}{
 		Ref:               refLabel,
 		Ignore:            ignore,
-		SparseCheckout:    slices.Clone(repo.SparseCheckout),
+		SparseCheckout:    repo.SparseCheckout,
 		RecurseSubmodules: repo.RecurseSubmodules,
 	}
 	h, _ := source.CacheKeyHash(payload, 8)


### PR DESCRIPTION
## What

Pass 1 of a multi-pass behavior-preserving cleanup of code shipped since v0.4.5 (`ee29b6f`). A parallel per-file audit (one agent per changed file + adversarial verify per edit) surfaced 5 high-confidence edits across 4 files; the other 24 files were confirmed already clean.

- **cli/common.go** — `errors.As` with a write-only target → `errors.AsType[*orchestrator.FailuresError]` (the repo's prevailing Go 1.26 idiom; drops the write-only var).
- **cli/root.go** — reuse the existing `drainLogNotes()` helper instead of re-implementing its nil-check + drain inline.
- **testrunner/runner.go** — `verdict()` reuses `Report.AnyFailed()` instead of restating its identical predicate, keeping the two in lockstep.
- **source/git/fetcher.go** — drop `slices.Clone(repo.SparseCheckout)` in `gitCacheKey`: the struct is only JSON-marshaled for the cache-key hash and never retained or mutated, so the clone was dead defensiveness; drop the now-orphaned `slices` import.

## Verification

- gofmt · `go build ./...` · `go vet ./...` · `go test ./...` · `go test -race` (affected pkgs) · `golangci-lint`: all clean.
- **Byte-equivalence**: `build all` byte-identical on Biohazard (`9256d8dafd74`). zariel matches modulo a **pre-existing** intermittent `checksum/secret` annotation flake that the base binary exhibits identically (flagged separately for a deterministic-serialization fix) — when both binaries are in the same cache state the diff is 0 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)