### PR TITLE
refactor: cleanup sweep pass 4 — fold HR parent gate onto base.RequireRefresh (post-v0.4.5)

### DIFF
--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -150,7 +150,12 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 	// driftDetection / install.crds / upgrade strategy / rollback to
 	// every HR, so all of them were hit by this).
 	if parent, ok := c.LookupParent(id); ok {
-		err := c.Require(ctx, id, hr.Timeout,
+		// The parent's render may have replaced this HR in the store
+		// with a patched copy; re-read so the rest of reconcile uses
+		// the canonical spec instead of the pre-patch snapshot we
+		// were dispatched with.
+		fresh, ok, err := base.RequireRefresh[*manifest.HelmRelease](
+			ctx, c.Controller, id, hr.Timeout,
 			[]manifest.DependencyRef{{NamedResource: parent}},
 			"waiting for parent KS",
 			func(sum depwait.Summary) error {
@@ -160,12 +165,8 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		if err != nil {
 			return err
 		}
-		// The parent's render may have replaced this HR in the store
-		// with a patched copy; re-read so the rest of reconcile uses
-		// the canonical spec instead of the pre-patch snapshot we
-		// were dispatched with.
-		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
-			hr = obj
+		if ok {
+			hr = fresh
 		}
 	}
 	if err := c.PreflightError(id); err != nil {


### PR DESCRIPTION
## What

Pass 4 (convergence re-sweep) of the post-v0.4.5 cleanup. A fresh deep re-read found **27 of 28 files already clean** (after passes 1–3); this is the lone remaining improvement.

`helmrelease.reconcile`'s parent-Kustomization gate hand-rolled the `Require` + canonical store re-read two-step, while the `dependsOn` gate 15 lines below already uses `base.RequireRefresh` — the helper built to fuse exactly that pattern (its doc warns hand-rolled sites can "silently forget the re-read"). Routing the parent gate through `RequireRefresh` removes the duplicated two-step and the inconsistency the helper exists to prevent.

Behavior-preserving: identical `Require` args (same deps, pending message, `onFail` closure → identical error text), same `store.Get` re-read, `if ok { hr = fresh }` matching the prior snapshot-replace. The parent-patching rationale comment is retained.

## Verification

- gofmt · `go build ./...` · `go vet` · `go test ./...` · `go test -race` (controllers) · `golangci-lint`: all clean.
- **Byte-equivalence**: `build all` byte-identical on Biohazard (`9256d8dafd74`) and zariel (0 non-checksum diff lines) — both exercise the HR reconcile/parent-gate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)