### PR TITLE
fix(change): exclude external-sourced KS claims from the ownership index

### DIFF
--- a/pkg/change/bench_test.go
+++ b/pkg/change/bench_test.go
@@ -42,7 +42,7 @@ func BenchmarkBuildOwnership(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_ = buildOwnership(s, repoRoot, nil)
+		_ = buildOwnership(s, repoRoot, nil, nil)
 	}
 }
 

--- a/pkg/change/filter.go
+++ b/pkg/change/filter.go
@@ -41,6 +41,13 @@ type Filter struct {
 	// to drive the reverse edge. Nil disables reverse propagation.
 	consumerRefs map[manifest.NamedResource][]manifest.NamedResource
 
+	// externalKS is the set of external-sourced Kustomizations whose
+	// path claims are excluded from resolve()'s ownership index —
+	// supplied by the orchestrator from loader.ExternalSourcedKSIDs
+	// (mirroring loader.KSPathPrefixesLocalOnly on the parent-index
+	// side). Nil means no exclusions.
+	externalKS map[manifest.NamedResource]struct{}
+
 	// objs is captured from NewFilter so runtime AddEmitted can
 	// walk transitiveDeps without the caller re-supplying it. The
 	// pointer is set once at construction and never reassigned —
@@ -138,7 +145,7 @@ func keyOf(id manifest.NamedResource) nameKey {
 //     a forward dep of step 4), so a single HR edit can't reverse-
 //     cascade into every sibling sharing its source.
 func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister) *Filter {
-	return NewFilterWithCache(changes, sourceFiles, repoRoot, objs, nil, nil)
+	return NewFilterWithCache(changes, sourceFiles, repoRoot, objs, nil, nil, nil)
 }
 
 // NewFilterWithCache is NewFilter with a shared
@@ -156,7 +163,12 @@ func NewFilter(changes *Set, sourceFiles map[manifest.NamedResource]string, repo
 // HelmReleases are absent from the Store at resolve() time. It drives
 // the reverse edge (step 5 above). Pass nil to disable reverse
 // propagation (the default for tests that don't exercise it).
-func NewFilterWithCache(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister, cache *manifest.ComponentCache, consumerRefs map[manifest.NamedResource][]manifest.NamedResource) *Filter {
+//
+// externalKS is the set of external-sourced Kustomizations (from
+// loader.ExternalSourcedKSIDs) whose path claims resolve() must drop
+// from the ownership index; see buildOwnership. Pass nil for no
+// exclusions.
+func NewFilterWithCache(changes *Set, sourceFiles map[manifest.NamedResource]string, repoRoot string, objs ObjectLister, cache *manifest.ComponentCache, consumerRefs map[manifest.NamedResource][]manifest.NamedResource, externalKS map[manifest.NamedResource]struct{}) *Filter {
 	f := &Filter{
 		changes:        changes,
 		sourceFiles:    sourceFiles,
@@ -164,6 +176,7 @@ func NewFilterWithCache(changes *Set, sourceFiles map[manifest.NamedResource]str
 		objs:           objs,
 		componentCache: cache,
 		consumerRefs:   consumerRefs,
+		externalKS:     externalKS,
 	}
 	if changes == nil {
 		return f
@@ -471,7 +484,7 @@ func (f *Filter) resolve() {
 		queue = append(queue, id)
 	}
 
-	owners := buildOwnership(objs, f.repoRoot, f.componentCache)
+	owners := buildOwnership(objs, f.repoRoot, f.componentCache, f.externalKS)
 	// enqueueAncestorChain marks the structural parent that owns file
 	// (longest-prefix spec.path match) plus its meta-Kustomization
 	// ancestors as ancestor-only — they must render to inject patches /

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -226,6 +226,49 @@ func TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings(t *testing.T) {
 	}
 }
 
+func TestFilter_ExternalSourcedKSClaimsExcludedFromOwnership(t *testing.T) {
+	// An external-sourced KS (e.g. OCIRepository) with `path: ./` claims
+	// the repo root — since matchingPrefixes matches the root prefix,
+	// that makes it a false ancestor of EVERY changed file, and its own
+	// dependsOn then blocks the whole graph as a cycle (immich-app
+	// yucca-o11y; loader-side counterpart is issue #752). Its spec.path
+	// is relative to its own artifact, not the local tree, so resolve()
+	// must drop its claims when the orchestrator supplies it via
+	// externalKS.
+	external := &manifest.Kustomization{
+		Name: "yucca-o11y", Namespace: "flux-system",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./"},
+	}
+	plex := &manifest.Kustomization{
+		Name: "plex", Namespace: "media",
+		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/media/plex/app"},
+	}
+	externalID, plexID := external.Named(), plex.Named()
+	sourceFiles := map[manifest.NamedResource]string{
+		externalID: "flux/cluster/yucca-o11y.yaml",
+		plexID:     "apps/media/plex/app/ks.yaml",
+	}
+	lister := testutil.MapLister{externalID: external, plexID: plex}
+	changed := []string{"apps/media/plex/app/helmrelease.yaml"}
+
+	// Without the exclusion the root claim wins ancestor status — this
+	// pins the cascade the fix removes (and the root-prefix match that
+	// enables it).
+	f := NewFilterWithCache(NewSet(changed), sourceFiles, "", lister, nil, nil, nil)
+	if !f.ShouldReconcile(externalID) {
+		t.Fatalf("precondition: root-claiming KS should be an ancestor without exclusions; keep=%v", f.KeepNames())
+	}
+
+	f = NewFilterWithCache(NewSet(changed), sourceFiles, "", lister, nil, nil,
+		map[manifest.NamedResource]struct{}{externalID: {}})
+	if !f.ShouldReconcile(plexID) {
+		t.Fatalf("owner of the changed file must be kept; keep=%v", f.KeepNames())
+	}
+	if f.ShouldReconcile(externalID) {
+		t.Errorf("external-sourced root-claiming KS must not enter keep as ancestor; keep=%v", f.KeepNames())
+	}
+}
+
 func TestFilter_KeepNamespaces(t *testing.T) {
 	// Drive keep via NewFilter rather than mutating the struct.
 	ksA := &manifest.Kustomization{Name: "x", Namespace: "ns-a"}
@@ -766,6 +809,7 @@ func TestFilter_ReverseEdgeCentralizedOCIRepository(t *testing.T) {
 			hr:      {oci},
 			sibling: {otherOCI},
 		},
+		nil,
 	)
 
 	if !f.ShouldReconcile(oci) {
@@ -818,6 +862,7 @@ func TestFilter_ReverseEdgeNoCascadeFromChangedConsumer(t *testing.T) {
 			aID: {shared},
 			bID: {shared},
 		},
+		nil,
 	)
 
 	if !f.ShouldReconcile(aID) {
@@ -863,6 +908,7 @@ func TestFilter_ForwardEdgeChangedHRKeepsChartRefSource(t *testing.T) {
 			hr:      {oci},
 			sibling: {oci}, // shares the same chart source
 		},
+		nil,
 	)
 
 	if !f.ShouldReconcile(hr) {

--- a/pkg/change/ownership.go
+++ b/pkg/change/ownership.go
@@ -43,11 +43,24 @@ type ownershipIndex struct {
 // by loader.KSPathPrefixes during discovery are served from cache
 // here. nil cache falls back to a per-call local map; behavior is
 // identical, just without cross-call sharing.
-func buildOwnership(objs ObjectLister, repoRoot string, cache *manifest.ComponentCache) ownershipIndex {
+//
+// externalKS drops the claims of external-sourced Kustomizations (see
+// loader.ExternalSourcedKSIDs): their spec.path is relative to their own
+// source artifact, not the local tree, so letting them claim local
+// prefixes makes them false owners/ancestors of unrelated local files.
+// A `path: ./` on an OCIRepository-sourced KS claims the repo root,
+// which — since the root-prefix match landed in matchingPrefixes —
+// routes every changed file's ancestor chain through that KS; its own
+// dependsOn then blocks the whole graph as a cycle (same shape as the
+// loader-side issue #752). Mirrors KSPathPrefixesLocalOnly.
+func buildOwnership(objs ObjectLister, repoRoot string, cache *manifest.ComponentCache, externalKS map[manifest.NamedResource]struct{}) ownershipIndex {
 	objList := objs.ListObjects(manifest.KindKustomization)
 	kss := make([]*manifest.Kustomization, 0, len(objList))
 	for _, obj := range objList {
 		if ks, ok := obj.(*manifest.Kustomization); ok {
+			if _, external := externalKS[ks.Named()]; external {
+				continue
+			}
 			kss = append(kss, ks)
 		}
 	}

--- a/pkg/orchestrator/changefilter.go
+++ b/pkg/orchestrator/changefilter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/discovery"
+	"github.com/home-operations/flate/pkg/loader"
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -26,7 +27,11 @@ func (o *Orchestrator) buildChangeFilter(repoRoot string) error {
 	if changes == nil {
 		return nil
 	}
-	f := change.NewFilterWithCache(changes, o.sourceFiles, repoRoot, o.store, o.componentCache, o.sourceRefs)
+	// External-sourced KSes must not claim local paths in the ownership
+	// index — same exclusion the loader applies to the parent index via
+	// KSPathPrefixesLocalOnly (a `path: ./` on an OCI-sourced KS would
+	// otherwise own the repo root and cascade into every resolve).
+	f := change.NewFilterWithCache(changes, o.sourceFiles, repoRoot, o.store, o.componentCache, o.sourceRefs, loader.ExternalSourcedKSIDs(o.store, repoRoot))
 	// Wire OnAdd so a runtime keep-set extension (KS controller's
 	// emitRenderedChildren → keepEmitted) refires any source whose
 	// listener already short-circuited via PreGate before the


### PR DESCRIPTION
## Problem

Since the root-prefix match landed in `matchingPrefixes` (#871, v0.4.13), an external-sourced Kustomization with `path: ./` claims the repo root in the change filter's ownership index. Its `spec.path` is relative to its **own source artifact**, not the local tree — but `change.buildOwnership` builds claims from every KS unfiltered, so the root claim makes it a false ancestor of every changed file. If that KS also declares `dependsOn`, the inferred edges close a cycle and the entire graph reports blocked.

Real-world repro (immich-app/yucca-o11y): an OCIRepository-sourced KS (`path: ./`, `dependsOn: [grafana-operator]`) turned every `flate test` into

```
✗ 0 passed · 29 blocked
```

with every Kustomization `blocked by flux-system/yucca-o11y`. Bisect: v0.4.12 pass, v0.4.14 fail, same tree.

This is the change-filter twin of #752: the loader side already drops external-sourced KS claims from local path attribution (`KSPathPrefixesLocalOnly`) so "an external-sourced KS never becomes the structural parent of local resources" — the ownership index was the one consumer that missed the exclusion, latent until the root prefix became matchable.

## Fix

Mirror the loader-side exclusion: the orchestrator threads `loader.ExternalSourcedKSIDs(store, repoRoot)` into `change.NewFilterWithCache`, and `buildOwnership` skips those KSes before building claims. Nil set (tests, direct construction) keeps prior behavior.

## Verification

- New regression test `TestFilter_ExternalSourcedKSClaimsExcludedFromOwnership`, including a precondition assert pinning the pre-fix cascade (root-claiming KS becomes ancestor without the exclusion).
- Full test suite passes.
- Patched binary against the yucca-o11y repro, both clusters × both kinds: `✓ 1 passed · 29 skipped` — identical attribution to v0.4.12, with the #871 root-prefix behavior retained for local KSes.
