### PR TITLE
fix(kustomize): apply .sourceignore from the source root for working-tree renders

### DIFF
--- a/pkg/kustomize/flux.go
+++ b/pkg/kustomize/flux.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -46,11 +45,14 @@ var BuildMutex sync.Mutex
 // to the root (a path escaping it simply does not resolve), giving
 // SecureBuild's security posture for free.
 //
-// applyIgnore selects whether source-controller's default file exclusions
-// (.sops.yaml, binaries, CI dirs, in-tree .sourceignore) are applied while
-// auto-generating a kustomization — true for working-tree / self-referential
+// applyIgnore selects whether source-controller's file exclusions (its
+// defaults — .sops.yaml, binaries, CI dirs — plus every in-tree .sourceignore,
+// loaded from the source root exactly as source-controller does) are hidden
+// from the build's disk layer — true for working-tree / self-referential
 // sources that never passed through a fetcher's artifact filtering, false for
-// already-filtered fetched artifacts. spec.commonMetadata is applied post-build
+// already-filtered fetched artifacts. With the filter in place a spec.path or
+// kustomization resource that only exists outside the artifact fails to
+// resolve here as it would in-cluster. spec.commonMetadata is applied post-build
 // (the Generator does not handle it, mirroring kustomize-controller's
 // apply-time pass).
 //
@@ -81,13 +83,27 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 	}
 	sourceRoot = dr.root
 
+	// Working-tree sources read through the source-controller-filtered view of
+	// the disk (see ignorefs.go); the cache key carries the .sourceignore
+	// fingerprint because those files are loaded off-overlay, invisible to the
+	// read-set, so an in-place edit must miss by key instead.
+	diskFS, ignoreKey := dr.diskFS, ""
+	if applyIgnore {
+		ig, ierr := dr.ignored()
+		if ierr != nil {
+			return nil, ierr
+		}
+		diskFS, ignoreKey = ig.fs, ig.key
+	}
+
 	// Cross-run render cache: a stored render whose recorded disk inputs still
 	// validate against the live tree reproduces the output exactly, so krusty is
 	// skipped entirely. The readSet (see readset.go) makes a hit sound even for
