### PR TITLE
fix(discovery): substitute cross-tree base Kustomizations

### DIFF
--- a/pkg/controllers/emit/emit.go
+++ b/pkg/controllers/emit/emit.go
@@ -104,6 +104,14 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 		c.KeepEmitted(id, obj)
 		rendered = append(rendered, obj.Named())
 	}
+	// A KS whose spec.path re-includes its own definition file (the Zariel
+	// self-emit, or a cross-tree base/ overlay it belongs to, #777) re-emits
+	// ITSELF. Its own render is never the source of truth for its spec — that's
+	// its file or its parent's substituted/patched emission — and re-storing the
+	// self-copy would strip a parent-injected postBuild, flip-flopping spec.path
+	// back to unsubstituted. Skip the store write; renderedSet already drops the
+	// self-edge for attribution.
+	selfEmit := func(obj manifest.BaseManifest) bool { return obj.Named() == id }
 	// Pass 1 — data first.
 	for _, p := range objs {
 		switch {
@@ -111,7 +119,7 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 			continue // held for pass 2
 		case p.reconcilable:
 			keep(p.Obj)
-			if publish {
+			if publish && !selfEmit(p.Obj) {
 				c.Store.AddObject(p.Obj)
 			}
 		default:
@@ -123,7 +131,9 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 	for _, p := range objs {
 		if p.leaf {
 			keep(p.Obj)
-			leaves = append(leaves, p.Obj)
+			if !selfEmit(p.Obj) {
+				leaves = append(leaves, p.Obj)
+			}
 		}
 	}
 	c.ReportRendered(id, rendered)

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -197,12 +197,31 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	d.promoteOrphans(prefixes)
 
 	producers := &manifest.ProducerIndex{}
+	selfProduce := loader.BuildSelfProduceIndex(d.cfg.Store, repoRoot, producers, cfg.WipeSecrets)
+	// Gate cross-tree base Kustomizations (#777) on their emitting parent. Such a
+	// base sits under no KS spec.path, so BuildParentIndexFromPrefixes gave it no
+	// gate — it would reconcile the raw UNSUBSTITUTED copy and race the parent's
+	// substituted emission. Wiring its emitter into ParentOf makes its first
+	// render wait, exactly like the spec.path-prefix gate (see
+	// EmissionParentByFile). A KS already gated by spec.path, and self-emits
+	// (parent == id), are left alone.
+	for id, file := range d.sourceFiles {
+		if id.Kind != manifest.KindKustomization {
+			continue
+		}
+		if _, gated := parentOf[id]; gated {
+			continue
+		}
+		if parent, ok := selfProduce.EmissionParentByFile(file); ok && parent != id {
+			parentOf[id] = parent
+		}
+	}
 	return &Result{
 		RepoRoot:    repoRoot,
 		SourceFiles: d.sourceFiles,
 		SourceRefs:  d.sourceRefs,
 		ParentOf:    parentOf,
-		SelfProduce: loader.BuildSelfProduceIndex(d.cfg.Store, repoRoot, producers, cfg.WipeSecrets),
+		SelfProduce: selfProduce,
 		Producers:   producers,
 		Existence:   l.Existence,
 		WipeSecrets: cfg.WipeSecrets,

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -275,6 +275,76 @@ func TestRun_RequiresStoreAndLoader(t *testing.T) {
 	}
 }
 
+// TestRun_CrossTreeBaseEmissionGate pins the #777 gate: a Flux KS stored as a
+// cross-tree kustomize base (apps/base/app-a/ks.yaml pulled in by cluster-apps
+// via apps/test/app-a -> ../../base/app-a) gets cluster-apps wired as its
+// structural parent in ParentOf, even though its source file sits under no KS
+// spec.path. A self-emitting KS (spec.path covering its own definition file)
+// must NOT be gated on itself, or it would deadlock waiting for itself.
+func TestRun_CrossTreeBaseEmissionGate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	testutil.WriteFile(t, dir, "cluster/cluster-apps.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  path: ./apps/test
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/test/kustomization.yaml", "resources:\n  - ./app-a\n")
+	testutil.WriteFile(t, dir, "apps/test/app-a/kustomization.yaml", "resources:\n  - ../../base/app-a\n")
+	testutil.WriteFile(t, dir, "apps/base/app-a/kustomization.yaml", "resources:\n  - ks.yaml\n")
+	// ${VAR} path — unresolvable at discovery, so app-a's own walk can't follow
+	// it; only cluster-apps emits its file, giving an unambiguous gate.
+	testutil.WriteFile(t, dir, "apps/base/app-a/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-a
+  namespace: flux-system
+spec:
+  path: ./apps/${CLUSTER_ENV}/app-a
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+
+	// A self-emitting KS: its spec.path (./self) holds its own ks.yaml.
+	testutil.WriteFile(t, dir, "self/kustomization.yaml", "resources:\n  - ks.yaml\n")
+	testutil.WriteFile(t, dir, "self/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: selfish
+  namespace: flux-system
+spec:
+  path: ./self
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+
+	st := store.New()
+	res, err := discovery.Run(context.Background(), discovery.Config{Path: dir, Store: st, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	appA := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "app-a"}
+	clusterApps := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	if got := res.ParentOf[appA]; got != clusterApps {
+		t.Errorf("ParentOf[app-a] = %v, want cluster-apps (cross-tree emission gate)", got)
+	}
+
+	selfish := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "selfish"}
+	if got, gated := res.ParentOf[selfish]; gated {
+		t.Errorf("ParentOf[selfish] = %v, want absent (a self-emit must not gate on itself)", got)
+	}
+}
+
 func TestResolveScanPath_SymlinkResolved(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/pkg/loader/selfproduce.go
+++ b/pkg/loader/selfproduce.go
@@ -29,6 +29,9 @@ import (
 // Built once per Bootstrap (in discovery.Run) and read-only afterwards.
 type SelfProduceIndex struct {
 	byID map[manifest.NamedResource][]manifest.NamedResource
+	// emissionParentByFile: cross-tree base ks.yaml path → its single emitting
+	// parent KS. See EmissionParentByFile.
+	emissionParentByFile map[string]manifest.NamedResource
 }
 
 // ProducedBy returns the Kustomizations whose render subtree emits cm.
@@ -39,6 +42,22 @@ func (i *SelfProduceIndex) ProducedBy(cm manifest.NamedResource) []manifest.Name
 		return nil
 	}
 	return i.byID[cm]
+}
+
+// EmissionParentByFile returns the Flux Kustomization whose render subtree emits
+// the ks.yaml at the given repo-relative path, when exactly one does — i.e. a
+// cross-tree kustomize base (apps/base/app-X/ks.yaml pulled in via
+// apps/test/app-X -> ../../base/app-X, applied by cluster-apps with postBuild
+// substitution). discovery.Run gates such a base on that parent so it reconciles
+// the parent's substituted emission, not the raw file. Keyed by FILE so it maps
+// onto the loaded copy's store id regardless of namespace inheritance; nil-safe.
+// See #777.
+func (i *SelfProduceIndex) EmissionParentByFile(file string) (manifest.NamedResource, bool) {
+	if i == nil {
+		return manifest.NamedResource{}, false
+	}
+	p, ok := i.emissionParentByFile[file]
+	return p, ok
 }
 
 // BuildSelfProduceIndex resolves, per Flux Kustomization with a spec.path,
@@ -61,17 +80,21 @@ func (i *SelfProduceIndex) ProducedBy(cm manifest.NamedResource) []manifest.Name
 // a namePrefix/nameSuffix, are not covered here — they fall back to the
 // render-time listener (valuesFrom) or fail-loud/the flag (source auth).
 func BuildSelfProduceIndex(s *store.Store, repoRoot string, producers *manifest.ProducerIndex, wipeSecrets bool) *SelfProduceIndex {
-	idx := &SelfProduceIndex{byID: map[manifest.NamedResource][]manifest.NamedResource{}}
+	idx := &SelfProduceIndex{
+		byID:                 map[manifest.NamedResource][]manifest.NamedResource{},
+		emissionParentByFile: map[string]manifest.NamedResource{},
+	}
 	if repoRoot == "" {
 		return idx
 	}
 	b := &selfProduceBuilder{
-		repoRoot:    repoRoot,
-		dirs:        map[string]cachedDir{},
-		idx:         idx,
-		producers:   producers,
-		store:       s,
-		wipeSecrets: wipeSecrets,
+		repoRoot:     repoRoot,
+		dirs:         map[string]cachedDir{},
+		idx:          idx,
+		emittedFiles: map[string][]manifest.NamedResource{},
+		producers:    producers,
+		store:        s,
+		wipeSecrets:  wipeSecrets,
 	}
 	// A KS sourced from a genuine external repo renders that repo's tree, not the
 	// local checkout — walking its spec.path against repoRoot would record it as
@@ -86,6 +109,13 @@ func BuildSelfProduceIndex(s *store.Store, repoRoot string, producers *manifest.
 			continue
 		}
 		b.walkRoot(ks)
+	}
+	// Keep only files reached through exactly one parent — a base shared by peer
+	// overlays is ambiguous, so add no gate.
+	for file, parents := range b.emittedFiles {
+		if len(parents) == 1 {
+			idx.emissionParentByFile[file] = parents[0]
+		}
 	}
 	return idx
 }
@@ -103,6 +133,10 @@ type selfProduceBuilder struct {
 	// once. Discovery is serial, so no lock is needed.
 	dirs map[string]cachedDir
 	idx  *SelfProduceIndex
+	// emittedFiles accumulates each cross-tree-emitted ks.yaml path → the
+	// distinct parents reaching it; resolved to single-parent
+	// emissionParentByFile edges after the walk.
+	emittedFiles map[string][]manifest.NamedResource
 	// producers, when non-nil, receives target-Secret → ExternalSecret /
 	// SealedSecret edges discovered during the same walk. See
 	// BuildSelfProduceIndex.
@@ -237,6 +271,8 @@ func (b *selfProduceBuilder) recordProduced(relFile, baseNS, rootNS string, ks m
 				b.recordConfigMap(o, baseNS, rootNS, ks)
 			case *manifest.Secret:
 				b.materializeSecret(o, baseNS, rootNS)
+			case *manifest.Kustomization:
+				b.recordEmittedKS(relFile, ks)
 			case *manifest.RawObject:
 				b.recordProducer(o, baseNS, rootNS)
 			}
@@ -279,6 +315,13 @@ func (b *selfProduceBuilder) recordConfigMap(cm *manifest.ConfigMap, baseNS, roo
 	}
 	id := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: ns, Name: cm.Name}
 	b.idx.byID[id] = appendUniqueProducer(b.idx.byID[id], ks)
+}
+
+// recordEmittedKS notes that ks's render subtree reaches a Flux Kustomization
+// defined at relFile — i.e. ks emits that cross-tree base. Accumulated per file;
+// resolved to a single-parent gate after the walk (see EmissionParentByFile).
+func (b *selfProduceBuilder) recordEmittedKS(relFile string, ks manifest.NamedResource) {
+	b.emittedFiles[relFile] = appendUniqueProducer(b.emittedFiles[relFile], ks)
 }
 
 // recordProducer records the target(s) a producer generates — the Secret an

--- a/pkg/loader/selfproduce_test.go
+++ b/pkg/loader/selfproduce_test.go
@@ -88,6 +88,48 @@ func TestSelfProduceIndex_NilSafe(t *testing.T) {
 	if got := idx.ProducedBy(cmID("flux-system")); got != nil {
 		t.Errorf("nil index ProducedBy = %v, want nil", got)
 	}
+	if _, ok := idx.EmissionParentByFile("apps/base/app-a/ks.yaml"); ok {
+		t.Errorf("nil index EmissionParentByFile = ok, want absent")
+	}
+}
+
+// EmissionParentByFile records a base ks.yaml reached cross-tree through EXACTLY
+// one parent's render subtree (apps/base/app-a/ks.yaml pulled in via
+// apps/test/app-a -> ../../base/app-a, applied by cluster-apps) — the #777 gate
+// signal. A base shared by two distinct parents is ambiguous and omitted.
+func TestBuildSelfProduceIndex_EmissionParentByFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// app-a: pulled by exactly one parent (cluster-apps). ${VAR} path so the
+	// walk records only cluster-apps (no literal self-include).
+	testutil.WriteFile(t, dir, "apps/test/kustomization.yaml", "resources:\n  - ./app-a\n  - ./shared\n")
+	testutil.WriteFile(t, dir, "apps/test/app-a/kustomization.yaml", "resources:\n  - ../../base/app-a\n")
+	testutil.WriteFile(t, dir, "apps/base/app-a/kustomization.yaml", "resources:\n  - ks.yaml\n")
+	testutil.WriteFile(t, dir, "apps/base/app-a/ks.yaml",
+		"apiVersion: kustomize.toolkit.fluxcd.io/v1\nkind: Kustomization\nmetadata:\n  name: app-a\n  namespace: flux-system\nspec:\n  path: ./apps/${CLUSTER_ENV}/app-a\n")
+	// shared: pulled by BOTH cluster-apps (./apps/test -> ./shared) and
+	// cluster-apps2 (./apps/test2) — two distinct parents, ambiguous.
+	testutil.WriteFile(t, dir, "apps/test/shared/kustomization.yaml", "resources:\n  - ../../base/shared\n")
+	testutil.WriteFile(t, dir, "apps/test2/kustomization.yaml", "resources:\n  - ../base/shared\n")
+	testutil.WriteFile(t, dir, "apps/base/shared/kustomization.yaml", "resources:\n  - ks.yaml\n")
+	testutil.WriteFile(t, dir, "apps/base/shared/ks.yaml",
+		"apiVersion: kustomize.toolkit.fluxcd.io/v1\nkind: Kustomization\nmetadata:\n  name: shared\n  namespace: flux-system\nspec:\n  path: ./apps/${CLUSTER_ENV}/shared\n")
+
+	s := store.New()
+	s.AddObject(&manifest.Kustomization{Name: "cluster-apps", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/test"}})
+	s.AddObject(&manifest.Kustomization{Name: "cluster-apps2", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/test2"}})
+
+	idx := BuildSelfProduceIndex(s, dir, nil, true)
+
+	clusterApps := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "cluster-apps"}
+	if got, ok := idx.EmissionParentByFile("apps/base/app-a/ks.yaml"); !ok || got != clusterApps {
+		t.Errorf("EmissionParentByFile(app-a) = (%v, %v), want (cluster-apps, true)", got, ok)
+	}
+	if got, ok := idx.EmissionParentByFile("apps/base/shared/ks.yaml"); ok {
+		t.Errorf("EmissionParentByFile(shared) = (%v, true), want absent (two distinct parents are ambiguous)", got)
+	}
 }
 
 func secretID(ns, name string) manifest.NamedResource {

--- a/pkg/orchestrator/cross_tree_base_test.go
+++ b/pkg/orchestrator/cross_tree_base_test.go
@@ -1,0 +1,163 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestOrchestrator_CrossTreeBaseSubstitution reproduces issue #777: Flux
+// Kustomization manifests stored as kustomize bases (apps/base/app-X/ks.yaml,
+// spec.path ./apps/${CLUSTER_ENV}/app-X) that a parent KS (cluster-apps,
+// spec.path ./apps/test) pulls in cross-tree via overlays and applies with
+// postBuild.substituteFrom + a patch injecting substituteFrom into every child
+// KS. Real Flux only ever applies cluster-apps's substituted emission of each
+// app KS; the raw base file is never reconciled directly.
+//
+// Pre-fix, flate's file walk loaded each base KS as a standalone object whose
+// source file sits under no KS spec.path — so it had no parent gate and a root
+// (no-dependsOn) app KS reconciled the raw, UNSUBSTITUTED copy immediately,
+// failing "path is not a directory: ./apps/${CLUSTER_ENV}/app-a" before
+// cluster-apps emitted the substituted version. The app KS spec.path also
+// re-includes its own base, so its self-emission stripped the parent-injected
+// postBuild and flip-flopped back to the unsubstituted path.
+//
+// Post-fix: discovery gates each base KS on its emitting parent (cluster-apps),
+// so it reconciles only after the substituted emission lands instead of racing
+// it; and emit no longer lets a KS's self-emission clobber its own store object
+// (which would strip the postBuild). Every app KS resolves ${CLUSTER_ENV} →
+// test deterministically, for both the no-dependsOn root and the dependent.
+func TestOrchestrator_CrossTreeBaseSubstitution(t *testing.T) {
+	dir := t.TempDir()
+
+	// Entry KSes: cluster-settings (provides the substitution ConfigMap) and
+	// cluster-apps (fans out ./apps/test with postBuild substitution + a patch
+	// injecting substituteFrom into every emitted child Kustomization).
+	testutil.WriteFile(t, dir, "cluster/flux-system.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+spec:
+  path: ./settings
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  path: ./apps/test
+  dependsOn:
+    - name: cluster-settings
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+  patches:
+    - patch: |-
+        apiVersion: kustomize.toolkit.fluxcd.io/v1
+        kind: Kustomization
+        metadata:
+          name: not-used
+        spec:
+          postBuild:
+            substituteFrom:
+              - kind: ConfigMap
+                name: cluster-settings
+      target:
+        group: kustomize.toolkit.fluxcd.io
+        kind: Kustomization
+`)
+
+	testutil.WriteFile(t, dir, "settings/kustomization.yaml", "resources:\n  - ./cluster-settings.yaml\n")
+	testutil.WriteFile(t, dir, "settings/cluster-settings.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  CLUSTER_ENV: "test"
+`)
+
+	// Overlay: each app pulls its cross-tree base. The base's kustomization
+	// references ks.yaml (the Flux KS) AND cm.yaml (the workload), so
+	// cluster-apps's render emits the app KSes and app-X's own render
+	// re-includes its base (the self-reference that drove the flip-flop).
+	testutil.WriteFile(t, dir, "apps/test/kustomization.yaml", "resources:\n  - ./app-a\n  - ./app-b\n")
+	testutil.WriteFile(t, dir, "apps/test/app-a/kustomization.yaml", "resources:\n  - ../../base/app-a\n")
+	testutil.WriteFile(t, dir, "apps/test/app-b/kustomization.yaml", "resources:\n  - ../../base/app-b\n")
+
+	testutil.WriteFile(t, dir, "apps/base/app-a/kustomization.yaml", "resources:\n  - ks.yaml\n  - cm.yaml\n")
+	// app-a is a ROOT — no dependsOn — so it fires as soon as its source is
+	// ready, the case that consistently lost the race pre-fix.
+	testutil.WriteFile(t, dir, "apps/base/app-a/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-a
+  namespace: flux-system
+spec:
+  path: ./apps/${CLUSTER_ENV}/app-a
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/base/app-a/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-a-cm
+  namespace: flux-system
+`)
+
+	testutil.WriteFile(t, dir, "apps/base/app-b/kustomization.yaml", "resources:\n  - ks.yaml\n  - cm.yaml\n")
+	testutil.WriteFile(t, dir, "apps/base/app-b/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-b
+  namespace: flux-system
+spec:
+  path: ./apps/${CLUSTER_ENV}/app-b
+  dependsOn:
+    - name: app-a
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/base/app-b/cm.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-b-cm
+  namespace: flux-system
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+
+	for _, name := range []string{"app-a", "app-b"} {
+		id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+		ks, ok := o.store.GetObject(id).(*manifest.Kustomization)
+		if !ok {
+			t.Fatalf("%s missing from store", name)
+		}
+		if want := "./apps/test/" + name; ks.Path != want {
+			t.Errorf("%s spec.path = %q, want %q (${CLUSTER_ENV} should resolve to test)", name, ks.Path, want)
+		}
+		if info, failed := res.Failed[id]; failed {
+			t.Errorf("%s failed: %s", name, info.Message)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #777.

## Problem

A Flux Kustomization stored as a kustomize **base** (`apps/base/app-X/ks.yaml`, `spec.path: ./apps/${CLUSTER_ENV}/app-X`) that a parent KS (`cluster-apps`, `path ./apps/test`) pulls in **cross-tree** via overlays (`apps/test/app-X` → `resources: ../../base/app-X`) and applies with `postBuild.substituteFrom` reconciled the raw **unsubstituted** copy standalone, racing the parent's substituted emission. No-`dependsOn` root KSes consistently lost and failed `kustomization path is not a directory: ./apps/${CLUSTER_ENV}/app-X`.

## Root cause (two coupled bugs)

1. **No parent gate** — the base file is under no KS `spec.path`, so the prefix parent index gave it no gate; the root fired immediately, before the parent rendered.
2. **Self-emission flip-flop** — the base's `spec.path` re-includes its own base, so its own render re-emits itself, stripping the parent-injected `postBuild` (flate does full-object overwrite, not SSA field merge) and reverting `spec.path` to unsubstituted.

## Fix

- **`selfproduce.go`** — the render-graph walk flate already runs now records each cross-tree-emitted `ks.yaml` **file → emitting parent** (keyed by file so namespace inheritance can't desync it; single-parent only, ambiguous multi-parent omitted).
- **`discovery.go`** — wires that emitter into `ParentOf`, gating the base exactly like the `spec.path`-prefix gate, so it reconciles the parent's substituted emission.
- **`emit.go`** — a KS's self-emission no longer overwrites its own store object, so the parent-injected `postBuild` survives.

The base KS stays in the scheduler (**gated, not suppressed**), so a failed parent surfaces it as `blocked` and changed-only mode stays loud rather than emitting silent wrong output.

## Tests

- `cross_tree_base_test.go` — end-to-end (no-`dependsOn` root + dependent both resolve to `./apps/test/app-X`).
- `EmissionParentByFile` (single-parent recorded, multi-parent omitted) and the discovery gate + self-emit-exclusion unit tests.

Repro resolves all five `app-X` deterministically (10 CLI + 15× test runs); full suite (45 pkgs) + vet + gofmt + golangci-lint v2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)