### PR TITLE
fix(helm): treat dependency condition and tags keys as used values

### DIFF
--- a/pkg/helm/stalevalues.go
+++ b/pkg/helm/stalevalues.go
@@ -25,6 +25,10 @@ import (
 // Top-level only, and deliberately conservative to avoid false positives:
 //   - Keys addressed to a subchart (a dependency name/alias) or Helm's shared
 //     "global" are always treated as used — the subchart consumes them.
+//   - Keys gating a dependency are always treated as used: the top-level
+//     segment of every dependencies[].condition path in the tree, and "tags"
+//     when any dependency declares tags — Helm's dependency evaluation consumes
+//     them without any template naming them (#930).
 //   - If the chart accesses `.Values` opaquely — ranges/dumps the whole map
 //     (toYaml .Values), binds it to a variable, or indexes it with a non-literal
 //     key — we can't statically prove any key unused, so we report NOTHING.
@@ -65,9 +69,10 @@ func unreferencedValuePaths(src string, values map[string]any, allow map[string]
 }
 
 // knownTopLevelKeys are release top-level keys always treated as used,
-// regardless of the parent chart's templates: Helm's shared "global" key, and
+// regardless of the parent chart's templates: Helm's shared "global" key,
 // every declared dependency's name/alias (values addressed to a subchart nest
-// under these and are consumed by the subchart, not the parent).
+// under these and are consumed by the subchart, not the parent), and every key
+// gating a dependency (see addDependencyGateKeys).
 func knownTopLevelKeys(ch *chart.Chart) map[string]struct{} {
 	allow := map[string]struct{}{"global": {}}
 	if ch == nil {
@@ -91,7 +96,38 @@ func knownTopLevelKeys(ch *chart.Chart) map[string]struct{} {
 			allow[n] = struct{}{}
 		}
 	}
+	addDependencyGateKeys(ch, allow)
 	return allow
+}
+
+// addDependencyGateKeys allowlists the keys Helm's dependency evaluation
+// consumes from the top parent's values: the top-level segment of each
+// dependencies[].condition path (a comma-separated list of dotted paths), and
+// the shared "tags" block when any dependency declares tags. Conditions
+// anywhere in the tree resolve against the top parent's values, so subcharts'
+// own Chart.yaml dependencies are walked too (#930).
+func addDependencyGateKeys(ch *chart.Chart, allow map[string]struct{}) {
+	if ch == nil {
+		return
+	}
+	if ch.Metadata != nil {
+		for _, d := range ch.Metadata.Dependencies {
+			if d == nil {
+				continue
+			}
+			for cond := range strings.SplitSeq(d.Condition, ",") {
+				if top, _, _ := strings.Cut(strings.TrimSpace(cond), "."); top != "" {
+					allow[top] = struct{}{}
+				}
+			}
+			if len(d.Tags) > 0 {
+				allow["tags"] = struct{}{}
+			}
+		}
+	}
+	for _, sub := range ch.Dependencies() {
+		addDependencyGateKeys(sub, allow)
+	}
 }
 
 // chartTemplateText concatenates every template (including _helpers.tpl and

--- a/pkg/helm/stalevalues.go
+++ b/pkg/helm/stalevalues.go
@@ -26,9 +26,9 @@ import (
 //   - Keys addressed to a subchart (a dependency name/alias) or Helm's shared
 //     "global" are always treated as used — the subchart consumes them.
 //   - Keys gating a dependency are always treated as used: the top-level
-//     segment of every dependencies[].condition path in the tree, and "tags"
-//     when any dependency declares tags — Helm's dependency evaluation consumes
-//     them without any template naming them (#930).
+//     segment of the root chart's dependencies[].condition paths, and "tags"
+//     when any dependency in the tree declares tags — Helm's dependency
+//     evaluation consumes them without any template naming them (#930).
 //   - If the chart accesses `.Values` opaquely — ranges/dumps the whole map
 //     (toYaml .Values), binds it to a variable, or indexes it with a non-literal
 //     key — we can't statically prove any key unused, so we report NOTHING.
@@ -101,11 +101,15 @@ func knownTopLevelKeys(ch *chart.Chart) map[string]struct{} {
 }
 
 // addDependencyGateKeys allowlists the keys Helm's dependency evaluation
-// consumes from the top parent's values: the top-level segment of each
-// dependencies[].condition path (a comma-separated list of dotted paths), and
-// the shared "tags" block when any dependency declares tags. Conditions
-// anywhere in the tree resolve against the top parent's values, so subcharts'
-// own Chart.yaml dependencies are walked too (#930).
+// consumes from the release's top-level values: the top-level segment of each
+// root-chart dependencies[].condition path (a comma-separated list of dotted
+// paths), and the shared "tags" block when any dependency in the tree declares
+// tags (#930). Only the root chart's conditions are harvested — Helm prefixes a
+// nested chart's condition with its parent path, so those resolve under the
+// dependency's name, which is already allowlisted; flattening them here would
+// suppress a valid warning for an unrelated root key of the same name. Tag
+// evaluation reads the unprefixed top-level "tags" table at every depth, so the
+// whole tree is walked for tags.
 func addDependencyGateKeys(ch *chart.Chart, allow map[string]struct{}) {
 	if ch == nil {
 		return
@@ -120,14 +124,26 @@ func addDependencyGateKeys(ch *chart.Chart, allow map[string]struct{}) {
 					allow[top] = struct{}{}
 				}
 			}
-			if len(d.Tags) > 0 {
-				allow["tags"] = struct{}{}
+		}
+	}
+	if anyDependencyTags(ch) {
+		allow["tags"] = struct{}{}
+	}
+}
+
+// anyDependencyTags reports whether any dependency in ch's tree declares tags.
+func anyDependencyTags(ch *chart.Chart) bool {
+	if ch == nil {
+		return false
+	}
+	if ch.Metadata != nil {
+		for _, d := range ch.Metadata.Dependencies {
+			if d != nil && len(d.Tags) > 0 {
+				return true
 			}
 		}
 	}
-	for _, sub := range ch.Dependencies() {
-		addDependencyGateKeys(sub, allow)
-	}
+	return slices.ContainsFunc(ch.Dependencies(), anyDependencyTags)
 }
 
 // chartTemplateText concatenates every template (including _helpers.tpl and

--- a/pkg/helm/stalevalues_test.go
+++ b/pkg/helm/stalevalues_test.go
@@ -172,6 +172,15 @@ func TestKnownTopLevelKeys(t *testing.T) {
 			},
 		},
 	}