-	// `..`-escaping / transitive inputs a spec hash alone would miss.
-	key := renderKey(rawSpec, dr.root, subPath, applyIgnore)
+	// `..`-escaping / transitive inputs a spec hash alone would miss. Validation
+	// replays against the same (possibly filtered) disk view the build read.
+	key := renderKey(rawSpec, dr.root, subPath, ignoreKey)
 	if rc := cache.render; rc != nil && key != "" {
-		if snap, output, ok := rc.get(key); ok && snap.stillValid(dr.diskFS, dr.root) {
+		if snap, output, ok := rc.get(key); ok && snap.stillValid(diskFS, dr.root) {
 			return output, nil
 		}
 	}
@@ -106,10 +122,10 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 	// gets its own overlay). Reading source from disk also sidesteps the
 	// in-memory fs's filename restriction, so trees with exotic names (spaces,
 	// etc.) render.
-	memFS := newOverlayFS(dr.diskFS, rec)
+	memFS := newOverlayFS(diskFS, rec)
 
 	subDir := filepath.Join(sourceRoot, subPath)
-	if info, statErr := os.Stat(subDir); statErr != nil || !info.IsDir() {
+	if !memFS.IsDir(subDir) {
 		return nil, fmt.Errorf("%w: kustomization path is not a directory: %s", manifest.ErrInput, subPath)
 	}
 
@@ -122,34 +138,10 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 		return nil, err
 	}
 
-	// For working-tree / self-referential sources (applyIgnore), exclude
-	// source-controller-ignored files while auto-generating a kustomization, so
-	// the tree renders like a fetched artifact would. Fetched artifacts were
-	// already filtered by their fetcher, so they pass nil.
-	var ignore *sourceignore.Matcher
-	if applyIgnore {
-		m, ierr := sourceignore.New(subDir, nil, true)
-		if ierr != nil {
-			return nil, ierr
-		}
-		ignore = m
-		// sourceignore.New → flux.LoadIgnorePatterns reads .sourceignore files
-		// directly off disk, OUTSIDE the recording overlay, so their content is
-		// invisible to the read-set — an in-place edit would otherwise stale-hit
-		// a cached render. Read each one back through the overlay so its content
-		// is recorded and a change invalidates the entry. Scoped to the
-		// auto-generate path (no in-tree kustomization), the matcher's only
-		// output-affecting consumer (scanManifests); a .sourceignore added or
-		// removed is already caught by the directory listings the build records.
-		if _, hasKust := kustomizationFileIn(memFS, subDir); rec != nil && !hasKust {
-			recordIgnoreFiles(memFS, subDir)
-		}
-	}
-
 	// Merge spec.patches/images/components/targetNamespace/namePrefix/nameSuffix
 	// into the kustomization.yaml exactly as flux's Generator does, then write it
 	// into the memory layer for the build to consume. See generate.go.
-	data, kfile, err := generateManifest(memFS, subDir, rawSpec, ignore)
+	data, kfile, err := generateManifest(memFS, subDir, rawSpec)
 	if err != nil {
 		return nil, fmt.Errorf("flux kustomize generator: %w", err)
 	}
@@ -201,44 +193,36 @@ func RenderFlux(ctx context.Context, cache *TreeCache, sourceRoot string, applyI
 // stable fingerprint of everything that determines the output BEFORE the source
 // tree's content is consulted (the read-set validates that content). The full
 // rawSpec is hashed — generateManifest's merge and the post-build
-// applyOwnerLabels/applyCommonMetadata all derive from it. Empty (caching off
-// for this render) when the spec can't be hashed.
-func renderKey(rawSpec map[string]any, sourceRoot, subPath string, applyIgnore bool) string {
+// applyOwnerLabels/applyCommonMetadata all derive from it. ignoreKey is the
+// source root's .sourceignore fingerprint for a working-tree render, "" for a
+// fetched artifact. Empty (caching off for this render) when the spec can't be
+// hashed.
+func renderKey(rawSpec map[string]any, sourceRoot, subPath, ignoreKey string) string {
 	return manifest.Fingerprint(struct {
-		Spec        map[string]any
-		SourceRoot  string
-		SubPath     string
-		ApplyIgnore bool
-	}{rawSpec, sourceRoot, subPath, applyIgnore})
-}
-
-// ignoreFileName is the in-tree source-controller exclusion file flux's
-// LoadIgnorePatterns reads (off-overlay) and recurses subdirectories for.
-const ignoreFileName = ".sourceignore"
-
-// recordIgnoreFiles reads every .sourceignore under subDir back through the
-// recording overlay so each one's content lands in the render cache's read-set
-// (flux loads them off-disk, bypassing the overlay — see RenderFlux). The
-// read-through's side effect is the recording; the returned bytes are discarded.
-func recordIgnoreFiles(memFS filesys.FileSystem, subDir string) {
-	_ = memFS.Walk(subDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info == nil || info.IsDir() {
-			return nil
-		}
-		if filepath.Base(path) == ignoreFileName {
-			_, _ = memFS.ReadFile(path)
-		}
-		return nil
-	})
+		Spec       map[string]any
+		SourceRoot string
+		SubPath    string
+		Ignore     string
+	}{rawSpec, sourceRoot, subPath, ignoreKey})
 }
 
 // diskRoot holds the per-sourceRoot invariants RenderFlux reuses across every
 // Kustomization that targets the same root: the symlink-resolved absolute root
 // and its secure on-disk FS. diskFS is an immutable fsSecure value over a
 // stateless MakeFsOnDisk, so it is safe to share read-only across goroutines.
+// ignored lazily derives the working-tree view — diskFS behind the
+// source-controller ignore matcher loaded from root — plus the .sourceignore
+// fingerprint that keys it; built once per root because loading the matcher
+// walks the whole tree.
 type diskRoot struct {
-	root   string
-	diskFS filesys.FileSystem
+	root    string
+	diskFS  filesys.FileSystem
+	ignored func() (ignoredRoot, error)
+}
+
+type ignoredRoot struct {
+	fs  filesys.FileSystem
+	key string
 }
 
 // diskRootFor returns the cached diskRoot for sourceRoot, computing and
@@ -260,6 +244,17 @@ func (c *TreeCache) diskRootFor(sourceRoot string) (*diskRoot, error) {
 		return nil, fmt.Errorf("kustomize: secure fs %s: %w", resolved, err)
 	}
 	dr := &diskRoot{root: resolved, diskFS: diskFS}
+	dr.ignored = sync.OnceValues(func() (ignoredRoot, error) {
+		matcher, err := sourceignore.New(resolved, nil, true)
+		if err != nil {
+			return ignoredRoot{}, err
+		}
+		key, err := sourceignore.Fingerprint(resolved)
+		if err != nil {
+			return ignoredRoot{}, err
+		}
+		return ignoredRoot{fs: newIgnoreFS(diskFS, resolved, matcher), key: key}, nil
+	})
 	actual, _ := c.diskRoots.LoadOrStore(sourceRoot, dr)
 	return actual.(*diskRoot), nil
 }

--- a/pkg/kustomize/generate.go
+++ b/pkg/kustomize/generate.go
@@ -40,8 +40,6 @@ import (
 	kustypes "sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/yaml"
-
-	"github.com/home-operations/flate/pkg/source/sourceignore"
 )
 
 // Flux Kustomization spec field names (mirrors the unexported consts in
