### PR TITLE
fix(orchestrator): orphan unreferenced base Kustomizations

### DIFF
--- a/pkg/loader/kustomization.go
+++ b/pkg/loader/kustomization.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -218,4 +219,27 @@ func resolvePath(base, rel string) (string, bool) {
 // caller after stat), so this is the dir-descent path only.
 func resolveResourcePath(base, rel string) (string, bool) {
 	return resolvePath(base, rel)
+}
+
+// IsUnreferencedKustomizeResource reports whether the repo-relative file sits in
+// a directory whose kustomization.yaml does NOT list it as a resource — a stray
+// manifest a kustomize base deliberately excludes, so kustomize (and Flux) never
+// apply it. Orphan detection uses this to demote such a stray Flux Kustomization
+// to a warning instead of hard-failing a file that isn't wired into the tree
+// (the apps/base/app-X/ks.yaml-not-in-kustomization.yaml shape, #777). A
+// directory with no kustomization file returns false: there the manifest is a
+// loose top-level entry, not an excluded base resource.
+func IsUnreferencedKustomizeResource(repoRoot, file string) bool {
+	file = filepath.ToSlash(file)
+	dir := path.Dir(file)
+	d, ok := readKustomizeDirectives(repoRoot, dir)
+	if !ok {
+		return false
+	}
+	for _, r := range d.Resources {
+		if resolved, ok := resolveResourcePath(dir, r); ok && filepath.ToSlash(resolved) == file {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/loader/kustomization_test.go
+++ b/pkg/loader/kustomization_test.go
@@ -1,6 +1,10 @@
 package loader
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+)
 
 // TestResolveDataPath covers generator-file path resolution. Rows:
 //   - in-tree relative path resolves to its absolute equivalent;
@@ -65,6 +69,36 @@ func TestResolveResourcePath(t *testing.T) {
 			}
 			if ok && abs != tc.wantAbs {
 				t.Errorf("resolveResourcePath(%q, %q) = %q, want %q", tc.base, tc.rel, abs, tc.wantAbs)
+			}
+		})
+	}
+}
+
+// TestIsUnreferencedKustomizeResource pins the #777 orphan signal: a manifest is
+// "unreferenced" only when its own directory's kustomization.yaml exists and does
+// not list it. A listed file, or a directory with no kustomization at all (a
+// loose top-level entry), is not.
+func TestIsUnreferencedKustomizeResource(t *testing.T) {
+	dir := t.TempDir()
+	// excluded/ — kustomization references only cm.yaml; ks.yaml is a stray file.
+	testutil.WriteFile(t, dir, "excluded/kustomization.yaml", "resources:\n  - cm.yaml\n")
+	// referenced/ — kustomization references ks.yaml.
+	testutil.WriteFile(t, dir, "referenced/kustomization.yaml", "resources:\n  - ks.yaml\n  - cm.yaml\n")
+	// loose/ — a KS file with no kustomization.yaml beside it.
+
+	cases := []struct {
+		name string
+		file string
+		want bool
+	}{
+		{"excluded by own kustomization", "excluded/ks.yaml", true},
+		{"referenced by own kustomization", "referenced/ks.yaml", false},
+		{"no kustomization in dir", "loose/ks.yaml", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsUnreferencedKustomizeResource(dir, tc.file); got != tc.want {
+				t.Errorf("IsUnreferencedKustomizeResource(%q) = %v, want %v", tc.file, got, tc.want)
 			}
 		})
 	}

--- a/pkg/orchestrator/finalize.go
+++ b/pkg/orchestrator/finalize.go
@@ -52,6 +52,13 @@ func (o *Orchestrator) detectOrphans(failed map[manifest.NamedResource]store.Sta
 		}
 		parent, ok := loader.LongestParent(prefixes, file, id)
 		if !ok {
+			// No covering spec.path parent. A Flux KS that is a stray manifest its
+			// own kustomize base excludes (apps/base/app-X/ks.yaml not listed in the
+			// dir's kustomization.yaml) is one real Flux never applies — demote it
+			// rather than hard-failing a file that isn't wired into any tree (#777).
+			if loader.IsUnreferencedKustomizeResource(o.repoRoot, file) {
+				out[id] = info.Message
+			}
 			continue
 		}
 		// A covering parent that itself FAILED emitted nothing, so every child

