### PR TITLE
fix(orchestrator): a FAILED HelmRelease emits no rendered children

### DIFF
--- a/pkg/orchestrator/collect_manifests_test.go
+++ b/pkg/orchestrator/collect_manifests_test.go
@@ -1,0 +1,56 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+)
+
+// TestCollectManifests_FailedHelmReleaseEmitsNothing pins the cold-render-race
+// fix: a HelmRelease that ends StatusFailed contributes zero docs to
+// Result.Manifests even when an earlier transient render left it an artifact
+// (the parent KS's postBuild.substituteFrom not-yet-applied window). A passing
+// HelmRelease keeps its children, and a FAILED Kustomization's artifact is
+// untouched — the gate is HelmRelease-scoped.
+func TestCollectManifests_FailedHelmReleaseEmitsNothing(t *testing.T) {
+	st := store.New()
+
+	ready := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "app", Name: "ready"}
+	st.AddObject(&manifest.HelmRelease{Name: ready.Name, Namespace: ready.Namespace})
+	st.SetArtifact(ready, &store.HelmReleaseArtifact{Manifests: []map[string]any{
+		{"apiVersion": "v1", "kind": "ConfigMap", "metadata": map[string]any{"name": "ready-cm"}},
+	}})
+	st.UpdateStatus(ready, store.StatusReady, "")
+
+	// A stale artifact from a transient pre-substitution render that passed
+	// schema; the canonical substituted render then failed and marked it Failed.
+	failedHR := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "app", Name: "broken"}
+	st.AddObject(&manifest.HelmRelease{Name: failedHR.Name, Namespace: failedHR.Namespace})
+	st.SetArtifact(failedHR, &store.HelmReleaseArtifact{Manifests: []map[string]any{
+		{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": map[string]any{"name": "broken-deploy"}},
+	}})
+	st.UpdateStatus(failedHR, store.StatusFailed, "values don't meet the specifications of the schema(s)")
+
+	// A FAILED Kustomization with an artifact must still surface — the gate is
+	// HelmRelease-scoped (a KS render is a different lifecycle).
+	failedKS := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "apps"}
+	st.AddObject(&manifest.Kustomization{Name: failedKS.Name, Namespace: failedKS.Namespace})
+	st.SetArtifact(failedKS, &store.KustomizationArtifact{Manifests: []map[string]any{
+		{"apiVersion": "v1", "kind": "Namespace", "metadata": map[string]any{"name": "apps"}},
+	}})
+	st.UpdateStatus(failedKS, store.StatusFailed, "kustomize build boom")
+
+	o := &Orchestrator{store: st}
+	got := o.collectManifests(st.FailedResources())
+
+	if _, ok := got[ready]; !ok {
+		t.Errorf("passing HelmRelease %s must contribute its rendered children", ready)
+	}
+	if docs, ok := got[failedHR]; ok {
+		t.Errorf("FAILED HelmRelease %s must emit nothing (stale transient artifact); got %d docs", failedHR, len(docs))
+	}
+	if _, ok := got[failedKS]; !ok {
+		t.Errorf("FAILED Kustomization %s artifact must still surface (gate is HelmRelease-scoped)", failedKS)
+	}
+}

--- a/pkg/orchestrator/run.go
+++ b/pkg/orchestrator/run.go
@@ -204,44 +204,16 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 		// empty scan, …). Nil when none, sorted deterministically by the store.
 		Warnings: o.store.Warnings(),
 	}
-	// Apply --skip-secrets / --skip-crds / --skip-kinds uniformly here
-	// so embedders calling Render see consistent Result.Manifests
-	// regardless of producing controller. helm.TemplateDocs pre-filters
-	// HR output upstream, but Kustomization-rendered docs reach the
-	// artifact unfiltered (the Store must hold the full set so
-	// downstream valuesFrom / substituteFrom resolution finds Secret /
-	// ConfigMap objects). The drop happens here, on the slice that
-	// crosses the embed boundary — Store stays whole. Iter-15 #169
-	// patched the CLI emit paths; this closes the same gap one layer
-	// down for SDK consumers.
-	skip := o.cfg.HelmOptions.SkipResourceKinds()
-	for _, kind := range reconcilableKinds {
-		for _, obj := range o.store.ListObjects(kind) {
-			id := obj.Named()
-			var mans []map[string]any
-			if art, ok := o.store.GetArtifact(id).(store.RenderedArtifact); ok {
-				mans = art.RenderedManifests()
-			}
-			// Append any ResourceSet-rendered non-Flux docs whose
-			// owning KS is this one. The RS doc itself stays in the
-			// parent's render output (kustomize emitted it); these
-			// are its synthetic children that flate evaluates offline.
-			if kind == manifest.KindKustomization {
-				if ext := o.rsExtensions[id]; len(ext) > 0 {
-					mans = append(mans, ext...)
-				}
-			}
-			mans = manifest.DropKinds(mans, skip)
-			if len(mans) > 0 {
-				res.Manifests[id] = mans
-			}
-		}
-	}
+	// failed is computed once and reused for both the manifest harvest (which
+	// drops the orphaned children of FAILED HelmReleases — see collectManifests)
+	// and res.Failed below, so the two stay consistent.
+	failed := o.store.FailedResources()
+	res.Manifests = o.collectManifests(failed)
 	// Same projection logResourceFailures + aggregateFailures use —
 	// see sanitizeFailed for the contract. Centralizing in one
 	// helper keeps the three readers in sync if the strip rule
 	// changes.
-	maps.Copy(res.Failed, sanitizeFailed(o.store.FailedResources()))
+	maps.Copy(res.Failed, sanitizeFailed(failed))
 	maps.Copy(res.Orphans, o.orphans)
 	// Tag the derived (dependency-blocked) failures so a consumer can collapse
 	// the cascade under its root cause. A failure with no blockers is primary.
@@ -251,6 +223,46 @@ func (o *Orchestrator) render(ctx context.Context) (result *Result, err error) {
 		}
 	}
 	return res, runErr
+}
+
+// collectManifests harvests every reconcilable resource's rendered docs into a
+// Result.Manifests map, applying --skip-secrets/--skip-crds/--skip-kinds
+// uniformly so embedders see the same output the CLI emits. Kustomization docs
+// reach the artifact unfiltered (the Store must hold the full set for downstream
+// valuesFrom/substituteFrom resolution), so the skip-kind drop happens here, at
+// the embed boundary, leaving the Store whole.
+//
+// A FAILED HelmRelease contributes no children: its artifact may be a stale
+// transient render — the parent KS's postBuild.substituteFrom not yet applied,
+// so ${…} vars were still literal and passed schema — that the canonical
+// substituted render later rejects. Failed status is sticky (base.Controller
+// never downgrades it), so dropping it here is deterministic regardless of which
+// render won the cold-cache scheduling race.
+func (o *Orchestrator) collectManifests(failed map[manifest.NamedResource]store.StatusInfo) map[manifest.NamedResource][]map[string]any {
+	skip := o.cfg.HelmOptions.SkipResourceKinds()
+	out := map[manifest.NamedResource][]map[string]any{}
+	for _, kind := range reconcilableKinds {
+		for _, obj := range o.store.ListObjects(kind) {
+			id := obj.Named()
+			var docs []map[string]any
+			// Take the rendered artifact unless this is a FAILED HelmRelease
+			// (whose artifact may be a stale transient render — see above).
+			if _, failedHR := failed[id]; kind != manifest.KindHelmRelease || !failedHR {
+				if art, ok := o.store.GetArtifact(id).(store.RenderedArtifact); ok {
+					docs = art.RenderedManifests()
+				}
+			}
+			// ResourceSet children attach to their owning Kustomization (the RS
+			// doc itself stays in the parent's kustomize output).
+			if kind == manifest.KindKustomization {
+				docs = append(docs, o.rsExtensions[id]...)
+			}
+			if docs = manifest.DropKinds(docs, skip); len(docs) > 0 {
+				out[id] = docs
+			}
+		}
+	}
+	return out
 }
 
 // Stop shuts the controllers down in reverse-construction order. Safe to call


### PR DESCRIPTION
## Problem

`flate build all` on a **cold render cache** non-deterministically dropped a HelmRelease's rendered children. On Biohazard, `rclone-retro`'s app-template resources (Deployment, Services, CronJobs, Ingress, NetworkPolicies, ConfigMap) were present on ~60% of cold runs and absent on the rest (~20–40% flip; warm cache always stable, fresh process each run).

## Root cause (scheduling race upstream of the HR)

The parent Kustomization `rclone-retro-app` exists in two forms during one run:
1. the **file-loaded** copy (from `ks.yaml`) — no `postBuild.substituteFrom`;
2. the copy the cluster KS `0-biohazard-config` **re-emits** with `substituteFrom: [biohazard-vars, biohazard-secrets]` injected via its `patches` block.

The file-loaded copy has no *structural* parent (its source file isn't under any KS `spec.path`), so no depwait edge gates it on the patching cluster KS. It can render first, emitting the HR with `${…}` vars **still literal**. A literal `${CONFIG_TZ}` is a non-empty string and **passes** the app-template schema → that transient render succeeds and `SetArtifact`s its children. The canonical substituted render then resolves `${CONFIG_TZ}` to empty (it lives in an offline-unresolvable secret) → schema **rejects** it (`got null, want string`) → the HR ends **FAILED**. The early artifact was never retracted, and the manifest harvest surfaced every `RenderedArtifact` regardless of status — so the orphaned children leaked, and whether the early render won the cold-cache race decided 33-vs-15 docs.

(Found via a parallel root-cause investigation + adversarial verification; instrumented to confirm the two-render sequence.)

## Fix

Gate the harvest: a HelmRelease whose **terminal status is FAILED contributes no rendered children** — the Flux-faithful outcome (a failed release applies nothing). Failed status is sticky (`base.Controller` never downgrades it), so the output now depends only on terminal status, deterministically, regardless of which render won the race. The harvest is lifted into a testable `Orchestrator.collectManifests` method.

**Behavioral note:** this also drops the same leaked children from other failed HRs hitting the identical pattern (e.g. `nfs-web`, which previously surfaced them deterministically) — the intended correction, not a regression. Passing renders are untouched (an artifact-present-AND-Failed HR only arises from this transient pattern).

## Verification

- gofmt · `go build ./...` · `go vet` · `go test ./...` · `go test -race ./pkg/orchestrator/` · `golangci-lint`: clean.
- New `TestCollectManifests_FailedHelmReleaseEmitsNothing` (passing HR kept, failed HR dropped, failed KS untouched).
- **Determinism**: cold `build all` on Biohazard now stable across runs (was ~20–40% flip).
- **Surgical**: vs a prior full run, the only output delta is the removed children of FAILED HRs (`rclone-retro`, `nfs-web`) — 0 other lines changed, 0 added. zariel (no failed HRs) byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)