### PR TITLE
fix: drop UPX compression, packed binaries segfault (upx/upx#18902)

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -41,11 +41,6 @@ jobs:
           experimental: true
           install_args: --locked
 
-      - name: Install UPX
-        uses: crazy-max/ghaction-upx@c83f378efc804f828e988debb88ed6116feb2368 # v4.0.0
-        with:
-          install-only: true
-
       # Keyed per GOOS: GOCACHE entries differ per target. cache-poisoning
       # rationale in .github/zizmor.yml.
       - name: Cache Go build outputs

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,11 +40,6 @@ archives:
         formats:
           - zip
 
-upx:
-  - enabled: true
-    compress: best
-    lzma: true
-
 checksum:
   algorithm: sha256
   split: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,10 @@ FROM golang:${GO_VERSION}-alpine AS build
 ARG VERSION=dev
 ARG REVISION=dev
 WORKDIR /src
-RUN apk add --no-cache upx
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . ./
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${REVISION}" -o /out/flate ./cmd/flate
-RUN upx --best --lzma /out/flate
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/flate /flate


### PR DESCRIPTION
## Overview

Removes UPX compression from the goreleaser build and the container image.

UPX has an unfixed stub bug ([upx/upx#18902](https://github.com/upx/upx/issues/18902),
[discussion #958](https://github.com/upx/upx/discussions/958)) that segfaults packed binaries
depending on the size of the process environment. The stub's handoff `jmp *(%r14)` in
`src/stub/src/amd64-linux.elf-fold.S` lands one qword high when the environment is large, so the
jump target is an `envp` string pointer. The stub then executes stack bytes and faults on NX,
since the packed binary declares `PT_GNU_STACK RW-`.

The failure mode is unusually hostile to debug: exit 139 with no stdout, no stderr and no Go
traceback, because the process dies before the Go runtime exists to report anything. It depends
on the argv and envp layout rather than on the machine, so it presents as flaky rather than
reproducible, and adding or removing a single environment variable flips it.

## Reproduction

Against the shipped `v0.6.0` `linux/amd64` release binary, using the repro from the upstream
discussion:

```console
$ env -i $(printf 'V%s=xxxxxxxx ' $(seq 500)) ./flate --version
Segmentation fault
```

Same file unpacked with `upx -d`, same shell, same argv:

| env vars | packed | unpacked |
|---|---|---|
| 100 | 0/3 fail | 0/3 fail |
| 300 | 0/3 fail | 0/3 fail |
| 500 | **3/3 fail** | 0/3 fail |

## Additional information

- **Size.** The `linux_amd64` binary goes from 15.7 MB packed to 73.9 MB unpacked.
- **Both channels were packed.** The `upx:` block covers the release archives that
  `home-operations/flate/action` installs, and the Dockerfile covers the container image, so a
  consumer hits this whichever way they install flate.
- **This is not flate-specific.** #775 describes `upx --best --lzma` as a fleet convention, so any
  UPX-packed Go binary in the fleet is exposed to the same bug. flate is just where it surfaced.
- **Dropping only `--lzma` would not help.** The defect is in the stub's environment handling, not
  in the compressor.
- **No code changes.** The Go build is untouched; this only removes the packing step and the now
  unused UPX install in the goreleaser workflow.

Happy to split the Dockerfile and goreleaser changes, or to scope this down, if you would rather
handle the fleet convention separately.
