### PR TITLE
fix(helm): override sprig shuffle so renders are deterministic

### DIFF
--- a/pkg/helm/deterministic/doc.go
+++ b/pkg/helm/deterministic/doc.go
@@ -1,7 +1,8 @@
 // Package deterministic provides drop-in replacements for the
 // nondeterministic functions Helm exposes to chart templates through
-// sprig — the time- and crypto/rand-backed ones (now, randAlphaNum,
-// genCA, …) — so flate renders byte-identically run to run.
+// sprig — the time-, crypto/rand-, and math/rand-backed ones (now,
+// randAlphaNum, shuffle, genCA, …) — so flate renders byte-identically
+// run to run.
 //
 // Helm v4 applies action.Configuration.CustomTemplateFuncs LAST when it
 // assembles the engine FuncMap (maps.Copy over sprig's defaults in

--- a/pkg/helm/deterministic/rand.go
+++ b/pkg/helm/deterministic/rand.go
@@ -38,7 +38,23 @@ func randFuncs(s *stream) template.FuncMap {
 		"randBytes":    func(n int) (string, error) { return randBytes(s, n) },
 		"randInt":      func(minN, maxN int) int { return randInt(s, minN, maxN) },
 		"uuidv4":       func() string { return uuidv4(s) },
+		"shuffle":      func(in string) string { return shuffle(s, in) },
 	}
+}
+
+// shuffle returns a deterministic permutation of in's runes, drawn from the
+// stream. sprig maps "shuffle" to xstrings.Shuffle, which draws from a
+// process-global, time-seeded RNG — nondeterministic across renders. It is the
+// source of flipping checksum/secret annotations on charts whose secret
+// template passes a generated value through `| shuffle` (bitnami common's
+// passwords.manage with strong=true does exactly this for its secret_key).
+// Drawing from the per-render stream makes it reproducible; the result is a
+// valid permutation, not byte-identical to sprig.
+func shuffle(s *stream, in string) string {
+	r := []rune(in)
+	//nolint:gosec // G404: deterministic rendering deliberately draws from the seeded ChaCha8, not crypto/rand.
+	rand.New(s.c).Shuffle(len(r), func(i, j int) { r[i], r[j] = r[j], r[i] })
+	return string(r)
 }
 
 // randString returns n characters, each one stream byte mapped into charset by

--- a/pkg/helm/deterministic_render_test.go
+++ b/pkg/helm/deterministic_render_test.go
@@ -96,6 +96,50 @@ func TestTemplate_DeterministicRandom(t *testing.T) {
 	}
 }
 
+// TestTemplate_DeterministicShuffle guards the sprig `shuffle` override: a
+// chart that pipes a value through `| shuffle` — the shape bitnami common's
+// passwords.manage uses for a strong secret_key, behind a checksum/secret
+// annotation — must render byte-identically across two UNCACHED renders. sprig
+// maps shuffle to xstrings.Shuffle, which draws from a process-global,
+// time-seeded RNG; un-overridden, the two renders differ (and real-world
+// checksum/secret annotations flip run-to-run). The override redirects it to
+// the seeded per-render stream. Caching is disabled so byte-identity can only
+// come from the override.
+func TestTemplate_DeterministicShuffle(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "mychart/Chart.yaml",
+		"apiVersion: v2\nname: mychart\nversion: 0.1.0\ndescription: t\n")
+	// A sha256 over a shuffled value mirrors the checksum/secret shape; the
+	// shuffled field itself is also emitted so the guard covers both surfaces.
+	testutil.WriteFile(t, dir, "mychart/templates/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {{ .Release.Name }}-cm\n  annotations:\n    checksum/secret: {{ printf \"%s%s\" (randAlphaNum 8) (randAscii 12) | shuffle | sha256sum | quote }}\ndata:\n  pw: {{ \"abcdefghijklmnopqrstuvwxyz\" | shuffle | quote }}\n")
+
+	cli, err := NewClientWithOptions(cacheroot.New(t.TempDir()), ClientOptions{})
+	if err != nil {
+		t.Fatalf("NewClientWithOptions: %v", err)
+	}
+	cli.SetSourceResolver(localChartResolver(t, "chart-repo", "flux-system", dir))
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		Chart: manifest.HelmChart{
+			Name: "mychart", RepoName: "chart-repo",
+			RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
+		},
+	}
+
+	first, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	second, err := cli.Template(context.Background(), hr, nil, Options{})
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if first != second {
+		t.Errorf("uncached renders differ — shuffle not deterministic:\n first=%q\nsecond=%q", first, second)
+	}
+}
+
 // TestTemplate_DeterministicCerts is the Tier 3 integration guard: a chart
 // that generates a CA and a leaf signed by it (the caBundle/tls.crt shape)
 // must render byte-identically across two UNCACHED renders. sprig draws cert


### PR DESCRIPTION
## Problem

`flate build all` intermittently produced a different `checksum/secret` annotation run-to-run (reported as a render non-determinism flake). Pinned to **`Deployment/default/netbox`** (chart `netbox-8.3.3`): only that annotation flipped, the rest of the 87k-line output identical.

## Root cause

The chart's secret template builds `secret_key` via Bitnami common's `common.secrets.passwords.manage` with `strong: true`, which ends in `... | shuffle`. The deployment annotates `checksum/secret: <sha256 of the re-rendered secret>`, so a per-run shuffle flipped the hash (the emitted Secret itself is wiped, so the annotation was the only visible symptom).

flate's deterministic-render FuncMap overrides **every** nondeterministic sprig random function — `randAlphaNum`/`randAlpha`/`randNumeric`/`randAscii`/`randBytes`/`randInt`/`uuidv4` and the cert tier — **except `shuffle`**. sprig maps `shuffle` to `xstrings.Shuffle`, which draws from a process-global, time-seeded RNG: stable within a process, different across processes (so it surfaced as an across-invocation flake, masked within a single run by the render cache).

## Fix

Override `shuffle` to draw from the same per-render seeded ChaCha8 stream as the other random funcs (Fisher-Yates over the rune slice). Output is a valid permutation, reproducible from the release identity — consistent with the existing `randInt` approach.

## Verification

- **New guard** `TestTemplate_DeterministicShuffle` — two uncached renders byte-identical; fails before this change (both the `checksum/secret` and the shuffled field differ), passes after.
- **zariel** `build all`: now stable across 15 runs; the *only* change vs the prior stable output is the `checksum/secret` line itself (0 other differing lines).
- **Biohazard** `build all`: byte-identical to its baseline `9256d8dafd74` (no shuffle-using charts).
- gofmt · build · vet · `go test ./...` · `-race` (pkg/helm) · golangci-lint: all clean.

Note: existing render-cache entries written before this fix hold the old nondeterministic value until they're regenerated on the next cache miss (self-healing); a one-time `rm -rf ~/Library/Caches/flate/render` drops them immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)