### PR TITLE
ci(renovate): reactive dashboard + config runs in one workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,9 +11,12 @@ on:
       - .renovate/**.json5
   workflow_dispatch:
   issues:
-    types: [edited]
+    types:
+      - edited
   pull_request:
-    types: [closed, edited]
+    types:
+      - closed
+      - edited
 
 permissions: {}
 

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,17 +10,51 @@ on:
       - .renovaterc.json5
       - .renovate/**.json5
   workflow_dispatch:
+  issues:
+    types: [edited]
+  pull_request:
+    types: [closed, edited]
 
 permissions: {}
+
+concurrency:
+  group: renovate-${{ github.event.issue.number || github.event.pull_request.number || github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   renovate:
     name: Renovate
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.actor != vars.BOT_USERNAME &&
+        (
+          (
+            github.event_name == 'issues' &&
+            contains(github.event.issue.title, 'Renovate Dashboard') &&
+            (
+              contains(github.event.issue.body, '- [x]') ||
+              contains(github.event.issue.body, 'approve-all-pending-prs') ||
+              contains(github.event.issue.body, 'create-all-rate-limited-prs') ||
+              contains(github.event.issue.body, 'rebase-all-open-prs')
+            )
+          ) ||
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.user.login == vars.BOT_USERNAME &&
+            (
+              github.event.action == 'closed' ||
+              contains(github.event.pull_request.body, '- [x]')
+            )
+          )
+        )
+      )
     runs-on: ubuntu-24.04
     steps:
       - name: Generate Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.BOT_CLIENT_ID }}
           private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
@@ -41,6 +75,7 @@ jobs:
           echo "run_id=${RUN_URL##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Await Renovate Completion
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}
@@ -51,6 +86,7 @@ jobs:
             --exit-status
 
       - name: Renovate Output
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           RUN_ID: ${{ steps.dispatch.outputs.run_id }}


### PR DESCRIPTION
Test rollout (flate first) of reactive Renovate, folded into the existing `renovate.yaml` (single file per repo).

`renovate.yaml` now dispatches a **repo-scoped** run at the central runner (`home-operations/.github`) on three signals, instead of waiting for the hourly cron:

- **`push`** to `.renovaterc.json5` / `.renovate/**` — re-evaluate on config change (existing behaviour)
- **`issues: edited`** — a Dependency Dashboard checkbox was ticked
- **`pull_request: closed/edited`** — a Renovate PR merged, or its rebase box ticked

Checkbox/PR actions land in seconds instead of up to an hour.

## Behaviour
- **Config pushes / manual runs still await + stream logs** (restored). Since `gh workflow run` doesn't return the run id, the await step finds it by diffing the newest dispatched run before/after the dispatch.
- **Reactive events are fire-and-forget** (no await).
- Dispatch uses the existing convention: `.github`-scoped app token (`permission-actions: write`) + `gh workflow run … --field autodiscoverFilter=<repo>`.

## Safety / correctness
- Reactive events fire only on a real checkbox (`- [x]`) / dashboard command, or a closed/edited Renovate-authored PR; `push`/`workflow_dispatch` always run.
- The bot actor login is the org-level **`vars.BOT_USERNAME`** Actions variable (not hardcoded), so a rename is a one-place change. `env` can't be used in a job-level `if:`, which is why this is a `vars` variable, not `env`. (The org variable is set.)
- Guard blocks the bot's own dashboard edits (no loop).
- `pull_request` (not `pull_request_target`) — Renovate branches are in-repo, no fork risk; zizmor clean.
- `concurrency` collapses bursts; reactive items key by issue/PR number.

Depends on home-operations/.github#42 (merged) and #43 (cleanup). If flate behaves, this file becomes the org template.