### PR TITLE
refactor: cleanup sweep pass 5 — store AddObjects fast-path + stale doc fix (post-v0.4.5)

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -231,7 +231,7 @@ func bindSelector(fs *pflag.FlagSet, f *listFlags) {
 //     machinery as diff.
 //
 // Mutually exclusive with --path-orig (the absolute-path escape
-// hatch); the check fires at runtime in resolveBaselineIfRequested.
+// hatch); the check fires at runtime in resolveBaseline.
 func bindBase(fs *pflag.FlagSet, f *commonFlags) {
 	fs.StringVar(&f.base, "base", "",
 		"baseline git rev (e.g. main, origin/main, HEAD~3, SHA) — "+

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -288,7 +288,7 @@ func (s *Store) AddObjects(objs []manifest.BaseManifest) {
 		sh.mu.Lock()
 		for _, obj := range buckets[i] {
 			id := obj.Named()
-			if cur, ok := sh.objects[id]; ok && reflect.DeepEqual(cur, obj) {
+			if cur, ok := sh.objects[id]; ok && (cur == obj || reflect.DeepEqual(cur, obj)) {
 				continue
 			}
 			sh.setLocked(id, obj)


### PR DESCRIPTION
## What

Pass 5 (convergence re-sweep): 26/28 files clean, two small finds.

- **store.AddObjects** — add the `cur == obj` pointer-identity fast path the inner dedup omitted, matching `AddObject` and `SetArtifact`. Under the Store's documented immutability contract (same pointer ⟹ content-equal), the skip set is unchanged — this only short-circuits `reflect.DeepEqual` (~70% of per-object cost per the file's own note) on the dominant re-render shape where the emit controller re-emits identical child pointers.
- **cli.bindBase** — fix a stale doc comment pointing at `resolveBaselineIfRequested` (a phantom symbol from a rename); the `--path-orig`/`--base` mutual-exclusion check actually fires in `resolveBaseline`.

## Verification

- gofmt · build · vet · `go test ./...` · `-race` (store/cli) · `golangci-lint`: clean.
- **Byte-equivalence**: `build all` byte-identical on Biohazard (`9256d8dafd74`, exercises `AddObjects` per render) and zariel (0 non-checksum diff lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)