### PR TITLE
feat(cli): add --krmignore to override the scan root .krmignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Every reconcile-running command takes `--path <dir>` (default `.`); `--path-orig
 
 **Default output filters.** `--skip-secrets` and `--skip-crds` both default to `true` — `build` and `diff` strip rendered `Secret` and `CustomResourceDefinition` objects from manifest output. Pass `--skip-secrets=false` / `--skip-crds=false` to include them; `--skip-kinds <kind>` (repeatable) drops additional kinds. These are output-stream filters, distinct from `--allow-missing-secrets`, which gates source auth and generated HR values Secret readiness.
 
+**Scoping the scan.** A gitignore-syntax `.krmignore` at `--path` filters which files the scan loads (`!` re-includes work, so an allowlist like `/*`, `!/common/**`, `!/environments/production/**` mirrors a `GitRepository` `spec.ignore`). `--krmignore <file>` (`FLATE_KRMIGNORE`) reads that file in place of `<path>/.krmignore`, with patterns still relative to `--path`, so one checkout can keep a `.krmignore.staging` and a `.krmignore.production` and pick one per run.
+
 **Cache.** flate persists source fetches and helm template output under an on-disk cache (honoring Flux intervals). `flate cache gc` prunes stale entries; `flate cache clear-render` drops the persistent helm template-output cache.
 
 ## Changed-only mode

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -700,7 +700,7 @@ func TestBindCommon_DefaultValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("find build all: %v", err)
 	}
-	for _, name := range []string{"path", "namespace", "output", "concurrency", "skip-crds", "skip-secrets"} {
+	for _, name := range []string{"path", "krmignore", "namespace", "output", "concurrency", "skip-crds", "skip-secrets"} {
 		if build.Flags().Lookup(name) == nil {
 			t.Errorf("expected common flag %q on `build all`", name)
 		}
@@ -870,5 +870,52 @@ func TestRun_Diff_OneSidedFailureSuppressed(t *testing.T) {
 	}
 	if strings.Count(stderr, "flate error:") != 1 {
 		t.Errorf("failure summary should be printed exactly once:\n%s", stderr)
+	}
+}
+
+// TestKrmignoreFlag_OverridesScanRootIgnore exercises --krmignore end to
+// end: the named file replaces <path>/.krmignore for the scan, and a
+// file that doesn't exist fails the run rather than rendering unfiltered.
+func TestKrmignoreFlag_OverridesScanRootIgnore(t *testing.T) {
+	path := writeFixture(t)
+	testutil.WriteFileAt(t, filepath.Join(path, "flux", "extra.yaml"), `---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-extra
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps
+  sourceRef: {kind: GitRepository, name: flux-system, namespace: flux-system}
+`)
+	ignore := filepath.Join(t.TempDir(), "no-extra.krmignore")
+	testutil.WriteFileAt(t, ignore, "flux/extra.yaml\n")
+
+	stdout, stderr, code := runCLI(t, "get", "ks", "--path", path, "-o", "name")
+	if code != 0 {
+		t.Fatalf("get ks exited %d: stderr=%s", code, stderr)
+	}
+	if !strings.Contains(stdout, "apps-extra") {
+		t.Fatalf("unfiltered get ks should list apps-extra:\n%s", stdout)
+	}
+
+	stdout, stderr, code = runCLI(t, "get", "ks", "--path", path, "--krmignore", ignore, "-o", "name")
+	if code != 0 {
+		t.Fatalf("get ks --krmignore exited %d: stderr=%s", code, stderr)
+	}
+	if strings.Contains(stdout, "apps-extra") {
+		t.Errorf("--krmignore should drop apps-extra:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "apps") {
+		t.Errorf("--krmignore should keep apps:\n%s", stdout)
+	}
+
+	_, stderr, code = runCLI(t, "get", "ks", "--path", path, "--krmignore", ignore+".missing")
+	if code == 0 {
+		t.Fatal("expected non-zero exit for missing --krmignore file")
+	}
+	if !strings.Contains(stderr, ignore+".missing") {
+		t.Errorf("error should name the missing file; got %q", stderr)
 	}
 }

--- a/internal/cli/common.go
+++ b/internal/cli/common.go
@@ -42,6 +42,7 @@ type commonFlags struct {
 	// via repoRootOf and lets the side read its own .git remotes).
 	pathOrigRoot         string
 	pathOrigSelfURLs     []string
+	krmIgnore            string
 	base                 string
 	namespace            string
 	skipCRDs             bool
@@ -109,6 +110,8 @@ func bindCommon(fs *pflag.FlagSet, f *commonFlags, outputs ...format.Output) {
 	fs.StringVarP(&f.path, "path", "p", ".", "path to the Flux cluster directory")
 	fs.StringVarP(&f.pathOrig, "path-orig", "P", "",
 		"baseline path; when set, every command runs in changed-only mode")
+	fs.StringVar(&f.krmIgnore, "krmignore", "",
+		"gitignore-style file read instead of <path>/.krmignore; patterns are relative to --path")
 	bindBase(fs, f)
 	fs.StringVarP(&f.namespace, "namespace", "n", "",
 		"limit to this namespace (default: every namespace, or just the changed ones when --path-orig is set)")
@@ -425,6 +428,7 @@ func buildOrchCfg(c commonFlags, h helmFlags) orchestrator.Config {
 		// root, or the .git default of an explicit --path-orig. Replaces
 		// the core's old .git "widen" heuristic.
 		PathOrig:       c.baselineRoot(),
+		KRMIgnoreFile:  c.krmIgnore,
 		HelmOptions:    c.helmOptions(h),
 		WipeSecrets:    true,
 		RegistryConfig: c.registryConfig,

--- a/internal/cli/env_test.go
+++ b/internal/cli/env_test.go
@@ -164,6 +164,7 @@ func TestEnvKey(t *testing.T) {
 	for in, want := range map[string]string{
 		"path":         "FLATE_PATH",
 		"path-orig":    "FLATE_PATH_ORIG",
+		"krmignore":    "FLATE_KRMIGNORE",
 		"log-level":    "FLATE_LOG_LEVEL",
 		"skip-kinds":   "FLATE_SKIP_KINDS",
 		"api-versions": "FLATE_API_VERSIONS",

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -100,9 +100,15 @@ type Config struct {
 	// resolves it. Supplied explicitly by SDK consumers rendering
 	// extracted trees (no .git/config to read); empty ⇒ fall back to the
 	// working tree's .git remotes, preserving local behavior.
-	SelfURLs    []string
-	Store       *store.Store
-	WipeSecrets bool
+	SelfURLs []string
+	// KRMIgnoreFile, when non-empty, is read in place of <Path>/.krmignore
+	// for the initial scan; spec.path targets followed afterwards keep
+	// their own per-directory .krmignore. Lets one checkout carry several
+	// scan scopes (e.g. .krmignore.staging / .krmignore.production) and
+	// pick one per run.
+	KRMIgnoreFile string
+	Store         *store.Store
+	WipeSecrets   bool
 	// ComponentCache, when non-nil, memoizes
 	// manifest.ReadKustomizeComponents reads across discovery's
 	// internal passes (parent-index build, orphan promotion, the
@@ -269,9 +275,11 @@ func (d *discoverer) loadManifests(ctx context.Context, repoRoot string) error {
 	}
 	scanned := map[string]struct{}{}
 	total := 0
+	l.IgnoreFile = d.cfg.KRMIgnoreFile
 	if err := d.loadAt(ctx, scanRoot, scanned, &total); err != nil {
 		return err
 	}
+	l.IgnoreFile = ""
 	// Apply namespaces once over the initially-scanned set so the
 	// bootstrap-source alias and the first expansion pass see populated
 	// namespaces. The fixed-point loop below intentionally does NOT

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -570,3 +570,49 @@ configMapGenerator:
 		t.Errorf("TIMEZONE = %q, want UTC", got)
 	}
 }
+
+// TestRun_KRMIgnoreFileScopesInitialScanOnly pins the override's reach:
+// Config.KRMIgnoreFile filters the --path scan, while spec.path targets
+// followed afterwards still honor their own .krmignore rather than the
+// override (whose patterns are anchored at the scan root).
+func TestRun_KRMIgnoreFileScopesInitialScanOnly(t *testing.T) {
+	dir := t.TempDir()
+	ks := func(name, path string) string {
+		return `apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ` + name + `
+  namespace: flux-system
+spec:
+  path: ` + path + `
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  interval: 10m
+`
+	}
+	testutil.WriteFileAt(t, filepath.Join(dir, "cluster", "keep.yaml"), ks("keep", "./apps"))
+	testutil.WriteFileAt(t, filepath.Join(dir, "cluster", "drop.yaml"), ks("drop", "./apps"))
+	testutil.WriteFileAt(t, filepath.Join(dir, "cluster", ".krmignore"), "keep.yaml\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "override.krmignore"), "drop.yaml\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "leaf.yaml"), ks("leaf", "./apps/leaf"))
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "hidden.yaml"), ks("hidden", "./apps/leaf"))
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", ".krmignore"), "hidden.yaml\n")
+	testutil.WriteFileAt(t, filepath.Join(dir, "apps", "leaf", "kustomization.yaml"), "resources: []\n")
+
+	st := store.New()
+	if _, err := discovery.Run(context.Background(), discovery.Config{
+		Path: filepath.Join(dir, "cluster"), RepoRoot: dir, Store: st, WipeSecrets: true,
+		KRMIgnoreFile: filepath.Join(dir, "override.krmignore"),
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	id := func(name string) manifest.NamedResource {
+		return manifest.NamedResource{Kind: manifest.KindKustomization, Namespace: "flux-system", Name: name}
+	}
+	for name, want := range map[string]bool{"keep": true, "drop": false, "leaf": true, "hidden": false} {
+		if got := st.GetObject(id(name)) != nil; got != want {
+			t.Errorf("Store has %s = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/pkg/loader/ignore.go
+++ b/pkg/loader/ignore.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -29,17 +30,35 @@ type ignoreSet struct {
 // the full gitignore glob syntax, including ** for zero-or-more path
 // segments.
 func loadIgnore(root string) (*ignoreSet, error) {
-	out := &ignoreSet{}
-	path := filepath.Join(root, ".krmignore")
-	f, err := os.Open(path) //nolint:gosec // root is the cluster scan root
+	f, err := os.Open(filepath.Join(root, ".krmignore")) //nolint:gosec // root is the cluster scan root
 	if err != nil {
 		if os.IsNotExist(err) {
-			return out, nil
+			return &ignoreSet{}, nil
 		}
-		return out, err
+		return &ignoreSet{}, err
 	}
 	defer func() { _ = f.Close() }()
+	return parseIgnore(f, root)
+}
 
+// loadIgnoreFile reads the ignore file at path in place of
+// <root>/.krmignore. The patterns are still anchored at root, so a file
+// kept elsewhere in the repo (e.g. .krmignore.staging) reads exactly as
+// it would at the scan root. Unlike loadIgnore, a missing file is an
+// error: the caller named it explicitly.
+func loadIgnoreFile(path, root string) (*ignoreSet, error) {
+	f, err := os.Open(path) //nolint:gosec // path is a user-supplied ignore file
+	if err != nil {
+		return &ignoreSet{}, fmt.Errorf("loader: read krmignore %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return parseIgnore(f, root)
+}
+
+// parseIgnore builds the ignoreSet from one gitignore-grammar file,
+// anchoring its patterns at root.
+func parseIgnore(f *os.File, root string) (*ignoreSet, error) {
+	out := &ignoreSet{}
 	// domain is the root split into path segments, used by the gitignore
 	// pattern parser to anchor absolute-style patterns correctly.
 	domain := strings.Split(filepath.ToSlash(root), "/")

--- a/pkg/loader/ignore_test.go
+++ b/pkg/loader/ignore_test.go
@@ -315,3 +315,58 @@ data: {env: `+env+`}
 		}
 	})
 }
+
+// TestLoader_IgnoreFileOverride covers Loader.IgnoreFile: an explicitly
+// named file replaces <root>/.krmignore, its patterns anchor at the scan
+// root regardless of where the file lives, and naming a file that does
+// not exist fails loud instead of silently scanning unfiltered.
+func TestLoader_IgnoreFileOverride(t *testing.T) {
+	appID := manifest.NamedResource{Kind: manifest.KindConfigMap, Namespace: "default", Name: "app-config"}
+
+	dir := t.TempDir()
+	testutil.WriteFile(t, dir, ".krmignore", "/environments/staging/\n")
+	testutil.WriteFile(t, dir, "ignores/production.krmignore", "/environments/production/\n")
+	for _, env := range []string{"production", "staging"} {
+		testutil.WriteFile(t, dir, "environments/"+env+"/app.yaml", `apiVersion: v1
+kind: ConfigMap
+metadata: {name: app-config, namespace: default}
+data: {env: `+env+`}
+`)
+	}
+
+	envOf := func(t *testing.T, ignoreFile string) string {
+		t.Helper()
+		s := store.New()
+		l := New(s)
+		l.IgnoreFile = ignoreFile
+		if _, err := l.Load(t.Context(), dir); err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		cm, ok := s.GetObject(appID).(*manifest.ConfigMap)
+		if !ok {
+			t.Fatal("app-config was not loaded")
+		}
+		env, _ := cm.Data["env"].(string)
+		return env
+	}
+
+	t.Run("empty falls back to root .krmignore", func(t *testing.T) {
+		if got := envOf(t, ""); got != "production" {
+			t.Errorf("env = %q, want production", got)
+		}
+	})
+
+	t.Run("override anchors at the scan root", func(t *testing.T) {
+		if got := envOf(t, filepath.Join(dir, "ignores", "production.krmignore")); got != "staging" {
+			t.Errorf("env = %q, want staging", got)
+		}
+	})
+
+	t.Run("missing override file errors", func(t *testing.T) {
+		l := New(store.New())
+		l.IgnoreFile = filepath.Join(dir, "nope.krmignore")
+		if _, err := l.Load(t.Context(), dir); err == nil {
+			t.Fatal("Load: expected error for missing IgnoreFile")
+		}
+	})
+}

--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -86,6 +86,14 @@ type Loader struct {
 	// consumer's NamedResource; mirrors SourceFiles' lifecycle.
 	SourceRefs map[manifest.NamedResource][]manifest.NamedResource
 
+	// IgnoreFile, when non-empty, is the gitignore-grammar file Load
+	// reads in place of <root>/.krmignore, with its patterns anchored
+	// at the Load root. Discovery sets it for the --path scan only:
+	// spec.path targets followed afterwards keep their own
+	// per-directory .krmignore, exactly as if the file sat at the
+	// scan root.
+	IgnoreFile string
+
 	// PreferExisting suppresses overwrites of resources already in
 	// the store (and their SourceFiles entries). Used by the
 	// orchestrator's recursive spec.path discovery so the initial
@@ -138,7 +146,12 @@ func (l *Loader) Load(ctx context.Context, root string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	ignore, err := loadIgnore(abs)
+	var ignore *ignoreSet
+	if l.IgnoreFile != "" {
+		ignore, err = loadIgnoreFile(l.IgnoreFile, abs)
+	} else {
+		ignore, err = loadIgnore(abs)
+	}
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -59,6 +59,10 @@ type Config struct {
 	// Supplied explicitly by SDK consumers rendering extracted trees with
 	// no .git/config; empty ⇒ the working tree's .git remotes are read.
 	SelfURLs []string
+	// KRMIgnoreFile, when non-empty, is the gitignore-grammar file read in
+	// place of <Path>/.krmignore for the initial scan of Path; see
+	// discovery.Config.KRMIgnoreFile.
+	KRMIgnoreFile string
 	// PathOrig, when non-empty, switches every command into
 	// changed-only mode: only resources whose source files differ
 	// (plus the sources they reference) get reconciled.
@@ -542,7 +546,8 @@ func (o *Orchestrator) Bootstrap(ctx context.Context) error {
 	}
 	res, err := discovery.Run(ctx, discovery.Config{
 		Path: o.cfg.Path, RepoRoot: o.cfg.RepoRoot, SelfURLs: o.cfg.SelfURLs,
-		Store: o.store, WipeSecrets: o.cfg.WipeSecrets,
+		KRMIgnoreFile: o.cfg.KRMIgnoreFile,
+		Store:         o.store, WipeSecrets: o.cfg.WipeSecrets,
 		ComponentCache: o.componentCache,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds `--krmignore <file>` (env: `FLATE_KRMIGNORE`) to every reconcile-running subcommand. The named gitignore-syntax file is read in place of `<path>/.krmignore` for the initial scan, with patterns still anchored at `--path`. One checkout can keep a `.krmignore.staging` and a `.krmignore.production` and pick one per run, which is the follow-up agreed in #816.

## Changes

- `pkg/loader`: `Loader.IgnoreFile` selects an explicit ignore file; a missing file is an error rather than a silent unfiltered scan. `.krmignore` parsing is factored into `parseIgnore` shared by both paths.
- `pkg/discovery` / `pkg/orchestrator`: `Config.KRMIgnoreFile` plumbs the file through `Bootstrap` and `RenderTrees`, so `diff` applies the same override to both sides. It applies to the `--path` scan only; spec.path targets followed afterwards keep their own per-directory `.krmignore`, exactly as if the file sat at the scan root.
- `internal/cli`: the flag, wired into `buildOrchCfg`; the env binding comes from the existing `FLATE_` prefix logic.
- README: documents `.krmignore` (previously undocumented) and the new flag.

## Tests

- Loader: override anchors at the scan root, empty falls back to `.krmignore`, missing file errors.
- Discovery: override filters the initial scan while a followed spec.path dir still honors its own `.krmignore`.
- CLI: end-to-end `get ks --krmignore` drops the ignored Kustomization; missing file exits non-zero naming the file; flag and env key pinned in the existing tables.

`mise run vet`, `mise run lint`, and `mise run test` pass.

Closes #816