### PR TITLE
fix(loader): descend into ignored dirs when .krmignore has re-includes

### DIFF
--- a/pkg/loader/ignore.go
+++ b/pkg/loader/ignore.go
@@ -14,6 +14,13 @@ import (
 // file at the scan root.
 type ignoreSet struct {
 	matcher gitignore.Matcher
+	// hasNegation is true when any pattern is a `!` re-include. The
+	// walker's directory prune consults it: pruning an ignored
+	// directory would prevent a deeper `!` pattern from re-including
+	// files beneath it (per-file checks still filter everything the
+	// walk visits), which is how source-controller's sourceignore
+	// evaluates spec.ignore — see pkg/source/ignore.go.
+	hasNegation bool
 }
 
 // loadIgnore reads <root>/.krmignore (or returns an empty set if not
@@ -42,6 +49,9 @@ func loadIgnore(root string) (*ignoreSet, error) {
 		line := strings.TrimSpace(sc.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
+		}
+		if strings.HasPrefix(line, "!") {
+			out.hasNegation = true
 		}
 		patterns = append(patterns, gitignore.ParsePattern(line, domain))
 	}

--- a/pkg/loader/ignore_test.go
+++ b/pkg/loader/ignore_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/home-operations/flate/internal/testutil"
+	"github.com/home-operations/flate/pkg/manifest"
+	"github.com/home-operations/flate/pkg/store"
 )
 
 // TestLoadIgnore_GlobStarMatchesAcrossDirectories is the regression test for
@@ -234,4 +236,82 @@ func TestNormalizePrefix_LivesInParent(t *testing.T) {
 			t.Errorf("NormalizePrefix(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
+}
+
+// TestLoader_KrmignoreEnvironmentAllowlist mirrors the multi-environment
+// layout from issue #816: environments/<env>/ trees carry same-named
+// resources, so an unfiltered scan lets the alphabetically-last env
+// shadow the others in the Store. A .krmignore using the exact
+// allowlist patterns from the issue (the ones the reporter feeds to
+// GitRepository spec.ignore) must scope the walk to common/ plus one
+// environment, so the selected env's resources win.
+func TestLoader_KrmignoreEnvironmentAllowlist(t *testing.T) {
+	appID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "app-config"}
+	commonID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "common-settings"}
+
+	writeTree := func(t *testing.T, ignore string) *store.Store {
+		t.Helper()
+		dir := t.TempDir()
+		testutil.WriteFile(t, dir, ".krmignore", ignore)
+		testutil.WriteFile(t, dir, "common/settings.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: common-settings, namespace: default}
+`)
+		for _, env := range []string{"production", "staging"} {
+			testutil.WriteFile(t, dir, "environments/"+env+"/app.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: app-config, namespace: default}
+data: {env: `+env+`}
+`)
+		}
+		s := store.New()
+		if _, err := New(s).Load(t.Context(), dir); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		return s
+	}
+
+	envOf := func(t *testing.T, s *store.Store) string {
+		t.Helper()
+		obj := s.GetObject(appID)
+		if obj == nil {
+			t.Fatal("app-config was not loaded at all")
+		}
+		cm, ok := obj.(*manifest.ConfigMap)
+		if !ok {
+			t.Fatalf("app-config is %T, want *manifest.ConfigMap", obj)
+		}
+		env, _ := cm.Data["env"].(string)
+		return env
+	}
+
+	t.Run("no filtering: staging shadows production", func(t *testing.T) {
+		s := writeTree(t, "")
+		if got := envOf(t, s); got != "staging" {
+			t.Errorf("unfiltered walk: app-config env = %q, want %q (alphabetically-last env wins)", got, "staging")
+		}
+	})
+
+	t.Run("issue #816 allowlist patterns select production", func(t *testing.T) {
+		s := writeTree(t, `/*
+!/common/**/*.yaml
+!/environments/production/**/*.yaml
+`)
+		if got := envOf(t, s); got != "production" {
+			t.Errorf("allowlist walk: app-config env = %q, want %q", got, "production")
+		}
+		if s.GetObject(commonID) == nil {
+			t.Error("common-settings must be re-included by !/common/**/*.yaml")
+		}
+	})
+
+	t.Run("directory exclusion selects production", func(t *testing.T) {
+		s := writeTree(t, "/environments/staging/\n")
+		if got := envOf(t, s); got != "production" {
+			t.Errorf("exclusion walk: app-config env = %q, want %q", got, "production")
+		}
+		if s.GetObject(commonID) == nil {
+			t.Error("common-settings must still load")
+		}
+	})
 }

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -909,5 +909,11 @@ func (w *walker) shouldSkipDir(name, full string) bool {
 	if strings.HasPrefix(name, ".") && name != "." {
 		return true
 	}
+	// With `!` re-includes in play, an ignored directory can still hold
+	// re-included files, so descend and let the per-file checks filter —
+	// matching sourceignore's per-file evaluation of spec.ignore.
+	if w.ignore != nil && w.ignore.hasNegation {
+		return false
+	}
 	return w.ignoreMatches(full, true)
 }


### PR DESCRIPTION
## Summary

A `.krmignore` allowlist like the one from #816:

```
/*
!/common/**/*.yaml
!/environments/production/**/*.yaml
```

loaded nothing: `shouldSkipDir` pruned every `/*`-matched directory before the `!` negation patterns could re-include files beneath it. source-controller evaluates `spec.ignore` per file without pruning directories, so these patterns work on a real `GitRepository` but silently failed in `.krmignore`.

## Changes

- `ignoreSet` now tracks whether any pattern is a `!` re-include.
- When one exists, the walker skips the ignore-based directory prune and lets the existing per-file checks filter the walk (matching sourceignore's per-file semantics). Pattern sets without negations keep the prune.
- Regression test mirroring the multi-environment layout from #816: same-named resources across `environments/<env>/` trees shadow each other unfiltered, and the issue's exact ignore patterns scope the render to `common/` + one environment.

Relates to #816: with this fix, `.krmignore` covers that use case today, ahead of any multi-`--path` support.