### PR TITLE
feat: add --force-generic-provider

### DIFF
--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -40,18 +40,19 @@ type commonFlags struct {
 	// baseline side) are threaded explicitly rather than re-derived from a
 	// .git. Empty for an explicit --path-orig (the CLI defaults the root
 	// via repoRootOf and lets the side read its own .git remotes).
-	pathOrigRoot        string
-	pathOrigSelfURLs    []string
-	base                string
-	namespace           string
-	skipCRDs            bool
-	skipSecrets         bool
-	allowMissingSecrets bool
-	restrictEgress      bool
-	skipKinds           []string
-	output              string
-	registryConfig      string
-	concurrency         int
+	pathOrigRoot         string
+	pathOrigSelfURLs     []string
+	base                 string
+	namespace            string
+	skipCRDs             bool
+	skipSecrets          bool
+	allowMissingSecrets  bool
+	forceGenericProvider bool
+	restrictEgress       bool
+	skipKinds            []string
+	output               string
+	registryConfig       string
+	concurrency          int
 	// sourceRetry* tune the bounded retry applied uniformly to every source
 	// fetch on transient network errors. attempts is the total tries (first +
 	// retries); 1 disables. min/max bound the exponential backoff and jitter
@@ -118,6 +119,11 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 			"that only materialize in the live cluster. Usually unnecessary: a missing Secret "+
 			"declared by an in-repo ExternalSecret/SealedSecret (with a static target name) is "+
 			"auto-skipped without this flag. cert/proxy secretRefs still fail loud.")
+	fs.BoolVar(&f.forceGenericProvider, "force-generic-provider", false,
+		"route non-generic spec.provider sources (GitRepository/OCIRepository/Bucket) "+
+			"through the generic SecretRef path instead of failing. Works offline when "+
+			"static credentials are supplied; otherwise the fetch fails on the missing "+
+			"auth Secret, which --allow-missing-secrets soft-skips.")
 	fs.BoolVar(&f.restrictEgress, "restrict-egress", false,
 		"untrusted-render guard: block source fetches (kustomize remote resources/bases, "+
 			"Git/OCI/Helm/Bucket sources) to loopback, RFC1918, link-local, and cloud-metadata "+
@@ -430,6 +436,7 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 		},
 		GitDepth:                  c.gitDepth,
 		AllowMissingSecrets:       c.allowMissingSecrets,
+		ForceGenericProvider:      c.forceGenericProvider,
 		RestrictEgress:            c.restrictEgress,
 		CacheDir:                  c.resolveCacheRoot(),
 		HelmTemplateCacheBytes:    int64(c.helmTemplateCacheMB) << 20,

--- a/internal/cli/common_test.go
+++ b/internal/cli/common_test.go
@@ -33,6 +33,30 @@ func TestBindCommon_CacheDirFlag(t *testing.T) {
 	}
 }
 
