### PR TITLE
feat(values): warn when a postBuild substituteFrom Secret is unreadable offline

### DIFF
--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -139,9 +139,26 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 	// the same pre-render dance an embedder calling RenderFlux directly
 	// would perform. Keeping one canonical implementation here means
 	// changes to the contract only land in one place. Mirrors helm.Prepare.
-	ks, err = kustomize.Prepare(ks, values.NewStoreProvider(c.Store))
+	provider := values.NewStoreProvider(c.Store)
+	ks, err = kustomize.Prepare(ks, provider)
 	if err != nil {
 		return err
+	}
+	// A substituteFrom Secret flate can't read offline (absent, or an
+	// ExternalSecret-synthesized empty target) leaves the ${VAR}s it would
+	// supply empty — a dependent resource may then fail schema/template
+	// validation and drop out of the render. Surface that as a non-fatal
+	// advisory so the gap is explained rather than silent; substitution
+	// itself stays Flux-faithful. SOPS secrets resolve to placeholders and
+	// aren't reported. Render-global and keyed on the bare Secret name (not
+	// ns/name): the same logical secret is referenced by the many per-
+	// namespace KSes a cluster-config KS re-emits, so the store collapses
+	// them to one advisory line per secret name.
+	for _, name := range values.UnreadableSubstituteSecrets(ks, provider) {
+		c.Store.AddWarning(manifest.Warning{
+			Category: manifest.WarnUnresolvedSubstitution,
+			Message:  fmt.Sprintf("substituteFrom Secret %q could not be read offline; the ${VAR}s it provides render empty", name),
+		})
 	}
 	if err := c.PreflightError(id); err != nil {
 		return err

--- a/pkg/manifest/warning.go
+++ b/pkg/manifest/warning.go
@@ -43,6 +43,13 @@ const (
 	// WarnPathConfig: a --path / --path-orig misconfiguration (same root, or no
 	// detected changes). Render-global.
 	WarnPathConfig = "PathConfig"
+	// WarnUnresolvedSubstitution: a spec.postBuild.substituteFrom Secret could
+	// not be read offline (absent, or an ExternalSecret-synthesized empty
+	// target), so the ${VAR}s it would supply render as the empty string —
+	// dependent resources may then fail schema/template validation and drop
+	// out of the render. Render-global (Message names the Secret) so the many
+	// per-namespace KSes a cluster-config KS re-emits collapse to one line.
+	WarnUnresolvedSubstitution = "UnresolvedSubstitution"
 )
 
 // CompareWarning orders warnings deterministically by category, then resource,

--- a/pkg/orchestrator/warnings_test.go
+++ b/pkg/orchestrator/warnings_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/home-operations/flate/internal/testutil"
@@ -101,5 +102,49 @@ spec:
 	}
 	if !slices.Equal(got.Detail, []string{"oldUnusedKey"}) {
 		t.Errorf("warning Detail = %v, want [oldUnusedKey]", got.Detail)
+	}
+}
+
+// TestRender_UnresolvedSubstitutionWarning is the konflate-facing contract: a
+// Kustomization whose postBuild.substituteFrom Secret can't be read offline
+// (absent here, as an ExternalSecret-backed one is) surfaces a structured
+// Result.Warnings entry (Category WarnUnresolvedSubstitution, attributed to the
+// Secret) — explaining why the ${VAR}s it would supply render empty. The render
+// itself still succeeds: Secret refs are not hard dependency edges.
+func TestRender_UnresolvedSubstitutionWarning(t *testing.T) {
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, "kubernetes/flux/cluster-apps.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: cluster-apps, namespace: flux-system}
+spec:
+  path: ./kubernetes/apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+`)
+	testutil.WriteFile(t, dir, "kubernetes/apps/kustomization.yaml",
+		"apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nnamespace: flux-system\nresources:\n  - ./cm.yaml\n")
+	testutil.WriteFile(t, dir, "kubernetes/apps/cm.yaml",
+		"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: app\ndata:\n  k: v\n")
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	found := false
+	for _, w := range res.Warnings {
+		if w.Category == manifest.WarnUnresolvedSubstitution && strings.Contains(w.Message, `"cluster-secrets"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing UnresolvedSubstitution warning naming cluster-secrets; Warnings=%+v", res.Warnings)
 	}
 }

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -667,6 +667,38 @@ func ExpandPostBuildSubstituteReference(ks *manifest.Kustomization, p Provider) 
 	return nil
 }
 
+// UnreadableSubstituteSecrets returns the names of ks.PostBuildSubstituteFrom
+// Secret references whose data flate can't read offline — an absent Secret or
+// an ExternalSecret-synthesized empty target, both of which yield no data so
+// the ${VAR}s they would supply expand to the empty string. SOPS-encrypted
+// Secrets are NOT reported: their data is wiped to placeholders, so their vars
+// still substitute. Optional refs are skipped (the author marked them
+// best-effort). The result is sorted and de-duplicated; nil when none.
+//
+// This is a pure advisory query — it does not affect substitution. The
+// Kustomization controller surfaces the result as a WarnUnresolvedSubstitution
+// Warning so an unreadable secret is explained rather than silently leaving
+// empty values behind.
+func UnreadableSubstituteSecrets(ks *manifest.Kustomization, p Provider) []string {
+	if ks == nil || ks.Namespace == "" {
+		return nil
+	}
+	var unreadable []string
+	for _, ref := range ks.PostBuildSubstituteFrom {
+		if ref.Kind != manifest.KindSecret || ref.Optional {
+			continue
+		}
+		if data, err := lookupResourceData(ref.Kind, ks.Namespace, ref.Name, p); err == nil && data == nil {
+			unreadable = append(unreadable, ref.Name)
+		}
+	}
+	if len(unreadable) == 0 {
+		return nil
+	}
+	slices.Sort(unreadable)
+	return slices.Compact(unreadable)
+}
+
 // VarsMap returns the substitution variables for use with
 // kustomize.Substitute. Non-string scalar values are stringified;
 // nested maps/slices and other unsupported shapes are silently

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -466,6 +466,37 @@ func TestExpandPostBuildSubstituteReference_RejectsInvalidVarName(t *testing.T) 
 	}
 }
 
