### PR TITLE
fix(cli): stop terminal capability probes leaking into the shell

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -578,8 +578,15 @@ func runOrchestratorCfg(ctx context.Context, cfg orchestrator.Config, pre ...fun
 	// then finishMsg clears the frame and the program is detached from slog
 	// before Render's callers print anything.
 	if barSink != nil {
+		// With no input attached, Bubble Tea's startup terminal queries would
+		// get answered into the shell's input buffer; queryFilterFile strips
+		// them (progressBarEnabled guarantees out is a TTY *os.File).
+		out := barSink.out
+		if f, ok := out.(*os.File); ok {
+			out = &queryFilterFile{File: f}
+		}
 		p := tea.NewProgram(newBarModel(barSink.color),
-			tea.WithOutput(barSink.out),
+			tea.WithOutput(out),
 			tea.WithInput(nil),         // output-only: never capture the keyboard
 			tea.WithoutSignalHandler(), // the CLI context owns Ctrl-C, not the bar
 		)

--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"io"
 	"os"
 	"strings"
 	"sync"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/home-operations/flate/internal/style"
 )
@@ -55,6 +57,42 @@ func (w *barWriter) Write(p []byte) (int, error) {
 		return len(p), nil
 	}
 	return w.out.Write(p)
+}
+
+// terminalQueries are the capability probes Bubble Tea writes at program start
+// (DECRQM for synchronized output / unicode core). The bar runs with
+// WithInput(nil), so the terminal's replies are never consumed — they would sit
+// in the tty input buffer and spill into the shell's next prompt. Stripping the
+// probes keeps the program truly output-only; the renderer simply never enables
+// those modes, which is the same behavior as a terminal that doesn't reply.
+var terminalQueries = [][]byte{
+	[]byte(ansi.RequestModeSynchronizedOutput),
+	[]byte(ansi.RequestModeUnicodeCore),
+}
+
+// queryFilterFile wraps the bar's stderr TTY and drops terminalQueries from
+// everything written through it. It stays a term.File (embedded *os.File) so
+// Bubble Tea still recognizes the output as a terminal for sizing and state
+// restore; only Write is intercepted. Program.execute buffers each probe pair
+// in one call and flush writes the whole buffer in one Write, so a sequence is
+// never split across calls.
+type queryFilterFile struct {
+	*os.File
+}
+
+func (f *queryFilterFile) Write(p []byte) (int, error) {
+	filtered := p
+	for _, q := range terminalQueries {
+		if bytes.Contains(filtered, q) {
+			filtered = bytes.ReplaceAll(filtered, q, nil)
+		}
+	}
+	if len(filtered) > 0 {
+		if _, err := f.File.Write(filtered); err != nil {
+			return 0, err
+		}
+	}
+	return len(p), nil
 }
 
 // captureStderr redirects the process os.Stderr to a pipe and delivers each

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -52,6 +52,42 @@ func TestBarWriter_NoProgramWritesThrough(t *testing.T) {
 	}
 }
 
+// TestQueryFilterFile: the bar's output wrapper strips Bubble Tea's startup
+// terminal probes (mode 2026/2027 DECRQM) — whose replies nothing reads, since
+// the program runs input-less — while passing every other byte through and
+// reporting the full input length as written.
+func TestQueryFilterFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	w := &queryFilterFile{File: f}
+
+	in := []byte("\x1b[?2026$p\x1b[?2027$pframe \x1b[?2026h+content")
+	n, err := w.Write(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(in) {
+		t.Errorf("Write returned n=%d, want full length %d", n, len(in))
+	}
+	// A flush that is nothing but probes writes no bytes at all.
+	if _, err := w.Write([]byte("\x1b[?2026$p")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The set-mode sequence (2026h) and frame text survive; only the $p
+	// probes are dropped.
+	if want := "frame \x1b[?2026h+content"; string(got) != want {
+		t.Errorf("filtered output = %q, want %q", got, want)
+	}
+}
+
 // TestWriterIsTTY_NonFile: buffers (the e2e harness, pipes-as-buffers) are
 // never TTYs, so the bar stays off without a flag.
 func TestWriterIsTTY_NonFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #813.

When the live status bar is active, Bubble Tea v2 writes DECRQM capability probes for synchronized output / unicode core (`ESC[?2026$p` + `ESC[?2027$p`) to the terminal at program startup (`tea.go` in v2.0.8, gated on `shouldQuerySynchronizedOutput`). The bar deliberately runs with `tea.WithInput(nil)` so it never captures the keyboard — which also means nothing ever reads the terminal's replies. On terminals that answer the probes (Ghostty, Alacritty, WezTerm, kitty, Windows Terminal, most `TERM_PROGRAM` terminals except Apple Terminal), the replies sit in the tty input buffer and spill into the shell's next prompt as `2026;2$y2027;1$y` garbage. That matches every report on the issue, including why `--no-progress` avoids it and Apple Terminal doesn't show it.

v2.0.8 (latest) has no program option to suppress the probes, so this filters them out of the bar's output stream instead: `queryFilterFile` wraps the stderr TTY and drops the two probe sequences while passing everything else through. It embeds the `*os.File` and overrides only `Write`, so it still satisfies `term.File` — window sizing, terminal state restore, and color profile detection are unaffected. The renderer simply never enables those modes, which is identical to running on a terminal that doesn't reply.

Each probe pair is written contiguously in a single flush (`Program.execute` buffers the pair in one call; `flush` writes the whole buffer in one `Write`), so a per-Write scan cannot split a sequence.

## Verification

- New unit test `TestQueryFilterFile` covers stripping, passthrough of adjacent bytes (including the legitimate `ESC[?2026h` set-mode sequence), and the `io.Writer` length contract.
- A/B under a real pty (`script` with `TERM=xterm-ghostty`, `flate test all --path testdata/simple`): the unpatched binary emits `ESC[?2026$p` to the terminal, the patched one does not, with byte-identical rendering otherwise (colors, frame, summary).
- `go test ./...` and `golangci-lint run` are clean.

Arguably an upstream bug too — querying with `input == nil` can never work — but this keeps flate correct on current bubbletea.