### PR TITLE
fix(emit): default namespace-less rendered children to the emitting parent

### DIFF
--- a/pkg/controllers/emit/emit.go
+++ b/pkg/controllers/emit/emit.go
@@ -67,6 +67,16 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 		reconcilable bool
 		leaf         bool // held for pass 2 (Kustomization / HelmRelease)
 	}
+	// Default namespace-less rendered objects to the emitting parent's namespace,
+	// like kustomize-controller does on apply — otherwise a child that omits
+	// metadata.namespace (e.g. an OCIRepository with just a name) is emitted
+	// unnamespaced and never dedups against its namespace-inherited file-loaded
+	// copy, leaving the unsubstituted copy to be validated. A KS's render already
+	// applied spec.targetNamespace, so a doc is only namespace-less here when the
+	// KS sets none, where id.Namespace matches loader.ApplyNamespaceInheritance.
+	// StampNamespaces skips cluster-scoped kinds and preserves explicit
+	// namespaces, so it is a no-op once a namespace is set.
+	manifest.StampNamespaces(docs, id.Namespace)
 	opts := manifest.ParseDocOptions{WipeSecrets: wipeSecrets}
 	// Log under the invoking controller's identity plus component=emit, so a
 	// "skipped doc" line names both the controller whose render produced the

--- a/pkg/controllers/emit/emit_test.go
+++ b/pkg/controllers/emit/emit_test.go
@@ -3,7 +3,10 @@ package emit
 import (
 	"testing"
 
+	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
+	"github.com/home-operations/flate/pkg/task"
 )
 
 // TestShouldDispatchAsObject_KnownKinds documents which kinds the
@@ -104,5 +107,39 @@ func TestPass1Pass2Categories(t *testing.T) {
 		if IsLeafReconcilable(k) && !ShouldDispatchAsObject(k) {
 			t.Errorf("%T is a leaf reconcilable but not dispatch-as-object", k)
 		}
+	}
+}
+
+// TestChildren_DefaultsNamespace pins the fix for the unsubstituted-OCIRepository
+// bug: a namespace-less rendered child must inherit the emitting parent's
+// namespace, so it dedups against its namespace-inherited file-loaded copy
+// instead of lingering at empty namespace. An explicit namespace is preserved.
+func TestChildren_DefaultsNamespace(t *testing.T) {
+	s := store.New()
+	c := base.New(s, task.NewBounded(1), "test")
+	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "infra"}
+
+	Children(c, true, parent, []map[string]any{
+		{
+			"apiVersion": "source.toolkit.fluxcd.io/v1",
+			"kind":       "OCIRepository",
+			"metadata":   map[string]any{"name": "certmanager"},
+			"spec":       map[string]any{"url": "oci://quay.io/c", "provider": "generic"},
+		},
+		{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "cm", "namespace": "other"},
+		},
+	}, true)
+
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "certmanager"}) == nil {
+		t.Error("namespace-less OCIRepository was not defaulted to the parent namespace flux-system")
+	}
+	if obj := s.GetObject(manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "", Name: "certmanager"}); obj != nil {
+		t.Errorf("empty-namespace OCIRepository phantom present: %v", obj.Named())
+	}
+	if s.GetObject(manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "other", Name: "cm"}) == nil {
+		t.Error("explicit namespace not preserved for ConfigMap other/cm")
 	}
 }


### PR DESCRIPTION
## Problem

`flate test all` validated a generated `OCIRepository` with the raw `${OCI_REGISTRY_PROVIDER}` instead of the substituted value, failing the provider gate — even though the owning Kustomization and sibling HelmRelease substituted correctly.

A Kustomization with `postBuild.substituteFrom` that emits a child omitting `metadata.namespace` (e.g. `OCIRepository` with just a `name:`) produced **two** store objects:
- the **file-loaded** copy — inherited the KS namespace (`flux-system`) via `loader.ApplyNamespaceInheritanceWithRefs`, but stayed **unsubstituted**;
- the **render-emitted** copy — substituted, but at **empty** namespace.

Different ids ⇒ the substituted emission never overwrote the raw copy, so both were validated and the raw one hit the provider gate (`pkg/source/oci/fetcher.go`).

## Fix

The HelmRelease controller (`controller.go:316`) and the ResourceSet render (`resourceset/render.go:112`) already stamp their output namespaces; the **Kustomization path didn't**. Both KS and RS route through the shared `emit.Children`, so stamp there once:

```go
manifest.StampNamespaces(docs, id.Namespace)
```

The Kustomization is fixed for free — the change lives entirely in the shared emit helper, reusing the existing tested `manifest.StampNamespaces` (which skips cluster-scoped kinds and preserves explicit namespaces, so it's a no-op once a namespace is set).

`id.Namespace` is correct because the KS render already merges `spec.targetNamespace` into the kustomize build (`kustomize/flux.go` → `generate.go`), so a doc is only namespace-less when the KS sets no `targetNamespace` — exactly where `id.Namespace` (= `ks.Namespace`) matches the file-load inheritance and the two dedup. (RS has no `targetNamespace`, so `id.Namespace` = `rs.Namespace`; its render-level stamp is kept as a no-op since it's a documented `resourceset.Render` contract.)

## Verification

- Repro: a namespace-less `OCIRepository` under a `postBuild` KS now yields **one** `flux-system/<name>` object, substituted (provider `generic`) — past the gate to a real fetch; no empty-namespace duplicate.
- `TestChildren_DefaultsNamespace` (network-free) pins the behavior.
- `TestOrchestrator_TransformerTargetNamespace` and `TestRender_DefaultsNamespace` still pass; full suite (45 pkgs) + vet + gofmt + golangci-lint v2 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)