@@ -67,15 +65,13 @@ const (
 //
 // It is a faithful port of Generator.GenerateManifest: same field order, same
 // _placeholder / originAnnotations empty-build guards, same sigs.k8s.io/yaml
-// encoder, so the output is byte-identical to flux's. ignore, when non-nil,
-// reproduces flux's NewGeneratorWithIgnore behavior for the auto-generated
-// (path: ./) case — source-controller-excluded files (.sops.yaml, binaries, …)
-// are skipped while scanning for resources, so a working-tree source renders
-// like a fetched artifact would (this is the bo0tzz fix). The base path comes
-// from fsys.CleanedAbs (the real on-disk path under the memory-over-disk
-// overlay), matching flux's filepath.Abs(dirPath).
-func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]any, ignore *sourceignore.Matcher) ([]byte, string, error) {
-	data, kfile, foundExisting, err := findOrGenerateKustomization(fsys, dirPath, ignore)
+// encoder, so the output is byte-identical to flux's. Source-controller's file
+// exclusions are not consulted here: a working-tree fsys already hides them
+// (see ignorefs.go), so the scan sees the same files a fetched artifact holds.
+// The base path comes from fsys.CleanedAbs (the real on-disk path under the
+// memory-over-disk overlay), matching flux's filepath.Abs(dirPath).
+func generateManifest(fsys filesys.FileSystem, dirPath string, obj map[string]any) ([]byte, string, error) {
+	data, kfile, foundExisting, err := findOrGenerateKustomization(fsys, dirPath)
 	if err != nil {
 		return nil, "", err
 	}
@@ -225,7 +221,7 @@ func kustomizationFileIn(fsys filesys.FileSystem, dir string) (path string, ok b
 // findOrGenerateKustomization returns the existing kustomization file's bytes
 // (foundExisting=true) or, when none is present, synthesizes one from the YAML
 // manifests in dirPath via scanManifests. Mirrors the like-named flux function.
-func findOrGenerateKustomization(fsys filesys.FileSystem, dirPath string, ignore *sourceignore.Matcher) (data []byte, kfile string, foundExisting bool, err error) {
+func findOrGenerateKustomization(fsys filesys.FileSystem, dirPath string) (data []byte, kfile string, foundExisting bool, err error) {
 	if kpath, ok := kustomizationFileIn(fsys, dirPath); ok {
 		b, rerr := fsys.ReadFile(kpath)
 		return b, kpath, true, rerr
@@ -239,7 +235,7 @@ func findOrGenerateKustomization(fsys filesys.FileSystem, dirPath string, ignore
 	if err != nil {
 		return nil, "", false, err
 	}
-	files, err := scanManifests(fsys, base.String(), ignore)
+	files, err := scanManifests(fsys, base.String())
 	if err != nil {
 		return nil, "", false, err
 	}
@@ -275,9 +271,9 @@ func findOrGenerateKustomization(fsys filesys.FileSystem, dirPath string, ignore
 // resources: a sub-directory that itself carries a kustomization file is added
 // as a resource and not descended into; every other .yaml/.yml file is added
 // once it parses as Kubernetes YAML. Mirrors the like-named flux function
-// (filter==false: no sourceignore consulted — that filtering happened at
-// materialize time).
-func scanManifests(fsys filesys.FileSystem, base string, ignore *sourceignore.Matcher) ([]string, error) {
+// (filter==false: no sourceignore consulted — that filtering happens at the
+// filesystem, see ignorefs.go).
+func scanManifests(fsys filesys.FileSystem, base string) ([]string, error) {
 	var paths []string
 	rf := provider.NewDefaultDepProvider().GetResourceFactory()
 
@@ -297,15 +293,6 @@ func scanManifests(fsys filesys.FileSystem, base string, ignore *sourceignore.Ma
 		}
 		if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
 			return nil
-		}
-		// Skip source-controller-excluded files (sourceignore defaults +
-		// in-tree .sourceignore) for working-tree sources — flux's
-		// filter==true behavior, which keeps a stray .sops.yaml or binary
-		// out of an auto-generated kustomization's resource list.
-		if ignore != nil {
-			if rel, rerr := filepath.Rel(base, path); rerr == nil && ignore.Match(rel, false) {
-				return nil
-			}
 		}
 		contents, err := fsys.ReadFile(path)
 		if err != nil {

--- a/pkg/kustomize/generate_test.go
+++ b/pkg/kustomize/generate_test.go
@@ -27,6 +27,22 @@ func testOverlayFS(t *testing.T, root string) filesys.FileSystem {
 	return newOverlayFS(disk, nil)
 }
 
+// testIgnoreOverlayFS is testOverlayFS with the source-controller ignore
+// matcher loaded from root in front of the disk layer — the working-tree
+// (applyIgnore) view RenderFlux builds against.
+func testIgnoreOverlayFS(t *testing.T, root string) filesys.FileSystem {
+	t.Helper()
+	disk, err := fluxfilesys.MakeFsOnDiskSecure(root)
+	if err != nil {
+		t.Fatalf("secure fs: %v", err)
+	}
+	matcher, err := sourceignore.New(root, nil, true)
+	if err != nil {
+		t.Fatalf("matcher: %v", err)
+	}
+	return newOverlayFS(newIgnoreFS(disk, root, matcher), nil)
+}
+
 // These tests pin flate's in-memory generateManifest to flux's real on-disk
 // Generator.GenerateManifest. The acceptance gate for the whole in-memory
 // redesign is byte-equivalence: for an identical source tree and Kustomization
@@ -226,7 +242,7 @@ func TestGenerateManifest_ByteEquivalentToFlux(t *testing.T) {
 				t.Fatalf("flux GenerateManifest: %v", err)
 			}
 
-			got, _, err := generateManifest(testOverlayFS(t, root), filepath.Join(root, tc.subPath), deepCopyDoc(t, doc), nil)
+			got, _, err := generateManifest(testOverlayFS(t, root), filepath.Join(root, tc.subPath), deepCopyDoc(t, doc))
 			if err != nil {
 				t.Fatalf("generateManifest: %v", err)
 			}
@@ -245,7 +261,7 @@ func renderInMemory(t *testing.T, root, subPath string, doc map[string]any) []by
 	t.Helper()
 	fsys := testOverlayFS(t, root)
 	absSub := filepath.Join(root, subPath)
-	data, kfile, err := generateManifest(fsys, absSub, doc, nil)
+	data, kfile, err := generateManifest(fsys, absSub, doc)
 	if err != nil {
 		t.Fatalf("generateManifest: %v", err)
 	}
@@ -356,24 +372,20 @@ func TestBuild_InMemorySandbox(t *testing.T) {
 
 // TestGenerateManifest_SourceIgnoreFiltersScan is the bo0tzz fix: a working tree
 // carrying a root .sops.yaml renders cleanly through a `path: ./` Kustomization
-// because the sourceignore matcher keeps the SOPS config out of the
+// because the ignore filesystem keeps the SOPS config out of the
 // auto-generated kustomization's resource list — the same artifact a real
-// GitRepository fetch would produce. Without the matcher the SOPS config is
+// GitRepository fetch would produce. Without the filter the SOPS config is
 // scanned as a manifest and the build fails.
 func TestGenerateManifest_SourceIgnoreFiltersScan(t *testing.T) {
 	root := writeTree(t, map[string]string{
 		".sops.yaml": "creation_rules:\n  - path_regex: .*\n    age: age1example\n",
 		"cm.yaml":    cmYAML("config"),
 	})
-	matcher, err := sourceignore.New(root, nil, true)
-	if err != nil {
-		t.Fatalf("matcher: %v", err)
-	}
 
-	// With the matcher, scanManifests skips .sops.yaml so a path:./ build over
-	// the working tree renders the ConfigMap.
-	fsys := testOverlayFS(t, root)
-	data, kfile, err := generateManifest(fsys, root, ksDoc(nil), matcher)
+	// Behind the ignore filesystem, scanManifests never sees .sops.yaml so a
+	// path:./ build over the working tree renders the ConfigMap.
+	fsys := testIgnoreOverlayFS(t, root)
+	data, kfile, err := generateManifest(fsys, root, ksDoc(nil))
 	if err != nil {
 		t.Fatalf("generateManifest(ignore): %v", err)
 	}
@@ -392,10 +404,10 @@ func TestGenerateManifest_SourceIgnoreFiltersScan(t *testing.T) {
 		t.Fatalf("expected rendered ConfigMap, got:\n%s", out)
 	}
 
-	// Without the matcher (a fetched artifact, already filtered, would not hit
+	// Without the filter (a fetched artifact, already filtered, would not hit
 	// this), scanManifests includes .sops.yaml and fails to decode it — the bug
 	// the filter fixes.
-	if _, _, err := generateManifest(testOverlayFS(t, root), root, ksDoc(nil), nil); err == nil {
+	if _, _, err := generateManifest(testOverlayFS(t, root), root, ksDoc(nil)); err == nil {
 		t.Fatal("expected generate/scan to fail on the unfiltered .sops.yaml, got nil")
 	}
 }
@@ -425,7 +437,7 @@ func TestFindOrGenerate_MemoryPopulatedSubdirNotDescended(t *testing.T) {
 		t.Fatalf("seed memory: %v", err)
 	}
 
-	data, _, foundExisting, err := findOrGenerateKustomization(fsys, root, nil)
+	data, _, foundExisting, err := findOrGenerateKustomization(fsys, root)
 	if err != nil {
 		t.Fatalf("findOrGenerateKustomization: %v", err)
 	}

--- a/pkg/kustomize/ignorefs.go
+++ b/pkg/kustomize/ignorefs.go
@@ -1,0 +1,183 @@
+package kustomize
+
+// ignorefs.go hides source-controller-excluded paths from the disk layer of a
+// working-tree build. A GitRepository artifact only contains the files that
+// survive source-controller's ignore matcher (its defaults plus every in-tree
+// .sourceignore), so a Kustomization whose spec.path — or whose kustomization
+// resources — resolve into an excluded directory fails on the cluster even
+// though the files exist in the checkout. Filtering at the filesystem rather
+// than in the resource scan makes every read the build performs (the spec.path
+// check, kustomize's own resource resolution, the auto-generate scan) see the
+// artifact's shape, so the render fails where Flux would.
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+
+	"github.com/home-operations/flate/pkg/source/safepath"
+	"github.com/home-operations/flate/pkg/source/sourceignore"
+)
+
+// ignoreFS wraps a disk filesystem rooted at root and reports every path the
+// matcher excludes as absent. Writes pass through untouched (the overlay never
+// writes to disk). Safe for concurrent use.
+type ignoreFS struct {
+	disk    filesys.FileSystem
+	root    string
+	matcher *sourceignore.Matcher
+	// dirs memoizes the survivor scan a matched directory needs (see hidden);
+	// the tree is static for the life of the FS, so a verdict never changes.
+	dirs *sync.Map // rel dir -> hidden bool
+}
+
+func newIgnoreFS(disk filesys.FileSystem, root string, matcher *sourceignore.Matcher) filesys.FileSystem {
+	return ignoreFS{disk: disk, root: root, matcher: matcher, dirs: &sync.Map{}}
+}
+
+var errSurvivorFound = errors.New("survivor found")
+
+// hidden reports whether path is excluded from the artifact. A matched file is
+// always hidden. A matched directory is hidden only when nothing under it is
+// re-included by a deeper `!` pattern: source-controller's archive walk skips
+// the directory entry itself but keeps descending, so an allowlist such as
+// `/*` + `!/charts/x/` still ships charts/x/** (with charts/ recreated as its
+// parent). Paths at or outside root are never hidden.
+func (ig ignoreFS) hidden(path string, isDir bool) bool {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(ig.root, abs)
+	if err != nil || rel == "." || safepath.Escaped(rel) {
+		return false
+	}
+	if !ig.matcher.Match(rel, isDir) {
+		return false
+	}
+	if !isDir {
+		return true
+	}
+	if v, ok := ig.dirs.Load(rel); ok {
+		return v.(bool)
+	}
+	h := !ig.hasSurvivor(abs)
+	ig.dirs.Store(rel, h)
+	return h
+}
+
+// hasSurvivor reports whether any regular file under dir escapes the matcher.
+func (ig ignoreFS) hasSurvivor(dir string) bool {
+	err := filepath.WalkDir(dir, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !d.Type().IsRegular() {
+			return nil
+		}
+		rel, rerr := filepath.Rel(ig.root, p)
+		if rerr != nil {
+			return nil
+		}
+		if !ig.matcher.Match(rel, false) {
+			return errSurvivorFound
+		}
+		return nil
+	})
+	return errors.Is(err, errSurvivorFound)
+}
+
+func notExist(op, path string) error {
+	return &fs.PathError{Op: op, Path: path, Err: fs.ErrNotExist}
+}
+
+func (ig ignoreFS) Create(path string) (filesys.File, error) { return ig.disk.Create(path) }
+func (ig ignoreFS) Mkdir(path string) error                  { return ig.disk.Mkdir(path) }
+func (ig ignoreFS) MkdirAll(path string) error               { return ig.disk.MkdirAll(path) }
+func (ig ignoreFS) RemoveAll(path string) error              { return ig.disk.RemoveAll(path) }
+func (ig ignoreFS) WriteFile(path string, d []byte) error    { return ig.disk.WriteFile(path, d) }
+
+func (ig ignoreFS) Exists(path string) bool {
+	return ig.disk.Exists(path) && !ig.hidden(path, ig.disk.IsDir(path))
+}
+
+func (ig ignoreFS) IsDir(path string) bool {
+	return ig.disk.IsDir(path) && !ig.hidden(path, true)
+}
+
+func (ig ignoreFS) Open(path string) (filesys.File, error) {
+	if ig.hidden(path, ig.disk.IsDir(path)) {
+		return nil, notExist("open", path)
+	}
+	return ig.disk.Open(path)
+}
+
+func (ig ignoreFS) ReadFile(path string) ([]byte, error) {
+	if ig.hidden(path, ig.disk.IsDir(path)) {
+		return nil, notExist("open", path)
+	}
+	return ig.disk.ReadFile(path)
+}
+
+func (ig ignoreFS) CleanedAbs(path string) (filesys.ConfirmedDir, string, error) {
+	d, f, err := ig.disk.CleanedAbs(path)
+	if err != nil {
+		return d, f, err
+	}
+	full := d.String()
+	if f != "" {
+		full = filepath.Join(full, f)
+	}
+	if ig.hidden(full, f == "") {
+		return "", "", notExist("stat", path)
+	}
+	return d, f, nil
+}
+
+func (ig ignoreFS) ReadDir(path string) ([]string, error) {
+	if ig.hidden(path, true) {
+		return nil, notExist("open", path)
+	}
+	entries, err := ig.disk.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	kept := entries[:0]
+	for _, e := range entries {
+		child := filepath.Join(path, e)
+		if !ig.hidden(child, ig.disk.IsDir(child)) {
+			kept = append(kept, e)
+		}
+	}
+	return kept, nil
+}
+
+func (ig ignoreFS) Glob(pattern string) ([]string, error) {
+	paths, err := ig.disk.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	kept := paths[:0]
+	for _, p := range paths {
+		if !ig.hidden(p, ig.disk.IsDir(p)) {
+			kept = append(kept, p)
+		}
+	}
+	return kept, nil
+}
+
+// Walk skips hidden files and prunes hidden directories. A matched directory
+// that is NOT hidden (it has a re-included descendant) is still descended, with
+// its excluded children dropped individually.
+func (ig ignoreFS) Walk(path string, walkFn filepath.WalkFunc) error {
+	return ig.disk.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && ig.hidden(p, info.IsDir()) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		return walkFn(p, info, err)
+	})
+}

--- a/pkg/kustomize/ignorefs_test.go
+++ b/pkg/kustomize/ignorefs_test.go
@@ -1,0 +1,215 @@
+package kustomize
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/source/sourceignore"
+)
+
+// allowlistIgnore is the mono-repo .sourceignore shape from #936: exclude
+// everything at the root, re-include the manifest directories.
+const allowlistIgnore = "# Exclude all\n/*\n# Include manifest directories\n!/clusters/\n!/charts/x/\n"
+
+func testIgnoreFS(t *testing.T, root string) ignoreFS {
+	t.Helper()
+	matcher, err := sourceignore.New(root, nil, true)
+	if err != nil {
+		t.Fatalf("matcher: %v", err)
+	}
+	disk := testOverlayFS(t, root).(overlayFS).disk
+	return newIgnoreFS(disk, root, matcher).(ignoreFS)
+}
+
+func TestIgnoreFS_HidesExcludedPaths(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		".sourceignore":         allowlistIgnore,
+		"clusters/dev/cm.yaml":  cmYAML("dev"),
+		"bundles/common/a.yaml": cmYAML("a"),
+		"charts/x/Chart.yaml":   "name: x\n",
+		"charts/y/Chart.yaml":   "name: y\n",
+		"README.md":             "hi\n",
+	})
+	ig := testIgnoreFS(t, root)
+	abs := func(rel string) string { return filepath.Join(root, rel) }
+
+	cases := []struct {
+		rel     string
+		visible bool
+	}{
+		{"clusters", true},
+		{"clusters/dev", true},
+		{"clusters/dev/cm.yaml", true},
+		{"bundles", false},
+		{"bundles/common", false},
+		{"bundles/common/a.yaml", false},
+		{"README.md", false},
+		// charts/ matches /* but a deeper `!` keeps charts/x/**, so the parent
+		// still exists in the artifact while its excluded sibling does not.
+		{"charts", true},
+		{"charts/x", true},
+		{"charts/x/Chart.yaml", true},
+		{"charts/y", false},
+		{"charts/y/Chart.yaml", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.rel, func(t *testing.T) {
+			p := abs(tc.rel)
+			if got := ig.Exists(p); got != tc.visible {
+				t.Errorf("Exists = %v, want %v", got, tc.visible)
+			}
+			isDir := ig.disk.IsDir(p)
+			if got := ig.IsDir(p); got != (tc.visible && isDir) {
+				t.Errorf("IsDir = %v, want %v", got, tc.visible && isDir)
+			}
+			_, _, err := ig.CleanedAbs(p)
+			if (err == nil) != tc.visible {
+				t.Errorf("CleanedAbs err = %v, want visible=%v", err, tc.visible)
+			}
+			if !isDir {
+				_, err := ig.ReadFile(p)
+				if (err == nil) != tc.visible {
+					t.Errorf("ReadFile err = %v, want visible=%v", err, tc.visible)
+				}
+				if !tc.visible && !errors.Is(err, os.ErrNotExist) {
+					t.Errorf("hidden ReadFile error should be not-exist, got %v", err)
+				}
+			}
+		})
+	}
+
+	// The root itself is never hidden, and its listing drops hidden children.
+	if !ig.IsDir(root) {
+		t.Fatal("root must stay visible")
+	}
+	entries, err := ig.ReadDir(root)
+	if err != nil {
+		t.Fatalf("ReadDir root: %v", err)
+	}
+	slices.Sort(entries)
+	if want := []string{"charts", "clusters"}; !slices.Equal(entries, want) {
+		t.Errorf("ReadDir root = %v, want %v", entries, want)
+	}
+
+	var walked []string
+	if err := ig.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			rel, _ := filepath.Rel(root, p)
+			walked = append(walked, filepath.ToSlash(rel))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	slices.Sort(walked)
+	if want := []string{"charts/x/Chart.yaml", "clusters/dev/cm.yaml"}; !slices.Equal(walked, want) {
+		t.Errorf("Walk files = %v, want %v", walked, want)
+	}
+}
+
+// TestRenderFlux_SourceignoreAllowlist is the regression for #936: a root
+// .sourceignore allowlist that leaves a directory out of the artifact must make
+// a working-tree render fail the way Flux does, whether the directory is the
+// Kustomization's spec.path or a base an in-tree kustomization.yaml pulls in.
+// A fetched artifact (applyIgnore=false) is left alone: its fetcher already
+// filtered it.
+func TestRenderFlux_SourceignoreAllowlist(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		".sourceignore":                       allowlistIgnore,
+		"bundles/common/kustomization.yaml":   existingKustomization("cm.yaml"),
+		"bundles/common/cm.yaml":              cmYAML("common"),
+		"clusters/dev/app/kustomization.yaml": existingKustomization("../../../bundles/common"),
+		"clusters/dev/ok/cm.yaml":             cmYAML("ok"),
+	})
+	ctx := context.Background()
+	spec := func(path string) map[string]any {
+		return ksDoc(map[string]any{"path": path})
+	}
+
+	t.Run("spec.path excluded", func(t *testing.T) {
+		_, err := RenderFlux(ctx, NewTreeCache(), root, true, "bundles/common", spec("./bundles/common"))
+		if !errors.Is(err, manifest.ErrInput) || !strings.Contains(err.Error(), "not a directory") {
+			t.Fatalf("expected the excluded spec.path to be reported missing, got %v", err)
+		}
+	})
+
+	t.Run("kustomization base excluded", func(t *testing.T) {
+		_, err := RenderFlux(ctx, NewTreeCache(), root, true, "clusters/dev/app", spec("./clusters/dev/app"))
+		if err == nil || !strings.Contains(err.Error(), "bundles/common") {
+			t.Fatalf("expected the build to fail resolving the excluded base, got %v", err)
+		}
+	})
+
+	t.Run("allowlisted path renders", func(t *testing.T) {
+		out, err := RenderFlux(ctx, NewTreeCache(), root, true, "clusters/dev/ok", spec("./clusters/dev/ok"))
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if !strings.Contains(string(out), "name: ok") {
+			t.Fatalf("expected rendered ConfigMap, got:\n%s", out)
+		}
+	})
+
+	t.Run("fetched artifact not refiltered", func(t *testing.T) {
+		out, err := RenderFlux(ctx, NewTreeCache(), root, false, "bundles/common", spec("./bundles/common"))
+		if err != nil {
+			t.Fatalf("render: %v", err)
+		}
+		if !strings.Contains(string(out), "name: common") {
+			t.Fatalf("expected rendered ConfigMap, got:\n%s", out)
+		}
+	})
+}
+
+// TestRenderFlux_SourceignoreCacheReplaysFilteredView pins that a cached render
+// of a working-tree source validates against the filtered disk view it was
+// recorded through: a probe of a hidden path is recorded as absent and must
+// still read as absent on replay, or every such render would miss forever.
+func TestRenderFlux_SourceignoreCacheReplaysFilteredView(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		".sourceignore": "b.yaml\n",
+		"a.yaml":        cmYAML("a"),
+		"b.yaml":        cmYAML("b"),
+	})
+	cache := NewTreeCache()
+	cache.SetRenderCache(t.TempDir(), 1<<30)
+	ctx := context.Background()
+
+	out1, err := RenderFlux(ctx, cache, root, true, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("first render: %v", err)
+	}
+	if strings.Contains(string(out1), "name: b") {
+		t.Fatalf("b.yaml should be excluded; got %s", out1)
+	}
+	dr, err := cache.diskRootFor(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ig, err := dr.ignored()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := renderKey(demoRawSpec, dr.root, ".", ig.key)
+	snap, _, ok := cache.render.get(key)
+	if !ok {
+		t.Fatal("first render did not populate the cache")
+	}
+	cache.render.put(key, snap, []byte("SENTINEL\n"))
+	out2, err := RenderFlux(ctx, cache, root, true, ".", demoRawSpec)
+	if err != nil {
+		t.Fatalf("second render: %v", err)
+	}
+	if string(out2) != "SENTINEL\n" {
+		t.Errorf("expected a cache hit against the filtered view; got a re-render:\n%s", out2)
+	}
+}

--- a/pkg/kustomize/render_cache_test.go
+++ b/pkg/kustomize/render_cache_test.go
@@ -44,7 +44,7 @@ func TestRenderFlux_CacheHitMissInvalidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key := renderKey(demoRawSpec, dr.root, ".", false)
+	key := renderKey(demoRawSpec, dr.root, ".", "")
 	snap, _, ok := cache.render.get(key)
 	if !ok {
 		t.Fatal("first render did not populate the cache")
@@ -79,15 +79,18 @@ func TestRenderFlux_CacheHitMissInvalidate(t *testing.T) {
 // TestRenderFlux_SourceignoreContentInvalidates is the regression for the
 // adversarially-found stale hit: .sourceignore is loaded off-disk (outside the
 // recording overlay), so an in-place edit that changes which resources an
-// auto-generated kustomization includes must still invalidate the cache.
+// auto-generated kustomization includes must still invalidate the cache. The
+// ignore matcher is memoized per root for the life of a TreeCache (one run), so
+// the edit is made between two runs sharing the on-disk render cache.
 func TestRenderFlux_SourceignoreContentInvalidates(t *testing.T) {
 	root := writeTree(t, map[string]string{
 		"a.yaml":        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: a\n",
 		"b.yaml":        "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: b\n",
 		".sourceignore": "# excludes nothing yet\n",
 	})
+	cacheDir := t.TempDir()
 	cache := NewTreeCache()
-	cache.SetRenderCache(t.TempDir(), 1<<30)
+	cache.SetRenderCache(cacheDir, 1<<30)
 	ctx := context.Background()
 
 	out1, err := RenderFlux(ctx, cache, root, true /* applyIgnore */, ".", demoRawSpec)
@@ -104,6 +107,8 @@ func TestRenderFlux_SourceignoreContentInvalidates(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cache = NewTreeCache()
+	cache.SetRenderCache(cacheDir, 1<<30)
 	out2, err := RenderFlux(ctx, cache, root, true, ".", demoRawSpec)
 	if err != nil {
 		t.Fatalf("second render: %v", err)

--- a/pkg/source/sourceignore/fingerprint_test.go
+++ b/pkg/source/sourceignore/fingerprint_test.go
@@ -1,0 +1,72 @@
+package sourceignore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func write(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fingerprint(t *testing.T, root string) string {
+	t.Helper()
+	fp, err := Fingerprint(root)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	return fp
+}
+
+func TestFingerprint(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.yaml", "a: 1\n")
+	base := fingerprint(t, root)
+
+	if fingerprint(t, root) != base {
+		t.Fatal("fingerprint must be stable across calls")
+	}
+
+	write(t, root, "unrelated.yaml", "b: 2\n")
+	if fingerprint(t, root) != base {
+		t.Fatal("a file that is not a .sourceignore must not change the fingerprint")
+	}
+
+	write(t, root, ".sourceignore", "b.yaml\n")
+	withRoot := fingerprint(t, root)
+	if withRoot == base {
+		t.Fatal("adding a root .sourceignore must change the fingerprint")
+	}
+
+	write(t, root, ".sourceignore", "c.yaml\n")
+	edited := fingerprint(t, root)
+	if edited == withRoot {
+		t.Fatal("editing .sourceignore in place must change the fingerprint")
+	}
+
+	write(t, root, "sub/.sourceignore", "d.yaml\n")
+	nested := fingerprint(t, root)
+	if nested == edited {
+		t.Fatal("adding a nested .sourceignore must change the fingerprint")
+	}
+
+	write(t, root, ".git/.sourceignore", "ignored\n")
+	if fingerprint(t, root) != nested {
+		t.Fatal(".git/ must be skipped, as LoadIgnorePatterns skips it")
+	}
+
+	if err := os.Remove(filepath.Join(root, "sub", ".sourceignore")); err != nil {
+		t.Fatal(err)
+	}
+	if fingerprint(t, root) != edited {
+		t.Fatal("removing a .sourceignore must restore the earlier fingerprint")
+	}
+}

--- a/pkg/source/sourceignore/matcher.go
+++ b/pkg/source/sourceignore/matcher.go
@@ -12,7 +12,11 @@
 package sourceignore
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -65,4 +69,44 @@ func (m *Matcher) Match(rel string, isDir bool) bool {
 // splitPath breaks p into its components using the OS path separator.
 func splitPath(p string) []string {
 	return strings.Split(p, string(filepath.Separator))
+}
+
+// Fingerprint digests every .sourceignore file under root — relative path and
+// content, in LoadIgnorePatterns' traversal order — so work cached against a
+// Matcher built from root can be keyed on the files that shaped it: an edit,
+// addition, or removal of any .sourceignore changes the result. Directories
+// named .git are skipped, as the loader skips them.
+func Fingerprint(root string) (string, error) {
+	h := sha256.New()
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if p != root && d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.Name() != flux.IgnoreFile {
+			return nil
+		}
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return err
+		}
+		b, err := os.ReadFile(p) //nolint:gosec // p is a .sourceignore found by walking root
+		if err != nil {
+			return err
+		}
+		h.Write([]byte(filepath.ToSlash(rel)))
+		h.Write([]byte{0})
+		h.Write(b)
+		h.Write([]byte{0})
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("sourceignore fingerprint: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }


### PR DESCRIPTION
Closes #936