--- a/pkg/orchestrator/orphan_unreferenced_test.go
+++ b/pkg/orchestrator/orphan_unreferenced_test.go
@@ -1,0 +1,92 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+)
+
+// TestOrchestrator_UnreferencedBaseKSOrphaned covers the committed form of the
+// #777 repro: apps/base/app-X/ks.yaml exists on disk but the base's
+// kustomization.yaml references only cm.yaml, so cluster-apps (and real Flux)
+// emit just the ConfigMaps and never apply the app KSes. flate's file walk still
+// loads the stray ks.yaml files; pre-fix it reconciled them standalone and
+// hard-failed the ${CLUSTER_ENV} path.
+//
+// Since real Flux would never apply an unreferenced base manifest, flate demotes
+// it to an orphan warning instead of a failure — both the no-dependsOn root and
+// its cascade dependent. The workload ConfigMaps still render.
+func TestOrchestrator_UnreferencedBaseKSOrphaned(t *testing.T) {
+	dir := t.TempDir()
+
+	testutil.WriteFile(t, dir, "cluster/flux-system.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cluster-apps
+  namespace: flux-system
+spec:
+  path: ./apps/test
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/test/kustomization.yaml", "resources:\n  - ./app-a\n  - ./app-b\n")
+	testutil.WriteFile(t, dir, "apps/test/app-a/kustomization.yaml", "resources:\n  - ../../base/app-a\n")
+	testutil.WriteFile(t, dir, "apps/test/app-b/kustomization.yaml", "resources:\n  - ../../base/app-b\n")
+
+	// Base kustomizations reference ONLY cm.yaml — ks.yaml is a stray file the
+	// base excludes, so nothing applies the app KSes.
+	for _, app := range []string{"app-a", "app-b"} {
+		testutil.WriteFile(t, dir, "apps/base/"+app+"/kustomization.yaml", "resources:\n  - cm.yaml\n")
+		testutil.WriteFile(t, dir, "apps/base/"+app+"/cm.yaml", "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: "+app+"-cm\n  namespace: flux-system\n")
+	}
+	testutil.WriteFile(t, dir, "apps/base/app-a/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-a
+  namespace: flux-system
+spec:
+  path: ./apps/${CLUSTER_ENV}/app-a
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+	testutil.WriteFile(t, dir, "apps/base/app-b/ks.yaml", `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app-b
+  namespace: flux-system
+spec:
+  path: ./apps/${CLUSTER_ENV}/app-b
+  dependsOn:
+    - name: app-a
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+`)
+
+	o, err := New(Config{Path: dir, WipeSecrets: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res, err := o.Render(context.Background())
+	if err != nil {
+		t.Fatalf("Render returned a failure error for unreferenced base KSes: %v", err)
+	}
+
+	for _, name := range []string{"app-a", "app-b"} {
+		id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+		if info, failed := res.Failed[id]; failed {
+			t.Errorf("%s hard-failed, want orphaned: %s", name, info.Message)
+		}
+		if _, orphaned := res.Orphans[id]; !orphaned {
+			t.Errorf("%s not orphaned; want it demoted (unreferenced base manifest)", name)
+		}
+	}
+	// The referenced workload ConfigMap is still applied.
+	if o.store.GetObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "app-a-cm"}) == nil {
+		t.Error("app-a-cm ConfigMap missing; the referenced base resource should still render")
+	}
+}


### PR DESCRIPTION
Follow-up to #779 for [#777](https://github.com/home-operations/flate/issues/777). The committed repro at https://github.com/fhoekstra/fluxcd-example-path-subst still failed, because it's a **different case** than #779 fixed.

## Diagnosis

The repro's base kustomizations reference only `cm.yaml`, **not** `ks.yaml`:
```
apps/base/app-a/kustomization.yaml → resources: [cm.yaml]   # ks.yaml NOT listed
```
So `cluster-apps` (and real Flux) emit only the 5 ConfigMaps — `flate build all` confirms zero `app-X` Kustomizations. The `app-X/ks.yaml` files are unreferenced; real Flux never creates them. But flate's file walk still loaded them and reconciled them standalone, hard-failing the two no-`dependsOn` roots on the unresolved `./apps/${CLUSTER_ENV}/app-X` path.

(#779 only engages when the parent *emits* the KS, i.e. `ks.yaml` *is* referenced — verified that form resolves all 5. This is the committed `cm.yaml`-only form.)

## Fix

A Flux KS that is a manifest its own kustomize base **excludes** (not listed in the directory's `kustomization.yaml`) is one real Flux would never apply. `detectOrphans` now demotes such a stray, un-parented, un-emitted KS to an **orphan warning** instead of a hard failure — both the root and its cascade dependents. The referenced workload ConfigMaps still render.

New `loader.IsUnreferencedKustomizeResource` reuses the existing `readKustomizeDirectives` + `resolveResourcePath`; only fires after the existing `rendered.has` (emitted) and spec.path-parent checks, so a genuinely-applied-but-failing KS is never silently orphaned.

## Verification

On the **actual committed repro**: exit 0, all five `app-X` orphaned (warnings, not failures), the 5 ConfigMaps render. Full suite (45 pkgs) + vet + gofmt + golangci-lint v2 clean. Regression tests at the orchestrator (committed-repro shape) and loader (`IsUnreferencedKustomizeResource`) levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)