+// TestUnreadableSubstituteSecrets reports only substituteFrom Secret refs whose
+// data flate can't read offline. A SOPS-wiped Secret (placeholder data) and a
+// real Secret are readable; a ConfigMap ref and an optional ref are skipped.
+func TestUnreadableSubstituteSecrets(t *testing.T) {
+	provider := &SliceProvider{
+		ConfigMaps: []*manifest.ConfigMap{{Name: "cm", Namespace: "flux-system", Data: map[string]any{"X": "1"}}},
+		Secrets: []*manifest.Secret{
+			// SOPS-wiped: data resolves to a placeholder, so its vars still substitute.
+			{Name: "sops-vars", Namespace: "flux-system", StringData: map[string]any{"Y": fmt.Sprintf(manifest.ValuePlaceholderTemplate, "Y")}},
+			// A real, readable Secret.
+			{Name: "real", Namespace: "flux-system", StringData: map[string]any{"Z": "z"}},
+		},
+	}
+	ks := &manifest.Kustomization{
+		Name: "apps", Namespace: "flux-system",
+		PostBuildSubstituteFrom: []manifest.SubstituteReference{
+			{Kind: manifest.KindSecret, Name: "absent-vars"},                // unreadable → reported
+			{Kind: manifest.KindSecret, Name: "sops-vars"},                  // placeholder data → readable
+			{Kind: manifest.KindSecret, Name: "real"},                       // real data → readable
+			{Kind: manifest.KindConfigMap, Name: "cm"},                      // not a Secret → skipped
+			{Kind: manifest.KindSecret, Name: "opt-absent", Optional: true}, // optional → skipped
+		},
+	}
+	if got, want := UnreadableSubstituteSecrets(ks, provider), []string{"absent-vars"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("UnreadableSubstituteSecrets = %v, want %v", got, want)
+	}
+	if got := UnreadableSubstituteSecrets(&manifest.Kustomization{Name: "x", Namespace: "ns"}, provider); got != nil {
+		t.Errorf("no substituteFrom should yield nil, got %v", got)
+	}
+}
+
 // TestReplaceValueAtPath_SingleCharQuoteNoPanic pins the
 // len(value) >= 2 guard: a single `'` or `"` previously slipped past
 // the prefix+suffix check (prefix == suffix on a single byte) and


### PR DESCRIPTION
## What

When a `spec.postBuild.substituteFrom` **Secret** can't be read offline — an absent Secret, or an ExternalSecret/1Password-backed target that synthesizes to empty data — the `${VAR}`s it would supply expand to the empty string. That's faithful to real Flux (envsubst, strict mode off), but when a chart *requires* a non-empty value (app-template `cronjob.timeZone`, nfs-web `server`, …) the dependent HelmRelease fails schema/template validation and drops out of the render. Until now that gap was opaque.

This surfaces it as a non-fatal **`Result.Warnings`** advisory (new `UnresolvedSubstitution` category) naming the unreadable Secret, so [konflate](https://github.com/home-operations/konflate) and the CLI footer explain *why* those resources are missing:

```
⚠ warnings (…)
  substituteFrom Secret "biohazard-vars" could not be read offline; the ${VAR}s it provides render empty (×184)
  substituteFrom Secret "biohazard-secrets" could not be read offline; the ${VAR}s it provides render empty (×2)
```

## How

- `manifest.WarnUnresolvedSubstitution` — new stable category.
- `values.UnreadableSubstituteSecrets(ks, p)` — pure query: the non-optional substituteFrom Secret refs whose `lookupResourceData` returns no data. SOPS-encrypted secrets resolve to wipe placeholders and are **not** reported.
- The Kustomization controller emits one **render-global** warning per secret *name* after `kustomize.Prepare` — the store collapses the many per-namespace KSes a cluster-config KS re-emits into a single advisory line per secret.

## Why a warning, not a rendered placeholder

An earlier experiment substituted a stable `..PLACEHOLDER_VAR..` for such vars so the resources would render "best-effort." It proved fundamentally fragile: deciding "is this undefined var secret-sourced?" at the envsubst layer can't distinguish a bare `${VAR}` from a load-bearing default (`${CHART_NAME:=app-template}`, whose default *names* a shared OCIRepository that HelmReleases reference by literal name → dangled chart sources → 5 HRs failed) or from indirection (a substitute value that is itself `${OTHER}`). Substitution is a thin, correct, single-pass Flux-faithful wrapper around `fluxcd/pkg/envsubst`; the fragility was entirely in the placeholder layer. So substitution is left exactly Flux-faithful and the situation is *explained* instead of faked.

## Verification

- `go build/vet`, `go test ./...`, `-race` (controllers/values/orchestrator), `golangci-lint` → clean.
- **stdout byte-identical to `main`** on `home-operations/flate`'s reference repos (Biohazard, zariel) — substitution is unchanged; the advisory is stderr/`Result.Warnings` only.
- New tests: `values.TestUnreadableSubstituteSecrets` (detection: absent → reported; SOPS-placeholder / real / ConfigMap / optional → not) and `orchestrator.TestRender_UnresolvedSubstitutionWarning` (the warning reaches `Result.Warnings`).
- The `#768` FAILED-HR gate is unchanged and remains the determinism gate for the still-failing HRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)