### PR TITLE
fix(source): route OCI HelmRepository semver constraints to ref.SemVer

### DIFF
--- a/pkg/source/helmchart/fetcher.go
+++ b/pkg/source/helmchart/fetcher.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Masterminds/semver/v3"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/internal/keylock"
@@ -153,8 +154,11 @@ func isOCIHelmRepo(r *manifest.HelmRepository) bool {
 // exactly as for a real OCIRepository.
 //
 // The HelmRepository's auth / TLS / insecure / provider are lifted (it
-// carries no proxySecretRef). The resolved version becomes a digest ref
-// when it contains ':' else a tag, matching the OCIRepository path.
+// carries no proxySecretRef). The version is classified by versionToOCIRef:
+// a ':' is a digest, an exact semver pin or a non-semver literal stays a
+// tag, and a semver constraint becomes a SemVer ref so the OCI fetcher
+// resolves it to the highest matching published tag — matching the
+// OCIRepository path.
 func synthesizeOCIRepository(r *manifest.HelmRepository, chartName, version string) *manifest.OCIRepository {
 	chartURL := normalizeChartURL(r.URL, chartName)
 	syn := &manifest.OCIRepository{Namespace: r.Namespace}
@@ -162,18 +166,54 @@ func synthesizeOCIRepository(r *manifest.HelmRepository, chartName, version stri
 	syn.URL = chartURL
 	syn.Provider = r.Provider
 	if version != "" {
-		ref := &manifest.OCIRepositoryRef{}
-		if strings.Contains(version, ":") {
-			ref.Digest = version
-		} else {
-			ref.Tag = version
-		}
-		syn.Reference = ref
+		syn.Reference = versionToOCIRef(version)
 	}
 	syn.SecretRef = r.SecretRef
 	syn.CertSecretRef = r.CertSecretRef
 	syn.Insecure = r.Insecure
 	return syn
+}
+
+// versionToOCIRef classifies a HelmRelease chart version into an OCI
+// reference. A ':' means a digest. Otherwise a string that parses as a
+// concrete semver version is an exact pin kept as a literal tag; a string
+// that is not a concrete version but is a valid semver constraint (1.20.x,
+// *, ~, ^, ranges) is routed to SemVer so the OCI fetcher's semver resolver
+// selects the highest matching published tag; anything else is a non-semver
+// literal tag (e.g. "latest").
+//
+// The isExactSemver-before-isSemverConstraint ordering is load-bearing:
+// semver.NewConstraint("1.20.0") succeeds as "=1.20.0", so testing the
+// constraint first would misroute exact pins and bare partials (1.20, 1) to
+// SemVer. Peeling concrete versions off first is what separates a pin from a
+// constraint.
+func versionToOCIRef(version string) *manifest.OCIRepositoryRef {
+	ref := &manifest.OCIRepositoryRef{}
+	switch {
+	case strings.Contains(version, ":"):
+		ref.Digest = version
+	case isExactSemver(version):
+		ref.Tag = version
+	case isSemverConstraint(version):
+		ref.SemVer = version
+	default:
+		ref.Tag = version
+	}
+	return ref
+}
+
+// isExactSemver reports whether version parses as a single concrete semver
+// version (an exact pin), including coerced partials such as "1.20" and "1".
+func isExactSemver(version string) bool {
+	_, err := semver.NewVersion(version)
+	return err == nil
+}
+
+// isSemverConstraint reports whether version parses as a semver constraint
+// (wildcards, tilde/caret, ranges).
+func isSemverConstraint(version string) bool {
+	_, err := semver.NewConstraint(version)
+	return err == nil
 }
 
 // syntheticChartName derives the stable <helmrepo>-<chart>-<short hash>

--- a/pkg/source/helmchart/fetcher_test.go
+++ b/pkg/source/helmchart/fetcher_test.go
@@ -79,6 +79,10 @@ func TestSynthesizeOCIRepository(t *testing.T) {
 	if d := synthesizeOCIRepository(r, "kromgo", "sha256:abc"); d.Reference == nil || d.Reference.Digest != "sha256:abc" || d.Reference.Tag != "" {
 		t.Errorf("digest Reference = %+v", d.Reference)
 	}
+	// semver constraint → SemVer ref (routed through versionToOCIRef)
+	if c := synthesizeOCIRepository(r, "kromgo", "1.20.x"); c.Reference == nil || c.Reference.SemVer != "1.20.x" || c.Reference.Tag != "" || c.Reference.Digest != "" {
+		t.Errorf("constraint Reference = %+v, want SemVer 1.20.x", c.Reference)
+	}
 	// empty version → no ref
 	if v := synthesizeOCIRepository(r, "kromgo", ""); v.Reference != nil {
 		t.Errorf("empty version → Reference = %+v, want nil", v.Reference)
@@ -86,6 +90,47 @@ func TestSynthesizeOCIRepository(t *testing.T) {
 	// distinct versions → distinct stable names
 	if synthesizeOCIRepository(r, "kromgo", "1.0.0").Name == synthesizeOCIRepository(r, "kromgo", "2.0.0").Name {
 		t.Error("distinct versions collided on synthetic name")
+	}
+}
+
+func TestVersionToOCIRef(t *testing.T) {
+	cases := []struct {
+		name       string
+		version    string
+		wantTag    string
+		wantSemVer string
+		wantDigest string
+	}{
+		// Semver constraints route to SemVer (GC-847-R1).
+		{"wildcard x", "1.20.x", "", "1.20.x", ""},
+		{"wildcard X", "1.20.X", "", "1.20.X", ""},
+		{"star", "*", "", "*", ""},
+		{"tilde", "~1.20.0", "", "~1.20.0", ""},
+		{"caret", "^1.20.0", "", "^1.20.0", ""},
+		{"range", ">=1.20.0 <1.21.0", "", ">=1.20.0 <1.21.0", ""},
+		// Exact pins stay literal tags (GC-847-R2).
+		{"exact pin", "1.20.0", "1.20.0", "", ""},
+		{"v-prefixed pin", "v1.20.0", "v1.20.0", "", ""},
+		// Bare partials parse as concrete versions and must stay tags: the
+		// canary for the isExactSemver-before-isSemverConstraint ordering.
+		{"bare minor partial", "1.20", "1.20", "", ""},
+		{"bare major partial", "1", "1", "", ""},
+		// Digest stays a digest (GC-847-R3).
+		{"digest", "sha256:abc", "", "", "sha256:abc"},
+		// Non-semver literal tags stay tags (GC-847-R4).
+		{"literal tag", "latest", "latest", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ref := versionToOCIRef(tc.version)
+			if ref == nil {
+				t.Fatalf("versionToOCIRef(%q) = nil", tc.version)
+			}
+			if ref.Tag != tc.wantTag || ref.SemVer != tc.wantSemVer || ref.Digest != tc.wantDigest {
+				t.Errorf("versionToOCIRef(%q) = {Tag:%q SemVer:%q Digest:%q}, want {Tag:%q SemVer:%q Digest:%q}",
+					tc.version, ref.Tag, ref.SemVer, ref.Digest, tc.wantTag, tc.wantSemVer, tc.wantDigest)
+			}
+		})
 	}
 }
 

--- a/pkg/source/oci/oci_test.go
+++ b/pkg/source/oci/oci_test.go
@@ -25,6 +25,27 @@ func TestPickSemverTag(t *testing.T) {
 			want: "1.3.0",
 		},
 		{
+			// GC-847-R1: 1.20.x resolves to the highest 1.20.* tag.
+			name: "wildcard selects highest patch in minor",
+			tags: []string{"1.20.0", "1.20.5", "1.21.0"},
+			expr: "1.20.x",
+			want: "1.20.5",
+		},
+		{
+			// GC-847-R1: ~1.20.0 == >=1.20.0 <1.21.0.
+			name: "tilde selects highest patch in minor",
+			tags: []string{"1.20.0", "1.20.5", "1.21.0"},
+			expr: "~1.20.0",
+			want: "1.20.5",
+		},
+		{
+			// GC-847-R1: ^1.20.0 == >=1.20.0 <2.0.0.
+			name: "caret selects highest minor in major",
+			tags: []string{"1.20.0", "1.20.5", "1.21.0"},
+			expr: "^1.20.0",
+			want: "1.21.0",
+		},
+		{
 			name: "regex filter narrows candidate set",
 			// Without filter the highest 1.x semver wins. With filter only
 			// rc-prereleased entries qualify; semver treats prereleases as


### PR DESCRIPTION
<!-- gc:github-issue-fix repo=home-operations/flate issue=847 root=fl-cx6 -->

## Summary

For `type: oci` HelmRepositories, a chart `version` that is a semver
*constraint* (`1.20.x`, `1.20.X`, `*`, `~1.20.0`, `^1.20.0`,
`>=1.20.0 <1.21.0`) previously landed on `ref.Tag` and failed with
`resolve <version>: invalid reference: invalid tag`.

`synthesizeOCIRepository` now classifies the version via a new package-private
`versionToOCIRef` before building the synthetic `OCIRepository`:

- a `:` is treated as a **digest** → `ref.Digest`
- an exact pin or non-semver literal stays a **tag** → `ref.Tag`
- a genuine semver **constraint** routes to `ref.SemVer`, so the existing OCI
  semver resolver selects the highest matching published tag (no change under
  `pkg/source/oci/`)

The `isExactSemver`-before-`isSemverConstraint` ordering keeps exact pins and
bare partials (`1.20`, `1`) on `ref.Tag`.

## Testing

- `TestVersionToOCIRef` (12 classification subtests) and extended
  `TestSynthesizeOCIRepository` in `pkg/source/helmchart/fetcher_test.go`
- `pickSemverTag` wildcard / tilde / caret cases in `pkg/source/oci/oci_test.go`
- `go test`, `go vet`, and `golangci-lint` (v2.12.2) clean

## Requirements covered

| ID | Requirement |
| --- | --- |
| GC-847-R1 | Semver constraints resolve to the highest matching published OCI chart tag |
| GC-847-R2 | Exact version pins / bare partials keep resolving to that exact tag |
| GC-847-R3 | Digest references keep resolving by digest |
| GC-847-R4 | Non-semver literal tags keep resolving as tags |
| GC-847-R5 | Automated tests prove constraint resolution and guard the regressions |

Closes home-operations/flate#847
