### PR TITLE
fix(values): preserve configMapGenerator values with unresolved substitution placeholders

### DIFF
--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -531,18 +531,18 @@ func updateHelmReleaseValues(ref manifest.ValuesReference, found string, values 
 		return values, err
 	}
 
-	// Wiped Secret values surface here as the literal placeholder
-	// string. yaml.Unmarshal of a scalar string into a map errors out
-	// — treat as empty so a wiped values-file (common pattern: kustomize
-	// `secretGenerator` wrapping a SOPS-encrypted values.yaml) doesn't
-	// block the whole HR render.
-	if manifest.IsValuePlaceholder(found) {
-		return values, nil
-	}
 	key := valuesRefCacheKey(ref.Kind, namespace, ref.Name, ref.GetValuesKey(), found)
 	parsed, ok := cache.lookup(key)
 	if !ok {
 		if err := yaml.Unmarshal([]byte(found), &parsed); err != nil {
+			// Wiped Secret values surface here as the literal placeholder
+			// string. yaml.Unmarshal of a scalar string into a map errors out
+			// — treat as empty so a wiped values-file (common pattern: kustomize
+			// `secretGenerator` wrapping a SOPS-encrypted values.yaml) doesn't
+			// block the whole HR render.
+			if manifest.IsValuePlaceholder(found) {
+				return values, nil
+			}
 			return values, fmt.Errorf("expected '%s' values to be valid YAML: %w", ref.Name, err)
 		}
 		if parsed == nil {

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -797,3 +797,67 @@ func TestExpandValueReferences_TargetPathDoesNotCorruptSharedCache(t *testing.T)
 		t.Errorf("TargetPath write leaked into a prior HR's shared values: %#v", a.Values["image"])
 	}
 }
+
+// TestExpandValueReferences_YAMLContainingPlaceholderIsMerged verifies that
+// a ConfigMap whose values.yaml contains placeholder tokens inside valid YAML
+// values (e.g. from postBuild substitution on a configMapGenerator) is correctly
+// parsed and merged into hr.Values instead of being discarded.
+func TestExpandValueReferences_YAMLContainingPlaceholderIsMerged(t *testing.T) {
+	cm := &manifest.ConfigMap{
+		Name:      "generator-cm",
+		Namespace: "default",
+		Data: map[string]any{
+			"values.yaml": "domain: ..PLACEHOLDER_DOMAIN..\nport: 8080\n",
+		},
+	}
+	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
+	hr := &manifest.HelmRelease{
+		Name:      "demo",
+		Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "ConfigMap", Name: "generator-cm"},
+			},
+		},
+	}
+	if err := ExpandValueReferences(hr, provider, nil); err != nil {
+		t.Fatalf("ExpandValueReferences failed: %v", err)
+	}
+	if hr.Values["domain"] != "..PLACEHOLDER_DOMAIN.." {
+		t.Errorf("domain = %v, want ..PLACEHOLDER_DOMAIN..", hr.Values["domain"])
+	}
+	if fmt.Sprint(hr.Values["port"]) != "8080" {
+		t.Errorf("port = %v, want 8080", hr.Values["port"])
+	}
+}
+
+// TestExpandValueReferences_WipedScalarPlaceholderTolerated verifies that
+// a Secret whose values.yaml is a wiped scalar placeholder string (e.g. from
+// a SOPS-encrypted values file) is safely treated as empty rather than failing
+// YAML unmarshaling.
+func TestExpandValueReferences_WipedScalarPlaceholderTolerated(t *testing.T) {
+	sec := &manifest.Secret{
+		Name:      "sops-secret",
+		Namespace: "default",
+		StringData: map[string]any{
+			"values.yaml": "..PLACEHOLDER_values.yaml..",
+		},
+	}
+	provider := &SliceProvider{Secrets: []*manifest.Secret{sec}}
+	hr := &manifest.HelmRelease{
+		Name:      "demo",
+		Namespace: "default",
+		HelmReleaseSpec: helmv2.HelmReleaseSpec{
+			ValuesFrom: []manifest.ValuesReference{
+				{Kind: "Secret", Name: "sops-secret"},
+			},
+		},
+	}
+	if err := ExpandValueReferences(hr, provider, nil); err != nil {
+		t.Fatalf("ExpandValueReferences failed for wiped scalar placeholder: %v", err)
+	}
+	if len(hr.Values) != 0 {
+		t.Errorf("expected empty values, got %v", hr.Values)
+	}
+}
+


### PR DESCRIPTION
## Overview

In `pkg/values/values.go` within `updateHelmReleaseValues`, an aggressive early check `if manifest.IsValuePlaceholder(found)` was executing before attempting `yaml.Unmarshal`.

When a configMapGenerator (or ConfigMap) contained valid YAML key-value pairs where one of the values had been substituted with a placeholder token (e.g. ..PLACEHOLDER_DOMAIN..), `manifest.IsValuePlaceholder(found)` evaluated to true because the YAML string contained "..PLACEHOLDER_". 
Consequently, `updateHelmReleaseValues` discarded the entire values.yaml payload and returned values unchanged.

This PR address this issue https://github.com/home-operations/flate/issues/869


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Antigravity, I personally successfully tested the fix on all my previously failing use case and have not identified any regression.
