### PR TITLE
fix(go)!: update to go 1.27.0 and adopt generic methods

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,8 +1,8 @@
 [tools]
 actionlint = "1.7.12"
-go = "1.26.6"
+go = "1.27.0"
 "go:golang.org/x/vuln/cmd/govulncheck" = "v1.7.0"
-golangci-lint = "2.12.2"
+golangci-lint = "2.13.0"
 lefthook = "2.1.10"
 oxfmt = "0.64.0"
 zizmor = "1.29.0"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -23,45 +23,45 @@ url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/3849248
 provenance = "github-attestations"
 
 [[tools.go]]
-version = "1.26.6"
+version = "1.27.0"
 backend = "core:go"
 
 [tools.go."platforms.linux-arm64"]
-checksum = "sha256:d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e"
-url = "https://dl.google.com/go/go1.26.6.linux-arm64.tar.gz"
+checksum = "sha256:51798d2c42d0e1c6ed7fd9f48728b4193abac9e8aad6dbac2fe96a81f5909bda"
+url = "https://dl.google.com/go/go1.27.0.linux-arm64.tar.gz"
 
 [tools.go."platforms.linux-x64"]
-checksum = "sha256:708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89"
-url = "https://dl.google.com/go/go1.26.6.linux-amd64.tar.gz"
+checksum = "sha256:675c26c449cbb18fc24b74650de1eabbae6e16f64326fd85a283fb3b58280685"
+url = "https://dl.google.com/go/go1.27.0.linux-amd64.tar.gz"
 
 [tools.go."platforms.macos-arm64"]
-checksum = "sha256:2dc95ce4675829f2df0e86b28bcef3283635902062a5f0580ca659bf570f3204"
-url = "https://dl.google.com/go/go1.26.6.darwin-arm64.tar.gz"
+checksum = "sha256:90493b3bbd5e10f91d12153198bf1994fd756399b4fec93b49b0c6e2acdeeb3e"
+url = "https://dl.google.com/go/go1.27.0.darwin-arm64.tar.gz"
 
 [[tools."go:golang.org/x/vuln/cmd/govulncheck"]]
 version = "1.7.0"
 backend = "go:golang.org/x/vuln/cmd/govulncheck"
 
 [[tools.golangci-lint]]
-version = "2.12.2"
+version = "2.13.0"
 backend = "aqua:golangci/golangci-lint"
 
 [tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:44cd40a8c76c86755375adfeea52cfd3533cb43d7bd647771e0ae065e166df3a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470996"
+checksum = "sha256:3a91c7bb9c135099a97858bea431d6dd2f54e4bf68d479c776c2350428d60e41"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471362"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413471054"
+checksum = "sha256:a10e8d8359d76b9e2b41da60f9d98bb26fd53c7a453caa82e0a172d6f72fd2ca"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471346"
 provenance = "github-attestations"
 
 [tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"
-url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/413470950"
+checksum = "sha256:72eae670097978e61b78a773a25c27439e35d54094fd986cee5eeeb25d7144fd"
+url = "https://github.com/golangci/golangci-lint/releases/download/v2.13.0/golangci-lint-2.13.0-darwin-arm64.tar.gz"
+url_api = "https://api.github.com/repos/golangci/golangci-lint/releases/assets/521471400"
 provenance = "github-attestations"
 
 [[tools.lefthook]]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/home-operations/flate
 
-go 1.26.0
+go 1.27.0
 
 require (
 	cel.dev/cel-go v0.32.0

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -302,8 +302,7 @@ func TestAggregateScopedFailures_FoldsBlocked(t *testing.T) {
 	if !strings.Contains(msg, "1 blocked") {
 		t.Errorf("blocked count should be summarized: %q", msg)
 	}
-	var fe *orchestrator.FailuresError
-	if !errors.As(err, &fe) {
+	if _, ok := errors.AsType[*orchestrator.FailuresError](err); !ok {
 		t.Errorf("aggregate must be a *orchestrator.FailuresError, got %T", err)
 	}
 }

--- a/internal/cli/diff.go
+++ b/internal/cli/diff.go
@@ -13,7 +13,6 @@ import (
 	"github.com/home-operations/flate/pkg/diff"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/orchestrator"
-	"github.com/home-operations/flate/pkg/store"
 )
 
 func newDiffCmd() *cobra.Command {
@@ -301,7 +300,7 @@ func gatherArtifacts(o *orchestrator.Orchestrator, res *orchestrator.Result, kin
 		}
 	}
 	docs := diff.DocsFromManifests(sub, func(id manifest.NamedResource) string {
-		if ks, ok := store.Get[*manifest.Kustomization](o.Store(), id); ok {
+		if ks, ok := o.Store().Get[*manifest.Kustomization](id); ok {
 			return strings.TrimPrefix(ks.Path, "./")
 		}
 		return ""

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -118,8 +118,7 @@ func run(version string, args []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		// reportFailures already rendered a styled report for this error; don't
 		// reprint it as a flat "flate error: …" line.
-		var reported reportedError
-		if !errors.As(err, &reported) {
+		if _, ok := errors.AsType[reportedError](err); !ok {
 			_, _ = io.WriteString(stderr, "flate error: "+err.Error()+"\n")
 		}
 		return 1

--- a/pkg/change/bench_test.go
+++ b/pkg/change/bench_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -83,10 +81,10 @@ func seedKSStore(n int) (*store.Store, map[manifest.NamedResource]string) {
 		path := fmt.Sprintf("./apps/app-%d", i)
 		ks := &manifest.Kustomization{
 			Name: name, Namespace: "flux-system",
-			KustomizationSpec: kustomizev1.KustomizationSpec{Path: path},
-			SourceKind:        manifest.KindGitRepository,
-			SourceName:        "flux-system",
-			SourceNamespace:   "flux-system",
+			Path:            path,
+			SourceKind:      manifest.KindGitRepository,
+			SourceName:      "flux-system",
+			SourceNamespace: "flux-system",
 		}
 		s.AddObject(ks)
 		sourceFiles[ks.Named()] = fmt.Sprintf("apps/app-%d/ks.yaml", i)

--- a/pkg/change/filter_test.go
+++ b/pkg/change/filter_test.go
@@ -4,8 +4,6 @@ import (
 	"slices"
 	"testing"
 
-	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
@@ -69,17 +67,13 @@ func TestFilter_ResolveDirectMatch(t *testing.T) {
 func TestFilter_SharedComponentPropagatesToAllConsumers(t *testing.T) {
 	plex := &manifest.Kustomization{
 		Name: "plex", Namespace: "media",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path:       "apps/media/plex/app",
-			Components: []string{"../../../../components/volsync"},
-		},
+		Path:       "apps/media/plex/app",
+		Components: []string{"../../../../components/volsync"},
 	}
 	atuin := &manifest.Kustomization{
 		Name: "atuin", Namespace: "default",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path:       "apps/default/atuin/app",
-			Components: []string{"../../../../components/volsync"},
-		},
+		Path:       "apps/default/atuin/app",
+		Components: []string{"../../../../components/volsync"},
 	}
 	hrPlex := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "media", Name: "plex"}
 	hrAtuin := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "atuin"}
@@ -113,11 +107,11 @@ func TestFilter_AncestorKSAlsoKept(t *testing.T) {
 	// post-mutation spec. See #58.
 	meta := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps"},
+		Path: "apps",
 	}
 	plex := &manifest.Kustomization{
 		Name: "plex", Namespace: "media",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/media/plex/app"},
+		Path: "apps/media/plex/app",
 	}
 	hrPlex := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "media", Name: "plex"}
 	metaID, plexID := meta.Named(), plex.Named()
@@ -153,11 +147,11 @@ func TestFilter_AncestorKSAlsoKept(t *testing.T) {
 func TestFilter_StructuralParentOfOwnerKSAlsoKept(t *testing.T) {
 	parent := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/main"},
+		Path: "apps/main",
 	}
 	leaf := &manifest.Kustomization{
 		Name: "actual", Namespace: "self-hosted",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/base/self-hosted/actual"},
+		Path: "apps/base/self-hosted/actual",
 	}
 	hrActual := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "self-hosted", Name: "actual"}
 	parentID, leafID := parent.Named(), leaf.Named()
@@ -187,15 +181,15 @@ func TestFilter_AncestorKSDoesNotPullInUnrelatedSiblings(t *testing.T) {
 	// does not widen sibling-resource coverage.
 	meta := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps"},
+		Path: "apps",
 	}
 	plex := &manifest.Kustomization{
 		Name: "plex", Namespace: "media",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/media/plex/app"},
+		Path: "apps/media/plex/app",
 	}
 	atuin := &manifest.Kustomization{
 		Name: "atuin", Namespace: "default",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/default/atuin/app"},
+		Path: "apps/default/atuin/app",
 	}
 	metaID, plexID, atuinID := meta.Named(), plex.Named(), atuin.Named()
 	hrAtuin := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "atuin"}
@@ -237,11 +231,11 @@ func TestFilter_ExternalSourcedKSClaimsExcludedFromOwnership(t *testing.T) {
 	// externalKS.
 	external := &manifest.Kustomization{
 		Name: "yucca-o11y", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./"},
+		Path: "./",
 	}
 	plex := &manifest.Kustomization{
 		Name: "plex", Namespace: "media",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/media/plex/app"},
+		Path: "apps/media/plex/app",
 	}
 	externalID, plexID := external.Named(), plex.Named()
 	sourceFiles := map[manifest.NamedResource]string{
@@ -299,10 +293,8 @@ func TestFilter_TransitiveDepsHelmRelease(t *testing.T) {
 		Chart: manifest.HelmChart{
 			RepoKind: manifest.KindOCIRepository, RepoName: "app-template", RepoNamespace: "flux-system",
 		},
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: manifest.KindConfigMap, Name: "plex-values"},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: manifest.KindConfigMap, Name: "plex-values"},
 		},
 	}
 	hrID := hr.Named()
@@ -329,7 +321,7 @@ func TestFilter_TransitiveDepsKustomization(t *testing.T) {
 		Name: "apps", Namespace: "flux-system",
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		DependsOn: []manifest.DependencyRef{{
-			NamedResource: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "repositories"},
+			Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "repositories",
 		}},
 	}
 	ksID := ks.Named()
@@ -361,7 +353,7 @@ func TestFilter_DependsOnNotFollowed(t *testing.T) {
 		Name: "a", Namespace: "flux-system",
 		SourceKind: manifest.KindGitRepository, SourceName: "src", SourceNamespace: "flux-system",
 		DependsOn: []manifest.DependencyRef{{
-			NamedResource: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "b"},
+			Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "b",
 		}},
 	}
 	b := &manifest.Kustomization{Name: "b", Namespace: "flux-system"}
@@ -477,11 +469,11 @@ func TestFilter_AddEmittedRejectsAncestorOnlyEmitter(t *testing.T) {
 	siblingApp := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "media", Name: "plex-app"}
 
 	leafKSObj := &manifest.Kustomization{Name: "reloader-app", Namespace: "kube-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system/reloader/app"}}
+		Path: "kubernetes/apps/kube-system/reloader/app"}
 	clusterAppsObj := &manifest.Kustomization{Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"}}
+		Path: "kubernetes/apps"}
 	siblingObj := &manifest.Kustomization{Name: "plex-app", Namespace: "media",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/media/plex/app"}}
+		Path: "kubernetes/apps/media/plex/app"}
 
 	f := NewFilter(
 		NewSet([]string{"kubernetes/apps/kube-system/reloader/app/ocirepository.yaml"}),
@@ -547,13 +539,13 @@ func TestFilter_AddEmittedNoCascadeAcrossDeepAncestorChain(t *testing.T) {
 
 	objs := testutil.MapLister{
 		clusterApps: &manifest.Kustomization{Name: clusterApps.Name, Namespace: clusterApps.Namespace,
-			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"}},
+			Path: "kubernetes/apps"},
 		kubeSystem: &manifest.Kustomization{Name: kubeSystem.Name, Namespace: kubeSystem.Namespace,
-			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system"}},
+			Path: "kubernetes/apps/kube-system"},
 		reloader: &manifest.Kustomization{Name: reloader.Name, Namespace: reloader.Namespace,
-			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system/reloader"}},
+			Path: "kubernetes/apps/kube-system/reloader"},
 		reloaderApp: &manifest.Kustomization{Name: reloaderApp.Name, Namespace: reloaderApp.Namespace,
-			KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/kube-system/reloader/app"}},
+			Path: "kubernetes/apps/kube-system/reloader/app"},
 		mediaSibling:    &manifest.Kustomization{Name: mediaSibling.Name, Namespace: mediaSibling.Namespace},
 		spegelSibling:   &manifest.Kustomization{Name: spegelSibling.Name, Namespace: spegelSibling.Namespace},
 		reloaderSibling: &manifest.Kustomization{Name: reloaderSibling.Name, Namespace: reloaderSibling.Namespace},
@@ -737,10 +729,8 @@ func TestFilter_TransitiveDepsHelmReleaseViaHelmChartCRD(t *testing.T) {
 	}
 	hc := &manifest.HelmChartSource{
 		Name: "demo-chart", Namespace: "apps",
-		HelmChartSpec: sourcev1.HelmChartSpec{
-			SourceRef: sourcev1.LocalHelmChartSourceReference{
-				Kind: manifest.KindOCIRepository, Name: "backing-oci",
-			},
+		SourceRef: sourcev1.LocalHelmChartSourceReference{
+			Kind: manifest.KindOCIRepository, Name: "backing-oci",
 		},
 	}
 	hrID := hr.Named()
@@ -789,9 +779,9 @@ func TestFilter_ReverseEdgeCentralizedOCIRepository(t *testing.T) {
 	sibling := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "envoy-gateway", Name: "other"}
 	otherOCI := manifest.NamedResource{Kind: manifest.KindOCIRepository, Namespace: "flux-system", Name: "something-else"}
 	reposKS := &manifest.Kustomization{Name: "repositories", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "repositories"}}
+		Path: "repositories"}
 	appKS := &manifest.Kustomization{Name: "envoy-gateway", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "clusters/main/kubernetes/networking/envoy-gateway/app"}}
+		Path: "clusters/main/kubernetes/networking/envoy-gateway/app"}
 
 	f := NewFilterWithCache(
 		NewSet([]string{ociFile}),
@@ -938,28 +928,22 @@ func TestFilter_ForwardEdgeChangedHRKeepsChartRefSource(t *testing.T) {
 func TestFilter_SubstituteFromConfigMapKeepsProducerKustomization(t *testing.T) {
 	clusterAppsObj := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "kubernetes/apps",
-		},
+		Path: "kubernetes/apps",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "cluster-settings"},
 		},
 	}
 	clusterVarsObj := &manifest.Kustomization{
 		Name: "cluster-vars", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "kubernetes/flux/vars",
-			// The CM lives in a shared Component referenced by
-			// cluster-vars — ownersOf returns cluster-vars for any
-			// file under the resolved component path.
-			Components: []string{"../../components/cluster-settings"},
-		},
+		Path: "kubernetes/flux/vars",
+		// The CM lives in a shared Component referenced by
+		// cluster-vars — ownersOf returns cluster-vars for any
+		// file under the resolved component path.
+		Components: []string{"../../components/cluster-settings"},
 	}
 	ntfyObj := &manifest.Kustomization{
 		Name: "ntfy", Namespace: "communication",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "kubernetes/apps/communication/ntfy/app",
-		},
+		Path: "kubernetes/apps/communication/ntfy/app",
 	}
 	hrObj := &manifest.HelmRelease{Name: "ntfy", Namespace: "communication"}
 	// rawSettings is the DiscoveryOnly-indexed pre-render form:
@@ -1025,9 +1009,7 @@ func TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly(t *testing.T
 	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "parent-apps"}
 	childObj := &manifest.Kustomization{
 		Name: "child-app", Namespace: "apps",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "kubernetes/apps/child",
-		},
+		Path: "kubernetes/apps/child",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "shared-settings"},
 		},
@@ -1035,9 +1017,7 @@ func TestFilter_AddEmittedKeepsSubstituteFromProducerDependencyOnly(t *testing.T
 	child := childObj.Named()
 	producerObj := &manifest.Kustomization{
 		Name: "settings-producer", Namespace: "apps",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "kubernetes/apps/settings",
-		},
+		Path: "kubernetes/apps/settings",
 	}
 	producer := producerObj.Named()
 	// CM with namespace="" mirrors the DiscoveryOnly pre-render form.
@@ -1091,7 +1071,7 @@ func TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer(t *testing.T) {
 	parent := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "parent-apps"}
 	childObj := &manifest.Kustomization{
 		Name: "child-app", Namespace: "apps",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/child"},
+		Path: "kubernetes/apps/child",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "shared-settings"},
 		},
@@ -1099,7 +1079,7 @@ func TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer(t *testing.T) {
 	child := childObj.Named()
 	producerObj := &manifest.Kustomization{
 		Name: "settings-producer", Namespace: "apps",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps/settings"},
+		Path: "kubernetes/apps/settings",
 	}
 	producer := producerObj.Named()
 	cmID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "", Name: "shared-settings"}
@@ -1136,21 +1116,21 @@ func TestFilter_AddEmittedFiresOnAddForSubstituteFromProducer(t *testing.T) {
 func TestFilter_ChainedSubstituteFromProducers(t *testing.T) {
 	aObj := &manifest.Kustomization{
 		Name: "consumer", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/consumer"},
+		Path: "kubernetes/consumer",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "cm-a"},
 		},
 	}
 	bObj := &manifest.Kustomization{
 		Name: "producer-b", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/b"},
+		Path: "kubernetes/b",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "cm-b"},
 		},
 	}
 	cObj := &manifest.Kustomization{
 		Name: "producer-c", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/c"},
+		Path: "kubernetes/c",
 	}
 	a, b, c := aObj.Named(), bObj.Named(), cObj.Named()
 
@@ -1190,7 +1170,7 @@ func TestFilter_ChainedSubstituteFromProducers(t *testing.T) {
 func TestFilter_SelfProducerSkippedInResolve(t *testing.T) {
 	selfObj := &manifest.Kustomization{
 		Name: "self", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/self"},
+		Path: "kubernetes/self",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "self-settings"},
 		},
@@ -1235,11 +1215,11 @@ func TestFilter_ProducerByNameDoesNotLeakAcrossNamespaces(t *testing.T) {
 	// only to its own CM file.
 	aObj := &manifest.Kustomization{
 		Name: "producer-a", Namespace: "ns1",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "p1"},
+		Path: "p1",
 	}
 	bObj := &manifest.Kustomization{
 		Name: "producer-b", Namespace: "ns2",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "p2"},
+		Path: "p2",
 	}
 	a, b := aObj.Named(), bObj.Named()
 

