### PR TITLE
fix(cli): strip the Kitty keyboard probe from progress output

### DIFF
--- a/internal/cli/progress.go
+++ b/internal/cli/progress.go
@@ -60,7 +60,8 @@ func (w *barWriter) Write(p []byte) (int, error) {
 }
 
 // terminalQueries are the capability probes Bubble Tea writes at program start
-// (DECRQM for synchronized output / unicode core). The bar runs with
+// (DECRQM for synchronized output / unicode core, and the renderer's Kitty
+// keyboard protocol query on the first frame). The bar runs with
 // WithInput(nil), so the terminal's replies are never consumed — they would sit
 // in the tty input buffer and spill into the shell's next prompt. Stripping the
 // probes keeps the program truly output-only; the renderer simply never enables
@@ -68,14 +69,16 @@ func (w *barWriter) Write(p []byte) (int, error) {
 var terminalQueries = [][]byte{
 	[]byte(ansi.RequestModeSynchronizedOutput),
 	[]byte(ansi.RequestModeUnicodeCore),
+	[]byte(ansi.RequestKittyKeyboard),
 }
 
 // queryFilterFile wraps the bar's stderr TTY and drops terminalQueries from
 // everything written through it. It stays a term.File (embedded *os.File) so
 // Bubble Tea still recognizes the output as a terminal for sizing and state
-// restore; only Write is intercepted. Program.execute buffers each probe pair
-// in one call and flush writes the whole buffer in one Write, so a sequence is
-// never split across calls.
+// restore; only Write is intercepted. Both probe paths reach Write whole:
+// Program.execute buffers each probe pair in one call, and the renderer's
+// frame flush writes its entire buffer in one Write, so a sequence is never
+// split across calls.
 type queryFilterFile struct {
 	*os.File
 }

--- a/internal/cli/progress_test.go
+++ b/internal/cli/progress_test.go
@@ -53,9 +53,10 @@ func TestBarWriter_NoProgramWritesThrough(t *testing.T) {
 }
 
 // TestQueryFilterFile: the bar's output wrapper strips Bubble Tea's startup
-// terminal probes (mode 2026/2027 DECRQM) — whose replies nothing reads, since
-// the program runs input-less — while passing every other byte through and
-// reporting the full input length as written.
+// terminal probes (mode 2026/2027 DECRQM and the renderer's Kitty keyboard
+// query) — whose replies nothing reads, since the program runs input-less —
+// while passing every other byte through and reporting the full input length
+// as written.
 func TestQueryFilterFile(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "bar")
 	if err != nil {
@@ -64,7 +65,9 @@ func TestQueryFilterFile(t *testing.T) {
 	defer f.Close()
 	w := &queryFilterFile{File: f}
 
-	in := []byte("\x1b[?2026$p\x1b[?2027$pframe \x1b[?2026h+content")
+	// The Kitty *set* sequence (\x1b[=0;1u) rides in the same frame flush as
+	// the query (\x1b[?u) and must survive the strip.
+	in := []byte("\x1b[?2026$p\x1b[?2027$pframe \x1b[?2026h\x1b[=0;1u\x1b[?u+content")
 	n, err := w.Write(in)
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +76,7 @@ func TestQueryFilterFile(t *testing.T) {
 		t.Errorf("Write returned n=%d, want full length %d", n, len(in))
 	}
 	// A flush that is nothing but probes writes no bytes at all.
-	if _, err := w.Write([]byte("\x1b[?2026$p")); err != nil {
+	if _, err := w.Write([]byte("\x1b[?2026$p\x1b[?u")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -81,9 +84,9 @@ func TestQueryFilterFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The set-mode sequence (2026h) and frame text survive; only the $p
-	// probes are dropped.
-	if want := "frame \x1b[?2026h+content"; string(got) != want {
+	// The set sequences (2026h, =0;1u) and frame text survive; only the
+	// query probes are dropped.
+	if want := "frame \x1b[?2026h\x1b[=0;1u+content"; string(got) != want {
 		t.Errorf("filtered output = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Follow-up to #840; fixes the remaining leak in #813.

#840 stripped the two DECRQM probes (modes 2026/2027) that `Program.execute` sends at startup, but Bubble Tea v2 emits one more reply-generating probe on a different path: the renderer writes the Kitty keyboard protocol query (`CSI ? u`, `ansi.RequestKittyKeyboard`) into the first live frame flush. The bar runs with `WithInput(nil)`, so on terminals that implement the protocol (Ghostty, Kitty) the reply (`CSI ? 1 u`) sits unread in the tty input buffer and spills onto the shell's next prompt as `1u` - exactly what was reported after 0.4.11. Terminals that don't implement the protocol stay silent, which is why macOS Terminal and others were unaffected.

This adds the query to the sequences `queryFilterFile` strips. The per-`Write` matching remains sound: the renderer flushes each frame buffer in a single `Write` (ultraviolet `TerminalRenderer.Flush`), so the sequence is never split across calls. The test now also covers the trap that stripping `CSI ? u` must not damage the Kitty *set* sequence (`CSI = 0 ; 1 u`) that rides in the same flush.

Verified under a real PTY with a 300-Kustomization synthetic fixture (quick runs only hit the closing flush, which skips the query - that's why small fixtures never reproduced it): before this change the binary emits `\x1b[?u` to the terminal, after it emits neither that nor the DECRQM probes. Scanned bubbletea v2.0.8 for other reply-generating sequences on the output-only path; clipboard, color, DA1, cursor-position, and XTVERSION queries only fire when the app explicitly requests them, which the bar never does.