### PR TITLE
docs: cleanup sweep pass 6 — style comment lists yellow(3) (post-v0.4.5)

### DIFF
--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -30,7 +30,7 @@ const (
 )
 
 // Semantic styles, by ANSI base color (0-7) so they downsample cleanly on
-// 16-color terminals: 1 red, 2 green, 6 cyan; faint and bold carry no hue.
+// 16-color terminals: 1 red, 2 green, 3 yellow, 6 cyan; faint and bold carry no hue.
 var (
 	greenStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 	redStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))


### PR DESCRIPTION
## What

Pass 6 (final convergence confirmation) of the post-v0.4.5 cleanup: **27/28 files clean**, the lone find is comment-only.

`internal/style`'s semantic-styles doc comment enumerated "1 red, 2 green, 6 cyan" but the block defines `yellowStyle` (`Color("3")`, backing `Warn`), added after the comment. List it so the comment matches the code.

Comment-only — zero behavior impact (byte-equivalence guaranteed by construction). Build/vet/golangci-lint clean.

This is the concluding pass: findings across the sweep were 5 → 4 → 4 → 1 → 2 → 1, with passes 5–6 surfacing only isolated stale-comment corrections. The substantive cleanup converged by pass 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)