--- a/pkg/controllers/base/base.go
+++ b/pkg/controllers/base/base.go
@@ -501,9 +501,8 @@ func (c *Controller) Require(
 // sites). Wait and re-read were two statements joined only by convention;
 // fusing them means a future gate site can't call Require and silently forget
 // the re-read.
-func RequireRefresh[T manifest.BaseManifest](
+func (c *Controller) RequireRefresh[T manifest.BaseManifest](
 	ctx context.Context,
-	c *Controller,
 	id manifest.NamedResource,
 	timeout *metav1.Duration,
 	deps []manifest.DependencyRef,
@@ -514,7 +513,7 @@ func RequireRefresh[T manifest.BaseManifest](
 		var zero T
 		return zero, false, err
 	}
-	obj, ok := store.Get[T](c.Store, id)
+	obj, ok := c.Store.Get[T](id)
 	return obj, ok, nil
 }
 
@@ -596,7 +595,7 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 	fn func(context.Context, T) error,
 ) []manifest.NamedResource {
 	defer Recover(s, id, log)
-	obj, ok := store.Get[T](s, id)
+	obj, ok := s.Get[T](id)
 	if !ok {
 		// Object deleted (or wrong type) between discovery/enqueue and run.
 		// Write a terminal Ready with a brief reason so dependents unblock and
@@ -611,8 +610,7 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 		// A dependency gate is unsatisfied. Surface the blocked deps WITHOUT
 		// writing Failed — the node keeps the Pending status Require wrote and
 		// stays parkable + re-runnable.
-		var blocked *depwait.ErrBlocked
-		if errors.As(err, &blocked) {
+		if blocked, ok := errors.AsType[*depwait.ErrBlocked](err); ok {
 			return blocked.Deps
 		}
 		// ErrSourceSkipped propagates a soft-skip from a referenced source
@@ -630,8 +628,7 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 		// failure under its root cause instead of reprinting the nested chain.
 		// Any other error is a primary failure (its own render/template/build)
 		// and leaves the blocked set empty.
-		var depErr *manifest.DependencyFailedError
-		if errors.As(err, &depErr) {
+		if depErr, ok := errors.AsType[*manifest.DependencyFailedError](err); ok {
 			s.SetBlocked(id, depErr.Failed)
 		}
 		s.UpdateStatus(id, store.StatusFailed, err.Error())
@@ -656,16 +653,15 @@ func RunWithStatusOutcome[T manifest.BaseManifest](
 // preflight pre-checks, then RunWithStatusOutcome. drainLevel threads the
 // scheduler's fixpoint level into Require via ctx. The orchestrator's Dispatcher
 // calls this, routing by Kind, so no per-kind match check is needed here.
-func DispatchNode[T manifest.BaseManifest](
+func (c *Controller) DispatchNode[T manifest.BaseManifest](
 	ctx context.Context,
-	c *Controller,
 	id manifest.NamedResource,
 	drainLevel int,
 	suspended func(T) bool,
 	reconcile func(context.Context, T) error,
 ) []manifest.NamedResource {
 	ctx = WithDrainLevel(ctx, drainLevel)
-	obj, ok := store.Get[T](c.Store, id)
+	obj, ok := c.Store.Get[T](id)
 	if !ok {
 		// Vanished — RunWithStatusOutcome's vanished branch records a terminal status.
 		return RunWithStatusOutcome[T](ctx, c.Store, id, c.log, reconcile)

--- a/pkg/controllers/base/base_test.go
+++ b/pkg/controllers/base/base_test.go
@@ -299,7 +299,7 @@ func TestDispatchNode(t *testing.T) {
 	suspended := func(hr *manifest.HelmRelease) bool { return hr.Name == "suspended" }
 	reconcile := func(_ context.Context, _ *manifest.HelmRelease) error { ran.Add(1); return nil }
 	dispatch := func(id manifest.NamedResource) {
-		base.DispatchNode(t.Context(), c, id, 0, suspended, reconcile)
+		c.DispatchNode(t.Context(), id, 0, suspended, reconcile)
 	}
 
 	// Suspended → PreGate bails to Ready/"suspended", no reconcile.

--- a/pkg/controllers/emit/emit.go
+++ b/pkg/controllers/emit/emit.go
@@ -99,7 +99,7 @@ func Children(c *base.Controller, wipeSecrets bool, id manifest.NamedResource, d
 		}
 		reconcilable := ShouldDispatchAsObject(obj)
 		objs = append(objs, parsed{
-			Child:        Child{Obj: obj, Doc: doc},
+			Obj: obj, Doc: doc,
 			reconcilable: reconcilable,
 			leaf:         reconcilable && IsLeafReconcilable(obj),
 		})

--- a/pkg/controllers/helmrelease/controller.go
+++ b/pkg/controllers/helmrelease/controller.go
@@ -107,7 +107,7 @@ func (c *Controller) Start(_ context.Context) {
 // dependency set (nil = terminalized) and whether id ended Ready. The
 // orchestrator's scheduler Dispatcher calls this for HelmRelease nodes.
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
-	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+	return c.DispatchNode(ctx, id, drainLevel,
 		func(hr *manifest.HelmRelease) bool { return hr.Suspend },
 		c.reconcile)
 }
@@ -154,8 +154,8 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		// with a patched copy; re-read so the rest of reconcile uses
 		// the canonical spec instead of the pre-patch snapshot we
 		// were dispatched with.
-		fresh, ok, err := base.RequireRefresh[*manifest.HelmRelease](
-			ctx, c.Controller, id, hr.Timeout,
+		fresh, ok, err := c.RequireRefresh[*manifest.HelmRelease](
+			ctx, id, hr.Timeout,
 			[]manifest.DependencyRef{{NamedResource: parent}},
 			"waiting for parent KS",
 			func(sum depwait.Summary) error {
@@ -183,8 +183,8 @@ func (c *Controller) reconcile(ctx context.Context, hr *manifest.HelmRelease) er
 		// with explicit spec.dependsOn but no structural parent — or one
 		// whose parent re-emitted us after the parent-gate cleared — keeps
 		// the pre-mutation snapshot through chart resolution.
-		fresh, ok, err := base.RequireRefresh[*manifest.HelmRelease](
-			ctx, c.Controller, id, hr.Timeout, deps,
+		fresh, ok, err := c.RequireRefresh[*manifest.HelmRelease](
+			ctx, id, hr.Timeout, deps,
 			"resolving dependencies", base.DepFailed(id))
 		if err != nil {
 			return err
@@ -564,18 +564,16 @@ func preparePrereqs(hr *manifest.HelmRelease) []manifest.DependencyRef {
 	// chartRefs); Prepare's ResolveChartRef would synchronously read
 	// the HelmChartSource from the store to materialize it.
 	if hr.Chart.RepoKind == manifest.KindHelmChart && hr.Chart.Version == "" {
-		out = append(out, manifest.DependencyRef{NamedResource: manifest.NamedResource{
-			Kind: manifest.KindHelmChart, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName,
-		}})
+		out = append(out, manifest.DependencyRef{
+			Kind: manifest.KindHelmChart, Namespace: hr.Chart.RepoNamespace, Name: hr.Chart.RepoName})
 	}
 
 	for _, ref := range hr.ValuesFrom {
 		if ref.Optional {
 			continue
 		}
-		out = append(out, manifest.DependencyRef{NamedResource: manifest.NamedResource{
-			Kind: ref.Kind, Namespace: hr.Namespace, Name: ref.Name,
-		}})
+		out = append(out, manifest.DependencyRef{
+			Kind: ref.Kind, Namespace: hr.Namespace, Name: ref.Name})
 	}
 
 	return out

--- a/pkg/controllers/helmrelease/controller_test.go
+++ b/pkg/controllers/helmrelease/controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
-	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
@@ -22,7 +21,7 @@ import (
 
 func newTestController(t *testing.T, filter *change.Filter) (*Controller, *store.Store) {
 	t.Helper()
-	return newTestControllerWithOptions(t, ReconcileOptions{Options: base.Options{Filter: filter}})
+	return newTestControllerWithOptions(t, ReconcileOptions{Filter: filter})
 }
 
 func newTestControllerWithParentOf(t *testing.T, parentOf map[manifest.NamedResource]manifest.NamedResource) (*Controller, *store.Store) {
@@ -31,7 +30,7 @@ func newTestControllerWithParentOf(t *testing.T, parentOf map[manifest.NamedReso
 		parent, ok := parentOf[id]
 		return parent, ok
 	}
-	return newTestControllerWithOptions(t, ReconcileOptions{Options: base.Options{ParentOf: resolver}})
+	return newTestControllerWithOptions(t, ReconcileOptions{ParentOf: resolver})
 }
 
 func newTestControllerWithOptions(t *testing.T, opts ReconcileOptions) (*Controller, *store.Store) {
@@ -82,10 +81,8 @@ func TestMaterializeHelmChartSource_RepointsAndRegisters(t *testing.T) {
 	c, st := newTestController(t, nil)
 	st.AddObject(&manifest.HelmRepository{
 		Name: "truecharts", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
-			URL:  "oci://oci.trueforge.org/truecharts",
-			Type: manifest.RepoTypeOCI,
-		},
+		URL:  "oci://oci.trueforge.org/truecharts",
+		Type: manifest.RepoTypeOCI,
 	})
 	hr := &manifest.HelmRelease{
 		Name: "kromgo", Namespace: "apps",
@@ -117,7 +114,7 @@ func TestMaterializeHelmChartSource_RepointsAndRegisters(t *testing.T) {
 	// Synthetic HelmChart registered for the source controller, seeded
 	// Pending so the chart-source depwait never observes it as absent.
 	synID := manifest.NamedResource{Kind: manifest.KindHelmChart, Namespace: got.Chart.RepoNamespace, Name: got.Chart.RepoName}
-	obj := st.GetByName(manifest.KindHelmChart, synID.Namespace, synID.Name)
+	obj := st.GetObjectByName(manifest.KindHelmChart, synID.Namespace, synID.Name)
 	if obj == nil {
 		t.Fatalf("synthetic HelmChart %s not added to store", synID)
 	}
@@ -143,7 +140,7 @@ func TestMaterializeHelmChartSource_IdempotentReSeed(t *testing.T) {
 	c, st := newTestController(t, nil)
 	st.AddObject(&manifest.HelmRepository{
 		Name: "bitnami", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example/bitnami"},
+		URL: "https://charts.example/bitnami",
 	})
 	mkHR := func(name string) *manifest.HelmRelease {
 		return &manifest.HelmRelease{
@@ -215,10 +212,8 @@ func TestMaterializeHelmChartSource_LateArrival(t *testing.T) {
 	// HelmRepository arrives mid-run (render-emitted / lazily promoted).
 	st.AddObject(&manifest.HelmRepository{
 		Name: "truecharts", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
-			URL:  "oci://oci.trueforge.org/truecharts",
-			Type: manifest.RepoTypeOCI,
-		},
+		URL:  "oci://oci.trueforge.org/truecharts",
+		Type: manifest.RepoTypeOCI,
 	})
 
 	// Pass 2: now present — must repoint to the synthetic HelmChart.
@@ -235,7 +230,7 @@ func TestMaterializeHelmChartSource_HTTPRepoMaterializes(t *testing.T) {
 	c, st := newTestController(t, nil)
 	st.AddObject(&manifest.HelmRepository{
 		Name: "bitnami", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example/bitnami"},
+		URL: "https://charts.example/bitnami",
 	})
 	hr := &manifest.HelmRelease{
 		Name: "redis", Namespace: "apps",
@@ -248,7 +243,7 @@ func TestMaterializeHelmChartSource_HTTPRepoMaterializes(t *testing.T) {
 	if !repointed || got.Chart.RepoKind != manifest.KindHelmChart {
 		t.Fatalf("HTTP HelmRepository was not materialized: %+v (repointed=%v)", got.Chart, repointed)
 	}
-	if hc, ok := st.GetByName(manifest.KindHelmChart, got.Chart.RepoNamespace, got.Chart.RepoName).(*manifest.HelmChartSource); !ok || hc.SourceRef.Name != "bitnami" {
+	if hc, ok := st.GetObjectByName(manifest.KindHelmChart, got.Chart.RepoNamespace, got.Chart.RepoName).(*manifest.HelmChartSource); !ok || hc.SourceRef.Name != "bitnami" {
 		t.Errorf("synthetic HelmChart does not reference the bitnami repo: %v", got.Chart)
 	}
 }
@@ -261,7 +256,7 @@ func TestMaterializeHelmChartSource_EmptyVersion(t *testing.T) {
 	c, st := newTestController(t, nil)
 	st.AddObject(&manifest.HelmRepository{
 		Name: "bitnami", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example/bitnami"},
+		URL: "https://charts.example/bitnami",
 	})
 	hr := &manifest.HelmRelease{
 		Name: "redis", Namespace: "apps",
@@ -280,7 +275,7 @@ func TestController_SuspendedShortCircuitsToReady(t *testing.T) {
 	c, st := newTestController(t, nil)
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{Suspend: true},
+		Suspend: true,
 	}
 	st.AddObject(hr)
 
@@ -351,14 +346,12 @@ data:
 	})
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Interval: metav1Duration(time.Hour),
-			Timeout:  ptrDuration(100 * time.Millisecond),
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: manifest.KindConfigMap, Name: "present-values"},
-				{Kind: manifest.KindSecret, Name: "app-values"},
-				{Kind: manifest.KindConfigMap, Name: "runtime-values"},
-			},
+		Interval: metav1Duration(time.Hour),
+		Timeout:  ptrDuration(100 * time.Millisecond),
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: manifest.KindConfigMap, Name: "present-values"},
+			{Kind: manifest.KindSecret, Name: "app-values"},
+			{Kind: manifest.KindConfigMap, Name: "runtime-values"},
 		},
 		Chart: manifest.HelmChart{
 			Name:          "mychart",
@@ -425,13 +418,11 @@ data:
 	})
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Interval: metav1Duration(time.Hour),
-			Timeout:  ptrDuration(100 * time.Millisecond),
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: manifest.KindConfigMap, Name: "present-values"},
-				{Kind: manifest.KindSecret, Name: "app-values"},
-			},
+		Interval: metav1Duration(time.Hour),
+		Timeout:  ptrDuration(100 * time.Millisecond),
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: manifest.KindConfigMap, Name: "present-values"},
+			{Kind: manifest.KindSecret, Name: "app-values"},
 		},
 		Chart: manifest.HelmChart{
 			Name: "mychart", RepoName: "charts",
@@ -474,11 +465,9 @@ func TestController_MissingValuesFromNoProducerFailsWithoutFlag(t *testing.T) {
 	st.UpdateStatus(src.Named(), store.StatusReady, "")
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Interval:   metav1Duration(time.Hour),
-			Timeout:    ptrDuration(100 * time.Millisecond),
-			ValuesFrom: []manifest.ValuesReference{{Kind: manifest.KindSecret, Name: "no-producer"}},
-		},
+		Interval:   metav1Duration(time.Hour),
+		Timeout:    ptrDuration(100 * time.Millisecond),
+		ValuesFrom: []manifest.ValuesReference{{Kind: manifest.KindSecret, Name: "no-producer"}},
 		Chart: manifest.HelmChart{
 			Name: "mychart", RepoName: "charts",
 			RepoNamespace: "flux-system", RepoKind: manifest.KindGitRepository,
@@ -502,11 +491,9 @@ func TestController_HelmChartSourceResolvedViaResolver(t *testing.T) {
 	c, st := newTestController(t, nil)
 	src := &manifest.HelmChartSource{
 		Name: "podinfo", Namespace: "flux-system",
-		HelmChartSpec: sourcev1.HelmChartSpec{
-			Chart:     "podinfo",
-			Version:   "6.3.2",
-			SourceRef: sourcev1.LocalHelmChartSourceReference{Name: "podinfo", Kind: manifest.KindHelmRepository},
-		},
+		Chart:     "podinfo",
+		Version:   "6.3.2",
+		SourceRef: sourcev1.LocalHelmChartSourceReference{Name: "podinfo", Kind: manifest.KindHelmRepository},
 	}
 	st.AddObject(src)
 
@@ -532,11 +519,9 @@ func TestController_HelmChartSourceResolvedViaResolver(t *testing.T) {
 func TestHelmReleaseFingerprint_StableAcrossLabelStamping(t *testing.T) {
 	base := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Interval: metav1Duration(time.Hour),
-		},
-		Chart:  manifest.HelmChart{Name: "podinfo", RepoName: "podinfo", RepoNamespace: "flux-system", RepoKind: manifest.KindHelmRepository},
-		Values: map[string]any{"replicas": 2},
+		Interval: metav1Duration(time.Hour),
+		Chart:    manifest.HelmChart{Name: "podinfo", RepoName: "podinfo", RepoNamespace: "flux-system", RepoKind: manifest.KindHelmRepository},
+		Values:   map[string]any{"replicas": 2},
 	}
 	stamped := base.Clone()
 	stamped.Labels = map[string]string{
@@ -558,8 +543,8 @@ func TestHelmReleaseFingerprint_StableAcrossLabelStamping(t *testing.T) {
 func TestHelmReleaseFingerprint_DifferentOnSpecChange(t *testing.T) {
 	base := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{Interval: metav1Duration(time.Hour)},
-		Chart:           manifest.HelmChart{Name: "podinfo"},
+		Interval: metav1Duration(time.Hour),
+		Chart:    manifest.HelmChart{Name: "podinfo"},
 	}
 	patched := base.Clone()
 	patched.DriftDetection = &helmv2.DriftDetection{Mode: helmv2.DriftDetectionEnabled}
@@ -639,10 +624,9 @@ func TestEmitRenderedChildren_SourceKindGetsKeepEmittedAndMarkRendered(t *testin
 	)
 
 	c := New(st, ts, hc, helm.Options{}, false)
-	c.Configure(ReconcileOptions{Options: base.Options{
+	c.Configure(ReconcileOptions{
 		Filter:        filter,
-		RenderTracker: tracker,
-	}})
+		RenderTracker: tracker})
 	c.Start(context.Background())
 	t.Cleanup(func() { c.Close(); ts.BlockTillDone() })
 
@@ -724,7 +708,7 @@ func TestEmitRenderedChildren_DedupReplay_NoStoreWrites(t *testing.T) {
 		testutil.MapLister{},
 	)
 	c := New(st, ts, hc, helm.Options{}, false)
-	c.Configure(ReconcileOptions{Options: base.Options{Filter: filter, RenderTracker: tracker}})
+	c.Configure(ReconcileOptions{Filter: filter, RenderTracker: tracker})
 	c.Start(context.Background())
 	t.Cleanup(func() { c.Close(); ts.BlockTillDone() })
 
@@ -950,7 +934,7 @@ func TestController_CollectHRDepsClone(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
 		DependsOn: []manifest.DependencyRef{
-			{NamedResource: manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "other"}},
+			{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "other"},
 		},
 	}
 	got := c.collectHRDeps(hr)
@@ -1022,10 +1006,8 @@ func TestController_AlreadyReady_NoTransientPending(t *testing.T) {
 
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Interval: metav1Duration(time.Hour),
-			Timeout:  ptrDuration(100 * time.Millisecond),
-		},
+		Interval: metav1Duration(time.Hour),
+		Timeout:  ptrDuration(100 * time.Millisecond),
 		Chart: manifest.HelmChart{
 			Name: "mychart", RepoName: "charts", RepoNamespace: "flux-system",
 			RepoKind: manifest.KindGitRepository,

--- a/pkg/controllers/helmrelease/reconcile_test.go
+++ b/pkg/controllers/helmrelease/reconcile_test.go
@@ -5,11 +5,8 @@ import (
 	"testing"
 	"time"
 
-	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -28,15 +25,13 @@ func TestReconcile_ChartSourceNotReady(t *testing.T) {
 	// hangs until timeout, then fails.
 	src := &manifest.OCIRepository{
 		Name: "podinfo", Namespace: "flux-system",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example.test/podinfo"},
+		URL: "oci://example.test/podinfo",
 	}
 	st.AddObject(src)
 
 	hr := &manifest.HelmRelease{
 		Name: "podinfo", Namespace: "flux-system",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Timeout: ptrDuration(100 * time.Millisecond),
-		},
+		Timeout: ptrDuration(100 * time.Millisecond),
 		Chart: manifest.HelmChart{
 			Name: "podinfo", RepoKind: manifest.KindOCIRepository,
 			RepoName: "podinfo", RepoNamespace: "flux-system",
@@ -62,9 +57,7 @@ func TestReconcile_DependsOnFailed(t *testing.T) {
 
 	hr := &manifest.HelmRelease{
 		Name: "depender", Namespace: "flux-system",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Timeout: ptrDuration(100 * time.Millisecond),
-		},
+		Timeout:   ptrDuration(100 * time.Millisecond),
 		DependsOn: []manifest.DependencyRef{{NamedResource: dep.Named()}},
 	}
 	st.AddObject(hr)
@@ -84,9 +77,7 @@ func TestReconcile_ParentGateWaits(t *testing.T) {
 	parent := &manifest.Kustomization{Name: "apps", Namespace: "flux-system"}
 	hr := &manifest.HelmRelease{
 		Name: "child", Namespace: "flux-system",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Timeout: ptrDuration(80 * time.Millisecond),
-		},
+		Timeout: ptrDuration(80 * time.Millisecond),
 	}
 	c, st := newTestControllerWithParentOf(t, map[manifest.NamedResource]manifest.NamedResource{
 		hr.Named(): parent.Named(),
@@ -112,9 +103,7 @@ func TestReconcile_ParentGateViaResolverFunc(t *testing.T) {
 	parent := &manifest.Kustomization{Name: "apps", Namespace: "flux-system"}
 	hr := &manifest.HelmRelease{
 		Name: "child", Namespace: "flux-system",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Timeout: ptrDuration(80 * time.Millisecond),
-		},
+		Timeout: ptrDuration(80 * time.Millisecond),
 	}
 	// Resolver returns the parent for the HR only — closes over
 	// captured state, the production shape (which combines a map +
@@ -125,7 +114,7 @@ func TestReconcile_ParentGateViaResolverFunc(t *testing.T) {
 		}
 		return manifest.NamedResource{}, false
 	}
-	c, st := newTestControllerWithOptions(t, ReconcileOptions{Options: base.Options{ParentOf: resolver}})
+	c, st := newTestControllerWithOptions(t, ReconcileOptions{ParentOf: resolver})
 	st.AddObject(parent) // never reaches Ready
 	st.AddObject(hr)
 	info := dispatchToFixpoint(t, c, st, hr.Named())
@@ -179,9 +168,7 @@ func TestReconcile_MissingChartFails(t *testing.T) {
 	c, st := newTestController(t, nil)
 	hr := &manifest.HelmRelease{
 		Name: "broken", Namespace: "flux-system",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			Timeout: ptrDuration(80 * time.Millisecond),
-		},
+		Timeout: ptrDuration(80 * time.Millisecond),
 		// Chart left empty — depwait on an unset source ref times out.
 	}
 	st.AddObject(hr)

--- a/pkg/controllers/helmrelease/valuesfrom.go
+++ b/pkg/controllers/helmrelease/valuesfrom.go
@@ -12,7 +12,6 @@ import (
 	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/depwait"
 	"github.com/home-operations/flate/pkg/manifest"
-	"github.com/home-operations/flate/pkg/store"
 )
 
 // resolvePreRenderValuesFrom reduces hr's valuesFrom to the set helm.Prepare
@@ -67,7 +66,7 @@ func (c *Controller) resolvePreRenderValuesFrom(ctx context.Context, id manifest
 			}
 			return nil, err
 		}
-		if obj, ok := store.Get[*manifest.HelmRelease](c.Store, id); ok {
+		if obj, ok := c.Store.Get[*manifest.HelmRelease](id); ok {
 			hr = obj
 		}
 		if len(omittedValuesRefs) > 0 {
@@ -159,7 +158,7 @@ func cloneWithValuesFrom(hr *manifest.HelmRelease, filtered []manifest.ValuesRef
 }
 
 func (c *Controller) valuesRefExists(id manifest.NamedResource) bool {
-	return c.Store.GetByName(id.Kind, id.Namespace, id.Name) != nil
+	return c.Store.GetObjectByName(id.Kind, id.Namespace, id.Name) != nil
 }
 
 func valuesRefID(hr *manifest.HelmRelease, ref manifest.ValuesReference) (manifest.NamedResource, bool) {

--- a/pkg/controllers/kustomization/controller.go
+++ b/pkg/controllers/kustomization/controller.go
@@ -85,7 +85,7 @@ func (c *Controller) Start(_ context.Context) {
 // dependency set (nil = terminalized) and whether id ended Ready. The
 // orchestrator's scheduler Dispatcher calls this for Kustomization nodes.
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
-	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+	return c.DispatchNode(ctx, id, drainLevel,
 		func(ks *manifest.Kustomization) bool { return ks.Suspend },
 		c.reconcile)
 }
@@ -114,8 +114,8 @@ func (c *Controller) reconcile(ctx context.Context, ks *manifest.Kustomization) 
 		// stale-spec snapshot captured by RunWithStatus, producing
 		// duplicate renders that linger in the store with the wrong
 		// namespace. See #102.
-		fresh, ok, err := base.RequireRefresh[*manifest.Kustomization](
-			ctx, c.Controller, id, ks.Timeout, deps,
+		fresh, ok, err := c.RequireRefresh[*manifest.Kustomization](
+			ctx, id, ks.Timeout, deps,
 			"", base.DepFailed(id)) // empty pendingMsg: status set above (kept Ready on a no-op re-run)
 		if err != nil {
 			return err
@@ -252,9 +252,7 @@ func (c *Controller) collectDeps(ks *manifest.Kustomization) []manifest.Dependen
 	deps := slices.Clone(ks.DependsOn)
 	if ks.SourceKind != "" && ks.SourceName != "" {
 		deps = append(deps, manifest.DependencyRef{
-			NamedResource: manifest.NamedResource{
-				Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
-			},
+			Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName,
 		})
 	}
 	if parent, ok := c.LookupParent(ks.Named()); ok {

--- a/pkg/controllers/kustomization/fingerprint_test.go
+++ b/pkg/controllers/kustomization/fingerprint_test.go
@@ -3,8 +3,6 @@ package kustomization
 import (
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -17,10 +15,8 @@ import (
 func TestKustomizationFingerprint_StableAcrossLabelStamping(t *testing.T) {
 	base := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path:            "./apps",
-			TargetNamespace: "apps",
-		},
+		Path:            "./apps",
+		TargetNamespace: "apps",
 	}
 	stamped := base.Clone()
 	stamped.Labels = map[string]string{
@@ -42,7 +38,7 @@ func TestKustomizationFingerprint_StableAcrossLabelStamping(t *testing.T) {
 func TestKustomizationFingerprint_DifferentOnSpecChange(t *testing.T) {
 	base := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps", TargetNamespace: "apps"},
+		Path: "./apps", TargetNamespace: "apps",
 	}
 	patched := base.Clone()
 	patched.TargetNamespace = "production"
@@ -60,7 +56,7 @@ func TestKustomizationFingerprint_DifferentOnSpecChange(t *testing.T) {
 func TestKustomizationFingerprint_SourceRootInputs(t *testing.T) {
 	ks := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	}
 	if a, b := kustomizationFingerprint(ks, "/repo-a"), kustomizationFingerprint(ks, "/repo-b"); a == b {
 		t.Errorf("fingerprint must differ across distinct sourceRoots; both = %q", a)

--- a/pkg/controllers/kustomization/parent_test.go
+++ b/pkg/controllers/kustomization/parent_test.go
@@ -3,11 +3,8 @@ package kustomization
 import (
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
-	"github.com/home-operations/flate/pkg/controllers/base"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -23,9 +20,9 @@ func TestCollectDeps_AppendsStructuralParent(t *testing.T) {
 	child := &manifest.Kustomization{Name: "karma", Namespace: "observability"}
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{Options: base.Options{ParentOf: mapResolver(map[manifest.NamedResource]manifest.NamedResource{
+	c.Configure(Options{ParentOf: mapResolver(map[manifest.NamedResource]manifest.NamedResource{
 		child.Named(): parent,
-	})}})
+	})})
 	deps := c.collectDeps(child)
 	for _, d := range deps {
 		if d.NamedResource == parent {
@@ -126,14 +123,14 @@ func TestCollectDeps_SubstituteFromIgnoresMalformedRefs(t *testing.T) {
 func TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer(t *testing.T) {
 	consumerObj := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/apps"},
+		Path: "kubernetes/apps",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "cluster-settings"},
 		},
 	}
 	producerObj := &manifest.Kustomization{
 		Name: "cluster-vars", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/flux/vars"},
+		Path: "kubernetes/flux/vars",
 	}
 	consumer := consumerObj.Named()
 	producer := producerObj.Named()
@@ -154,7 +151,7 @@ func TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer(t *testing.T) {
 	)
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{Options: base.Options{Filter: f}})
+	c.Configure(Options{Filter: f})
 	deps := c.collectDeps(consumerObj)
 
 	wantCM := manifest.NamedResource{
@@ -184,7 +181,7 @@ func TestCollectDeps_AppendsSubstituteFromConfigMapAndProducer(t *testing.T) {
 func TestCollectDeps_SkipsSelfProducer(t *testing.T) {
 	selfObj := &manifest.Kustomization{
 		Name: "app", Namespace: "foo",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "kubernetes/foo/app"},
+		Path: "kubernetes/foo/app",
 		PostBuildSubstituteFrom: []manifest.SubstituteReference{
 			{Kind: manifest.KindConfigMap, Name: "settings"},
 		},
@@ -206,7 +203,7 @@ func TestCollectDeps_SkipsSelfProducer(t *testing.T) {
 	)
 
 	c := New(store.New(), nil, nil, false)
-	c.Configure(Options{Options: base.Options{Filter: f}})
+	c.Configure(Options{Filter: f})
 	deps := c.collectDeps(selfObj)
 
 	for _, d := range deps {

--- a/pkg/controllers/kustomization/reconcile_test.go
+++ b/pkg/controllers/kustomization/reconcile_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
@@ -37,7 +36,7 @@ data: {greeting: hi}
 	s := store.New()
 	bootstrap := &manifest.GitRepository{
 		Name: "flux-system", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
+		URL: "file://" + root,
 	}
 	s.AddObject(bootstrap)
 	s.SetArtifact(bootstrap.Named(), &store.SourceArtifact{
@@ -82,11 +81,9 @@ func TestReconcile_HappyPath(t *testing.T) {
 	c, s, root := newControllerWithFixture(t)
 	ks := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps",
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
+		Path: "./apps",
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		Contents: map[string]any{},
@@ -123,11 +120,9 @@ func TestReconcile_FingerprintDedup_SkipsRender(t *testing.T) {
 	c, s, _ := newControllerWithFixture(t)
 	ks := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps",
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
+		Path: "./apps",
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		Contents: map[string]any{},
@@ -168,11 +163,9 @@ func TestReconcile_AlreadyReady_NoTransientPending(t *testing.T) {
 	c, s, _ := newControllerWithFixture(t)
 	ks := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps",
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
+		Path: "./apps",
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		Contents: map[string]any{},
@@ -228,11 +221,9 @@ func TestReconcile_GenuineReRender_DoesDowngrade(t *testing.T) {
 	c, s, _ := newControllerWithFixture(t)
 	ks := &manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps",
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
+		Path: "./apps",
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		Contents: map[string]any{},
@@ -286,11 +277,9 @@ func TestReconcile_SuspendShortCircuits(t *testing.T) {
 	c, s, _ := newControllerWithFixture(t)
 	ks := &manifest.Kustomization{
 		Name: "suspended", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps", Suspend: true,
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
+		Path: "./apps", Suspend: true,
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 	}
@@ -314,11 +303,9 @@ func TestReconcile_MissingPathFails(t *testing.T) {
 	c, s, _ := newControllerWithFixture(t)
 	ks := &manifest.Kustomization{
 		Name: "broken", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./nonexistent",
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
+		Path: "./nonexistent",
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		Contents: map[string]any{},
@@ -344,13 +331,11 @@ func TestReconcile_DependsOnFailed(t *testing.T) {
 
 	ks := &manifest.Kustomization{
 		Name: "depender", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps",
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
-			},
-			Timeout: &metav1.Duration{Duration: 100 * time.Millisecond},
+		Path: "./apps",
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository, Name: "flux-system", Namespace: "flux-system",
 		},
+		Timeout:    &metav1.Duration{Duration: 100 * time.Millisecond},
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
 		DependsOn: []manifest.DependencyRef{
 			{NamedResource: dep.Named()},

--- a/pkg/controllers/kustomization/source_root_test.go
+++ b/pkg/controllers/kustomization/source_root_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -23,7 +22,7 @@ func TestResolveSourceRoot_FallsBackToBootstrapWhenSourceRefEmpty(t *testing.T) 
 	s := store.New()
 	bootstrap := &manifest.GitRepository{
 		Name: "flux-system", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file:///repo"},
+		URL: "file:///repo",
 	}
 	s.AddObject(bootstrap)
 	s.SetArtifact(bootstrap.Named(), &store.SourceArtifact{
@@ -55,7 +54,7 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 	s := store.New()
 	gitrepo := &manifest.GitRepository{
 		Name: "external", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file:///external"},
+		URL: "file:///external",
 	}
 	s.AddObject(gitrepo)
 	s.SetArtifact(gitrepo.Named(), &store.SourceArtifact{
@@ -64,7 +63,7 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 	// Seed bootstrap too — the fallback must not preempt the explicit ref.
 	bootstrap := &manifest.GitRepository{
 		Name: "flux-system", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file:///repo"},
+		URL: "file:///repo",
 	}
 	s.AddObject(bootstrap)
 	s.SetArtifact(bootstrap.Named(), &store.SourceArtifact{
@@ -74,10 +73,10 @@ func TestResolveSourceRoot_ExplicitSourceRefUnchanged(t *testing.T) {
 	c := New(s, nil, nil, false)
 	ks := &manifest.Kustomization{
 		Name: "foo", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
-		SourceKind:        manifest.KindGitRepository,
-		SourceName:        "external",
-		SourceNamespace:   "flux-system",
+		Path:            "./app",
+		SourceKind:      manifest.KindGitRepository,
+		SourceName:      "external",
+		SourceNamespace: "flux-system",
 	}
 	got, _, err := c.resolveSource(ks)
 	if err != nil {
@@ -95,7 +94,7 @@ func TestResolveSourceRoot_NoBootstrapNoSourceRefErrors(t *testing.T) {
 	c := New(store.New(), nil, nil, false)
 	ks := &manifest.Kustomization{
 		Name: "foo", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./app"},
+		Path: "./app",
 	}
 	_, _, err := c.resolveSource(ks)
 	if err == nil {

--- a/pkg/controllers/resourceset/controller.go
+++ b/pkg/controllers/resourceset/controller.go
@@ -83,7 +83,7 @@ func (c *Controller) Start(_ context.Context) {
 // nodes. A ResourceSet has no Suspend field, so the suspended predicate
 // is always false.
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
-	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+	return c.DispatchNode(ctx, id, drainLevel,
 		func(*manifest.ResourceSet) bool { return false },
 		c.reconcile)
 }
@@ -107,8 +107,8 @@ func (c *Controller) reconcile(ctx context.Context, rs *manifest.ResourceSet) er
 		// targetNamespace into a duplicate copy). Without the refresh the
 		// first render would use the stale-spec snapshot. Mirrors the KS
 		// controller (#102).
-		fresh, ok, err := base.RequireRefresh[*manifest.ResourceSet](
-			ctx, c.Controller, id, nil, deps,
+		fresh, ok, err := c.RequireRefresh[*manifest.ResourceSet](
+			ctx, id, nil, deps,
 			"", base.DepFailed(id)) // empty pendingMsg: status set above
 		if err != nil {
 			return err
@@ -189,9 +189,7 @@ func (c *Controller) collectDeps(rs *manifest.ResourceSet) []manifest.Dependency
 	deps := make([]manifest.DependencyRef, 0, len(rs.DependsOn)+len(rs.InputsFrom)+1)
 	for _, dep := range rs.DependsOn {
 		deps = append(deps, manifest.DependencyRef{
-			NamedResource: manifest.NamedResource{
-				Kind: dep.Kind, Namespace: cmp.Or(dep.Namespace, rs.Namespace), Name: dep.Name,
-			},
+			Kind: dep.Kind, Namespace: cmp.Or(dep.Namespace, rs.Namespace), Name: dep.Name,
 			ReadyExpr: dep.ReadyExpr,
 		})
 	}
@@ -202,11 +200,9 @@ func (c *Controller) collectDeps(rs *manifest.ResourceSet) []manifest.Dependency
 		// InputProviderReference is same-namespace by spec — RSIPs live in
 		// the ResourceSet's own namespace.
 		deps = append(deps, manifest.DependencyRef{
-			NamedResource: manifest.NamedResource{
-				Kind:      manifest.KindResourceSetInputProvider,
-				Namespace: rs.Namespace,
-				Name:      ref.Name,
-			},
+			Kind:      manifest.KindResourceSetInputProvider,
+			Namespace: rs.Namespace,
+			Name:      ref.Name,
 		})
 	}
 	if parent, ok := c.LookupParent(rs.Named()); ok {
@@ -223,7 +219,7 @@ func (c *Controller) collectDeps(rs *manifest.ResourceSet) []manifest.Dependency
 // re-expands against the now-complete RSIP set. Returns false when id is not
 // a RS in the store.
 func (c *Controller) WantsDrainRerun(id manifest.NamedResource) bool {
-	rs, ok := store.Get[*manifest.ResourceSet](c.Store, id)
+	rs, ok := c.Store.Get[*manifest.ResourceSet](id)
 	if !ok {
 		return false
 	}

--- a/pkg/controllers/resourceset/controller_test.go
+++ b/pkg/controllers/resourceset/controller_test.go
@@ -53,11 +53,9 @@ func staticRSIP(name, ns string, labels map[string]string, defaults map[string]s
 	}
 	return &manifest.ResourceSetInputProvider{
 		Name: name, Namespace: ns,
-		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-			Type:          fluxopv1.InputProviderStatic,
-			DefaultValues: vals,
-		},
-		Labels: labels,
+		Type:          fluxopv1.InputProviderStatic,
+		DefaultValues: vals,
+		Labels:        labels,
 	}
 }
 
@@ -86,16 +84,14 @@ func TestReconcile_NamedInputsFrom_ParksOnRSIP(t *testing.T) {
 	c, s := newController(t)
 	rs := &manifest.ResourceSet{
 		Name: "acl", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputsFrom: []fluxopv1.InputProviderReference{
-				{Kind: manifest.KindResourceSetInputProvider, Name: "rsip"},
-			},
-			ResourcesTemplate: `---
+		InputsFrom: []fluxopv1.InputProviderReference{
+			{Kind: manifest.KindResourceSetInputProvider, Name: "rsip"},
+		},
+		ResourcesTemplate: `---
 apiVersion: example.com/v1
 kind: Widget
 metadata: {name: << inputs.user >>, namespace: flux-system}
 `,
-		},
 	}
 	s.AddObject(rs)
 
@@ -135,21 +131,19 @@ func TestReconcile_SelectorInputsFrom_LateRSIP(t *testing.T) {
 	c, s := newController(t)
 	rs := &manifest.ResourceSet{
 		Name: "acl", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputsFrom: []fluxopv1.InputProviderReference{
-				{Kind: manifest.KindResourceSetInputProvider, Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"role": "db"},
-				}},
-			},
-			// Guard on inputs so the no-match first pass (nil input set under
-			// Flatten) renders nothing; once the RSIP arrives the input set is
-			// populated and the Widget emits.
-			ResourcesTemplate: `<< if inputs >>---
+		InputsFrom: []fluxopv1.InputProviderReference{
+			{Kind: manifest.KindResourceSetInputProvider, Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"role": "db"},
+			}},
+		},
+		// Guard on inputs so the no-match first pass (nil input set under
+		// Flatten) renders nothing; once the RSIP arrives the input set is
+		// populated and the Widget emits.
+		ResourcesTemplate: `<< if inputs >>---
 apiVersion: example.com/v1
 kind: Widget
 metadata: {name: << inputs.user >>, namespace: flux-system}
 << end >>`,
-		},
 	}
 	s.AddObject(rs)
 
@@ -186,8 +180,7 @@ func TestReconcile_EmitsFluxChildToStore(t *testing.T) {
 	c, s := newController(t)
 	rs := &manifest.ResourceSet{
 		Name: "fleet", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			ResourcesTemplate: `---
+		ResourcesTemplate: `---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata: {name: child, namespace: flux-system}
@@ -195,7 +188,6 @@ spec:
   path: ./child
   sourceRef: {kind: GitRepository, name: flux-system}
 `,
-		},
 	}
 	s.AddObject(rs)
 
@@ -204,7 +196,7 @@ spec:
 		t.Fatalf("status = %+v, want Ready", info)
 	}
 	childID := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "child"}
-	child, ok := store.Get[*manifest.Kustomization](s, childID)
+	child, ok := s.Get[*manifest.Kustomization](childID)
 	if !ok || child == nil {
 		t.Fatalf("expected RS-emitted Kustomization %s in store (AddObject), got ok=%v", childID, ok)
 	}
@@ -217,13 +209,11 @@ func TestReconcile_RenderError_MarksFailed(t *testing.T) {
 	c, s := newController(t)
 	rs := &manifest.ResourceSet{
 		Name: "broken", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			ResourcesTemplate: `---
+		ResourcesTemplate: `---
 apiVersion: v1
 kind: ConfigMap
 metadata: {name: << .nonexistent.field >>}
 `,
-		},
 	}
 	s.AddObject(rs)
 
@@ -240,10 +230,8 @@ func TestWantsDrainRerun_NamedOnly(t *testing.T) {
 	c, s := newController(t)
 	rs := &manifest.ResourceSet{
 		Name: "named", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputsFrom: []fluxopv1.InputProviderReference{
-				{Kind: manifest.KindResourceSetInputProvider, Name: "rsip"},
-			},
+		InputsFrom: []fluxopv1.InputProviderReference{
+			{Kind: manifest.KindResourceSetInputProvider, Name: "rsip"},
 		},
 	}
 	s.AddObject(rs)

--- a/pkg/controllers/source/controller.go
+++ b/pkg/controllers/source/controller.go
@@ -118,7 +118,7 @@ func (c *Controller) Owns(id manifest.NamedResource) bool {
 // whether id ended Ready. The orchestrator's scheduler Dispatcher calls this
 // for source-kind nodes.
 func (c *Controller) ReconcileNode(ctx context.Context, id manifest.NamedResource, drainLevel int) []manifest.NamedResource {
-	return base.DispatchNode(ctx, c.Controller, id, drainLevel,
+	return c.DispatchNode(ctx, id, drainLevel,
 		suspendedSource, c.reconcile)
 }
 

--- a/pkg/controllers/source/controller_test.go
+++ b/pkg/controllers/source/controller_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/home-operations/flate/internal/testutil"
@@ -97,7 +96,7 @@ func TestController_FetchesAndStoresArtifact(t *testing.T) {
 
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+		URL: "https://example/r.git",
 	}
 	st.AddObject(repo)
 
@@ -119,7 +118,7 @@ func TestController_FetchErrorMarksFailed(t *testing.T) {
 
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+		URL: "https://example/r.git",
 	}
 	st.AddObject(repo)
 
@@ -138,7 +137,7 @@ func TestController_SuspendedShortCircuitsToReady(t *testing.T) {
 
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git", Suspend: true},
+		URL: "https://example/r.git", Suspend: true,
 	}
 	st.AddObject(repo)
 
@@ -165,7 +164,7 @@ func TestController_UnregisteredKindIgnored(t *testing.T) {
 
 	unregistered := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+		URL: "https://example/r.git",
 	}
 	st.AddObject(unregistered)
 
@@ -173,7 +172,7 @@ func TestController_UnregisteredKindIgnored(t *testing.T) {
 	// is alive and the unregistered skip is targeted.
 	oci := &manifest.OCIRepository{
 		Name: "o", Namespace: "ns",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+		URL: "oci://example/img",
 	}
 	st.AddObject(oci)
 	if info := dispatchToFixpoint(t, c, st, oci.Named()); info.Status != store.StatusReady {
@@ -206,7 +205,7 @@ func TestController_OwnsExcludesForeignKind(t *testing.T) {
 
 	flux := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{BucketName: "b", Endpoint: "minio:9000"},
+		BucketName: "b", Endpoint: "minio:9000",
 	}
 	st.AddObject(flux)
 	if !c.Owns(flux.Named()) {
@@ -231,7 +230,7 @@ func TestController_AllowMissingSecretsConvertsFailureToSkip(t *testing.T) {
 
 	repo := &manifest.OCIRepository{
 		Name: "r", Namespace: "ns",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+		URL: "oci://example/img",
 	}
 	st.AddObject(repo)
 
@@ -258,7 +257,7 @@ func TestController_AllowMissingSecretsOffStillFails(t *testing.T) {
 
 	repo := &manifest.OCIRepository{
 		Name: "r", Namespace: "ns",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+		URL: "oci://example/img",
 	}
 	st.AddObject(repo)
 
@@ -285,7 +284,7 @@ func TestController_ProducerBackedMissingSecretSkippedWithoutFlag(t *testing.T) 
 
 	repo := &manifest.OCIRepository{
 		Name: "r", Namespace: "ns",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+		URL: "oci://example/img",
 	}
 	st.AddObject(repo)
 
@@ -308,7 +307,7 @@ func TestController_MissingSecretNoProducerFailsWithoutFlag(t *testing.T) {
 
 	repo := &manifest.OCIRepository{
 		Name: "r", Namespace: "ns",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: "oci://example/img"},
+		URL: "oci://example/img",
 	}
 	st.AddObject(repo)
 
@@ -334,7 +333,7 @@ func TestController_ChangeFilterSkipsUnaffected(t *testing.T) {
 
 	repo := &manifest.GitRepository{
 		Name: "r", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://example/r.git"},
+		URL: "https://example/r.git",
 	}
 	st.AddObject(repo)
 
@@ -366,7 +365,7 @@ func TestController_ExistenceFetcher_NoTransientPendingOnReemit(t *testing.T) {
 	})
 	repo := &manifest.HelmRepository{
 		Name: "charts", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example", Type: "default"},
+		URL: "https://charts.example", Type: "default",
 	}
 	st.AddObject(repo)
 	if info := dispatchToFixpoint(t, c, st, repo.Named()); info.Status != store.StatusReady {
@@ -391,10 +390,8 @@ func TestController_ExistenceFetcher_NoTransientPendingOnReemit(t *testing.T) {
 	// must keep the source Ready without a transient Pending write.
 	reemit := &manifest.HelmRepository{
 		Name: "charts", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{
-			URL: "https://charts.example", Type: "default",
-			Interval: metav1.Duration{Duration: time.Hour},
-		},
+		URL: "https://charts.example", Type: "default",
+		Interval: metav1.Duration{Duration: time.Hour},
 	}
 	st.AddObject(reemit)
 	reconcileNode(c, repo.Named(), 0)

--- a/pkg/depwait/classify_test.go
+++ b/pkg/depwait/classify_test.go
@@ -15,9 +15,8 @@ func classifyDep(t *testing.T, w *Waiter, ref manifest.DependencyRef, drain int)
 }
 
 func ksDep(name string) manifest.DependencyRef {
-	return manifest.DependencyRef{NamedResource: manifest.NamedResource{
-		Kind: manifest.KindKustomization, Namespace: "ns", Name: name,
-	}}
+	return manifest.DependencyRef{
+		Kind: manifest.KindKustomization, Namespace: "ns", Name: name}
 }
 
 // TestClassify_CoreStates exercises the non-ReadyExpr branches that drive the

--- a/pkg/diff/dyff.go
+++ b/pkg/diff/dyff.go
@@ -94,15 +94,13 @@ func diffSyntaxReport(report dyff.Report, pathPrefix, rootPrefix, changePrefix s
 		PathPrefix:            pathPrefix,
 		RootDescriptionPrefix: rootPrefix,
 		ChangeTypePrefix:      changePrefix,
-		HumanReport: dyff.HumanReport{
-			Report:                report,
-			Indent:                0,
-			UseIndentLines:        true,
-			NoTableStyle:          true,
-			OmitHeader:            true,
-			PrefixMultiline:       true,
-			MultilineContextLines: 4,
-			MinorChangeThreshold:  0.1,
-		},
+		Report:                report,
+		Indent:                0,
+		UseIndentLines:        true,
+		NoTableStyle:          true,
+		OmitHeader:            true,
+		PrefixMultiline:       true,
+		MultilineContextLines: 4,
+		MinorChangeThreshold:  0.1,
 	}
 }

--- a/pkg/discovery/bootstrap.go
+++ b/pkg/discovery/bootstrap.go
@@ -3,8 +3,6 @@ package discovery
 import (
 	"log/slog"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -50,7 +48,7 @@ func (d *discoverer) seedBootstrapSource() (string, error) {
 	if d.cfg.Store.GetObject(id) == nil {
 		repo := &manifest.GitRepository{
 			Name: id.Name, Namespace: id.Namespace,
-			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + root},
+			URL: "file://" + root,
 		}
 		d.cfg.Store.AddObject(repo)
 	}
@@ -100,7 +98,7 @@ func (d *discoverer) aliasMissingKustomizationSources(repoRoot string) []manifes
 	// a second map.
 	existing := knownSourceIDs(d.cfg.Store, manifest.KindGitRepository, manifest.KindOCIRepository)
 	var aliased []manifest.NamedResource
-	for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
+	for _, ks := range d.cfg.Store.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		id := manifest.NamedResource{Kind: ks.SourceKind, Namespace: ks.SourceNamespace, Name: ks.SourceName}
 		if _, ok := existing[id]; ok {
 			continue
@@ -136,7 +134,7 @@ func (d *discoverer) overrideSelfReferentialGitRepositories(repoRoot string) []m
 		return nil
 	}
 	var overridden []manifest.NamedResource
-	for _, repo := range store.ListAs[*manifest.GitRepository](d.cfg.Store, manifest.KindGitRepository) {
+	for _, repo := range d.cfg.Store.ListAs[*manifest.GitRepository](manifest.KindGitRepository) {
 		id := repo.Named()
 		normalized := normalizeGitURL(repo.URL)
 		if normalized == "" {
@@ -185,7 +183,7 @@ func newBootstrapAlias(id manifest.NamedResource, repoRoot string) (manifest.Bas
 		url := "file://" + repoRoot
 		return &manifest.GitRepository{
 			Name: id.Name, Namespace: id.Namespace,
-			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: url},
+			URL: url,
 		}, url, true
 	case manifest.KindOCIRepository:
 		// Synthetic oci:// URL — never resolved, only present so the
@@ -196,7 +194,7 @@ func newBootstrapAlias(id manifest.NamedResource, repoRoot string) (manifest.Bas
 		url := "oci://flate-bootstrap-alias/" + id.Namespace + "/" + id.Name
 		return &manifest.OCIRepository{
 			Name: id.Name, Namespace: id.Namespace,
-			OCIRepositorySpec: sourcev1.OCIRepositorySpec{URL: url},
+			URL: url,
 		}, url, true
 	}
 	return nil, "", false

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -293,7 +293,7 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	ksExpanded := map[manifest.NamedResource]struct{}{}
 	for {
 		added := 0
-		for _, ks := range store.ListAs[*manifest.Kustomization](d.cfg.Store, manifest.KindKustomization) {
+		for _, ks := range d.cfg.Store.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 			id := ks.Named()
 			if _, seen := ksExpanded[id]; seen {
 				continue

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -559,7 +559,7 @@ configMapGenerator:
 	cmID := manifest.NamedResource{
 		Kind: manifest.KindConfigMap, Namespace: "flux-system", Name: "cluster-settings",
 	}
-	cm, _ := store.GetByName[*manifest.ConfigMap](st, manifest.KindConfigMap, "flux-system", "cluster-settings")
+	cm, _ := st.GetByName[*manifest.ConfigMap](manifest.KindConfigMap, "flux-system", "cluster-settings")
 	if cm == nil {
 		t.Fatalf("ConfigMap %s not synthesized from configMapGenerator", cmID)
 	}

--- a/pkg/helm/oci_chart_test.go
+++ b/pkg/helm/oci_chart_test.go
@@ -91,10 +91,8 @@ func TestLocateOCIChart_NoArtifactErrors(t *testing.T) {
 	st := store.New()
 	repo := &manifest.OCIRepository{
 		Name: "chart", Namespace: "flux-system",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       "oci://ghcr.io/test/chart",
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "0.1.0"},
-		},
+		URL:       "oci://ghcr.io/test/chart",
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "0.1.0"},
 	}
 	st.AddObject(repo)
 	// Intentionally NO SetArtifact.
@@ -232,9 +230,7 @@ func setupOCIChartTest(t *testing.T, slot, label string) (*Client, *manifest.Hel
 	st := store.New()
 	repo := &manifest.OCIRepository{
 		Name: "chart-" + label, Namespace: "flux-system",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL: "oci://ghcr.io/test/chart-" + label,
-		},
+		URL: "oci://ghcr.io/test/chart-" + label,
 	}
 	st.AddObject(repo)
 	st.SetArtifact(repo.Named(), &store.SourceArtifact{

--- a/pkg/helm/postrender.go
+++ b/pkg/helm/postrender.go
@@ -65,13 +65,11 @@ func runKustomizePostRender(in *bytes.Buffer, k *helmv2.Kustomize) (*bytes.Buffe
 		}
 	}
 	cfg := kustypes.Kustomization{
-		TypeMeta: kustypes.TypeMeta{
-			APIVersion: kustypes.KustomizationVersion,
-			Kind:       kustypes.KustomizationKind,
-		},
-		Resources: []string{inputFile},
-		Images:    adaptImages(k.Images),
-		Patches:   patches,
+		APIVersion: kustypes.KustomizationVersion,
+		Kind:       kustypes.KustomizationKind,
+		Resources:  []string{inputFile},
+		Images:     adaptImages(k.Images),
+		Patches:    patches,
 	}
 
 	raw, err := json.Marshal(cfg)

--- a/pkg/helm/resolver.go
+++ b/pkg/helm/resolver.go
@@ -46,12 +46,12 @@ type storeResolver struct {
 }
 
 func (r *storeResolver) HelmRepository(namespace, name string) *manifest.HelmRepository {
-	obj, _ := store.GetByName[*manifest.HelmRepository](r.store, manifest.KindHelmRepository, namespace, name)
+	obj, _ := r.store.GetByName[*manifest.HelmRepository](manifest.KindHelmRepository, namespace, name)
 	return obj
 }
 
 func (r *storeResolver) OCIRepository(namespace, name string) *manifest.OCIRepository {
-	obj, _ := store.GetByName[*manifest.OCIRepository](r.store, manifest.KindOCIRepository, namespace, name)
+	obj, _ := r.store.GetByName[*manifest.OCIRepository](manifest.KindOCIRepository, namespace, name)
 	return obj
 }
 
@@ -62,6 +62,6 @@ func (r *storeResolver) LocalSourceArtifact(kind, namespace, name string) *store
 }
 
 func (r *storeResolver) HelmChart(namespace, name string) *manifest.HelmChartSource {
-	obj, _ := store.GetByName[*manifest.HelmChartSource](r.store, manifest.KindHelmChart, namespace, name)
+	obj, _ := r.store.GetByName[*manifest.HelmChartSource](manifest.KindHelmChart, namespace, name)
 	return obj
 }

--- a/pkg/helm/resolver_test.go
+++ b/pkg/helm/resolver_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/helm"
 	"github.com/home-operations/flate/pkg/manifest"
@@ -40,7 +38,7 @@ data:
 	st := store.New()
 	gr := &manifest.GitRepository{
 		Name: "chart-repo", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + dir},
+		URL: "file://" + dir,
 	}
 	st.AddObject(gr)
 	st.SetArtifact(gr.Named(), &store.SourceArtifact{

--- a/pkg/kustomize/generate.go
+++ b/pkg/kustomize/generate.go
@@ -81,10 +81,8 @@ func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]an
 	}
 
 	kus := kustypes.Kustomization{
-		TypeMeta: kustypes.TypeMeta{
-			APIVersion: kustypes.KustomizationVersion,
-			Kind:       kustypes.KustomizationKind,
-		},
+		APIVersion: kustypes.KustomizationVersion,
+		Kind:       kustypes.KustomizationKind,
 	}
 	if err := yaml.Unmarshal(data, &kus); err != nil {
 		return nil, "", err
@@ -247,10 +245,8 @@ func findOrGenerateKustomization(fsys filesys.FileSystem, dirPath string, ignore
 	}
 
 	kus := kustypes.Kustomization{
-		TypeMeta: kustypes.TypeMeta{
-			APIVersion: kustypes.KustomizationVersion,
-			Kind:       kustypes.KustomizationKind,
-		},
+		APIVersion: kustypes.KustomizationVersion,
+		Kind:       kustypes.KustomizationKind,
 	}
 	var resources []string
 	for _, file := range files {

--- a/pkg/loader/depsubst.go
+++ b/pkg/loader/depsubst.go
@@ -46,7 +46,7 @@ func ResolveDependsOnSubstitutions(s *store.Store) {
 		v, ok := union[name]
 		return v, ok
 	}
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		resolved := resolveDeps(ks.DependsOn, mapping)
 		if resolved == nil {
 			continue
@@ -67,7 +67,7 @@ func ResolveDependsOnSubstitutions(s *store.Store) {
 func substituteUnion(s *store.Store) map[string]string {
 	union := map[string]string{}
 	conflicting := map[string]struct{}{}
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		for k, v := range values.VarsMap(ks.PostBuildSubstitute) {
 			if _, bad := conflicting[k]; bad {
 				continue

--- a/pkg/loader/depsubst_test.go
+++ b/pkg/loader/depsubst_test.go
@@ -11,7 +11,7 @@ func ksWithDeps(name, ns string, sub map[string]any, depNames ...string) *manife
 	deps := make([]manifest.DependencyRef, len(depNames))
 	for i, dn := range depNames {
 		deps[i] = manifest.DependencyRef{
-			NamedResource: manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: ns, Name: dn},
+			Kind: manifest.KindKustomization, Namespace: ns, Name: dn,
 		}
 	}
 	return &manifest.Kustomization{
@@ -23,7 +23,7 @@ func ksWithDeps(name, ns string, sub map[string]any, depNames ...string) *manife
 
 func firstDepName(t *testing.T, s *store.Store, ns, name string) string {
 	t.Helper()
-	ks, ok := store.GetByName[*manifest.Kustomization](s, manifest.KindKustomization, ns, name)
+	ks, ok := s.GetByName[*manifest.Kustomization](manifest.KindKustomization, ns, name)
 	if !ok {
 		t.Fatalf("Kustomization %s/%s missing from store", ns, name)
 	}

--- a/pkg/loader/inherit.go
+++ b/pkg/loader/inherit.go
@@ -95,9 +95,9 @@ func ApplyNamespaceInheritanceWithRefs(s *store.Store, sourceFiles map[manifest.
 // top-level Flux Operator and HelmChart source objects after namespace
 // inheritance has had a chance to project kustomize/Flux namespaces.
 func ApplyDefaultNamespaces(s *store.Store, sourceFiles map[manifest.NamedResource]string) {
-	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSet](s, manifest.KindResourceSet))
-	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider))
-	applyDefaultNS(s, sourceFiles, store.ListAs[*manifest.HelmChartSource](s, manifest.KindHelmChart))
+	applyDefaultNS(s, sourceFiles, s.ListAs[*manifest.ResourceSet](manifest.KindResourceSet))
+	applyDefaultNS(s, sourceFiles, s.ListAs[*manifest.ResourceSetInputProvider](manifest.KindResourceSetInputProvider))
+	applyDefaultNS(s, sourceFiles, s.ListAs[*manifest.HelmChartSource](manifest.KindHelmChart))
 }
 
 // applyDefaultNS assigns manifest.DefaultNamespace to every object in objs
@@ -170,7 +170,7 @@ func resolveNamespace(file string, flux, kust []pathEntry) string {
 // stay unsorted.
 func indexFluxByPath(s *store.Store, sourceFiles map[manifest.NamedResource]string, kust []pathEntry) []pathEntry {
 	var out []pathEntry
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		if ks.Path == "" {
 			continue
 		}

--- a/pkg/loader/inherit_test.go
+++ b/pkg/loader/inherit_test.go
@@ -19,12 +19,10 @@ func TestApplyNamespaceInheritance_FluxTargetNamespaceWins(t *testing.T) {
 
 	s := store.New()
 	parent := &manifest.Kustomization{
-		Name:      "plex",
-		Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path:            "apps/plex",
-			TargetNamespace: "media",
-		},
+		Name:            "plex",
+		Namespace:       "flux-system",
+		Path:            "apps/plex",
+		TargetNamespace: "media",
 	}
 	hr := &manifest.HelmRelease{
 		Name:      "plex",
@@ -154,9 +152,7 @@ func TestApplyNamespaceInheritance_CrossTreeBasePattern(t *testing.T) {
 	// spec.targetNamespace is set in the source YAML.
 	ks := &manifest.Kustomization{
 		Name: "romm",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./apps/base/games/romm",
-		},
+		Path: "./apps/base/games/romm",
 	}
 	hr := &manifest.HelmRelease{Name: "romm"}
 	s.AddObject(ks)
@@ -252,11 +248,9 @@ func TestApplyNamespaceInheritance_FluxOperatorAndHelmChartSource(t *testing.T) 
 	s := store.New()
 	ks := &manifest.Kustomization{
 		Name: "workload",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: manifest.KindGitRepository,
-				Name: "repo",
-			},
+		SourceRef: kustomizev1.CrossNamespaceSourceReference{
+			Kind: manifest.KindGitRepository,
+			Name: "repo",
 		},
 		SourceKind:      manifest.KindGitRepository,
 		SourceName:      "repo",
@@ -265,19 +259,17 @@ func TestApplyNamespaceInheritance_FluxOperatorAndHelmChartSource(t *testing.T) 
 			"metadata": map[string]any{"name": "workload"},
 		},
 		DependsOn: []manifest.DependencyRef{{
-			NamedResource: manifest.NamedResource{Kind: manifest.KindKustomization, Name: "infra"},
+			Kind: manifest.KindKustomization, Name: "infra",
 		}},
 	}
 	rs := &manifest.ResourceSet{Name: "apps"}
 	rsip := &manifest.ResourceSetInputProvider{Name: "apps-inputs"}
 	hc := &manifest.HelmChartSource{
-		Name: "chart",
-		HelmChartSpec: sourcev1.HelmChartSpec{
-			Chart: "podinfo",
-			SourceRef: sourcev1.LocalHelmChartSourceReference{
-				Kind: manifest.KindHelmRepository,
-				Name: "podinfo",
-			},
+		Name:  "chart",
+		Chart: "podinfo",
+		SourceRef: sourcev1.LocalHelmChartSourceReference{
+			Kind: manifest.KindHelmRepository,
+			Name: "podinfo",
 		},
 	}
 	s.AddObject(ks)

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -479,7 +479,7 @@ func (l *Loader) dirCoveredByOtherKS(dir string) bool {
 		return false
 	}
 	dirRel := filepath.ToSlash(rel) + "/"
-	for _, ks := range store.ListAs[*manifest.Kustomization](l.Store, manifest.KindKustomization) {
+	for _, ks := range l.Store.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		if ks.Path == "" {
 			continue
 		}
@@ -789,7 +789,7 @@ func parentNamespaceFor(prefixes []KSPathPrefix, s *store.Store, absPath, repoRo
 	if !ok {
 		return ""
 	}
-	ks, _ := store.GetByName[*manifest.Kustomization](s, manifest.KindKustomization, owner.Namespace, owner.Name)
+	ks, _ := s.GetByName[*manifest.Kustomization](manifest.KindKustomization, owner.Namespace, owner.Name)
 	if ks == nil {
 		return ""
 	}

--- a/pkg/loader/loader_test.go
+++ b/pkg/loader/loader_test.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -53,9 +51,9 @@ spec:
 	// covers apps/test/network/). Pre-seeded so the guard sees it regardless
 	// of walk order.
 	s.AddObject(&manifest.Kustomization{
-		Name:              "cluster-apps",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "apps/test"},
+		Name:      "cluster-apps",
+		Namespace: "flux-system",
+		Path:      "apps/test",
 	})
 
 	l := New(s)

--- a/pkg/loader/parent.go
+++ b/pkg/loader/parent.go
@@ -54,7 +54,7 @@ type KSPathPrefix struct {
 // resolves). Only an in-tree, non-bootstrap, non-aliased source CR is external.
 func ExternalSourcedKSIDs(s *store.Store, repoRoot string) map[manifest.NamedResource]struct{} {
 	out := map[manifest.NamedResource]struct{}{}
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		if ks.Path == "" || ks.SourceName == "" {
 			continue
 		}
@@ -128,7 +128,7 @@ func KSPathPrefixesWithCache(s *store.Store, repoRoot string, cache *manifest.Co
 	// reject/clean resolver, longest-first sort) is single-sourced there so
 	// it can't drift from change.buildOwnership. This side keeps only the
 	// KSPathPrefix shape and the LongestParent lookup semantics.
-	claims := manifest.BuildKSClaims(store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization), repoRoot, cache)
+	claims := manifest.BuildKSClaims(s.ListAs[*manifest.Kustomization](manifest.KindKustomization), repoRoot, cache)
 	out := make([]KSPathPrefix, len(claims))
 	for i, c := range claims {
 		out[i] = KSPathPrefix{ID: c.ID, Prefix: c.Prefix}

--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -3,8 +3,6 @@ package loader
 import (
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -31,21 +29,21 @@ func TestKSPathPrefixesLocalOnly_DropsExternalSourced(t *testing.T) {
 	bootstrap := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
 		SourceKind: manifest.KindGitRepository, SourceName: "flux-system", SourceNamespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+		Path: "./kubernetes/apps",
 	}
 	// Self/aliased source: an in-tree GitRepository with a working-tree artifact
 	// (URL-matched by discovery) — kept.
 	aliasedKS := &manifest.Kustomization{
 		Name: "self-apps", Namespace: "flux-system",
 		SourceKind: manifest.KindGitRepository, SourceName: "home-kubernetes", SourceNamespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/self"},
+		Path: "./kubernetes/self",
 	}
 	// External source: an in-tree GitRepository with NO working-tree artifact,
 	// claiming the WIDE ./kubernetes — must be dropped.
 	external := &manifest.Kustomization{
 		Name: "side-sync", Namespace: "flux-system",
 		SourceKind: manifest.KindGitRepository, SourceName: "side-repo", SourceNamespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes"},
+		Path: "./kubernetes",
 	}
 	s.AddObject(bootstrap)
 	s.AddObject(aliasedKS)
@@ -92,16 +90,12 @@ func TestBuildParentIndex_CrossTreeBasePattern(t *testing.T) {
 	clusterApps := &manifest.Kustomization{
 		Name:      "cluster-apps",
 		Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./kubernetes/apps/main",
-		},
+		Path:      "./kubernetes/apps/main",
 	}
 	karma := &manifest.Kustomization{
 		Name:      "karma",
 		Namespace: "observability",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path: "./kubernetes/apps/base/observability/karma",
-		},
+		Path:      "./kubernetes/apps/base/observability/karma",
 	}
 	s.AddObject(clusterApps)
 	s.AddObject(karma)
@@ -126,19 +120,19 @@ func TestBuildParentIndex_DeepestPrefixWins(t *testing.T) {
 	// the structural parent.
 	s := store.New()
 	outer := &manifest.Kustomization{
-		Name:              "outer",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Name:      "outer",
+		Namespace: "flux-system",
+		Path:      "./apps",
 	}
 	inner := &manifest.Kustomization{
-		Name:              "inner",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/media"},
+		Name:      "inner",
+		Namespace: "flux-system",
+		Path:      "./apps/media",
 	}
 	grandchild := &manifest.Kustomization{
-		Name:              "plex",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/media/plex/app"},
+		Name:      "plex",
+		Namespace: "flux-system",
+		Path:      "./apps/media/plex/app",
 	}
 	s.AddObject(outer)
 	s.AddObject(inner)
@@ -164,9 +158,9 @@ func TestBuildParentIndex_NoSelfMatch(t *testing.T) {
 	// match itself as parent. Edge case for in-place trees.
 	s := store.New()
 	ks := &manifest.Kustomization{
-		Name:              "self",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Name:      "self",
+		Namespace: "flux-system",
+		Path:      "./apps",
 	}
 	s.AddObject(ks)
 	sourceFiles := map[manifest.NamedResource]string{
@@ -186,14 +180,14 @@ func TestBuildParentIndex_PeersSharingSamePathHaveNoParent(t *testing.T) {
 	// other to reach Ready, then both time out).
 	s := store.New()
 	config := &manifest.Kustomization{
-		Name:              "0-config",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./clusters/main/flux"},
+		Name:      "0-config",
+		Namespace: "flux-system",
+		Path:      "./clusters/main/flux",
 	}
 	softServe := &manifest.Kustomization{
-		Name:              "0-soft-serve",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./clusters/main/flux"},
+		Name:      "0-soft-serve",
+		Namespace: "flux-system",
+		Path:      "./clusters/main/flux",
 	}
 	s.AddObject(config)
 	s.AddObject(softServe)
@@ -218,14 +212,14 @@ func TestBuildParentIndex_RendererOfDefinitionFileStillParents(t *testing.T) {
 	// this strict-ancestor edge must survive.
 	s := store.New()
 	root := &manifest.Kustomization{
-		Name:              "0-config",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./clusters/main/flux"},
+		Name:      "0-config",
+		Namespace: "flux-system",
+		Path:      "./clusters/main/flux",
 	}
 	app := &manifest.Kustomization{
-		Name:              "app",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Name:      "app",
+		Namespace: "flux-system",
+		Path:      "./apps",
 	}
 	s.AddObject(root)
 	s.AddObject(app)
@@ -246,14 +240,14 @@ func TestBuildParentIndex_NoSourceFileSkipped(t *testing.T) {
 	// has no detectable file — skip rather than blow up.
 	s := store.New()
 	parent := &manifest.Kustomization{
-		Name:              "parent",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Name:      "parent",
+		Namespace: "flux-system",
+		Path:      "./apps",
 	}
 	orphan := &manifest.Kustomization{
-		Name:              "orphan",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/orphan/app"},
+		Name:      "orphan",
+		Namespace: "flux-system",
+		Path:      "./apps/orphan/app",
 	}
 	s.AddObject(parent)
 	s.AddObject(orphan)
@@ -276,15 +270,15 @@ func TestKSPathPrefixes_SortsLongestFirst(t *testing.T) {
 	s := store.New()
 	root := &manifest.Kustomization{
 		Name: "root", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	}
 	mid := &manifest.Kustomization{
 		Name: "mid", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/team-a"},
+		Path: "./apps/team-a",
 	}
 	leaf := &manifest.Kustomization{
 		Name: "leaf", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/team-a/web"},
+		Path: "./apps/team-a/web",
 	}
 	s.AddObject(root)
 	s.AddObject(mid)
@@ -308,7 +302,7 @@ func TestKSPathPrefixes_SkipsEmptyPath(t *testing.T) {
 	s := store.New()
 	with := &manifest.Kustomization{
 		Name: "with", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	}
 	without := &manifest.Kustomization{Name: "without", Namespace: "flux-system"}
 	s.AddObject(with)
@@ -345,10 +339,8 @@ func TestKSPathPrefixes_IncludesSpecComponents(t *testing.T) {
 	s := store.New()
 	parent := &manifest.Kustomization{
 		Name: "parent", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{
-			Path:       "./apps/team-a",
-			Components: []string{"../shared/observability"},
-		},
+		Path:       "./apps/team-a",
+		Components: []string{"../shared/observability"},
 	}
 	s.AddObject(parent)
 
@@ -394,11 +386,11 @@ func TestLongestParent_DeepestMatchWins(t *testing.T) {
 	s := store.New()
 	root := &manifest.Kustomization{
 		Name: "root", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	}
 	leaf := &manifest.Kustomization{
 		Name: "leaf", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/team-a/web"},
+		Path: "./apps/team-a/web",
 	}
 	s.AddObject(root)
 	s.AddObject(leaf)

--- a/pkg/loader/selfproduce.go
+++ b/pkg/loader/selfproduce.go
@@ -101,7 +101,7 @@ func BuildSelfProduceIndex(s *store.Store, repoRoot string, producers *manifest.
 	// producing local ConfigMaps/Secrets it doesn't own (and cascade its skip).
 	// See loader.ExternalSourcedKSIDs.
 	external := ExternalSourcedKSIDs(s, repoRoot)
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		if ks.Path == "" {
 			continue
 		}

--- a/pkg/loader/selfproduce_test.go
+++ b/pkg/loader/selfproduce_test.go
@@ -5,8 +5,6 @@ import (
 	"slices"
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -36,9 +34,9 @@ func TestBuildSelfProduceIndex_BareDirComponentNamespace(t *testing.T) {
 
 	s := store.New()
 	clusterApps := &manifest.Kustomization{
-		Name:              "cluster-apps",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+		Name:      "cluster-apps",
+		Namespace: "flux-system",
+		Path:      "./kubernetes/apps",
 	}
 	s.AddObject(clusterApps)
 
@@ -69,9 +67,9 @@ func TestBuildSelfProduceIndex_NonProducerNotAttributed(t *testing.T) {
 
 	s := store.New()
 	ks := &manifest.Kustomization{
-		Name:              "cluster-apps",
-		Namespace:         "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+		Name:      "cluster-apps",
+		Namespace: "flux-system",
+		Path:      "./kubernetes/apps",
 	}
 	s.AddObject(ks)
 
@@ -117,9 +115,9 @@ func TestBuildSelfProduceIndex_EmissionParentByFile(t *testing.T) {
 
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/test"}})
+		Path: "./apps/test"})
 	s.AddObject(&manifest.Kustomization{Name: "cluster-apps2", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps/test2"}})
+		Path: "./apps/test2"})
 
 	idx := BuildSelfProduceIndex(s, dir, nil, true)
 
@@ -162,7 +160,7 @@ func TestBuildSelfProduceIndex_RecordsProducers(t *testing.T) {
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	})
 
 	producers := &manifest.ProducerIndex{}
@@ -203,7 +201,7 @@ func TestBuildSelfProduceIndex_NamePrefixNotFollowed(t *testing.T) {
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	})
 
 	producers := &manifest.ProducerIndex{}
@@ -243,7 +241,7 @@ func TestBuildSelfProduceIndex_SynthesizesPlaceholderSecret(t *testing.T) {
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	})
 	existing := &manifest.Secret{Name: "pre-secret", Namespace: "secure", StringData: map[string]any{"K": "real"}}
 	s.AddObject(existing)
@@ -287,7 +285,7 @@ func TestBuildSelfProduceIndex_MaterializesSopsSecret(t *testing.T) {
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	})
 
 	BuildSelfProduceIndex(s, dir, &manifest.ProducerIndex{}, true)
@@ -317,7 +315,7 @@ func TestBuildSelfProduceIndex_NoSynthesisWithoutWipe(t *testing.T) {
 	s := store.New()
 	s.AddObject(&manifest.Kustomization{
 		Name: "apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	})
 
 	BuildSelfProduceIndex(s, dir, &manifest.ProducerIndex{}, false)

--- a/pkg/loader/transformer_ns.go
+++ b/pkg/loader/transformer_ns.go
@@ -65,7 +65,7 @@ func StampTransformerTargetNamespaces(s *store.Store, sourceFiles map[manifest.N
 	// ancestry, and resolution re-reads kustomization.yaml files off
 	// disk. Live only for this pass.
 	cache := map[string]nsResolution{}
-	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 		if ks.TargetNamespace != "" {
 			continue
 		}

--- a/pkg/loader/transformer_ns_test.go
+++ b/pkg/loader/transformer_ns_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
 )
@@ -49,8 +47,8 @@ resources:
 
 func leafKS(name, path string) *manifest.Kustomization {
 	return &manifest.Kustomization{
-		Name:              name,
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: path},
+		Name: name,
+		Path: path,
 		Contents: map[string]any{
 			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
 			"kind":       "Kustomization",
@@ -73,7 +71,7 @@ func TestStampTransformerTargetNamespaces_NamespaceTransformer(t *testing.T) {
 
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
 
-	got, ok := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, ok := s.Get[*manifest.Kustomization](ks.Named())
 	if !ok {
 		t.Fatal("KS missing after stamp")
 	}
@@ -107,7 +105,7 @@ resources:
 
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
 
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	if got.TargetNamespace != "" {
 		t.Errorf("TargetNamespace=%q want empty (no NamespaceTransformer)", got.TargetNamespace)
 	}
@@ -148,7 +146,7 @@ fieldSpecs:
 
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
 
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	if got.TargetNamespace != "" {
 		t.Errorf("TargetNamespace=%q want empty (no NamespaceTransformer)", got.TargetNamespace)
 	}
@@ -168,7 +166,7 @@ func TestStampTransformerTargetNamespaces_ExplicitTargetNamespacePreserved(t *te
 
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
 
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	if got.TargetNamespace != "explicit" {
 		t.Errorf("TargetNamespace=%q want explicit (must not override)", got.TargetNamespace)
 	}
@@ -209,7 +207,7 @@ resources:
 
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
 
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	if got.TargetNamespace != "inner" {
 		t.Errorf("TargetNamespace=%q want inner (deepest overlay)", got.TargetNamespace)
 	}
@@ -244,7 +242,7 @@ func stampReplacementsKS(t *testing.T, root, overlayDir, overlayKustomization st
 		ks.Named(): overlayDir + "/app/ks.yaml",
 	}
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	return got
 }
 
@@ -435,7 +433,7 @@ func TestStampTransformerTargetNamespaces_NoEnclosingOverlay(t *testing.T) {
 	s.AddObject(ks)
 	sourceFiles := map[manifest.NamedResource]string{ks.Named(): "apps/bare/app/ks.yaml"}
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	if got.TargetNamespace != "" {
 		t.Errorf("TargetNamespace=%q want empty (no enclosing overlay)", got.TargetNamespace)
 	}
@@ -512,7 +510,7 @@ resources:
 		ks.Named(): "apps/outer/inner/app/ks.yaml",
 	}
 	StampTransformerTargetNamespaces(s, sourceFiles, root)
-	got, _ := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, _ := s.Get[*manifest.Kustomization](ks.Named())
 	if got.TargetNamespace != "inner" {
 		t.Errorf("TargetNamespace=%q want inner (deepest overlay)", got.TargetNamespace)
 	}

--- a/pkg/manifest/errors_test.go
+++ b/pkg/manifest/errors_test.go
@@ -75,8 +75,7 @@ func TestDependencyFailedError_Unwraps(t *testing.T) {
 		t.Errorf("expected errors.Is(err, ErrFlux) to be true (ErrInput wraps ErrFlux)")
 	}
 
-	var typed *DependencyFailedError
-	if !errors.As(err, &typed) {
+	if _, ok := errors.AsType[*DependencyFailedError](err); !ok {
 		t.Errorf("errors.As should match *DependencyFailedError")
 	}
 }

--- a/pkg/manifest/helmrelease.go
+++ b/pkg/manifest/helmrelease.go
@@ -337,8 +337,8 @@ func parseHelmRelease(doc map[string]any) (*HelmRelease, error) {
 			return nil, inputf("HelmRelease missing dependsOn.name")
 		}
 		dependsOn = append(dependsOn, DependencyRef{
-			NamedResource: NamedResource{Kind: KindHelmRelease, Namespace: cmp.Or(dep.Namespace, cr.Namespace), Name: dep.Name},
-			ReadyExpr:     dep.ReadyExpr,
+			Kind: KindHelmRelease, Namespace: cmp.Or(dep.Namespace, cr.Namespace), Name: dep.Name,
+			ReadyExpr: dep.ReadyExpr,
 		})
 	}
 	// spec.chart.spec.valuesFiles (inline template). spec.chartRef

--- a/pkg/manifest/io.go
+++ b/pkg/manifest/io.go
@@ -121,8 +121,7 @@ func DecodeDocs(r io.Reader) ([]map[string]any, error) {
 			// no nested type mismatch is possible. A genuine YAML syntax error
 			// is a single *yaml.LoadError (not the plural *LoadErrors) and so
 			// falls through to the hard error below.
-			var notManifest *yaml.LoadErrors
-			if errors.As(err, &notManifest) {
+			if _, ok := errors.AsType[*yaml.LoadErrors](err); ok {
 				continue
 			}
 			return nil, fmt.Errorf("%w: %w", ErrInput, err)

--- a/pkg/manifest/kustomization.go
+++ b/pkg/manifest/kustomization.go
@@ -191,8 +191,8 @@ func parseKustomization(doc map[string]any) (*Kustomization, error) {
 			return nil, inputf("Kustomization missing dependsOn.name")
 		}
 		dependsOn = append(dependsOn, DependencyRef{
-			NamedResource: NamedResource{Kind: KindKustomization, Namespace: cmp.Or(dep.Namespace, ns), Name: dep.Name},
-			ReadyExpr:     dep.ReadyExpr,
+			Kind: KindKustomization, Namespace: cmp.Or(dep.Namespace, ns), Name: dep.Name,
+			ReadyExpr: dep.ReadyExpr,
 		})
 	}
 

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -795,11 +795,9 @@ spec:
 
 	src := &HelmChartSource{
 		Name: "my-chart", Namespace: "flux-system",
-		HelmChartSpec: sourcev1.HelmChartSpec{
-			Chart: "podinfo", Version: "6.3.2",
-			SourceRef: sourcev1.LocalHelmChartSourceReference{
-				Name: "podinfo", Kind: KindHelmRepository,
-			},
+		Chart: "podinfo", Version: "6.3.2",
+		SourceRef: sourcev1.LocalHelmChartSourceReference{
+			Name: "podinfo", Kind: KindHelmRepository,
 		},
 	}
 	lookup := func(namespace, name string) *HelmChartSource {

--- a/pkg/manifest/producer.go
+++ b/pkg/manifest/producer.go
@@ -101,8 +101,8 @@ func (r *RawObject) secret(name string, declaredKeys []string) ProducerTarget {
 
 func (r *RawObject) target(kind, name string, declaredKeys []string) ProducerTarget {
 	return ProducerTarget{
-		NamedResource: NamedResource{Kind: kind, Namespace: r.Namespace, Name: name},
-		DeclaredKeys:  declaredKeys,
+		Kind: kind, Namespace: r.Namespace, Name: name,
+		DeclaredKeys: declaredKeys,
 	}
 }
 

--- a/pkg/manifest/producer_test.go
+++ b/pkg/manifest/producer_test.go
@@ -8,8 +8,8 @@ import (
 // secret is a small helper so each case reads as identity + declared keys.
 func secret(ns, name string, keys ...string) ProducerTarget {
 	return ProducerTarget{
-		NamedResource: NamedResource{Kind: KindSecret, Namespace: ns, Name: name},
-		DeclaredKeys:  keys,
+		Kind: KindSecret, Namespace: ns, Name: name,
+		DeclaredKeys: keys,
 	}
 }
 
@@ -70,7 +70,7 @@ func TestProducerTargets(t *testing.T) {
 			raw:  &RawObject{Kind: "ObjectBucketClaim", Namespace: "default", Name: "netbox-obc"},
 			want: []ProducerTarget{
 				secret("default", "netbox-obc"),
-				{NamedResource: NamedResource{Kind: KindConfigMap, Namespace: "default", Name: "netbox-obc"}},
+				{Kind: KindConfigMap, Namespace: "default", Name: "netbox-obc"},
 			},
 		},
 		{

--- a/pkg/orchestrator/cycles_test.go
+++ b/pkg/orchestrator/cycles_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/store"
@@ -15,8 +13,8 @@ import (
 func makeKS(name, ns string, deps ...manifest.NamedResource) *manifest.Kustomization {
 	return &manifest.Kustomization{
 		Name: name, Namespace: ns,
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./" + name},
-		DependsOn:         testutil.DepRefs(deps...),
+		Path:      "./" + name,
+		DependsOn: testutil.DepRefs(deps...),
 	}
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -391,7 +391,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	ts := task.NewBounded(cfg.Concurrency)
 	cache := cmp.Or(cfg.SourceCache, source.NewCache(layout))
 	secretGet := func(ns, name string) *manifest.Secret {
-		s, _ := store.GetByName[*manifest.Secret](st, manifest.KindSecret, ns, name)
+		s, _ := st.GetByName[*manifest.Secret](manifest.KindSecret, ns, name)
 		return s
 	}
 	// Route helm.Client's source-CR lookups straight through the canonical

--- a/pkg/orchestrator/orchestrator_test.go
+++ b/pkg/orchestrator/orchestrator_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/change"
 	"github.com/home-operations/flate/pkg/helm"
@@ -30,19 +28,19 @@ import (
 func TestDetectOrphans(t *testing.T) {
 	parent := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+		Path: "./kubernetes/apps",
 	}
 	orphan := &manifest.Kustomization{
 		Name: "orphan", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps/orphan/app"},
+		Path: "./kubernetes/apps/orphan/app",
 	}
 	emittedChild := &manifest.Kustomization{
 		Name: "wired", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps/wired/app"},
+		Path: "./kubernetes/apps/wired/app",
 	}
 	root := &manifest.Kustomization{
 		Name: "another-root", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./standalone"},
+		Path: "./standalone",
 	}
 
 	o := &Orchestrator{
@@ -91,7 +89,7 @@ func TestDetectOrphans(t *testing.T) {
 func TestDetectOrphans_NonReconcilableKindsIgnored(t *testing.T) {
 	parent := &manifest.Kustomization{
 		Name: "p", Namespace: "ns",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./apps"},
+		Path: "./apps",
 	}
 	cm := &manifest.ConfigMap{Name: "stuck", Namespace: "ns"}
 
@@ -123,11 +121,11 @@ func TestDetectOrphans_NonReconcilableKindsIgnored(t *testing.T) {
 func TestDetectOrphans_ParentFailedIsCascadeNotOrphan(t *testing.T) {
 	parent := &manifest.Kustomization{
 		Name: "cluster-apps", Namespace: "flux-system",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps"},
+		Path: "./kubernetes/apps",
 	}
 	child := &manifest.Kustomization{
 		Name: "plex", Namespace: "media",
-		KustomizationSpec: kustomizev1.KustomizationSpec{Path: "./kubernetes/apps/media/plex/app"},
+		Path: "./kubernetes/apps/media/plex/app",
 	}
 
 	o := &Orchestrator{

--- a/pkg/resourceset/inputs.go
+++ b/pkg/resourceset/inputs.go
@@ -199,7 +199,7 @@ func StoreResolver(s *store.Store) ProviderResolver {
 				Namespace: namespace,
 				Name:      ref.Name,
 			}
-			obj, ok := store.Get[*manifest.ResourceSetInputProvider](s, id)
+			obj, ok := s.Get[*manifest.ResourceSetInputProvider](id)
 			if !ok {
 				return nil, nil
 			}
@@ -209,7 +209,7 @@ func StoreResolver(s *store.Store) ProviderResolver {
 			return nil, nil
 		}
 		var out []*manifest.ResourceSetInputProvider
-		for _, p := range store.ListAs[*manifest.ResourceSetInputProvider](s, manifest.KindResourceSetInputProvider) {
+		for _, p := range s.ListAs[*manifest.ResourceSetInputProvider](manifest.KindResourceSetInputProvider) {
 			if p.Namespace != namespace {
 				continue
 			}

--- a/pkg/resourceset/render_test.go
+++ b/pkg/resourceset/render_test.go
@@ -22,28 +22,24 @@ import (
 func TestRender_PermuteScopesByProviderName(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "myrset", Namespace: "default",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
-			Inputs:        []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
-			InputsFrom: []fluxopv1.InputProviderReference{{
-				Kind: manifest.KindResourceSetInputProvider, Name: "myrsip",
-			}},
-			// Permute templates dereference inputs by provider name.
-			// `myrset` (the rs.Name) wraps the inline input;
-			// `myrsip` wraps the RSIP's defaultValues.
-			ResourcesTemplate: `apiVersion: v1
+		InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+		Inputs:        []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
+		InputsFrom: []fluxopv1.InputProviderReference{{
+			Kind: manifest.KindResourceSetInputProvider, Name: "myrsip",
+		}},
+		// Permute templates dereference inputs by provider name.
+		// `myrset` (the rs.Name) wraps the inline input;
+		// `myrsip` wraps the RSIP's defaultValues.
+		ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: << index inputs "myrset" "env" >>-<< index inputs "myrsip" "tenant" >>
   namespace: default`,
-		},
 	}
 	rsip := &manifest.ResourceSetInputProvider{
 		Name: "myrsip", Namespace: "default",
-		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-			Type:          fluxopv1.InputProviderStatic,
-			DefaultValues: fluxopv1.ResourceSetInput{"tenant": jsonTmpl(t, `"alpha"`)},
-		},
+		Type:          fluxopv1.InputProviderStatic,
+		DefaultValues: fluxopv1.ResourceSetInput{"tenant": jsonTmpl(t, `"alpha"`)},
 	}
 	resolver := func(ref fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
 		if ref.Name == "myrsip" {
@@ -72,29 +68,25 @@ metadata:
 func TestRender_PermuteMultiInlineCartesian(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "rset", Namespace: "default",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"env": jsonTmpl(t, `"prod"`)},
-				{"env": jsonTmpl(t, `"stage"`)},
-			},
-			InputsFrom: []fluxopv1.InputProviderReference{{
-				Kind: manifest.KindResourceSetInputProvider, Name: "rsip",
-			}},
-			ResourcesTemplate: `apiVersion: v1
+		InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"env": jsonTmpl(t, `"prod"`)},
+			{"env": jsonTmpl(t, `"stage"`)},
+		},
+		InputsFrom: []fluxopv1.InputProviderReference{{
+			Kind: manifest.KindResourceSetInputProvider, Name: "rsip",
+		}},
+		ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: << index inputs "rset" "env" >>-<< index inputs "rsip" "tenant" >>
   namespace: default`,
-		},
 	}
 	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
 		return []*manifest.ResourceSetInputProvider{{
 			Name: "rsip", Namespace: "default",
-			ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-				Type:          fluxopv1.InputProviderStatic,
-				DefaultValues: fluxopv1.ResourceSetInput{"tenant": jsonTmpl(t, `"alpha"`)},
-			},
+			Type:          fluxopv1.InputProviderStatic,
+			DefaultValues: fluxopv1.ResourceSetInput{"tenant": jsonTmpl(t, `"alpha"`)},
 		}}, nil
 	}
 	docs, err := resourceset.Render(rs, resolver)
@@ -120,27 +112,23 @@ metadata:
 func TestRender_PermuteSkipsEmptyProviderByDefault(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "rset", Namespace: "default",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
-			Inputs:        []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
-			InputsFrom: []fluxopv1.InputProviderReference{{
-				Kind: manifest.KindResourceSetInputProvider, Name: "dyn",
-			}},
-			ResourcesTemplate: `apiVersion: v1
+		InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+		Inputs:        []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
+		InputsFrom: []fluxopv1.InputProviderReference{{
+			Kind: manifest.KindResourceSetInputProvider, Name: "dyn",
+		}},
+		ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: << index inputs "rset" "env" >>
   namespace: default`,
-		},
 	}
 	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
 		// Dynamic provider (GitHubBranch etc.) — flate can't fetch
 		// remote APIs offline, so it exports zero input sets.
 		return []*manifest.ResourceSetInputProvider{{
 			Name: "dyn", Namespace: "default",
-			ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-				Type: fluxopv1.InputProviderGitHubBranch,
-			},
+			Type: fluxopv1.InputProviderGitHubBranch,
 		}}, nil
 	}
 	docs, err := resourceset.Render(rs, resolver)
@@ -160,26 +148,22 @@ metadata:
 func TestRender_PermuteIncludeEmptyProvidersCollapses(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "rset", Namespace: "default",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputStrategy: &fluxopv1.InputStrategySpec{
-				Name:                  fluxopv1.InputStrategyPermute,
-				IncludeEmptyProviders: true,
-			},
-			Inputs: []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
-			InputsFrom: []fluxopv1.InputProviderReference{{
-				Kind: manifest.KindResourceSetInputProvider, Name: "dyn",
-			}},
-			ResourcesTemplate: `apiVersion: v1
+		InputStrategy: &fluxopv1.InputStrategySpec{
+			Name:                  fluxopv1.InputStrategyPermute,
+			IncludeEmptyProviders: true,
+		},
+		Inputs: []fluxopv1.ResourceSetInput{{"env": jsonTmpl(t, `"prod"`)}},
+		InputsFrom: []fluxopv1.InputProviderReference{{
+			Kind: manifest.KindResourceSetInputProvider, Name: "dyn",
+		}},
+		ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata: {name: x, namespace: default}`,
-		},
 	}
 	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
 		return []*manifest.ResourceSetInputProvider{{
 			Name: "dyn", Namespace: "default",
-			ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-				Type: fluxopv1.InputProviderGitHubBranch,
-			},
+			Type: fluxopv1.InputProviderGitHubBranch,
 		}}, nil
 	}
 	docs, err := resourceset.Render(rs, resolver)
@@ -202,13 +186,11 @@ func TestRender_PermuteMaxPermutationsRejected(t *testing.T) {
 	}
 	rs := &manifest.ResourceSet{
 		Name: "rset", Namespace: "default",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
-			Inputs:        inputs,
-			ResourcesTemplate: `apiVersion: v1
+		InputStrategy: &fluxopv1.InputStrategySpec{Name: fluxopv1.InputStrategyPermute},
+		Inputs:        inputs,
+		ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata: {name: x, namespace: default}`,
-		},
 	}
 	_, err := resourceset.Render(rs, nil)
 	if err == nil {
@@ -230,18 +212,16 @@ func jsonTmpl(t *testing.T, raw string) *apix.JSON {
 func TestRender_InputsExpandTemplates(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "apps", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"tenant": jsonTmpl(t, `"frontend"`)},
-				{"tenant": jsonTmpl(t, `"backend"`)},
-			},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"tenant": jsonTmpl(t, `"frontend"`)},
+			{"tenant": jsonTmpl(t, `"backend"`)},
+		},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1",
 					"kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.tenant >>-cm", "namespace": "<< inputs.tenant >>"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -265,23 +245,21 @@ func TestRender_InputsExpandTemplates(t *testing.T) {
 func TestRender_Deduplication(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "apps", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"tenant": jsonTmpl(t, `"a"`)},
-				{"tenant": jsonTmpl(t, `"b"`)},
-			},
-			Resources: []*apix.JSON{
-				// Shared — same name regardless of input.
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"tenant": jsonTmpl(t, `"a"`)},
+			{"tenant": jsonTmpl(t, `"b"`)},
+		},
+		Resources: []*apix.JSON{
+			// Shared — same name regardless of input.
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "shared", "namespace": "flux-system"}
 				}`),
-				// Per-tenant.
-				jsonTmpl(t, `{
+			// Per-tenant.
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.tenant >>", "namespace": "flux-system"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -299,13 +277,11 @@ func TestRender_Deduplication(t *testing.T) {
 func TestRender_NoInputsRendersOnce(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "policies", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "flux-allowlist", "namespace": "flux-system"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -324,20 +300,18 @@ func TestRender_NoInputsRendersOnce(t *testing.T) {
 func TestRender_DefaultsNamespace(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "tenant-x",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{{"name": jsonTmpl(t, `"a"`)}},
-			Resources: []*apix.JSON{
-				// Namespaced — should default to tenant-x.
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{{"name": jsonTmpl(t, `"a"`)}},
+		Resources: []*apix.JSON{
+			// Namespaced — should default to tenant-x.
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.name >>"}
 				}`),
-				// Cluster-scoped — must stay namespace-less.
-				jsonTmpl(t, `{
+			// Cluster-scoped — must stay namespace-less.
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "Namespace",
 					"metadata": {"name": "<< inputs.name >>"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -366,17 +340,15 @@ func TestRender_DefaultsNamespace(t *testing.T) {
 func TestRender_CommonMetadata(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			CommonMetadata: &fluxopv1.CommonMetadata{
-				Labels:      map[string]string{"team": "platform"},
-				Annotations: map[string]string{"owner": "x"},
-			},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		CommonMetadata: &fluxopv1.CommonMetadata{
+			Labels:      map[string]string{"team": "platform"},
+			Annotations: map[string]string{"owner": "x"},
+		},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "x", "namespace": "flux-system"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -397,13 +369,11 @@ func TestRender_CommonMetadata(t *testing.T) {
 func TestRender_OwnerLabels(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "apps", Namespace: "tenant-a",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "x"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -425,17 +395,15 @@ func TestRender_OwnerLabels(t *testing.T) {
 func TestRender_SprigFunctions(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"tenant": jsonTmpl(t, `"Team One"`)},
-			},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"tenant": jsonTmpl(t, `"Team One"`)},
+		},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.tenant | slugify >>", "namespace": "flux-system"},
 					"data": {"upper": "<< inputs.tenant | upper >>"}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -458,13 +426,12 @@ func TestRender_SprigFunctions(t *testing.T) {
 func TestRender_DisabledReconcileAnnotationSkips(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"tenant": jsonTmpl(t, `"a"`)},
-				{"tenant": jsonTmpl(t, `"b"`)},
-			},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"tenant": jsonTmpl(t, `"a"`)},
+			{"tenant": jsonTmpl(t, `"b"`)},
+		},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {
 						"name": "<< inputs.tenant >>", "namespace": "flux-system",
@@ -473,7 +440,6 @@ func TestRender_DisabledReconcileAnnotationSkips(t *testing.T) {
 						}
 					}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -497,10 +463,9 @@ func TestRender_DisabledReconcileAnnotationSkips(t *testing.T) {
 func TestRender_InputsProviderBuiltinField(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "apps", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{{"tenant": jsonTmpl(t, `"a"`)}},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{{"tenant": jsonTmpl(t, `"a"`)}},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "x", "namespace": "flux-system"},
 					"data": {
@@ -509,7 +474,6 @@ func TestRender_InputsProviderBuiltinField(t *testing.T) {
 						"providerNamespace": "<< inputs.provider.namespace >>"
 					}
 				}`),
-			},
 		},
 	}
 	docs, err := resourceset.Render(rs, nil)
@@ -535,14 +499,12 @@ func TestRender_InputsProviderBuiltinField(t *testing.T) {
 func TestRender_MissingKeyErrors(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{{"tenant": jsonTmpl(t, `"a"`)}},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{{"tenant": jsonTmpl(t, `"a"`)}},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.nonexistent >>", "namespace": "flux-system"}
 				}`),
-			},
 		},
 	}
 	_, err := resourceset.Render(rs, nil)
@@ -554,24 +516,20 @@ func TestRender_MissingKeyErrors(t *testing.T) {
 func TestRender_UsesResourceSetInputProviderStatusExportedInputs(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "apps", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputsFrom: []fluxopv1.InputProviderReference{{
-				Kind: manifest.KindResourceSetInputProvider, Name: "branches",
-			}},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		InputsFrom: []fluxopv1.InputProviderReference{{
+			Kind: manifest.KindResourceSetInputProvider, Name: "branches",
+		}},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.name >>", "namespace": "flux-system"},
 					"data": {"id": "<< inputs.id >>"}
 				}`),
-			},
 		},
 	}
 	rsip := &manifest.ResourceSetInputProvider{
 		Name: "branches", Namespace: "flux-system",
-		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-			Type: fluxopv1.InputProviderGitHubBranch,
-		},
+		Type: fluxopv1.InputProviderGitHubBranch,
 		Status: fluxopv1.ResourceSetInputProviderStatus{
 			ExportedInputs: []fluxopv1.ResourceSetInput{{
 				"name": jsonTmpl(t, `"feature-a"`),
@@ -600,10 +558,8 @@ func TestRender_UsesResourceSetInputProviderStatusExportedInputs(t *testing.T) {
 func TestResourceSetInputProvider_StatusExportedInputsOverrideDerivedID(t *testing.T) {
 	rsip := &manifest.ResourceSetInputProvider{
 		Name: "static", Namespace: "flux-system",
-		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-			Type:          fluxopv1.InputProviderStatic,
-			DefaultValues: fluxopv1.ResourceSetInput{"id": jsonTmpl(t, `"default-id"`)},
-		},
+		Type:          fluxopv1.InputProviderStatic,
+		DefaultValues: fluxopv1.ResourceSetInput{"id": jsonTmpl(t, `"default-id"`)},
 		Status: fluxopv1.ResourceSetInputProviderStatus{
 			ExportedInputs: []fluxopv1.ResourceSetInput{{
 				"id": jsonTmpl(t, `"exported-id"`),
@@ -625,14 +581,12 @@ func TestResourceSetInputProvider_StatusExportedInputsOverrideDerivedID(t *testi
 func TestRender_MalformedTemplateErrors(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{{"name": jsonTmpl(t, `"a"`)}},
-			Resources: []*apix.JSON{
-				jsonTmpl(t, `{
+		Inputs: []fluxopv1.ResourceSetInput{{"name": jsonTmpl(t, `"a"`)}},
+		Resources: []*apix.JSON{
+			jsonTmpl(t, `{
 					"apiVersion": "v1", "kind": "ConfigMap",
 					"metadata": {"name": "<< inputs.name "}
 				}`), // unterminated template
-			},
 		},
 	}
 	_, err := resourceset.Render(rs, nil)
@@ -649,11 +603,10 @@ func TestRender_MalformedTemplateErrors(t *testing.T) {
 func TestRender_ToYamlNindent(t *testing.T) {
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"layerSelector": jsonTmpl(t, `{"mediaType": "x", "operation": "copy"}`)},
-			},
-			ResourcesTemplate: `apiVersion: source.toolkit.fluxcd.io/v1
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"layerSelector": jsonTmpl(t, `{"mediaType": "x", "operation": "copy"}`)},
+		},
+		ResourcesTemplate: `apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: app
@@ -661,7 +614,6 @@ metadata:
 spec:
   layerSelector: << inputs.layerSelector | toYaml | nindent 4 >>
 `,
-		},
 	}
 	docs, err := resourceset.Render(rs, nil)
 	if err != nil {
@@ -681,21 +633,18 @@ spec:
 func TestRender_InputsFrom_StaticProvider(t *testing.T) {
 	rsip := &manifest.ResourceSetInputProvider{
 		Name: "apps", Namespace: "kube-system",
-		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-			Type: fluxopv1.InputProviderStatic,
-			DefaultValues: fluxopv1.ResourceSetInput{
-				"defaults": jsonTmpl(t, `{"capacity": "1Gi"}`),
-				"apps":     jsonTmpl(t, `[{"app": "alpha"}, {"app": "bravo", "capacity": "5Gi"}]`),
-			},
+		Type: fluxopv1.InputProviderStatic,
+		DefaultValues: fluxopv1.ResourceSetInput{
+			"defaults": jsonTmpl(t, `{"capacity": "1Gi"}`),
+			"apps":     jsonTmpl(t, `[{"app": "alpha"}, {"app": "bravo", "capacity": "5Gi"}]`),
 		},
 	}
 	rs := &manifest.ResourceSet{
 		Name: "volsync", Namespace: "kube-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			InputsFrom: []fluxopv1.InputProviderReference{
-				{Name: "apps"},
-			},
-			ResourcesTemplate: `<<- range $app := inputs.apps >>
+		InputsFrom: []fluxopv1.InputProviderReference{
+			{Name: "apps"},
+		},
+		ResourcesTemplate: `<<- range $app := inputs.apps >>
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -706,7 +655,6 @@ data:
   capacity: << get $app "capacity" | default inputs.defaults.capacity >>
 <<- end >>
 `,
-		},
 	}
 	resolver := func(ref fluxopv1.InputProviderReference, ns string) ([]*manifest.ResourceSetInputProvider, error) {
 		if ref.Name == "apps" && ns == "kube-system" {
@@ -739,27 +687,23 @@ data:
 func TestRender_InputsFrom_DynamicProviderEmptySkip(t *testing.T) {
 	rsip := &manifest.ResourceSetInputProvider{
 		Name: "branches", Namespace: "flux-system",
-		ResourceSetInputProviderSpec: fluxopv1.ResourceSetInputProviderSpec{
-			Type: fluxopv1.InputProviderGitHubBranch,
-			URL:  "https://github.com/foo/bar",
-		},
+		Type: fluxopv1.InputProviderGitHubBranch,
+		URL:  "https://github.com/foo/bar",
 	}
 	rs := &manifest.ResourceSet{
 		Name: "matrix", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"tenant": jsonTmpl(t, `"inline-only"`)},
-			},
-			InputsFrom: []fluxopv1.InputProviderReference{
-				{Name: "branches"},
-			},
-			ResourcesTemplate: `apiVersion: v1
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"tenant": jsonTmpl(t, `"inline-only"`)},
+		},
+		InputsFrom: []fluxopv1.InputProviderReference{
+			{Name: "branches"},
+		},
+		ResourcesTemplate: `apiVersion: v1
 kind: ConfigMap
 metadata:
   name: << inputs.tenant >>
   namespace: flux-system
 `,
-		},
 	}
 	resolver := func(_ fluxopv1.InputProviderReference, _ string) ([]*manifest.ResourceSetInputProvider, error) {
 		return []*manifest.ResourceSetInputProvider{rsip}, nil
@@ -794,13 +738,11 @@ metadata:
 `
 	rs := &manifest.ResourceSet{
 		Name: "test", Namespace: "flux-system",
-		ResourceSetSpec: fluxopv1.ResourceSetSpec{
-			Inputs: []fluxopv1.ResourceSetInput{
-				{"name": jsonTmpl(t, `"a"`)},
-				{"name": jsonTmpl(t, `"b"`)},
-			},
-			ResourcesTemplate: tmpl,
+		Inputs: []fluxopv1.ResourceSetInput{
+			{"name": jsonTmpl(t, `"a"`)},
+			{"name": jsonTmpl(t, `"b"`)},
 		},
+		ResourcesTemplate: tmpl,
 	}
 	docs, err := resourceset.Render(rs, nil)
 	if err != nil {

--- a/pkg/source/bucket/bucket_test.go
+++ b/pkg/source/bucket/bucket_test.go
@@ -15,10 +15,8 @@ func TestFetcher_NonGenericProviderFailsLoud(t *testing.T) {
 	f := &bucket.Fetcher{}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			Provider:   sourcev1.BucketProviderAmazon,
-			BucketName: "x", Endpoint: "s3.amazonaws.com",
-		},
+		Provider:   sourcev1.BucketProviderAmazon,
+		BucketName: "x", Endpoint: "s3.amazonaws.com",
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {
@@ -33,11 +31,9 @@ func TestFetcher_SecretRefWithoutGetter(t *testing.T) {
 	f := &bucket.Fetcher{} // no Secrets
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			Provider:   sourcev1.BucketProviderGeneric,
-			BucketName: "x", Endpoint: "minio:9000",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		Provider:   sourcev1.BucketProviderGeneric,
+		BucketName: "x", Endpoint: "minio:9000",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {
@@ -59,11 +55,9 @@ func TestFetcher_SecretRefMissingKeys(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			Provider:   sourcev1.BucketProviderGeneric,
-			BucketName: "x", Endpoint: "minio:9000",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		Provider:   sourcev1.BucketProviderGeneric,
+		BucketName: "x", Endpoint: "minio:9000",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {
@@ -80,11 +74,9 @@ func TestFetcher_SecretRefNotFound(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			Provider:   sourcev1.BucketProviderGeneric,
-			BucketName: "x", Endpoint: "minio:9000",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		Provider:   sourcev1.BucketProviderGeneric,
+		BucketName: "x", Endpoint: "minio:9000",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	_, err := f.Fetch(context.Background(), b)
 	if err == nil {

--- a/pkg/source/bucket/transport_test.go
+++ b/pkg/source/bucket/transport_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
@@ -43,9 +41,7 @@ func TestFetcher_ResolveTransport_FromSecret(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-		},
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
 	}
 	tr, err := f.resolveTransport(b)
 	if err != nil {
@@ -73,9 +69,7 @@ func TestFetcher_ResolveTransport_PartialCertKey(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-		},
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "must provide both") {
@@ -91,9 +85,7 @@ func TestFetcher_ResolveTransport_AllKeysMissing(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-		},
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "tls.crt") {
@@ -107,9 +99,7 @@ func TestFetcher_ResolveTransport_SecretNotFound(t *testing.T) {
 	}
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
-		},
+		CertSecretRef: &manifest.LocalObjectReference{Name: "missing"},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "secret ns/missing not found") {
@@ -121,9 +111,7 @@ func TestFetcher_ResolveTransport_CertSecretRefWithoutGetter(t *testing.T) {
 	f := &Fetcher{} // no Secrets
 	b := &manifest.Bucket{
 		Name: "b", Namespace: "ns",
-		BucketSpec: sourcev1.BucketSpec{
-			CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
-		},
+		CertSecretRef: &manifest.LocalObjectReference{Name: "tls"},
 	}
 	_, err := f.resolveTransport(b)
 	if err == nil || !strings.Contains(err.Error(), "source.SecretGetter") {

--- a/pkg/source/git/auth_test.go
+++ b/pkg/source/git/auth_test.go
@@ -15,10 +15,8 @@ func TestFetcher_NonGenericProvider(t *testing.T) {
 	f := &Fetcher{}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:      "https://github.com/x/y.git",
-			Provider: sourcev1.GitProviderGitHub,
-		},
+		URL:      "https://github.com/x/y.git",
+		Provider: sourcev1.GitProviderGitHub,
 	}
 	_, err := f.Fetch(context.Background(), repo)
 	if err == nil {
@@ -42,10 +40,8 @@ func TestFetcher_HTTPSBasicAuth(t *testing.T) {
 	}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "https://github.com/x/y.git",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		URL:       "https://github.com/x/y.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
@@ -74,10 +70,8 @@ func TestFetcher_HTTPSBearerWinsOverBasic(t *testing.T) {
 	}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "https://github.com/x/y.git",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		URL:       "https://github.com/x/y.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
@@ -100,10 +94,8 @@ func TestFetcher_HTTPSMissingCreds(t *testing.T) {
 	}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "https://github.com/x/y.git",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		URL:       "https://github.com/x/y.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	_, err := f.resolveAuth(repo)
 	if err == nil || !strings.Contains(err.Error(), "missing username/password") {
@@ -115,7 +107,7 @@ func TestFetcher_NoSecretIsAnonymous(t *testing.T) {
 	f := &Fetcher{}
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "https://github.com/x/y.git"},
+		URL: "https://github.com/x/y.git",
 	}
 	auth, err := f.resolveAuth(repo)
 	if err != nil {
@@ -130,10 +122,8 @@ func TestFetcher_SecretRefMissingGetter(t *testing.T) {
 	f := &Fetcher{} // no Secrets
 	repo := &manifest.GitRepository{
 		Name: "g", Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "https://github.com/x/y.git",
-			SecretRef: &manifest.LocalObjectReference{Name: "creds"},
-		},
+		URL:       "https://github.com/x/y.git",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
 	}
 	_, err := f.resolveAuth(repo)
 	if err == nil || !strings.Contains(err.Error(), "SecretGetter") {

--- a/pkg/source/git/git_test.go
+++ b/pkg/source/git/git_test.go
@@ -27,7 +27,7 @@ func TestFetcher_LocalFileURL(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 
 	f := &Fetcher{Cache: cache}
@@ -62,7 +62,7 @@ func TestFetcher_RestrictSchemesBlocksFileURL(t *testing.T) {
 	mustInitRepo(t, src)
 	repo := &manifest.GitRepository{
 		Name: "evil", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 
 	blocked := &Fetcher{Cache: source.NewCache(cacheroot.New(t.TempDir())), RestrictSchemes: true}
@@ -92,7 +92,7 @@ func TestFetcher_RestrictSchemesAllowsRemoteURLs(t *testing.T) {
 	for _, url := range []string{"https://github.com/o/r", "ssh://git@github.com/o/r", "git@github.com:o/r.git"} {
 		repo := &manifest.GitRepository{
 			Name: "r", Namespace: "flux-system",
-			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: url},
+			URL: url,
 		}
 		if err := f.validateRepo(repo); err != nil {
 			t.Errorf("validateRepo(%q) under RestrictSchemes must pass: %v", url, err)
@@ -128,7 +128,7 @@ func TestFetcher_MutableDefaultRefRefreshesCache(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 	f := &Fetcher{Cache: cache}
 
@@ -159,10 +159,8 @@ func TestFetcher_MutableRefUsesFreshIntervalCache(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:      "file://" + src,
-			Interval: metav1.Duration{Duration: time.Hour},
-		},
+		URL:      "file://" + src,
+		Interval: metav1.Duration{Duration: time.Hour},
 	}
 	f := &Fetcher{Cache: cache}
 
@@ -190,7 +188,7 @@ func TestFetcher_MutableRefreshFailureKeepsPreviousSlot(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 	f := &Fetcher{Cache: cache}
 
@@ -220,10 +218,8 @@ func TestFetcher_RefByName(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Name: "refs/tags/v0.1.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Name: "refs/tags/v0.1.0"},
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -244,10 +240,8 @@ func TestFetcher_RefByName_Unresolvable(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Name: "refs/heads/does-not-exist"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Name: "refs/heads/does-not-exist"},
 	}
 	f := &Fetcher{Cache: cache}
 	_, err := f.Fetch(context.Background(), repo)
@@ -267,11 +261,9 @@ func TestFetcher_RefByNameFallbackFetchesExplicitRef(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:            "file://" + src,
-			Reference:      &sourcev1.GitRepositoryRef{Name: "refs/pull/1/head"},
-			SparseCheckout: []string{"apps/a"},
-		},
+		URL:            "file://" + src,
+		Reference:      &sourcev1.GitRepositoryRef{Name: "refs/pull/1/head"},
+		SparseCheckout: []string{"apps/a"},
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -299,10 +291,8 @@ func TestFetcher_SemVerRef(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0", SemVer: ">=1.1.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0", SemVer: ">=1.1.0"},
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -327,12 +317,10 @@ func TestFetcher_CommitPrecedesRefName(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL: "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{
-				Commit: first,
-				Name:   "refs/tags/v1.1.0",
-			},
+		URL: "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{
+			Commit: first,
+			Name:   "refs/tags/v1.1.0",
 		},
 	}
 	f := &Fetcher{Cache: cache}
@@ -357,12 +345,10 @@ func TestFetcher_CommitPrecedesUnresolvableRefName(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL: "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{
-				Commit: first,
-				Name:   "refs/pull/does-not-exist/head",
-			},
+		URL: "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{
+			Commit: first,
+			Name:   "refs/pull/does-not-exist/head",
 		},
 	}
 	f := &Fetcher{Cache: cache}
@@ -387,10 +373,8 @@ func TestFetcher_CommitMustBeReachableFromBranch(t *testing.T) {
 
 	commitOnly := &manifest.GitRepository{
 		Name: "commit-only", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Commit: mainOnly},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Commit: mainOnly},
 	}
 	if _, err := f.Fetch(context.Background(), commitOnly); err != nil {
 		t.Fatalf("commit-only fetch should populate the unconstrained cache slot: %v", err)
@@ -398,12 +382,10 @@ func TestFetcher_CommitMustBeReachableFromBranch(t *testing.T) {
 
 	constrained := &manifest.GitRepository{
 		Name: "constrained", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL: "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{
-				Branch: "staging",
-				Commit: mainOnly,
-			},
+		URL: "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{
+			Branch: "staging",
+			Commit: mainOnly,
 		},
 	}
 	_, err := f.Fetch(context.Background(), constrained)
@@ -430,10 +412,8 @@ func TestFetcher_SparseCheckout(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:            "file://" + src,
-			SparseCheckout: []string{"apps/a"},
-		},
+		URL:            "file://" + src,
+		SparseCheckout: []string{"apps/a"},
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -464,10 +444,8 @@ func TestFetcher_AppliesSpecIgnore(t *testing.T) {
 	cache := source.NewCache(cacheroot.New(t.TempDir()))
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:    "file://" + src,
-			Ignore: &patterns,
-		},
+		URL:    "file://" + src,
+		Ignore: &patterns,
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -498,11 +476,9 @@ func TestFetcher_CacheMarkerSurvivesIgnore(t *testing.T) {
 	commit := mustHead(t, src)
 	repo := &manifest.GitRepository{
 		Name: "test", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
-			Ignore:    &patterns,
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+		Ignore:    &patterns,
 	}
 	f := &Fetcher{Cache: cache}
 	art, err := f.Fetch(context.Background(), repo)
@@ -544,11 +520,9 @@ func TestFetcher_CommitCacheKeyIncludesIgnore(t *testing.T) {
 	ignore := "docs.md\n"
 	ignoredRepo := &manifest.GitRepository{
 		Name: "ignored", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
-			Ignore:    &ignore,
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Commit: commit},
+		Ignore:    &ignore,
 	}
 	ignored, err := f.Fetch(context.Background(), ignoredRepo)
 	if err != nil {
@@ -560,10 +534,8 @@ func TestFetcher_CommitCacheKeyIncludesIgnore(t *testing.T) {
 
 	plainRepo := &manifest.GitRepository{
 		Name: "plain", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Commit: commit},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Commit: commit},
 	}
 	plain, err := f.Fetch(context.Background(), plainRepo)
 	if err != nil {

--- a/pkg/source/git/mirror_test.go
+++ b/pkg/source/git/mirror_test.go
@@ -48,7 +48,7 @@ func TestMirror_BareClonePersistsAcrossFetches(t *testing.T) {
 	cache := source.NewCache(layout)
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
 
@@ -90,9 +90,7 @@ func TestMirror_FallsBackForSubmodules(t *testing.T) {
 	f := &Fetcher{Mirrors: mirror.New(cacheroot.New(t.TempDir()))}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL: "https://example.com/x", RecurseSubmodules: true,
-		},
+		URL: "https://example.com/x", RecurseSubmodules: true,
 	}
 	if f.canUseMirror(repo) {
 		t.Error("RecurseSubmodules should disable the mirror path")
@@ -129,10 +127,8 @@ func TestMirror_TagResolvesAcrossRefs(t *testing.T) {
 	// First: fetch a tag.
 	tagRepo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
 	}
 	art, err := f.Fetch(context.Background(), tagRepo)
 	if err != nil {
@@ -145,7 +141,7 @@ func TestMirror_TagResolvesAcrossRefs(t *testing.T) {
 	// Second: fetch HEAD (same commit but different ref path).
 	headRepo := &manifest.GitRepository{
 		Name: "u", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 	art2, err := f.Fetch(context.Background(), headRepo)
 	if err != nil {
@@ -169,10 +165,8 @@ func TestMirror_TagRefreshFetchesOnlyRequestedTag(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
 	repo := &manifest.GitRepository{
 		Name: "tagged", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
 	}
 	if _, err := f.Fetch(context.Background(), repo); err != nil {
 		t.Fatalf("Fetch v1: %v", err)
@@ -212,10 +206,8 @@ func TestMirror_RefNameResolvesNonBranchRefs(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
 	repo := &manifest.GitRepository{
 		Name: "pull", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Name: "refs/pull/1/head"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Name: "refs/pull/1/head"},
 	}
 
 	art, err := f.Fetch(context.Background(), repo)
@@ -239,12 +231,10 @@ func TestMirror_CommitMustBeReachableFromBranch(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout)}
 	repo := &manifest.GitRepository{
 		Name: "constrained", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL: "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{
-				Branch: "staging",
-				Commit: mainOnly,
-			},
+		URL: "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{
+			Branch: "staging",
+			Commit: mainOnly,
 		},
 	}
 

--- a/pkg/source/git/shallow_test.go
+++ b/pkg/source/git/shallow_test.go
@@ -49,7 +49,7 @@ func TestMirror_ShallowCloneTruncatesHistory(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout), Depth: 1}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 
 	art, err := f.Fetch(context.Background(), repo)
@@ -94,10 +94,8 @@ func TestMirror_ShallowTagFetch(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout), Depth: 1}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
 	}
 
 	art, err := f.Fetch(context.Background(), repo)
@@ -129,7 +127,7 @@ func TestMirror_ShallowIncrementalFetchAfterTipMove(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout), Depth: 1}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+		URL: "file://" + src,
 	}
 
 	art1, err := f.Fetch(context.Background(), repo)
@@ -171,10 +169,8 @@ func TestMirror_ShallowSemverFetchesTagTips(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout), Depth: 1}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{SemVer: ">=1.0.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{SemVer: ">=1.0.0"},
 	}
 
 	art, err := f.Fetch(context.Background(), repo)
@@ -206,10 +202,8 @@ func TestMirror_NarrowInitialFetchSkipsOtherRefs(t *testing.T) {
 	f := &Fetcher{Cache: cache, Mirrors: mirror.New(layout), Depth: 1}
 	repo := &manifest.GitRepository{
 		Name: "t", Namespace: "flux-system",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{
-			URL:       "file://" + src,
-			Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
-		},
+		URL:       "file://" + src,
+		Reference: &sourcev1.GitRepositoryRef{Tag: "v1.0.0"},
 	}
 	if _, err := f.Fetch(context.Background(), repo); err != nil {
 		t.Fatalf("Fetch tag: %v", err)
@@ -278,7 +272,7 @@ func TestFetch_ShallowLegacyClone(t *testing.T) {
 		f := &Fetcher{Cache: cache, Depth: 1} // nil Mirrors → legacy path
 		repo := &manifest.GitRepository{
 			Name: "t", Namespace: "flux-system",
-			GitRepositorySpec: sourcev1.GitRepositorySpec{URL: "file://" + src},
+			URL: "file://" + src,
 		}
 		art, err := f.Fetch(context.Background(), repo)
 		if err != nil {
@@ -303,10 +297,8 @@ func TestFetch_ShallowLegacyClone(t *testing.T) {
 		f := &Fetcher{Cache: cache, Depth: 1}
 		repo := &manifest.GitRepository{
 			Name: "t", Namespace: "flux-system",
-			GitRepositorySpec: sourcev1.GitRepositorySpec{
-				URL:            "file://" + src,
-				SparseCheckout: []string{"apps/a"},
-			},
+			URL:            "file://" + src,
+			SparseCheckout: []string{"apps/a"},
 		}
 		art, err := f.Fetch(context.Background(), repo)
 		if err != nil {

--- a/pkg/source/git/tls_test.go
+++ b/pkg/source/git/tls_test.go
@@ -4,8 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-
 	"github.com/home-operations/flate/internal/testutil"
 	"github.com/home-operations/flate/pkg/manifest"
 )
@@ -13,7 +11,7 @@ import (
 func gitRepoWithSecret(name, url, secretName string) *manifest.GitRepository {
 	repo := &manifest.GitRepository{
 		Name: name, Namespace: "ns",
-		GitRepositorySpec: sourcev1.GitRepositorySpec{URL: url},
+		URL: url,
 	}
 	if secretName != "" {
 		repo.SecretRef = &manifest.LocalObjectReference{Name: secretName}

--- a/pkg/source/helmchart/fetcher.go
+++ b/pkg/source/helmchart/fetcher.go
@@ -124,11 +124,9 @@ func Synthesize(r *manifest.HelmRepository, chartName, version string) *manifest
 	return &manifest.HelmChartSource{
 		Name:      syntheticChartName(r.Name, chartName, chartURL, version),
 		Namespace: r.Namespace,
-		HelmChartSpec: sourcev1.HelmChartSpec{
-			Chart:     chartName,
-			Version:   version,
-			SourceRef: sourcev1.LocalHelmChartSourceReference{Kind: manifest.KindHelmRepository, Name: r.Name},
-		},
+		Chart:     chartName,
+		Version:   version,
+		SourceRef: sourcev1.LocalHelmChartSourceReference{Kind: manifest.KindHelmRepository, Name: r.Name},
 	}
 }
 

--- a/pkg/source/helmchart/fetcher_test.go
+++ b/pkg/source/helmchart/fetcher_test.go
@@ -14,18 +14,16 @@ import (
 func ociRepo(url string) *manifest.HelmRepository {
 	return &manifest.HelmRepository{
 		Name: "truecharts", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: url, Type: manifest.RepoTypeOCI},
+		URL: url, Type: manifest.RepoTypeOCI,
 	}
 }
 
 func helmChart(repoName, chart, version string) *manifest.HelmChartSource {
 	return &manifest.HelmChartSource{
 		Name: repoName + "-" + chart, Namespace: "flux-system",
-		HelmChartSpec: sourcev1.HelmChartSpec{
-			Chart:     chart,
-			Version:   version,
-			SourceRef: sourcev1.LocalHelmChartSourceReference{Kind: manifest.KindHelmRepository, Name: repoName},
-		},
+		Chart:     chart,
+		Version:   version,
+		SourceRef: sourcev1.LocalHelmChartSourceReference{Kind: manifest.KindHelmRepository, Name: repoName},
 	}
 }
 
@@ -47,9 +45,9 @@ func TestIsOCIHelmRepo(t *testing.T) {
 		repo *manifest.HelmRepository
 		want bool
 	}{
-		{"type oci", &manifest.HelmRepository{HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://x", Type: manifest.RepoTypeOCI}}, true},
-		{"oci:// url no type", &manifest.HelmRepository{HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "oci://reg/x"}}, true},
-		{"http default", &manifest.HelmRepository{HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "https://charts.example"}}, false},
+		{"type oci", &manifest.HelmRepository{URL: "https://x", Type: manifest.RepoTypeOCI}, true},
+		{"oci:// url no type", &manifest.HelmRepository{URL: "oci://reg/x"}, true},
+		{"http default", &manifest.HelmRepository{URL: "https://charts.example"}, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,7 +61,7 @@ func TestIsOCIHelmRepo(t *testing.T) {
 func TestSynthesizeOCIRepository(t *testing.T) {
 	r := &manifest.HelmRepository{
 		Name: "truecharts", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: "oci://oci.trueforge.org/truecharts/", Type: manifest.RepoTypeOCI},
+		URL: "oci://oci.trueforge.org/truecharts/", Type: manifest.RepoTypeOCI,
 	}
 	syn := synthesizeOCIRepository(r, "kromgo", "3.0.0")
 	if syn.URL != "oci://oci.trueforge.org/truecharts/kromgo" {

--- a/pkg/source/helmchart/http_test.go
+++ b/pkg/source/helmchart/http_test.go
@@ -16,8 +16,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	sourcev1 "github.com/fluxcd/source-controller/api/v1"
-
 	"github.com/home-operations/flate/pkg/manifest"
 	"github.com/home-operations/flate/pkg/source"
 	"github.com/home-operations/flate/pkg/source/cacheroot"
@@ -26,7 +24,7 @@ import (
 func httpRepo(url string) *manifest.HelmRepository {
 	return &manifest.HelmRepository{
 		Name: "repo", Namespace: "flux-system",
-		HelmRepositorySpec: sourcev1.HelmRepositorySpec{URL: url},
+		URL: url,
 	}
 }
 

--- a/pkg/source/oci/fetch_test.go
+++ b/pkg/source/oci/fetch_test.go
@@ -17,7 +17,6 @@ import (
 
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/opencontainers/go-digest"
-	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -51,13 +50,11 @@ func TestFetcher_ExtractsLayerWithoutTitleAnnotation(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "flux-manifests",
 		Namespace: "flux-system",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL: fmt.Sprintf("oci://%s/fluxcd/flux-manifests", mustURL(t, srv.URL).Host),
-			// httptest.NewTLSServer issues a self-signed cert; flate
-			// maps spec.insecure to TLS InsecureSkipVerify.
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "v2.8.8"},
-		},
+		URL:       fmt.Sprintf("oci://%s/fluxcd/flux-manifests", mustURL(t, srv.URL).Host),
+		// httptest.NewTLSServer issues a self-signed cert; flate
+		// maps spec.insecure to TLS InsecureSkipVerify.
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "v2.8.8"},
 	}
 
 	art, err := f.Fetch(t.Context(), repo)
@@ -109,11 +106,9 @@ func TestFetcher_PartialSlotInvalidated(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "partial",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/partial", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "v1"},
-		},
+		URL:       fmt.Sprintf("oci://%s/partial", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "v1"},
 	}
 
 	// First fetch populates the slot fully.
@@ -176,11 +171,9 @@ func TestFetcher_ExtractCollidesWithOCILayoutName(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "collider",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/collider", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "v1"},
-		},
+		URL:       fmt.Sprintf("oci://%s/collider", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "v1"},
 	}
 
 	art, err := f.Fetch(t.Context(), repo)
@@ -214,11 +207,9 @@ func TestFetcher_MutableTagRefreshesCache(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "mutable",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
-		},
+		URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
 	}
 
 	art1, err := f.Fetch(t.Context(), repo)
@@ -251,12 +242,10 @@ func TestFetcher_MutableTagUsesFreshIntervalResolveCache(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "mutable",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Interval:  metav1.Duration{Duration: time.Hour},
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
-		},
+		URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Interval:  metav1.Duration{Duration: time.Hour},
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
 	}
 
 	art1, err := f.Fetch(t.Context(), repo)
@@ -285,11 +274,9 @@ func TestFetcher_TagCacheHitSkipsSecondPull(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "stable-tag",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/stable-tag", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "v1"},
-		},
+		URL:       fmt.Sprintf("oci://%s/stable-tag", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "v1"},
 	}
 
 	art1, err := f.Fetch(t.Context(), repo)
@@ -317,11 +304,9 @@ func TestFetcher_MutableRefreshFailureKeepsPreviousSlot(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "mutable",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
-		},
+		URL:       fmt.Sprintf("oci://%s/mutable", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Tag: "latest"},
 	}
 
 	art, err := f.Fetch(t.Context(), repo)
@@ -345,11 +330,9 @@ func TestFetcher_DigestRefUsesCachedSlot(t *testing.T) {
 	repo := &manifest.OCIRepository{
 		Name:      "pinned",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/pinned", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
-		},
+		URL:       fmt.Sprintf("oci://%s/pinned", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
 	}
 	if _, err := f.Fetch(t.Context(), repo); err != nil {
 		t.Fatalf("first Fetch: %v", err)
@@ -368,13 +351,11 @@ func TestFetcher_DigestCacheKeyIncludesLayerSelector(t *testing.T) {
 	copyRepo := &manifest.OCIRepository{
 		Name:      "copy",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       fmt.Sprintf("oci://%s/app", mustURL(t, srv.URL).Host),
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
-			LayerSelector: &sourcev1.OCILayerSelector{
-				Operation: manifest.OCILayerOperationCopy,
-			},
+		URL:       fmt.Sprintf("oci://%s/app", mustURL(t, srv.URL).Host),
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
+		LayerSelector: &sourcev1.OCILayerSelector{
+			Operation: manifest.OCILayerOperationCopy,
 		},
 	}
 	copyArt, err := f.Fetch(t.Context(), copyRepo)
@@ -388,11 +369,9 @@ func TestFetcher_DigestCacheKeyIncludesLayerSelector(t *testing.T) {
 	extractRepo := &manifest.OCIRepository{
 		Name:      "extract",
 		Namespace: "test",
-		OCIRepositorySpec: sourcev1.OCIRepositorySpec{
-			URL:       copyRepo.URL,
-			Insecure:  true,
-			Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
-		},
+		URL:       copyRepo.URL,
+		Insecure:  true,
+		Reference: &sourcev1.OCIRepositoryRef{Digest: v1.manifestDigest},
 	}
 	extractArt, err := f.Fetch(t.Context(), extractRepo)
 	if err != nil {
@@ -571,8 +550,8 @@ func startMutableFakeRegistry(t *testing.T, artifacts ...fakeOCIArtifact) (*http
 func mustManifestJSON(t *testing.T, configBytes, layerBytes []byte, configMT, layerMT string) []byte {
 	t.Helper()
 	m := ocispec.Manifest{
-		Versioned: specs.Versioned{SchemaVersion: 2},
-		MediaType: ocispec.MediaTypeImageManifest,
+		SchemaVersion: 2,
+		MediaType:     ocispec.MediaTypeImageManifest,
 		Config: ocispec.Descriptor{
 			MediaType: configMT,
 			Digest:    digest.Digest(sha256Digest(configBytes)),

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -435,10 +435,11 @@ func (s *Store) DeleteObject(id manifest.NamedResource) bool {
 	return sh.deleteLocked(id)
 }
 
-// GetByName returns the object matching (kind, namespace, name), or nil
+// GetObjectByName returns the object matching (kind, namespace, name), or nil
 // when none is present. Hot-path callers (valuesFrom expansion, source
-// resolution) should prefer this over filtering ListObjects.
-func (s *Store) GetByName(kind, namespace, name string) manifest.BaseManifest {
+// resolution) should prefer this over filtering ListObjects. The typed
+// GetByName is its assert-to-T sibling, as Get is to GetObject.
+func (s *Store) GetObjectByName(kind, namespace, name string) manifest.BaseManifest {
 	sh := s.shardForKind(kind)
 	sh.mu.RLock()
 	defer sh.mu.RUnlock()

--- a/pkg/store/typed.go
+++ b/pkg/store/typed.go
@@ -12,11 +12,11 @@ import "github.com/home-operations/flate/pkg/manifest"
 //	ks, ok := s.GetObject(id).(*manifest.Kustomization)
 //
 //	// after
-//	ks, ok := store.Get[*manifest.Kustomization](s, id)
+//	ks, ok := s.Get[*manifest.Kustomization](id)
 //
 // The constraint on T is manifest.BaseManifest — any stored manifest
 // type — so Get and GetByName share one uniform, type-safe lookup.
-func Get[T manifest.BaseManifest](s *Store, id manifest.NamedResource) (T, bool) {
+func (s *Store) Get[T manifest.BaseManifest](id manifest.NamedResource) (T, bool) {
 	if s == nil {
 		var zero T
 		return zero, false
@@ -26,17 +26,17 @@ func Get[T manifest.BaseManifest](s *Store, id manifest.NamedResource) (T, bool)
 }
 
 // GetByName is the (kind, namespace, name) sibling of Get — performs
-// the same store lookup as Store.GetByName and asserts the result to
-// T. Returns (zero, false) on miss or type mismatch.
+// the same store lookup as Store.GetObjectByName and asserts the
+// result to T. Returns (zero, false) on miss or type mismatch.
 //
 // Useful when the caller has the human-readable triple (e.g. from a
 // SecretRef or valuesFrom) rather than a NamedResource.
-func GetByName[T manifest.BaseManifest](s *Store, kind, namespace, name string) (T, bool) {
+func (s *Store) GetByName[T manifest.BaseManifest](kind, namespace, name string) (T, bool) {
 	if s == nil {
 		var zero T
 		return zero, false
 	}
-	obj, ok := s.GetByName(kind, namespace, name).(T)
+	obj, ok := s.GetObjectByName(kind, namespace, name).(T)
 	return obj, ok
 }
 
@@ -52,7 +52,7 @@ func GetByName[T manifest.BaseManifest](s *Store, kind, namespace, name string) 
 //	}
 //
 //	// after
-//	for _, ks := range store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization) {
+//	for _, ks := range s.ListAs[*manifest.Kustomization](manifest.KindKustomization) {
 //	    // use ks
 //	}
 //
@@ -61,7 +61,7 @@ func GetByName[T manifest.BaseManifest](s *Store, kind, namespace, name string) 
 // defensive net rather than a real filter — but keeping it cheap
 // means a future invariant relaxation degrades safely rather than
 // panicking.
-func ListAs[T manifest.BaseManifest](s *Store, kind string) []T {
+func (s *Store) ListAs[T manifest.BaseManifest](kind string) []T {
 	if s == nil {
 		return nil
 	}

--- a/pkg/store/typed_test.go
+++ b/pkg/store/typed_test.go
@@ -14,7 +14,7 @@ func TestGet_ReturnsTypedObject(t *testing.T) {
 	ks := &manifest.Kustomization{Name: "apps", Namespace: "flux-system"}
 	s.AddObject(ks)
 
-	got, ok := store.Get[*manifest.Kustomization](s, ks.Named())
+	got, ok := s.Get[*manifest.Kustomization](ks.Named())
 	if !ok {
 		t.Fatalf("expected hit; got miss")
 	}
@@ -29,7 +29,7 @@ func TestGet_MissReturnsZeroFalse(t *testing.T) {
 	s := store.New()
 	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "ghost"}
 
-	got, ok := store.Get[*manifest.Kustomization](s, id)
+	got, ok := s.Get[*manifest.Kustomization](id)
 	if ok {
 		t.Fatalf("expected miss; got hit")
 	}
@@ -48,7 +48,7 @@ func TestGet_WrongTypeReturnsZeroFalse(t *testing.T) {
 	s.AddObject(hr)
 
 	id := manifest.NamedResource{Kind: manifest.KindHelmRelease, Namespace: "default", Name: "demo"}
-	got, ok := store.Get[*manifest.Kustomization](s, id)
+	got, ok := s.Get[*manifest.Kustomization](id)
 	if ok {
 		t.Errorf("Get with wrong type should miss; got hit %v", got)
 	}
@@ -59,7 +59,7 @@ func TestGet_WrongTypeReturnsZeroFalse(t *testing.T) {
 // (zero, false) without panic.
 func TestGet_NilStoreSafe(t *testing.T) {
 	id := manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: "x"}
-	if got, ok := store.Get[*manifest.Kustomization](nil, id); ok || got != nil {
+	if got, ok := (*store.Store)(nil).Get[*manifest.Kustomization](id); ok || got != nil {
 		t.Errorf("nil store: want (nil, false); got (%v, %v)", got, ok)
 	}
 }
@@ -72,7 +72,7 @@ func TestGetByName_ReturnsTypedObject(t *testing.T) {
 	sec := &manifest.Secret{Name: "creds", Namespace: "flux-system"}
 	s.AddObject(sec)
 
-	got, ok := store.GetByName[*manifest.Secret](s, manifest.KindSecret, "flux-system", "creds")
+	got, ok := s.GetByName[*manifest.Secret](manifest.KindSecret, "flux-system", "creds")
 	if !ok {
 		t.Fatalf("expected hit; got miss")
 	}
@@ -83,7 +83,7 @@ func TestGetByName_ReturnsTypedObject(t *testing.T) {
 
 // TestGetByName_NilStoreSafe mirrors Get's defensive nil guard.
 func TestGetByName_NilStoreSafe(t *testing.T) {
-	if got, ok := store.GetByName[*manifest.Secret](nil, manifest.KindSecret, "ns", "name"); ok || got != nil {
+	if got, ok := (*store.Store)(nil).GetByName[*manifest.Secret](manifest.KindSecret, "ns", "name"); ok || got != nil {
 		t.Errorf("nil store: want (nil, false); got (%v, %v)", got, ok)
 	}
 }
@@ -100,7 +100,7 @@ func TestListAs_TypedSlice(t *testing.T) {
 	// Add a HelmRelease to confirm kind filtering excludes other kinds.
 	s.AddObject(&manifest.HelmRelease{Name: "noisy", Namespace: "flux-system"})
 
-	got := store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization)
+	got := s.ListAs[*manifest.Kustomization](manifest.KindKustomization)
 	if len(got) != 3 {
 		t.Fatalf("expected 3 KSes; got %d", len(got))
 	}
@@ -117,7 +117,7 @@ func TestListAs_TypedSlice(t *testing.T) {
 
 // TestListAs_NilStoreReturnsNil mirrors Get's nil-store guard.
 func TestListAs_NilStoreReturnsNil(t *testing.T) {
-	if got := store.ListAs[*manifest.Kustomization](nil, manifest.KindKustomization); got != nil {
+	if got := (*store.Store)(nil).ListAs[*manifest.Kustomization](manifest.KindKustomization); got != nil {
 		t.Errorf("nil store: want nil slice; got %v", got)
 	}
 }
@@ -127,7 +127,7 @@ func TestListAs_NilStoreReturnsNil(t *testing.T) {
 // iteration without nil-check.
 func TestListAs_EmptyKindReturnsEmpty(t *testing.T) {
 	s := store.New()
-	got := store.ListAs[*manifest.Kustomization](s, manifest.KindKustomization)
+	got := s.ListAs[*manifest.Kustomization](manifest.KindKustomization)
 	if got == nil {
 		t.Errorf("want empty slice, not nil")
 	}

--- a/pkg/values/bench_test.go
+++ b/pkg/values/bench_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -53,8 +51,8 @@ func BenchmarkExpandValueReferences_SharedLargeCM(b *testing.B) {
 	for b.Loop() {
 		hr := &manifest.HelmRelease{
 			Name: "app", Namespace: "default",
-			HelmReleaseSpec: helmv2.HelmReleaseSpec{ValuesFrom: []manifest.ValuesReference{ref}},
-			Values:          map[string]any{"replicaCount": 2},
+			ValuesFrom: []manifest.ValuesReference{ref},
+			Values:     map[string]any{"replicaCount": 2},
 		}
 		if err := ExpandValueReferences(hr, provider, cache); err != nil {
 			b.Fatalf("ExpandValueReferences: %v", err)
@@ -101,8 +99,8 @@ counts:
 		// in place; the merge result accumulates across runs otherwise.
 		hr := &manifest.HelmRelease{
 			Name: "demo", Namespace: "default",
-			HelmReleaseSpec: helmv2.HelmReleaseSpec{ValuesFrom: refs},
-			Values:          map[string]any{"image": map[string]any{"repository": "nginx"}},
+			ValuesFrom: refs,
+			Values:     map[string]any{"image": map[string]any{"repository": "nginx"}},
 		}
 		if err := ExpandValueReferences(hr, provider, cache); err != nil {
 			b.Fatalf("ExpandValueReferences: %v", err)
@@ -135,7 +133,7 @@ func BenchmarkExpandValueReferences_ManyKeyCM(b *testing.B) {
 	for b.Loop() {
 		hr := &manifest.HelmRelease{
 			Name: "app", Namespace: "default",
-			HelmReleaseSpec: helmv2.HelmReleaseSpec{ValuesFrom: []manifest.ValuesReference{ref}},
+			ValuesFrom: []manifest.ValuesReference{ref},
 		}
 		if err := ExpandValueReferences(hr, provider, cache); err != nil {
 			b.Fatalf("ExpandValueReferences: %v", err)

--- a/pkg/values/values.go
+++ b/pkg/values/values.go
@@ -41,12 +41,12 @@ func NewStoreProvider(s *store.Store) Provider { return &storeProvider{s: s} }
 type storeProvider struct{ s *store.Store }
 
 func (p *storeProvider) ConfigMap(namespace, name string) *manifest.ConfigMap {
-	c, _ := store.GetByName[*manifest.ConfigMap](p.s, manifest.KindConfigMap, namespace, name)
+	c, _ := p.s.GetByName[*manifest.ConfigMap](manifest.KindConfigMap, namespace, name)
 	return c
 }
 
 func (p *storeProvider) Secret(namespace, name string) *manifest.Secret {
-	s, _ := store.GetByName[*manifest.Secret](p.s, manifest.KindSecret, namespace, name)
+	s, _ := p.s.GetByName[*manifest.Secret](manifest.KindSecret, namespace, name)
 	return s
 }
 

--- a/pkg/values/values_test.go
+++ b/pkg/values/values_test.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	helmv2 "github.com/fluxcd/helm-controller/api/v2"
-
 	"github.com/home-operations/flate/pkg/manifest"
 )
 
@@ -111,10 +109,8 @@ func TestExpandValueReferences_ConfigMap(t *testing.T) {
 	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
-		},
-		Values: map[string]any{"image": map[string]any{"repository": "x"}},
+		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
+		Values:     map[string]any{"image": map[string]any{"repository": "x"}},
 	}
 	if err := ExpandValueReferences(hr, provider, nil); err != nil {
 		t.Fatalf("ExpandValueReferences: %v", err)
@@ -143,9 +139,7 @@ func TestExpandValueReferences_IgnoresConfigMapBinaryData(t *testing.T) {
 	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "mixed"}},
-		},
+		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "mixed"}},
 	}
 	if err := ExpandValueReferences(hr, provider, nil); err != nil {
 		t.Fatalf("ExpandValueReferences: %v", err)
@@ -178,9 +172,7 @@ func TestExpandValueReferences_MalformedSiblingTolerated(t *testing.T) {
 	}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
-		},
+		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
 	}
 	if err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}, nil); err != nil {
 		t.Fatalf("malformed sibling must not fail the ref (Flux reads only the named key): %v", err)
@@ -200,9 +192,7 @@ func TestExpandValueReferences_MalformedRequestedKeyStillFails(t *testing.T) {
 	}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
-		},
+		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
 	}
 	err := ExpandValueReferences(hr, &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}, nil)
 	if err == nil {
@@ -221,10 +211,8 @@ func TestExpandValueReferences_TargetPath(t *testing.T) {
 	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "ConfigMap", Name: "k", ValuesKey: "v", TargetPath: "auth.password"},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "ConfigMap", Name: "k", ValuesKey: "v", TargetPath: "auth.password"},
 		},
 	}
 	if err := ExpandValueReferences(hr, provider, nil); err != nil {
@@ -246,15 +234,13 @@ environment = ["FOO=bar", "BAZ=qux"]
 	}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{
-					Kind:       "ConfigMap",
-					Name:       "runner",
-					ValuesKey:  "config.toml",
-					TargetPath: "runners.config",
-					Literal:    true,
-				},
+		ValuesFrom: []manifest.ValuesReference{
+			{
+				Kind:       "ConfigMap",
+				Name:       "runner",
+				ValuesKey:  "config.toml",
+				TargetPath: "runners.config",
+				Literal:    true,
 			},
 		},
 	}
@@ -279,15 +265,13 @@ func TestExpandValueReferences_LiteralTargetPathEscapedDot(t *testing.T) {
 	}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{
-					Kind:       "ConfigMap",
-					Name:       "scrape",
-					ValuesKey:  "value",
-					TargetPath: `annotations.prometheus\.io/scrape`,
-					Literal:    true,
-				},
+		ValuesFrom: []manifest.ValuesReference{
+			{
+				Kind:       "ConfigMap",
+				Name:       "scrape",
+				ValuesKey:  "value",
+				TargetPath: `annotations.prometheus\.io/scrape`,
+				Literal:    true,
 			},
 		},
 	}
@@ -304,10 +288,8 @@ func TestExpandValueReferences_MissingOptionalTargetPath(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
 		Values: map[string]any{"existing": "kept"},
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k", Optional: true},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k", Optional: true},
 		},
 	}
 	provider := &SliceProvider{}
@@ -325,10 +307,8 @@ func TestExpandValueReferences_MissingOptionalTargetPath(t *testing.T) {
 func TestExpandValueReferences_MissingRequiredTargetPathFails(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k"},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "ConfigMap", Name: "absent", ValuesKey: "v", TargetPath: "k"},
 		},
 	}
 
@@ -346,10 +326,8 @@ func TestExpandValueReferences_MissingOptionalKeySkipped(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
 		Values: map[string]any{"existing": "kept"},
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "ConfigMap", Name: "extra", ValuesKey: "missing.yaml", Optional: true},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "ConfigMap", Name: "extra", ValuesKey: "missing.yaml", Optional: true},
 		},
 	}
 
@@ -376,9 +354,7 @@ func TestExpandValueReferences_CacheHits(t *testing.T) {
 	hr := func() *manifest.HelmRelease {
 		return &manifest.HelmRelease{
 			Name: "demo", Namespace: "default",
-			HelmReleaseSpec: helmv2.HelmReleaseSpec{
-				ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
-			},
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
 		}
 	}
 
@@ -435,9 +411,7 @@ func TestExpandValueReferences_CacheInvalidatesOnContentChange(t *testing.T) {
 	mk := func() *manifest.HelmRelease {
 		return &manifest.HelmRelease{
 			Name: "demo", Namespace: "default",
-			HelmReleaseSpec: helmv2.HelmReleaseSpec{
-				ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
-			},
+			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
 		}
 	}
 
@@ -473,9 +447,7 @@ func TestExpandValueReferences_NilCache(t *testing.T) {
 	provider := &SliceProvider{ConfigMaps: []*manifest.ConfigMap{cm}}
 	hr := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
-		},
+		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "extra"}},
 	}
 	if err := ExpandValueReferences(hr, provider, nil); err != nil {
 		t.Fatalf("ExpandValueReferences nil cache: %v", err)
@@ -700,9 +672,7 @@ func nestedValuesCM() *manifest.ConfigMap {
 func wholeDocHR() *manifest.HelmRelease {
 	return &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
-		},
+		ValuesFrom: []manifest.ValuesReference{{Kind: "ConfigMap", Name: "platform"}},
 	}
 }
 
@@ -768,11 +738,9 @@ func TestExpandValueReferences_TargetPathDoesNotCorruptSharedCache(t *testing.T)
 	// corrupt it. The TargetPath presence must force the eager path.
 	b := &manifest.HelmRelease{
 		Name: "demo", Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "ConfigMap", Name: "platform"},
-				{Kind: "ConfigMap", Name: "inject", ValuesKey: "v", TargetPath: "image.pullPolicy"},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "ConfigMap", Name: "platform"},
+			{Kind: "ConfigMap", Name: "inject", ValuesKey: "v", TargetPath: "image.pullPolicy"},
 		},
 	}
 	if err := ExpandValueReferences(b, provider, cache); err != nil {
@@ -814,10 +782,8 @@ func TestExpandValueReferences_YAMLContainingPlaceholderIsMerged(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name:      "demo",
 		Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "ConfigMap", Name: "generator-cm"},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "ConfigMap", Name: "generator-cm"},
 		},
 	}
 	if err := ExpandValueReferences(hr, provider, nil); err != nil {
@@ -847,10 +813,8 @@ func TestExpandValueReferences_WipedScalarPlaceholderTolerated(t *testing.T) {
 	hr := &manifest.HelmRelease{
 		Name:      "demo",
 		Namespace: "default",
-		HelmReleaseSpec: helmv2.HelmReleaseSpec{
-			ValuesFrom: []manifest.ValuesReference{
-				{Kind: "Secret", Name: "sops-secret"},
-			},
+		ValuesFrom: []manifest.ValuesReference{
+			{Kind: "Secret", Name: "sops-secret"},
 		},
 	}
 	if err := ExpandValueReferences(hr, provider, nil); err != nil {
@@ -860,4 +824,3 @@ func TestExpandValueReferences_WipedScalarPlaceholderTolerated(t *testing.T) {
 		t.Errorf("expected empty values, got %v", hr.Values)
 	}
 }
-


### PR DESCRIPTION
Rolls flate to Go 1.27.0 (same recipe as the other home-operations Go repos) and takes advantage of the new generic-methods language feature where the existing API was shaped around its absence.

**Toolchain**
- `.mise/config.toml` + `go.mod` to `go 1.27.0` (lockfile refreshed).
- golangci-lint `2.12.2` → `2.13.0` (2.12.2 is go1.26-built and hard-fails on a 1.27 target).

**`go fix` modernizers** (applied and re-run to a fixed point — a second pass makes no further changes)
- `errors.AsType` in the CLI, base controller, and manifest decoding.
- Promoted-field composite literals across `DependencyRef`, the Flux source specs, kustomize types, dyff options, and a large swath of test literals (~50 files, net −350 lines).

**Generic methods** (new in 1.27)
- `pkg/store`'s typed helpers are now methods: `s.Get[T](id)`, `s.GetByName[T](kind, ns, name)`, `s.ListAs[T](kind)` — these were package functions taking the store as a first argument purely because methods couldn't have type parameters. The untyped `Store.GetByName` is renamed `GetObjectByName` so the typed method gets the natural name (it had only 3 real call sites; the typed one had 12).
- `pkg/controllers/base`'s `RequireRefresh` and `DispatchNode` are now methods on `*Controller`: `c.DispatchNode(ctx, id, drainLevel, suspended, reconcile)` with T still inferred from the callbacks. `RunWithStatus`/`RunWithStatusOutcome` stay functions — their receiver would be `store.Store`, a foreign type.

**BREAKING CHANGE:** `pkg/store`'s `Get`/`GetByName`/`ListAs` are methods now, `Store.GetByName` → `Store.GetObjectByName`, and `base.RequireRefresh`/`base.DispatchNode` are methods on `*Controller`. (konflate, the only known consumer, uses none of these — verified.)

Verified: build, vet, gofmt (1.27), golangci-lint 2.13.0 (0 issues), `go test -race ./...` fully green, govulncheck 0 vulnerabilities, and `go fix` is idempotent on the result.

Note for local commits: a Homebrew go 1.26.x `gofmt` on PATH cannot parse generic methods and makes the shared `format-go` pre-commit hook fail on these files; `brew upgrade go` (or letting mise shims win in PATH) resolves it.