+// TestBindCommon_ForceGenericProviderFlag pins the whole
+// --force-generic-provider handoff: flag → commonFlags →
+// orchestrator.Config. Config is what puts ForceGeneric on the git/OCI/
+// bucket fetchers, so dropping that assignment would silently disable the
+// flag with every other test still green.
+func TestBindCommon_ForceGenericProviderFlag(t *testing.T) {
+	parse := func(t *testing.T, args ...string) orchestrator.Config {
+		t.Helper()
+		var f commonFlags
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		bindCommon(fs, &f)
+		if err := fs.Parse(args); err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		return buildOrchCfg(f, helmFlags{})
+	}
+	if cfg := parse(t); cfg.ForceGenericProvider {
+		t.Errorf("default: ForceGenericProvider = true, want false")
+	}
+	if cfg := parse(t, "--force-generic-provider"); !cfg.ForceGenericProvider {
+		t.Errorf("--force-generic-provider: ForceGenericProvider = false, want true")
+	}
+}
+
 // TestCacheDir_FlagAndEnvPopulateRoot runs build all twice — once via
 // --cache-dir and once via FLATE_CACHE_DIR — against fresh tempdirs
 // and asserts each one ends up non-empty. The kustomize stage cache

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -76,6 +76,12 @@ type Config struct {
 	// refs let HelmReleases render with the remaining values.
 	AllowMissingSecrets bool
 
+	// ForceGenericProvider sends non-generic spec.provider sources
+	// (GitRepository, OCIRepository, Bucket) down the generic SecretRef path
+	// instead of rejecting them up front. That path works offline when static
+	// credentials are supplied; otherwise it fails on the missing secret.
+	ForceGenericProvider bool
+
 	// RestrictEgress is the untrusted-render switch. It (1) enables the SSRF
 	// egress guard for ALL source fetches (kustomize remote resources/bases +
 	// Git/OCI/Helm/Bucket sources) — outbound dials to loopback/RFC1918/link-
@@ -412,6 +418,7 @@ func New(cfg Config) (*Orchestrator, error) {
 		Mirrors:         mirror.New(layout),
 		Depth:           cfg.GitDepth,
 		RestrictSchemes: cfg.RestrictEgress,
+		ForceGeneric:    cfg.ForceGenericProvider,
 	}
 	// Resolve kustomize remote git bases (resources: URLs carrying ?ref= or a
 	// git marker) through the same clone/mirror/ref-resolution machinery as
@@ -429,7 +436,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	srcCtrl.Fetchers[manifest.KindExternalArtifact] = source.Wrap(
 		manifest.KindExternalArtifact, &external.Fetcher{})
 	srcCtrl.Fetchers[manifest.KindBucket] = source.Wrap(
-		manifest.KindBucket, &bucket.Fetcher{Cache: cache, Secrets: secretGet})
+		manifest.KindBucket, &bucket.Fetcher{Cache: cache, Secrets: secretGet, ForceGeneric: cfg.ForceGenericProvider})
 	// HelmRepository: existence-only — the controller just needs the
 	// resource in Ready so HelmRelease deps unblock. The chart itself is
 	// fetched per (chart, version) through a synthesized HelmChart (see
@@ -444,7 +451,7 @@ func New(cfg Config) (*Orchestrator, error) {
 	// Embedders that want one can still WithFetcher a source.ExistenceFetcher.
 	// Not separately retry-wrapped: each consuming fetcher's own WithRetry
 	// wrapper owns retries.
-	ociFetcher := &oci.Fetcher{Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet}
+	ociFetcher := &oci.Fetcher{Cache: cache, RegistryConfig: cfg.RegistryConfig, Secrets: secretGet, ForceGeneric: cfg.ForceGenericProvider}
 	srcCtrl.Fetchers[manifest.KindOCIRepository] = source.Wrap(
 		manifest.KindOCIRepository, ociFetcher)
 	// HelmChart: the single authoritative chart fetcher. The HR controller

--- a/pkg/source/bucket/bucket_test.go
+++ b/pkg/source/bucket/bucket_test.go
@@ -2,6 +2,7 @@ package bucket_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -84,5 +85,29 @@ func TestFetcher_SecretRefNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "secret ns/creds not found") {
 		t.Errorf("error should name the missing secret; got %v", err)
+	}
+}
+
+func TestFetcher_ForceGenericProvider(t *testing.T) {
+	// Gate bypassed: the generic path runs and fails on the absent secret.
+	f := &bucket.Fetcher{
+		ForceGeneric: true,
+		Secrets:      func(_, _ string) *manifest.Secret { return nil },
+	}
+	b := &manifest.Bucket{
+		Name: "b", Namespace: "ns",
+		Provider:   sourcev1.BucketProviderAmazon,
+		BucketName: "x", Endpoint: "s3.amazonaws.com",
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	_, err := f.Fetch(context.Background(), b)
+	if err == nil {
+		t.Fatalf("expected missing-secret error")
+	}
+	if strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("provider gate should be bypassed with ForceGeneric; got %v", err)
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("want ErrMissingSecret from the generic path; got %v", err)
 	}
 }

