### PR TITLE
refactor: cleanup sweep pass 3 — shed redundant work + allocations (post-v0.4.5)

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -267,6 +267,12 @@ func (c *commonFlags) includeNamespace(filter *change.Filter, ns string) bool {
 	if ns == "" {
 		return true
 	}
+	// Explicit --namespace is a single-element scope: compare directly
+	// rather than letting scopedNamespaces allocate a one-entry map per
+	// resource on this in-loop path.
+	if c.namespace != "" {
+		return ns == c.namespace
+	}
 	scope := c.scopedNamespaces(filter)
 	if scope == nil {
 		return true

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -172,7 +172,7 @@ func (m Model) Write(w io.Writer, color bool, elapsed time.Duration) error {
 // failuresBlock renders the root-cause rows: each primary failure (its inline
 // message and the resources it blocks) followed by each missing dependency.
 func (m Model) failuresBlock(color bool) string {
-	var rows []string
+	rows := make([]string, 0, len(m.Primary)+len(m.Missing))
 	for _, p := range m.Primary {
 		row := fmt.Sprintf("  %s  %s  %s",
 			style.Fail(style.GlyphFail, color), style.Dim(p.ID.Kind, color), p.ID.NamespacedName()) +

--- a/internal/testrunner/runner.go
+++ b/internal/testrunner/runner.go
@@ -177,11 +177,10 @@ func Run(j Job) Report {
 	// cascade still resolves to its root cause(s) in blockedCases.
 	blocked := map[manifest.NamedResource][]manifest.NamedResource{}
 	for _, kind := range kinds {
-		objs := j.Store.ListObjects(kind)
-		slices.SortFunc(objs, func(a, b manifest.BaseManifest) int {
-			return a.Named().Compare(b.Named())
-		})
-		for _, obj := range objs {
+		// ListObjects already returns this kind's objects sorted by
+		// (namespace, name); within a single kind that order is identical to
+		// NamedResource.Compare (Kind is constant), so no re-sort is needed.
+		for _, obj := range j.Store.ListObjects(kind) {
 			id := obj.Named()
 			if j.Name != "" && id.Name != j.Name {
 				continue

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -28,7 +28,11 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 	// the orchestrator side. Route through the shared component
 	// cache populated during Bootstrap so the per-KS component file
 	// reads are served from memory rather than re-stat'd here.
-	prefixes := loader.KSPathPrefixesLocalOnly(o.store, o.repoRoot, o.componentCache)
+	// Built lazily on the first failure that survives the cheap
+	// per-id guards below: a clean run (no reconcilable failures)
+	// never pays the full KS list + claim build + sort.
+	var prefixes []loader.KSPathPrefix
+	var prefixesBuilt bool
 	for id, info := range failed {
 		if !isReconcilableKind(id.Kind) {
 			continue
@@ -41,6 +45,10 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 		file, ok := o.sourceFiles[id]
 		if !ok {
 			continue
+		}
+		if !prefixesBuilt {
+			prefixes = loader.KSPathPrefixesLocalOnly(o.store, o.repoRoot, o.componentCache)
+			prefixesBuilt = true
 		}
 		parent, ok := loader.LongestParent(prefixes, file, id)
 		if !ok {


### PR DESCRIPTION
## What

Pass 3 (deep) of the cleanup sweep: leaner per-invocation paths surfaced by a perf/alloc/structure/correctness audit. All **behavior-preserving** (byte-identical render); the end-to-end delta is below the noise floor (`build all` warm ≈0.50s either way), so these are leanness/work-shedding wins, **not** measurable speedups — framed honestly.

- **testrunner.Run** — drop the redundant per-kind re-sort. `Store.ListObjects` already returns a single kind's objects sorted by `(namespace, name)`, which within one kind is identical to `NamedResource.Compare` (Kind is constant) — the `SortFunc` was re-sorting an already-sorted slice.
- **report.failuresBlock** — preallocate the `rows` slice to its exact final size (`len(Primary)+len(Missing)`) rather than growing from nil.
- **orchestrator.detectOrphans** — build the KS-path-prefix list lazily, only once a reconcilable failure survives the cheap per-id guards. A clean run (no such failures) no longer pays the full KS-claim build + sort.
- **cli.includeNamespace** — when `--namespace` is set (a single-element scope), compare the string directly instead of letting `scopedNamespaces` allocate a one-entry map per resource on this in-emit-loop / live-status path.

## Verification

- gofmt · `go build ./...` · `go vet` · `go test ./...` · `go test -race` (cli/report/testrunner/orchestrator) · `golangci-lint`: all clean.
- **Byte-equivalence** exercised on both `detectOrphans` paths: Biohazard (has failures → builds prefixes) `9256d8dafd74` identical; zariel (clean → lazy-skips the build) 0 non-checksum diff lines vs base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)