+	tagsOnlyNested := &chart.Chart{Metadata: &chart.Metadata{Name: "parent"}}
+	tagsOnlyNested.AddDependency(&chart.Chart{
+		Metadata: &chart.Metadata{
+			Name: "child",
+			Dependencies: []*chart.Dependency{
+				{Name: "grand", Tags: []string{"group"}},
+			},
+		},
+	})
 	ch := &chart.Chart{
 		Metadata: &chart.Metadata{
 			Name: "parent",
@@ -196,13 +205,21 @@ func TestKnownTopLevelKeys(t *testing.T) {
 			want: []string{"global"},
 		},
 		{
-			name: "names, aliases, condition segments, tags, and subchart conditions",
+			// operator's nested innerCrds.enabled condition resolves at
+			// operator.innerCrds.enabled, so innerCrds must NOT leak into
+			// the root allowlist.
+			name: "names, aliases, root condition segments, and tags",
 			ch:   ch,
 			want: []string{
-				"alloy-crd", "crds", "extra", "global", "innerCrds",
+				"alloy-crd", "crds", "extra", "global",
 				"metrics", "metricsEnabled", "operator", "podlogs",
 				"podlogs-crd", "tags",
 			},
+		},
+		{
+			name: "tags on a nested dependency still allowlist the shared tags block",
+			ch:   tagsOnlyNested,
+			want: []string{"child", "global", "tags"},
 		},
 	}
 	for _, tc := range cases {

--- a/pkg/helm/stalevalues_test.go
+++ b/pkg/helm/stalevalues_test.go
@@ -3,6 +3,8 @@ package helm
 import (
 	"slices"
 	"testing"
+
+	chart "helm.sh/helm/v4/pkg/chart/v2"
 )
 
 // allow is the default top-level allowlist for walker tests (no chart deps).
@@ -158,5 +160,62 @@ func TestValuesKeyReferenced(t *testing.T) {
 		if got := valuesKeyReferenced(src, key); got != want {
 			t.Errorf("valuesKeyReferenced(%q) = %v, want %v", key, got, want)
 		}
+	}
+}
+
+func TestKnownTopLevelKeys(t *testing.T) {
+	sub := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name: "operator",
+			Dependencies: []*chart.Dependency{
+				{Name: "inner-crd", Condition: "innerCrds.enabled"},
+			},
+		},
+	}
+	ch := &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name: "parent",
+			Dependencies: []*chart.Dependency{
+				{Name: "alloy-crd", Condition: "crds.deployAlloyCRD"},
+				{Name: "podlogs-crd", Alias: "podlogs", Condition: "crds.deployPodLogsCRD, extra.enabled"},
+				{Name: "metrics", Condition: "metricsEnabled", Tags: []string{"observability"}},
+				nil,
+			},
+		},
+	}
+	ch.AddDependency(sub)
+
+	cases := []struct {
+		name string
+		ch   *chart.Chart
+		want []string
+	}{
+		{
+			name: "nil chart still allows global",
+			ch:   nil,
+			want: []string{"global"},
+		},
+		{
+			name: "names, aliases, condition segments, tags, and subchart conditions",
+			ch:   ch,
+			want: []string{
+				"alloy-crd", "crds", "extra", "global", "innerCrds",
+				"metrics", "metricsEnabled", "operator", "podlogs",
+				"podlogs-crd", "tags",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := knownTopLevelKeys(tc.ch)
+			keys := make([]string, 0, len(got))
+			for k := range got {
+				keys = append(keys, k)
+			}
+			slices.Sort(keys)
+			if !slices.Equal(keys, tc.want) {
+				t.Fatalf("knownTopLevelKeys keys = %v, want %v", keys, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

The #744 stale-values detector reports a top-level key as `values not used by the chart` when the chart consumes it through `dependencies[].condition` in `Chart.yaml` rather than a `.Values.<key>` template reference. Acting on the warning removes a value that gates a subchart; on a CRD-bearing subchart (e.g. `alloy-operator`'s `crds.deployPodLogsCRD`) that deletes the CRD and every custom resource of that kind.

## Fix

Extend the `knownTopLevelKeys` allowlist in `pkg/helm/stalevalues.go`:

- the top-level segment of every `dependencies[].condition` path (comma-separated dotted paths), walked recursively through subcharts' own `Chart.yaml` since conditions resolve against the top parent's values
- `tags` when any dependency declares tags, since Helm evaluates those against the top-level `tags:` block

Consistent with the detector's fail-open design: broadening the allowlist can only suppress a warning, never invent one.

## Verification

- New `TestKnownTopLevelKeys` covering names/aliases, single and comma-separated condition paths, tags, and nested subchart conditions; `mise run test` and `mise run lint` pass
- Reproduced the issue's `alloy-operator` case end-to-end: a binary built from `main` warns `values not used by the chart: crds`, this branch reports no warning on the same input

Fixes #930