### PR TITLE
ci: skip release-please version-bump PRs in checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Go Lint
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,9 @@ permissions:
 
 jobs:
   test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Go Tests
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Guards the check jobs so only **genuine release-please PRs** are skipped, using a signal a contributor can't forge:

```yaml
if: >-
  ${{ !(startsWith(github.head_ref, 'release-please--')
  && github.event.pull_request.head.repo.full_name == github.repository) }}
```

The earlier `startsWith(github.head_ref, ...)`-only form was unsafe: `head_ref` is the PR's source branch name, which anyone can set - including from a fork - so a PR from a `release-please--*` branch would skip every check. Requiring the PR head repo to be this repo means fork PRs (the realistic path for outside contributors) always run the full suite. Ordinary PRs, pushes to `main`, and `workflow_dispatch` are unaffected.

Part of an org-wide CI conformity / minutes pass.
