### PR TITLE
fix(source): resolve relative HelmRepository chart URLs against repo base

### DIFF
--- a/pkg/source/helmchart/http.go
+++ b/pkg/source/helmchart/http.go
@@ -206,6 +206,10 @@ func normalizeChartDigest(digest string) string {
 
 // absChartURL resolves urlStr against base — HelmRepository index entries
 // often carry relative URLs which need joining against the repo's spec.url.
+// A trailing slash is forced on the base path so ResolveReference (RFC 3986)
+// treats spec.url as the index's base directory rather than a file: without it
+// `https://host/charts` + `emqx-5.8.9.tgz` would drop the `/charts` segment and
+// 404. Matches Helm's repo.ResolveReferenceURL and Flux source-controller.
 func absChartURL(base, urlStr string) (string, error) {
 	u, err := url.Parse(urlStr)
 	if err != nil {
@@ -218,6 +222,7 @@ func absChartURL(base, urlStr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	baseURL.Path = strings.TrimSuffix(baseURL.Path, "/") + "/"
 	return baseURL.ResolveReference(u).String(), nil
 }
 

--- a/pkg/source/helmchart/http_test.go
+++ b/pkg/source/helmchart/http_test.go
@@ -173,6 +173,64 @@ entries:
 `, digestLine)
 }
 
+// startHelmRepoSubpath serves the index.yaml and chart .tgz under a non-root
+// path prefix (e.g. /charts), mirroring real repos like https://repos.emqx.io/charts
+// and https://helm.ngc.nvidia.com/nvidia whose index entries carry RELATIVE urls.
+// A relative url must resolve against the repo's base directory, so the prefix
+// must be preserved — anything served at host root 404s.
+func startHelmRepoSubpath(t *testing.T, prefix string, chartBytes []byte, indexDigest string) (*httptest.Server, *int) {
+	t.Helper()
+	hits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc(prefix+"/index.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(helmRepoIndex(indexDigest)))
+	})
+	mux.HandleFunc(prefix+"/app-template-1.0.0.tgz", func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(chartBytes)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// TestFetchHTTPChart_SubpathRelativeURL reproduces issue #796: a HelmRepository
+// whose index lives under a path prefix (.../charts) and lists relative chart
+// urls. Without a trailing slash on spec.url, a naive ResolveReference drops the
+// last path segment and fetches from host root (404). Helm and Flux force a
+// trailing slash before resolving; flate must match.
+func TestFetchHTTPChart_SubpathRelativeURL(t *testing.T) {
+	chartBytes := buildChartTarGz(t, "app-template", "1.0.0")
+
+	t.Run("no trailing slash", func(t *testing.T) {
+		srv, hits := startHelmRepoSubpath(t, "/charts", chartBytes, chartDigest(chartBytes))
+		f := newHTTPFetcher(t, httpRepo(srv.URL+"/charts"))
+		art, err := f.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0"))
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if *hits != 1 {
+			t.Errorf("chart fetched %d times from subpath, want 1 (url resolved against host root?)", *hits)
+		}
+		if _, err := os.Stat(filepath.Join(art.LocalPath, "chart.tgz")); err != nil {
+			t.Errorf("chart.tgz not at LocalPath %s: %v", art.LocalPath, err)
+		}
+	})
+
+	t.Run("trailing slash", func(t *testing.T) {
+		srv, hits := startHelmRepoSubpath(t, "/charts", chartBytes, chartDigest(chartBytes))
+		f := newHTTPFetcher(t, httpRepo(srv.URL+"/charts/"))
+		if _, err := f.Fetch(context.Background(), helmChart("repo", "app-template", "1.0.0")); err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if *hits != 1 {
+			t.Errorf("chart fetched %d times from subpath, want 1", *hits)
+		}
+	})
+}
+
 func chartDigest(b []byte) string {
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])


### PR DESCRIPTION
## Summary

Fixes #796. A `HelmRepository` `index.yaml` may list chart `urls` as **relative** paths, which per the [Helm chart-repository spec](https://helm.sh/docs/topics/chart_repository/) resolve against the repository's base directory (where the index is served from).

`absChartURL` called `ResolveReference` on `spec.url` directly. Per RFC 3986, when the base has a path but **no trailing slash** (e.g. `https://repos.emqx.io/charts`, `https://helm.ngc.nvidia.com/nvidia`), the last segment is treated as a *file* and dropped — so the chart was fetched from the host root and 404'd:

- `https://repos.emqx.io/charts` + `emqx-5.8.9.tgz` → `https://repos.emqx.io/emqx-5.8.9.tgz` (404)

## Fix

Force a trailing slash on the base path before resolving, matching Helm's `repo.ResolveReferenceURL` and Flux source-controller. `spec.url` now works **with or without** a trailing slash; absolute index `urls` still pass through verbatim.

Only `Path` is set (not `RawPath`) — Go's `url.URL.EscapedPath()` rejects a stale `RawPath` that no longer round-trips to `Path`, so this is correct for escaped paths too, mirroring Flux source-controller exactly.

## Tests

Added `TestFetchHTTPChart_SubpathRelativeURL`, which serves an index under a `/charts` prefix with relative chart `urls`. Existing tests never caught this because the mock served from the host root (empty path, no segment to drop).

Against the unmodified code:
```
no_trailing_slash → FAIL: download .../app-template-1.0.0.tgz: 404 Not Found
trailing_slash    → PASS
```
After the fix both pass; full helmchart suite, `go vet`, `gofmt`, and `golangci-lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)