### PR TITLE
fix(loader): attribute children to Kustomizations whose spec.path has a leading slash

### DIFF
--- a/pkg/loader/parent_test.go
+++ b/pkg/loader/parent_test.go
@@ -403,3 +403,27 @@ func TestLongestParent_DeepestMatchWins(t *testing.T) {
 		t.Errorf("expected deepest parent 'leaf', got %q", got.Name)
 	}
 }
+
+// TestLongestParent_AbsoluteSpecPath is the #920 regression: a Kustomization
+// whose spec.path carries a leading slash (accepted by Flux, which resolves it
+// against the artifact root) must still be found as the parent of the files
+// under that directory. Before the fix its claim prefix kept the slash, so no
+// repo-relative source file ever matched and every child was orphaned.
+func TestLongestParent_AbsoluteSpecPath(t *testing.T) {
+	s := store.New()
+	ks := &manifest.Kustomization{
+		Name: "flux-instance", Namespace: "flux-system",
+		Path: "/kubernetes/apps/flux-system/flux-operator/instance",
+	}
+	s.AddObject(ks)
+
+	prefixes := KSPathPrefixesWithCache(s, "", nil)
+	hr := manifest.NamedResource{Kind: manifest.KindHelmRelease, Name: "flux-instance"}
+	parent, ok := LongestParent(prefixes, "kubernetes/apps/flux-system/flux-operator/instance/helm-release.yaml", hr)
+	if !ok {
+		t.Fatalf("expected the absolute spec.path KS to parent its helm-release.yaml; prefixes=%v", prefixes)
+	}
+	if parent != ks.Named() {
+		t.Errorf("parent = %v, want %v", parent, ks.Named())
+	}
+}

--- a/pkg/manifest/kustomize_fs.go
+++ b/pkg/manifest/kustomize_fs.go
@@ -177,9 +177,13 @@ func BuildKSClaims(kss []*Kustomization, repoRoot string, cache *ComponentCache)
 // NormalizeClaimBase turns a Kustomization spec.path into a clean,
 // slash-separated, repo-relative base with no trailing slash. ToSlash is
 // applied so Windows-style spec.path values (rare, but unconstrained by the
-// Flux CRD) normalize to the same shape as SourceFiles keys.
+// Flux CRD) normalize to the same shape as SourceFiles keys. A leading slash
+// is dropped: kustomize-controller resolves spec.path with SecureJoin, which
+// treats an absolute path as relative to the artifact root, so
+// `/kubernetes/apps` claims the same files as `./kubernetes/apps`.
 func NormalizeClaimBase(p string) string {
 	p = filepath.ToSlash(p)
 	p = strings.TrimPrefix(p, "./")
+	p = strings.TrimLeft(p, "/")
 	return strings.TrimSuffix(p, "/")
 }

--- a/pkg/manifest/kustomize_fs_test.go
+++ b/pkg/manifest/kustomize_fs_test.go
@@ -142,3 +142,29 @@ components: [./alpha, ./beta]
 	}
 	wg.Wait()
 }
+
+// TestNormalizeClaimBase pins the spec.path shapes that must all claim the
+// same repo-relative files. The leading-slash case is #920: Flux resolves
+// spec.path root-relatively, so `/kubernetes/apps` must not keep a slash that
+// a repo-relative source file can never match.
+func TestNormalizeClaimBase(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"./kubernetes/apps", "kubernetes/apps"},
+		{"kubernetes/apps/", "kubernetes/apps"},
+		{"/kubernetes/apps", "kubernetes/apps"},
+		{"/kubernetes/apps/", "kubernetes/apps"},
+		{"//kubernetes/apps", "kubernetes/apps"},
+		{"./", ""},
+		{"/", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := NormalizeClaimBase(tc.in); got != tc.want {
+				t.Errorf("NormalizeClaimBase(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #920