### PR TITLE
feat(cli): surface warnings and notes only in `flate test`

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -396,6 +396,56 @@ func TestRun_GetImages_RejectsBadOutput(t *testing.T) {
 
 // TestRun_TestAll exercises the report path on the fixture — every
 // resource should pass (✓ rows, no failures in the summary).
+// writeUnreadableSecretFixture writes a tree whose Flux Kustomization
+// substituteFroms a Secret flate can't read offline (absent, non-SOPS, no
+// producer), so the render emits a WarnUnresolvedSubstitution advisory.
+func writeUnreadableSecretFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	k8s := filepath.Join(root, "kubernetes")
+	testutil.WriteFileAt(t, filepath.Join(k8s, "flux", "cluster.yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata: {name: apps, namespace: flux-system}
+spec:
+  interval: 10m
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+`)
+	testutil.WriteFileAt(t, filepath.Join(k8s, "apps", "kustomization.yaml"), "resources:\n- cm.yaml\n")
+	testutil.WriteFileAt(t, filepath.Join(k8s, "apps", "cm.yaml"), `---
+apiVersion: v1
+kind: ConfigMap
+metadata: {name: hello, namespace: flux-system}
+data:
+  greeting: hi
+`)
+	return k8s
+}
+
+// TestRun_AdvisoriesOnlyInTest pins the contract: a render advisory (here an
+// unreadable substituteFrom Secret) surfaces in `flate test` output but NOT in
+// `flate build` — build is a data-producing verb, so warnings and deferred
+// notes belong to the diagnostic command, never the build's stdout or stderr.
+func TestRun_AdvisoriesOnlyInTest(t *testing.T) {
+	k8s := writeUnreadableSecretFixture(t)
+	const advisory = "could not be read offline"
+
+	bOut, bErr, _ := runCLI(t, "build", "all", "--path", k8s)
+	if strings.Contains(bOut, advisory) || strings.Contains(bErr, advisory) {
+		t.Errorf("build must not surface the advisory.\nstdout:\n%s\nstderr:\n%s", bOut, bErr)
+	}
+
+	tOut, _, _ := runCLI(t, "test", "all", "--path", k8s)
+	if !strings.Contains(tOut, advisory) {
+		t.Errorf("test must surface the advisory; stdout:\n%s", tOut)
+	}
+}
+
 func TestRun_TestAll(t *testing.T) {
 	path := writeFixture(t)
 	stdout, stderr, code := runCLI(t, "test", "all", "--path", path)

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -716,15 +716,17 @@ func (e reportedError) Error() string { return e.err.Error() }
 func (e reportedError) Unwrap() error { return e.err }
 
 // reportFailures renders the styled root-cause report — real errors shown once,
-// cascaded failures folded under the root that caused them, and any deferred log
-// lines in a footer — to w, scoped to c's namespace filter. It always drains the
-// log buffer (so notes aren't lost even on a clean run). When something rendered
-// and err is non-nil, err is wrapped as reportedError so the caller still exits
-// non-zero while run avoids printing it twice; otherwise err passes through.
+// cascaded failures folded under the root that caused them — to w, scoped to c's
+// namespace filter. Advisories (warnings) and deferred operational logs (notes)
+// are deliberately NOT rendered here: they belong to `flate test`, the
+// diagnostic command. A data-producing `flate build` stays quiet but for the
+// failure report it must surface — CI relies on the non-zero exit and the cause.
+// When something rendered and err is non-nil, err is wrapped as reportedError so
+// the caller still exits non-zero while run avoids printing it twice; otherwise
+// err passes through.
 func reportFailures(w io.Writer, o *orchestrator.Orchestrator, res *orchestrator.Result, c *commonFlags, err error, elapsed time.Duration) error {
-	notes := drainLogNotes()
 	failed, blocked := scopedFailures(o, res, c)
-	m := report.Build(failed, blocked, scopedWarnings(o, res, c), notes)
+	m := report.Build(failed, blocked, nil, nil)
 	if m.Empty() {
 		return err
 	}

--- a/internal/cli/defersink.go
+++ b/internal/cli/defersink.go
@@ -15,7 +15,14 @@ import (
 // the scattered Warn/Info lines (chiefly "resource orphaned") that otherwise
 // interleave with, and bury, the final report — and hands them to the command
 // to render in a quiet footer instead. Error records (panics) always pass
-// through inline so a crash stays loud.
+// through inline so a crash stays loud. Only `flate test` drains and renders
+// the held-back notes; a data-producing verb leaves them buffered (and they're
+// dropped at exit), so its output stays clean.
+//
+// When buffering is off the sink is transparent — every record passes straight
+// to the inner handler, live. setLogLevel turns it off for an explicitly chosen
+// --log-level: that's the user asking for logs, which must stream to stderr on
+// every command, not vanish into a footer only `test` renders.
 //
 // One shared buffer backs every handler slog derives via WithAttrs/WithGroup, so
 // attribute-scoped loggers buffer into the same place. drain() returns the
@@ -33,8 +40,10 @@ type noteBuffer struct {
 	counts map[string]int
 }
 
-func newDeferSink(inner slog.Handler) *deferSink {
-	return &deferSink{inner: inner, buf: &noteBuffer{on: true, counts: map[string]int{}}}
+// newDeferSink wraps inner. When buffer is true it holds back Warn/Info chatter
+// for `flate test` to render; when false it is transparent (live pass-through).
+func newDeferSink(inner slog.Handler, buffer bool) *deferSink {
+	return &deferSink{inner: inner, buf: &noteBuffer{on: buffer, counts: map[string]int{}}}
 }
 
 func (d *deferSink) Enabled(ctx context.Context, l slog.Level) bool { return d.inner.Enabled(ctx, l) }

--- a/internal/cli/defersink_test.go
+++ b/internal/cli/defersink_test.go
@@ -21,7 +21,7 @@ func (h captureHandler) WithGroup(string) slog.Handler      { return h }
 // through inline; after drain, buffering is off so later logs flow normally.
 func TestDeferSink_BuffersWarnPassesError(t *testing.T) {
 	var inline []string
-	sink := newDeferSink(captureHandler{&inline})
+	sink := newDeferSink(captureHandler{&inline}, true)
 	log := slog.New(sink)
 
 	log.Warn("resource orphaned", "id", "a")

--- a/internal/cli/logrouting_test.go
+++ b/internal/cli/logrouting_test.go
@@ -23,7 +23,7 @@ func TestSetLogLevel_StdlibLogDetachedFromNotes(t *testing.T) {
 	t.Cleanup(func() { slog.SetDefault(saved); log.SetOutput(os.Stderr) })
 
 	var sink bytes.Buffer
-	if err := setLogLevel("warn", &sink); err != nil {
+	if err := setLogLevel("warn", false, &sink); err != nil {
 		t.Fatalf("setLogLevel(warn): %v", err)
 	}
 	log.Printf("warning: destination for x is a table. Ignoring non-table value") // dependency stdlib log
@@ -44,11 +44,34 @@ func TestSetLogLevel_StdlibLogDetachedFromNotes(t *testing.T) {
 	// At debug the stdlib logger is reattached to the sink (visible for
 	// troubleshooting) rather than discarded.
 	var dbg bytes.Buffer
-	if err := setLogLevel("debug", &dbg); err != nil {
+	if err := setLogLevel("debug", true, &dbg); err != nil {
 		t.Fatalf("setLogLevel(debug): %v", err)
 	}
 	log.Printf("helm-coalesce-debug-line")
 	if !strings.Contains(dbg.String(), "helm-coalesce-debug-line") {
 		t.Errorf("at --log-level debug, stdlib log should reach the sink writer; got %q", dbg.String())
+	}
+}
+
+// TestSetLogLevel_ExplicitLevelStreamsLive pins the separation between the
+// test-only notes footer and explicit logging: when --log-level is set
+// explicitly, the deferring sink is transparent so records stream live to
+// stderr on every command (a normal logger). Without this, raising the log
+// level on a build/get/diff would be swallowed — the footer is `test`-only.
+func TestSetLogLevel_ExplicitLevelStreamsLive(t *testing.T) {
+	saved := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(saved); log.SetOutput(os.Stderr) })
+
+	var sink bytes.Buffer
+	if err := setLogLevel("info", true /* explicit */, &sink); err != nil {
+		t.Fatalf("setLogLevel(info, explicit): %v", err)
+	}
+	slog.Warn("resource orphaned", "id", "x")
+
+	if !strings.Contains(sink.String(), "resource orphaned") {
+		t.Errorf("explicit --log-level must stream slog live to the sink; got %q", sink.String())
+	}
+	if notes := drainLogNotes(); len(notes) != 0 {
+		t.Errorf("explicit --log-level must not hold records back as notes; got %v", notes)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -66,7 +66,11 @@ func New(version string) *cobra.Command {
 			logSink = barSink
 		}
 		lvl, _ := cmd.Flags().GetString("log-level")
-		return setLogLevel(lvl, logSink)
+		// Changed reports whether --log-level (or its FLATE_LOG_LEVEL env
+		// binding) was set explicitly. If so the user asked for logs: stream
+		// them live to stderr on every command. Left at the default, chatter is
+		// deferred into the notes buffer that only `flate test` renders.
+		return setLogLevel(lvl, cmd.Flags().Changed("log-level"), logSink)
 	}
 
 	root.AddCommand(
@@ -106,15 +110,11 @@ func run(version string, args []string, stdout, stderr io.Writer) int {
 	root.SetOut(stdout)
 	root.SetErr(stderr)
 	err := root.ExecuteContext(ctx)
-	// Flush any deferred log notes a command didn't already render (diff/get/
-	// cache, or a clean run) so nothing buffered is lost.
-	for _, n := range drainLogNotes() {
-		line := n.Text
-		if n.Count > 1 {
-			line = fmt.Sprintf("%s (×%d)", line, n.Count)
-		}
-		_, _ = io.WriteString(stderr, line+"\n")
-	}
+	// Deferred log notes (and Result.Warnings) are surfaced ONLY by `flate
+	// test`, the diagnostic command — a data-producing verb (build/get/diff/
+	// cache) stays quiet. So there is no end-of-run flush: anything buffered by
+	// a non-test verb is intentionally dropped (it has already been drained and
+	// rendered by `test`, or it belongs to a verb that doesn't report it).
 	if err != nil {
 		// reportFailures already rendered a styled report for this error; don't
 		// reprint it as a flat "flate error: …" line.
@@ -132,7 +132,7 @@ func run(version string, args []string, stdout, stderr io.Writer) int {
 // `--log-level bogus` fails clearly instead of silently degrading to
 // info — the previous behavior misled users who typo'd `--log-level
 // dbug` and assumed Debug output was simply quiet.
-func setLogLevel(lvl string, w io.Writer) error {
+func setLogLevel(lvl string, explicit bool, w io.Writer) error {
 	var l slog.Level
 	switch lvl {
 	case "debug":
@@ -147,11 +147,16 @@ func setLogLevel(lvl string, w io.Writer) error {
 		return fmt.Errorf("invalid --log-level %q: must be one of debug, info, warn, error", lvl)
 	}
 	// Wrap the text handler in a deferring sink so the Warn/Info chatter a
-	// failing run emits (chiefly "resource orphaned") is held back and rendered
-	// in the report footer instead of interleaving with output; Error records
-	// still pass straight through. Commands drain it via reportFailures; run
-	// flushes anything left so no note is lost.
-	logBuffer = newDeferSink(slog.NewTextHandler(w, &slog.HandlerOptions{Level: l}))
+	// failing run emits (chiefly "resource orphaned") is held back rather than
+	// interleaving with output; Error records still pass straight through. Only
+	// `flate test` drains and renders the held-back notes — a data-producing
+	// verb (build/get/diff) leaves them buffered, so its output stays clean.
+	//
+	// But an explicitly chosen --log-level is the user asking for logs: turn the
+	// buffering OFF so records stream live to stderr on every command, the
+	// behavior a normal logger would give. Without this, raising the log level
+	// on a build/get/diff would be silently swallowed (the footer is test-only).
+	logBuffer = newDeferSink(slog.NewTextHandler(w, &slog.HandlerOptions{Level: l}), !explicit)
 	slog.SetDefault(slog.New(logBuffer))
 	// slog.SetDefault also reroutes the standard library `log` package through
 	// this handler. A dependency's log.Printf — chiefly Helm's values-coalesce

--- a/test/e2e/stalevalues_test.go
+++ b/test/e2e/stalevalues_test.go
@@ -7,32 +7,34 @@ import (
 
 // TestE2E_StaleValuesWarning exercises #744 end-to-end: a HelmRelease pins a
 // value (`oldUnusedKey`) that no chart template references. The render still
-// succeeds (advisory only), and the unused key surfaces in the stderr warnings
-// footer attributed to that HR — while a sibling on a chart that consumes
-// .Values wholesale (toYaml) stays silent.
+// succeeds (advisory only). The advisory surfaces in `flate test` — the
+// diagnostic command — attributed to that HR, while `flate build` renders the
+// same output but stays quiet: warnings and notes never appear in a build, only
+// in test. (The advisory's content — opaque sibling silent, referenced values
+// never flagged — is unit-covered by orchestrator.TestRender_StaleValuesWarning.)
 func TestE2E_StaleValuesWarning(t *testing.T) {
-	stdout, stderr, code := runCLIBuffers("build", "hr", "--path", copyTree(t, testdataPath(t, "stalevalues")))
+	path := copyTree(t, testdataPath(t, "stalevalues"))
 
+	// build renders the same output but emits no advisory, on stdout or stderr.
+	bOut, bErr, code := runCLIBuffers("build", "hr", "--path", path)
 	if code != 0 {
-		t.Fatalf("stale-value detection is advisory and must not fail the render; exit=%d\nstderr:\n%s", code, stderr)
+		t.Fatalf("stale-value detection is advisory and must not fail the render; exit=%d\nstderr:\n%s", code, bErr)
 	}
-	// The unused key is flagged, attributed to the HR whose chart names its values.
+	if !strings.Contains(bOut, "app-cm") || !strings.Contains(bOut, "opaque-cm") {
+		t.Errorf("rendered HR output missing:\n%s", bOut)
+	}
+	// The advisory footer lived on stderr; it must be gone. (The rendered
+	// opaque-cm legitimately contains "oldUnusedKey" in its dumped values, so
+	// only stderr — never stdout — is asserted clean.)
+	if strings.Contains(bErr, "warnings") || strings.Contains(bErr, "oldUnusedKey") {
+		t.Errorf("build stderr must not surface the stale-value advisory:\n%s", bErr)
+	}
+
+	// test surfaces the advisory, attributed to the HR whose chart names its values.
+	tOut, tErr, _ := runCLIBuffers("test", "hr", "--path", path)
 	for _, want := range []string{"warnings", "apps/app", "oldUnusedKey"} {
-		if !strings.Contains(stderr, want) {
-			t.Errorf("stderr missing %q:\n%s", want, stderr)
+		if !strings.Contains(tOut, want) {
+			t.Errorf("test stdout missing %q:\n%s\nstderr:\n%s", want, tOut, tErr)
 		}
-	}
-	// The opaque-chart sibling pins the same key but must NOT warn (we can't
-	// prove it unused when the chart reads .Values wholesale).
-	if strings.Contains(stderr, "apps/opaque") {
-		t.Errorf("a chart that consumes .Values wholesale must not produce a stale-value warning:\n%s", stderr)
-	}
-	// Referenced values are never reported.
-	if strings.Contains(stderr, "greeting") || strings.Contains(stderr, "replicas") {
-		t.Errorf("referenced values must not appear in the warnings footer:\n%s", stderr)
-	}
-	// Rendered output is unaffected — both HRs produce their ConfigMaps.
-	if !strings.Contains(stdout, "app-cm") || !strings.Contains(stdout, "opaque-cm") {
-		t.Errorf("rendered HR output missing:\n%s", stdout)
 	}
 }


### PR DESCRIPTION
## What

Render advisories (`Result.Warnings` — unreadable `substituteFrom` secrets, stale HelmRelease values, …) and the deferred operational notes (the slog Warn/Info chatter held back from interleaving with output) now surface in **exactly one place: `flate test`**, the diagnostic/reporting command. They no longer clutter `flate build` (or `get`/`diff`/`cache`).

`flate build` is a data-producing verb — clean YAML on stdout. Previously the advisory footer leaked into every verb:
- `build` rendered warnings + notes in its stderr footer (`report.Build`), and
- `get`/`diff`/`cache`/clean flushed leftover notes at end-of-run (`run()`).

## Two distinct concerns, cleanly separated

The first cut removed the end-of-run flush wholesale — which also swallowed `--log-level` output on non-test commands (a real wart). This version separates them:

- **The test-only notes footer** (default verbosity). `reportFailures` (build's footer) renders **only the failure report** — CI still gets the non-zero exit and the root cause. The end-of-run note flush is removed. So a data-producing verb stays quiet; held-back chatter is rendered only by `flate test`.
- **Opt-in live logging.** An explicitly chosen `--log-level` is the user asking for logs, so the deferring sink becomes **transparent** and records stream live to stderr on **every** command (build/get/diff included) — the behavior a normal logger gives. Only at the default verbosity is chatter deferred into the notes buffer.

`flate test` is unchanged — it still drains and renders both the warnings and notes sections at default verbosity.

Build **stdout is byte-identical** (this only touches the stderr footer, the note flush, and the sink's buffering toggle).

## Verification

- Full gate clean: gofmt · `go build ./...` · `go vet ./...` · `go test ./...` · `-race` (cli) · golangci-lint v2 (0 issues).
- Behavior (zariel): default `build all` stderr quiet (no slog chatter); `build all --log-level debug` streams ~219 live log lines again; `test all` still shows the warnings section. Biohazard: `build all` stderr shows only the ✗ failure report; build stdout byte-identical to `main`.
- Tests:
  - `TestRun_AdvisoriesOnlyInTest` — build quiet on stdout **and** stderr; test surfaces the advisory.
  - `TestSetLogLevel_ExplicitLevelStreamsLive` — an explicit level streams slog live to stderr, not held back as notes.
  - `TestSetLogLevel_StdlibLogDetachedFromNotes` — unchanged determinism contract (default verbosity).
  - `TestE2E_StaleValuesWarning` updated to the new contract (build renders output, no advisory footer; test surfaces it); the advisory's *content* checks stay unit-covered by `orchestrator.TestRender_StaleValuesWarning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
