### PR TITLE
docs: point the CI badge at ci.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 > Render and diff Flux GitOps repositories fully offline — one static binary, no cluster, no `kubectl`, no shellouts.
 
-[![Tests](https://github.com/home-operations/flate/actions/workflows/tests.yaml/badge.svg)](https://github.com/home-operations/flate/actions/workflows/tests.yaml)
-[![Lint](https://github.com/home-operations/flate/actions/workflows/lint.yaml/badge.svg)](https://github.com/home-operations/flate/actions/workflows/lint.yaml)
+[![CI](https://github.com/home-operations/flate/actions/workflows/ci.yaml/badge.svg)](https://github.com/home-operations/flate/actions/workflows/ci.yaml)
 [![Release](https://img.shields.io/github/v/release/home-operations/flate)](https://github.com/home-operations/flate/releases)
 [![License](https://img.shields.io/github/license/home-operations/flate)](LICENSE)
 [![Discord](https://img.shields.io/discord/673534664354430999?label=discord&logo=discord&logoColor=white&color=blue)](https://discord.gg/home-operations)


### PR DESCRIPTION
## Overview

The `Tests`, `Lint` and `E2E` workflows were consolidated into `ci.yaml`, so the
README badges pointed at workflow files that no longer exist and rendered as
"no status". They collapse into a single `CI` badge.

Missed in the consolidation PR — the badges are Markdown, so nothing in
`actionlint`/`zizmor` or the workflow diff surfaced them.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES — change and description written by an AI agent (Claude Code) under maintainer direction.
