### PR TITLE
fix(values): honor literal valuesFrom target paths

### DIFF
--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -521,6 +521,12 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 		// Only reached when share==false (the caller sets share false the
 		// moment any ref carries a TargetPath), so `values` is owned and
 		// the in-place strvals write below is safe.
+		if ref.Literal {
+			if err := strvals.ParseLiteralInto(ref.TargetPath+"="+found, values); err != nil {
+				return values, fmt.Errorf("targetPath %q: %w", ref.TargetPath, err)
+			}
+			return values, nil
+		}
 		_, err := replaceValueAtPath(values, ref.TargetPath, found)
 		return values, err
 	}

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -498,7 +498,9 @@ func bagValueAsString(v any) (string, error) {
 // validation against `replicaCount: integer` and similar. The targetPath
 // path bypasses the cache — strvals parsing already mutates values in
 // place per-call and is comparatively cheap (no map allocation for the
-// parsed tree).
+// parsed tree). A ref with `literal: true` skips all of that syntax and
+// lands the value verbatim as a string (`helm --set-literal` semantics,
+// via replaceLiteralValueAtPath).
 //
 // Otherwise the found YAML is parsed (memoized in cache when non-nil, keyed
 // by kind, namespace, name, valuesKey, content-hash) and deep-merged.
@@ -522,10 +524,8 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 		// moment any ref carries a TargetPath), so `values` is owned and
 		// the in-place strvals write below is safe.
 		if ref.Literal {
-			if err := strvals.ParseLiteralInto(ref.TargetPath+"="+found, values); err != nil {
-				return values, fmt.Errorf("targetPath %q: %w", ref.TargetPath, err)
-			}
-			return values, nil
+			_, err := replaceLiteralValueAtPath(values, ref.TargetPath, found)
+			return values, err
 		}
 		_, err := replaceValueAtPath(values, ref.TargetPath, found)
 		return values, err
@@ -579,6 +579,30 @@ func replaceValueAtPath(values map[string]any, path, value string) (map[string]a
 		err = strvals.ParseInto(path+"="+value, values)
 	}
 	if err != nil {
+		return nil, fmt.Errorf("targetPath %q: %w", path, err)
+	}
+	return values, nil
+}
+
+// replaceLiteralValueAtPath writes value verbatim at the dot-notation path,
+// mirroring upstream Flux's chartutil.ReplacePathLiteralValue. Flux does not
+// use helm's strvals.ParseLiteralInto here: that parser has no backslash
+// escape support in the path, which would break `\.` targetPath segments
+// (e.g. `annotations.prometheus\.io/scrape`). Instead the value has its
+// strvals metacharacters pre-escaped and goes through ParseIntoString, which
+// keeps escape-aware path parsing while the value round-trips verbatim.
+func replaceLiteralValueAtPath(values map[string]any, path, value string) (map[string]any, error) {
+	// Backslash must be escaped first so the escapes added for the other
+	// metacharacters aren't themselves re-escaped.
+	escaper := strings.NewReplacer(
+		`\`, `\\`,
+		`,`, `\,`,
+		`[`, `\[`,
+		`]`, `\]`,
+		`{`, `\{`,
+		`}`, `\}`,
+	)
+	if err := strvals.ParseIntoString(path+"="+escaper.Replace(value), values); err != nil {
 		return nil, fmt.Errorf("targetPath %q: %w", path, err)
 	}
 	return values, nil

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -236,6 +236,37 @@ func TestExpandValueReferences_TargetPath(t *testing.T) {
 	}
 }
 
+func TestExpandValueReferences_LiteralTargetPath(t *testing.T) {
+config := `concurrent = 4
+environment = ["FOO=bar", "BAZ=qux"]
+`
+	cm := &manifest.ConfigMap{
+		Name: "runner", Namespace: "default",
+		Data: map[string]any{"config.toml": config},
+	}
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{
+					Kind:       "ConfigMap",
+					Name:       "runner",
+					ValuesKey:  "config.toml",
+					TargetPath: "runners.config",
+					Literal:    true,
+				},
+			},
+		},
+	}
+	if err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}, nil); err != nil {
+		t.Fatalf("ExpandValueReferences: %v", err)
+	}
+	runners := hr.Values["runners"].(map[string]any)
+	if runners["config"] != config {
+		t.Errorf("config: %q, want %q", runners["config"], config)
+	}
+}
+
 func TestExpandValueReferences_MissingOptionalTargetPath(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -237,7 +237,7 @@ func TestExpandValueReferences_TargetPath(t *testing.T) {
 }
 
 func TestExpandValueReferences_LiteralTargetPath(t *testing.T) {
-config := `concurrent = 4
+	config := `concurrent = 4
 environment = ["FOO=bar", "BAZ=qux"]
 `
 	cm := &manifest.ConfigMap{
@@ -264,6 +264,39 @@ environment = ["FOO=bar", "BAZ=qux"]
 	runners := hr.Values["runners"].(map[string]any)
 	if runners["config"] != config {
 		t.Errorf("config: %q, want %q", runners["config"], config)
+	}
+}
+
+// TestExpandValueReferences_LiteralTargetPathEscapedDot pins the Flux
+// chartutil.ReplacePathLiteralValue contract that a literal ref keeps `\.`
+// escape support in the targetPath (helm's own --set-literal parser does
+// not): the escaped segment stays one key, and the value — commas and all —
+// lands verbatim.
+func TestExpandValueReferences_LiteralTargetPathEscapedDot(t *testing.T) {
+	cm := &manifest.ConfigMap{
+		Name: "scrape", Namespace: "default",
+		Data: map[string]any{"value": "true,false"},
+	}
+	hr := &manifest.HelmRelease{
+		Name: "demo", Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{
+					Kind:       "ConfigMap",
+					Name:       "scrape",
+					ValuesKey:  "value",
+					TargetPath: `annotations.prometheus\.io/scrape`,
+					Literal:    true,
+				},
+			},
+		},
+	}
+	if err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}, nil); err != nil {
+		t.Fatalf("ExpandValueReferences: %v", err)
+	}
+	annotations := hr.Values["annotations"].(map[string]any)
+	if got := annotations["prometheus.io/scrape"]; got != "true,false" {
+		t.Errorf(`annotations = %#v, want key "prometheus.io/scrape" = "true,false"`, annotations)
 	}
 }
 


### PR DESCRIPTION
## Overview

Honor `ValuesReference.literal` when a HelmRelease inserts a referenced value through `targetPath`.

Without this, Flate parses the value as Helm `--set` syntax and can truncate content containing commas. Using `ParseLiteralInto` matches `helm --set-literal` and preserves arbitrary configuration content. A regression test covers GitLab Runner TOML containing commas and equals signs.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with investigating the issue