--- a/pkg/source/bucket/fetcher.go
+++ b/pkg/source/bucket/fetcher.go
@@ -19,16 +19,20 @@ import (
 // "generic" provider (any S3-API-compatible storage) is wired up
 // today via minio-go. The aws/gcp/azure providers parse and route
 // here but return a clear "not implemented" error rather than silently
-// falling back.
+// falling back, unless ForceGeneric sends them down the generic path.
 type Fetcher struct {
 	Cache   *source.Cache
 	Secrets source.SecretGetter
+
+	// ForceGeneric skips the provider gate; the generic path then needs
+	// static credentials (a SecretRef) or it fails.
+	ForceGeneric bool
 }
 
 // Fetch implements source.TypedFetcher[*manifest.Bucket]. The typed
 // signature is wrapped via source.Wrap at orchestrator registration.
 func (f *Fetcher) Fetch(ctx context.Context, b *manifest.Bucket) (*store.SourceArtifact, error) {
-	if b.Provider != "" && b.Provider != sourcev1.BucketProviderGeneric {
+	if !f.ForceGeneric && b.Provider != "" && b.Provider != sourcev1.BucketProviderGeneric {
 		return nil, source.ErrUnsupportedProvider("Bucket",
 			b.Namespace, b.Name, b.Provider, sourcev1.BucketProviderGeneric,
 			"S3-compatible")

--- a/pkg/source/git/auth_test.go
+++ b/pkg/source/git/auth_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -164,5 +165,29 @@ func TestIsSSHURL(t *testing.T) {
 		if isSSHURL(u) {
 			t.Errorf("isSSHURL(%q) = true, want false", u)
 		}
+	}
+}
+
+func TestFetcher_ForceGenericProvider(t *testing.T) {
+	// Gate bypassed: the generic path runs and fails on the absent secret.
+	f := &Fetcher{
+		ForceGeneric: true,
+		Secrets:      func(_, _ string) *manifest.Secret { return nil },
+	}
+	repo := &manifest.GitRepository{
+		Name: "g", Namespace: "ns",
+		URL:       "https://github.com/x/y.git",
+		Provider:  sourcev1.GitProviderGitHub,
+		SecretRef: &manifest.LocalObjectReference{Name: "creds"},
+	}
+	_, err := f.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatalf("expected missing-secret error")
+	}
+	if strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("provider gate should be bypassed with ForceGeneric; got %v", err)
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("want ErrMissingSecret from the generic path; got %v", err)
 	}
 }

--- a/pkg/source/git/fetcher.go
+++ b/pkg/source/git/fetcher.go
@@ -70,6 +70,11 @@ type Fetcher struct {
 	// (local fixtures, the synthetic self-source — which is pre-seeded and
 	// never reaches this fetch path anyway). Default false.
 	RestrictSchemes bool
+
+	// ForceGeneric skips the provider gate, sending non-generic providers
+	// down the generic SecretRef path. That path works offline when static
+	// credentials are supplied, and otherwise fails on the missing secret.
+	ForceGeneric bool
 }
 
 // Fetch implements source.TypedFetcher[*manifest.GitRepository].
@@ -77,7 +82,7 @@ type Fetcher struct {
 // registration — a payload mismatch returns ErrInput once at the
 // adapter site rather than panicking here.
 func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.GitRepository) (*store.SourceArtifact, error) {
-	if repo.Provider != "" && repo.Provider != sourcev1.GitProviderGeneric {
+	if !f.ForceGeneric && repo.Provider != "" && repo.Provider != sourcev1.GitProviderGeneric {
 		return nil, source.ErrUnsupportedProvider("GitRepository",
 			repo.Namespace, repo.Name, repo.Provider, sourcev1.GitProviderGeneric,
 			"SecretRef-based credentials")

--- a/pkg/source/oci/auth_test.go
+++ b/pkg/source/oci/auth_test.go
@@ -225,3 +225,26 @@ func TestFetcher_ResolveConfig_SecretNotFound(t *testing.T) {
 		t.Errorf("expected ErrMissingSecret wrap; got %v", err)
 	}
 }
+
+func TestFetcher_ForceGenericProvider(t *testing.T) {
+	// Gate bypassed: the generic path runs and fails on the absent secret.
+	f := &Fetcher{
+		ForceGeneric: true,
+		Secrets:      func(_, _ string) *manifest.Secret { return nil },
+	}
+	repo := ociRepo("o", func(s *sourcev1.OCIRepositorySpec) {
+		s.URL = "oci://ghcr.io/x/y"
+		s.Provider = sourcev1.AmazonOCIProvider
+		s.SecretRef = &manifest.LocalObjectReference{Name: "creds"}
+	})
+	_, err := f.Fetch(context.Background(), repo)
+	if err == nil {
+		t.Fatalf("expected missing-secret error")
+	}
+	if strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("provider gate should be bypassed with ForceGeneric; got %v", err)
+	}
+	if !errors.Is(err, manifest.ErrMissingSecret) {
+		t.Errorf("want ErrMissingSecret from the generic path; got %v", err)
+	}
+}

--- a/pkg/source/oci/fetcher.go
+++ b/pkg/source/oci/fetcher.go
@@ -36,6 +36,10 @@ type Fetcher struct {
 	Cache          *source.Cache
 	RegistryConfig string
 	Secrets        source.SecretGetter
+
+	// ForceGeneric skips the provider gate; the generic path then needs
+	// static credentials (SecretRef or --registry-config) or it fails.
+	ForceGeneric bool
 }
 
 // Fetch implements source.TypedFetcher[*manifest.OCIRepository].
@@ -47,7 +51,7 @@ type Fetcher struct {
 // fields, then hands off to fetch() — the workhorse in fetch.go that
 // owns slot lifecycle, oras Copy, layer extraction, and marker writes.
 func (f *Fetcher) Fetch(ctx context.Context, repo *manifest.OCIRepository) (*store.SourceArtifact, error) {
-	if repo.Provider != "" && repo.Provider != sourcev1.GenericOCIProvider {
+	if !f.ForceGeneric && repo.Provider != "" && repo.Provider != sourcev1.GenericOCIProvider {
 		return nil, source.ErrUnsupportedProvider("OCIRepository",
 			repo.Namespace, repo.Name, repo.Provider, sourcev1.GenericOCIProvider,
 			"SecretRef or --registry-config credentials")


### PR DESCRIPTION
## Overview

Adds `--force-generic-provider`, an opt-in flag that routes non-generic `spec.provider` sources through the generic credential path (flate currently rejects them outright). Covers GitRepository, OCIRepository and Bucket.

The gate rejects these before credential resolution, so a single such source fails the entire render (even when the source could be fetched with existing credentials - see home-operations/flate#838).

With this flag, a source that declares a `SecretRef`, or is covered by `--registry-config`,  fetches and renders normally when those credentials resolve. When the referenced Secret isn't present, which is the usual offline case, the fetch fails with `ErrMissingSecret`, and `--allow-missing-secrets` soft-skips it so the rest still renders. The two flags compose well, and together they enable renders in CI and other environments without cloud credentials.

A source declaring no `SecretRef` at all - the workload-identity shape - takes the existing anonymous path instead: public sources fetch fine, private ones still fail. This flag doesn't change that, and doesn't claim to.

This implements the approach originally proposed in home-operations/flate#838. It's opt-in (default behaviour unchanged) with a very small surface.

## Additional information

- home-operations/flate#838 proposes this option for OCIRepository/Bucket only. This extends it to GitRepository, where the same gate blocks `provider: github` sources.
- home-operations/flate#97 asked for something different: real `spec.provider` authentication matching source-controller. I've considered implementing it, but this flags seems more universal, and solves the problem well in my use case by making the GitHub App case degrade to a clean skip rather than authenticating. Possibly worth implementing later.

### Tests

- One test per source type asserting the gate is bypassed and the error is `ErrMissingSecret`, not the provider rejection.
- Pre-existing rejection tests still assert `not implemented` with the flag off, covering the unchanged default.
- `TestBindCommon_ForceGenericProviderFlag` tests the flag handoff to `orchestrator.Config`, both default off and flag-on.

Verified end-to-end against a real Flux repository: without the flags the render exits 1; with both, it completes and the remaining sources render fine.

`mise run test` and `lint` all clean.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used for for reviewing the code and docs, as well as auto-complete functionality within the IDE.