### PR TITLE
refactor: cleanup sweep pass 2 — cross-file dedup onto shared helpers (post-v0.4.5)

### DIFF
--- a/pkg/baseline/baseline.go
+++ b/pkg/baseline/baseline.go
@@ -18,6 +18,7 @@ import (
 	"github.com/home-operations/flate/internal/cas"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
 	"github.com/home-operations/flate/pkg/source/gittree"
+	"github.com/home-operations/flate/pkg/source/safepath"
 )
 
 // Result describes a materialized baseline tree on disk.
@@ -185,7 +186,7 @@ func relToRepo(repoRoot, path string) (string, error) {
 	// otherwise, handled above), so no IsAbs check is needed — reject
 	// only the repo-escaping ".." and "../…" forms. A dir literally named
 	// "..foo" is in-repo and stays accepted.
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if safepath.Escaped(rel) {
 		return "", fmt.Errorf("--path %q is outside the git repo at %q; pass --path-orig explicitly", path, repoRoot)
 	}
 	return rel, nil

--- a/pkg/kustomize/readset.go
+++ b/pkg/kustomize/readset.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/safepath"
 )
 
 // nodeKind classifies a probed path so a dir↔file↔absent transition the build
@@ -83,7 +84,7 @@ func newReadSet(root string) *readSet {
 // not-ok so the caller can bypass.
 func (rs *readSet) rel(abs string) (string, bool) {
 	r, err := filepath.Rel(rs.root, abs)
-	if err != nil || r == ".." || strings.HasPrefix(r, ".."+string(filepath.Separator)) {
+	if err != nil || safepath.Escaped(r) {
 		return "", false
 	}
 	return filepath.ToSlash(r), true

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -14,9 +14,7 @@ import (
 // (rare, but possible since the Flux CRD doesn't constrain it)
 // normalize to the same shape as loader.SourceFiles entries.
 func NormalizePrefix(p string) string {
-	p = filepath.ToSlash(p)
-	p = strings.TrimPrefix(p, "./")
-	return strings.TrimSuffix(p, "/") + "/"
+	return manifest.NormalizeClaimBase(p) + "/"
 }
 
 // KSPathPrefix pairs a Kustomization id with one of its

--- a/pkg/loader/selfproduce.go
+++ b/pkg/loader/selfproduce.go
@@ -127,7 +127,7 @@ func (b *selfProduceBuilder) directives(dir string) (kustomizeDirectives, bool) 
 func (b *selfProduceBuilder) walkRoot(ks *manifest.Kustomization) {
 	id := ks.Named()
 	rootNS := cmp.Or(ks.TargetNamespace, ks.Namespace)
-	specDir := strings.TrimSuffix(NormalizePrefix(ks.Path), "/")
+	specDir := manifest.NormalizeClaimBase(ks.Path)
 	visited := map[string]struct{}{}
 
 	if _, ok := b.directives(specDir); ok {

--- a/pkg/manifest/kustomize_fs.go
+++ b/pkg/manifest/kustomize_fs.go
@@ -155,7 +155,7 @@ func BuildKSClaims(kss []*Kustomization, repoRoot string, cache *ComponentCache)
 			continue
 		}
 		id := ks.Named()
-		base := normalizeClaimBase(ks.Path)
+		base := NormalizeClaimBase(ks.Path)
 		claims = append(claims, KSClaim{ID: id, Prefix: base + "/"})
 		for _, comp := range ks.Components {
 			add(id, base, comp)
@@ -170,11 +170,11 @@ func BuildKSClaims(kss []*Kustomization, repoRoot string, cache *ComponentCache)
 	return claims
 }
 
-// normalizeClaimBase turns a Kustomization spec.path into a clean,
+// NormalizeClaimBase turns a Kustomization spec.path into a clean,
 // slash-separated, repo-relative base with no trailing slash. ToSlash is
 // applied so Windows-style spec.path values (rare, but unconstrained by the
 // Flux CRD) normalize to the same shape as SourceFiles keys.
-func normalizeClaimBase(p string) string {
+func NormalizeClaimBase(p string) string {
 	p = filepath.ToSlash(p)
 	p = strings.TrimPrefix(p, "./")
 	return strings.TrimSuffix(p, "/")

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -191,7 +191,7 @@ func (f *Fetcher) cloneIntoSlot(ctx context.Context, repo *manifest.GitRepositor
 
 	cloneOpts := &git.CloneOptions{URL: url, NoCheckout: true, Auth: auth}
 	if proxy != nil {
-		cloneOpts.ProxyOptions = proxyOptions(proxy)
+		cloneOpts.ProxyOptions = mirror.ProxyOptions(proxy)
 	}
 	if repo.RecurseSubmodules {
 		cloneOpts.RecurseSubmodules = git.DefaultSubmoduleRecursionDepth
@@ -324,7 +324,7 @@ func fetchExplicitNamedRef(ctx context.Context, repo *git.Repository, auth trans
 		RefSpecs: []config.RefSpec{config.RefSpec("+" + name + ":" + name)},
 	}
 	if proxy != nil {
-		opts.ProxyOptions = proxyOptions(proxy)
+		opts.ProxyOptions = mirror.ProxyOptions(proxy)
 	}
 	if err := remote.FetchContext(ctx, opts); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return fmt.Errorf("fetch ref.name %s: %w", name, err)
@@ -471,16 +471,6 @@ func gitID(repo *manifest.GitRepository) string {
 func authIdentity(repo *manifest.GitRepository) string {
 	return source.AuthIdentityFromRefs(repo.Namespace,
 		repo.SecretRef, repo.ProxySecretRef)
-}
-
-// proxyOptions maps a resolved ProxyConfig into go-git transport options,
-// shared by the clone and explicit-ref fetch paths.
-func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
-	return transport.ProxyOptions{
-		URL:      proxy.Address,
-		Username: proxy.Username,
-		Password: proxy.Password,
-	}
 }
 
 // commitArtifact atomically commits the staged slot and stamps the

--- a/pkg/source/git/mirror/mirror.go
+++ b/pkg/source/git/mirror/mirror.go
@@ -67,9 +67,9 @@ func urlHash(url string) string {
 	return hex.EncodeToString(h[:8])
 }
 
-// proxyOptions converts a nullable ProxyConfig into go-git's inline
+// ProxyOptions converts a nullable ProxyConfig into go-git's inline
 // struct so every call site doesn't repeat the nil guard.
-func proxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
+func ProxyOptions(proxy *source.ProxyConfig) transport.ProxyOptions {
 	if proxy == nil {
 		return transport.ProxyOptions{}
 	}
@@ -118,7 +118,7 @@ func (m *Cache) OpenOrFetch(ctx context.Context, url string, auth transport.Auth
 		repo, err = git.PlainCloneContext(ctx, path, true, &git.CloneOptions{
 			URL:          url,
 			Auth:         auth,
-			ProxyOptions: proxyOptions(proxy),
+			ProxyOptions: ProxyOptions(proxy),
 			Depth:        plan.Depth,
 		})
 		if err == nil {
@@ -168,7 +168,7 @@ func (m *Cache) fetchInto(ctx context.Context, repo *git.Repository, auth transp
 	err := repo.FetchContext(ctx, &git.FetchOptions{
 		Auth:         auth,
 		RefSpecs:     refSpecs,
-		ProxyOptions: proxyOptions(proxy),
+		ProxyOptions: ProxyOptions(proxy),
 		Depth:        plan.Depth,
 		// All refspecs above are explicit (named refs, +refs/tags/*, or the
 		// +refs/*:refs/* fallback), so suppress go-git's default tag auto-

--- a/pkg/source/helmchart/auth.go
+++ b/pkg/source/helmchart/auth.go
@@ -1,6 +1,7 @@
 package helmchart
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
@@ -65,6 +66,14 @@ func (f *Fetcher) helmRepoTransport(r *manifest.HelmRepository) (*http.Transport
 	if err != nil {
 		return nil, err
 	}
+	return helmTransport(tlsCfg)
+}
+
+// helmTransport builds the helm-specific HTTP transport kernel: the SSRF
+// egress guard (source.NewHTTPTransport) carrying tlsCfg, with compression
+// disabled to match helm's own getter transport (chart tarballs are already
+// compressed — the only source kind that disables it).
+func helmTransport(tlsCfg *tls.Config) (*http.Transport, error) {
 	tr, err := source.NewHTTPTransport(tlsCfg, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -15,7 +15,6 @@ import (
 	repo "helm.sh/helm/v4/pkg/repo/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/store"
 )
 
@@ -241,8 +240,7 @@ var helmHTTPTimeout = 120 * time.Second
 // guard's blocking is gated by the process-global toggle, so this is inert
 // unless ssrfguard.Restrict is enabled.
 var helmGuardedTransport = func() *http.Transport {
-	tr, _ := source.NewHTTPTransport(nil, nil) // nil/nil never errors
-	tr.DisableCompression = true
+	tr, _ := helmTransport(nil) // nil/nil never errors
 	return tr
 }()
 

--- a/pkg/source/safepath/safepath.go
+++ b/pkg/source/safepath/safepath.go
@@ -46,7 +46,7 @@ func SafeJoin(base, rel string, rejectAbsolute bool) (string, error) {
 		}
 		target := filepath.Join(base, clean)
 		relInside, err := filepath.Rel(base, target)
-		if err != nil || isEscaped(relInside) {
+		if err != nil || Escaped(relInside) {
 			return "", fmt.Errorf("path escapes target directory: %q", rel)
 		}
 		return target, nil
@@ -60,13 +60,17 @@ func SafeJoin(base, rel string, rejectAbsolute bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("path resolution: %w", err)
 	}
-	if isEscaped(relInside) {
+	if Escaped(relInside) {
 		return "", fmt.Errorf("path traversal: %q escapes target directory", rel)
 	}
 	return target, nil
 }
 
-func isEscaped(rel string) bool {
+// Escaped reports whether a filepath.Rel result escapes its base: the rel is
+// exactly ".." or begins with a ".." path component (OS separator). It is the
+// shared containment predicate used by SafeJoin, Contains, and callers that
+// keep the rel string but must reject repo/root escapes.
+func Escaped(rel string) bool {
 	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
@@ -77,5 +81,5 @@ func isEscaped(rel string) bool {
 // remote-base copy to confine a symlink's resolved target to the base root.
 func Contains(root, target string) bool {
 	rel, err := filepath.Rel(root, target)
-	return err == nil && !isEscaped(rel)
+	return err == nil && !Escaped(rel)
 }


### PR DESCRIPTION
## What

Pass 2 of the multi-pass cleanup of post-v0.4.5 code: cross-file **deduplication**. A parallel duplication scan (9 area scanners → ranking/dedup judge → implement → adversarial verify) found 4 genuine consolidations; each replaced code is byte-identical to what it removes.

- **source/git** — export the nil-safe `mirror.ProxyOptions` and delete `fetcher.go`'s identical local `proxyOptions`. Both fetcher call sites are already inside `if proxy != nil`, so the mapping is byte-identical.
- **source/helmchart** — fold the two identical `source.NewHTTPTransport(...)` + `DisableCompression = true` sites (`helmRepoTransport`, `helmGuardedTransport`) into one `helmTransport` helper. Chart tarballs are the only source kind that disables compression, so the helper localizes that fact.
- **source/safepath** — export `Escaped` (was `isEscaped`) and route the two duplicated `..`-prefix containment checks (`baseline.relToRepo`, `kustomize readSet.rel`) through it — one shared predicate instead of three copies.
- **manifest.NormalizeClaimBase** (was `normalizeClaimBase`, now exported) single-sources the KS `spec.path` normalization that `loader.NormalizePrefix` and `selfproduce.walkRoot` each re-derived.

## Verification

- gofmt · `go build ./...` · `go vet ./...` · `go test ./...` · `go test -race` (source/kustomize/manifest/loader/baseline) · `golangci-lint`: all clean.
- **Byte-equivalence**: `build all` byte-identical on Biohazard (`9256d8dafd74`). Every consolidated body/predicate is character-identical to the code it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)